### PR TITLE
feat(quadraui): close Backend trait coverage gap (7 primitives + MSV/tree layout helpers)

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -13,11 +13,19 @@ use std::time::Duration;
 use crate::event::{Rect, UiEvent, Viewport};
 use crate::modal_stack::ModalStack;
 use crate::primitives::activity_bar::ActivityBarRowHit;
+use crate::primitives::completions::{Completions, CompletionsLayout};
 use crate::primitives::context_menu::{ContextMenu, ContextMenuLayout};
 use crate::primitives::dialog::{Dialog, DialogLayout};
+use crate::primitives::editor::Editor;
+use crate::primitives::find_replace::FindReplacePanel;
+use crate::primitives::message_list::MessageList;
+use crate::primitives::multi_section_view::{MultiSectionView, MultiSectionViewLayout};
+use crate::primitives::rich_text_popup::{RichTextPopup, RichTextPopupLayout};
+use crate::primitives::scrollbar::Scrollbar;
 use crate::primitives::status_bar::StatusBarHitRegion;
 use crate::primitives::tab_bar::TabBarHits;
 use crate::primitives::tooltip::{Tooltip, TooltipLayout};
+use crate::primitives::tree::TreeViewLayout;
 use crate::types::WidgetId;
 use crate::{
     Accelerator, AcceleratorId, ActivityBar, Form, ListView, Palette, StatusBar, TabBar, Terminal,
@@ -153,6 +161,82 @@ pub trait Backend {
     /// handler can resolve a click to a button without re-running
     /// layout. Mirrors [`draw_context_menu`](Self::draw_context_menu).
     fn draw_dialog(&mut self, dialog: &Dialog, layout: &DialogLayout) -> Vec<Rect>;
+
+    /// Draw a [`MultiSectionView`]. The backend computes the layout
+    /// internally with native metrics (cells for TUI, pixels +
+    /// `line_height` for GTK) and dispatches each section's body to
+    /// the appropriate inner-primitive painter (tree, list, etc.).
+    /// Hosts that need to hit-test clicks call [`Self::msv_layout`]
+    /// for the same layout instance.
+    fn draw_multi_section_view(&mut self, rect: Rect, view: &MultiSectionView);
+
+    /// Compute the layout the rasteriser would produce for `view` in
+    /// `rect`, using the backend's native metrics. Hosts call this
+    /// to drive hit-testing without re-deriving metrics — paint and
+    /// click consume one layout per frame, the source-of-truth
+    /// contract `MultiSectionView` exists to enforce.
+    fn msv_layout(&self, rect: Rect, view: &MultiSectionView) -> MultiSectionViewLayout;
+
+    /// Compute the tree layout the rasteriser would produce. Used by
+    /// hosts (especially MSV consumers) to resolve body clicks down
+    /// to row indices without re-deriving the row pitch (1 cell
+    /// uniform on TUI; `1.0×`/`1.4×` line_height by `Decoration` on
+    /// GTK).
+    fn tree_layout(&self, rect: Rect, tree: &TreeView) -> TreeViewLayout;
+
+    /// Draw an [`Editor`]. Returns paint-side data the host needs
+    /// for chrome alignment (cursor pixel position for caret blink
+    /// overlays, etc.). Asymmetric across backends: TUI populates
+    /// the result; GTK paints its own caret and returns the default.
+    fn draw_editor(&mut self, rect: Rect, editor: &Editor) -> EditorPaintResult;
+
+    /// Draw a [`MessageList`] (chat-style streaming row history).
+    /// The backend pulls panel background from its current theme;
+    /// hosts that want a custom panel bg compose the primitive
+    /// directly via the backend crate's free function.
+    fn draw_message_list(&mut self, rect: Rect, list: &MessageList);
+
+    /// Draw a [`RichTextPopup`] at its caller-resolved layout.
+    /// Mirrors [`draw_tooltip`](Self::draw_tooltip): host computes
+    /// anchor + viewport + measure and asks `popup.layout(...)` for
+    /// the bounds. Link hit regions are tracked on the backend's
+    /// internal state; hosts that need them query via the
+    /// backend-specific accessor today (link-hit-test trait method
+    /// is a follow-up).
+    fn draw_rich_text_popup(&mut self, popup: &RichTextPopup, layout: &RichTextPopupLayout);
+
+    /// Draw a [`FindReplacePanel`] (find/replace overlay sitting
+    /// above the editor). The backend pulls the editor-relative
+    /// origin from `rect.x` (TUI's `editor_left` parameter is
+    /// derived from `rect`); hosts that want a non-default offset
+    /// compose the panel into a sub-rect.
+    fn draw_find_replace(&mut self, rect: Rect, panel: &FindReplacePanel);
+
+    /// Draw a [`Completions`] popup at its caller-resolved layout.
+    /// Mirrors [`draw_tooltip`](Self::draw_tooltip): host computes
+    /// anchor + viewport + measure and asks `completions.layout(...)`
+    /// for the bounds.
+    fn draw_completions(&mut self, completions: &Completions, layout: &CompletionsLayout);
+
+    /// Draw a [`Scrollbar`] (standalone primitive, vs the
+    /// per-section scrollbars MSV paints internally). The backend
+    /// pulls cell/pixel background from its current theme.
+    fn draw_scrollbar(&mut self, rect: Rect, scrollbar: &Scrollbar);
+}
+
+/// Paint-side data returned by [`Backend::draw_editor`]. Carries
+/// information the host needs to align external chrome (caret blink
+/// overlay, virtual-text positioning) with the editor's painted
+/// content. Backends that paint their own caret (GTK) populate the
+/// default; backends that delegate caret rendering to the host (TUI
+/// terminal cursor) populate the actual cursor cell.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EditorPaintResult {
+    /// Cursor's painted position in backend-native units, if the
+    /// host is responsible for terminal-cursor positioning. `None`
+    /// when the backend painted its own caret OR when the cursor is
+    /// outside the viewport.
+    pub cursor_position: Option<(u16, u16)>,
 }
 
 /// Platform services the backend exposes to apps: clipboard, file dialogs,

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -765,6 +765,165 @@ impl Backend for GtkBackend {
             .map(|(x, y, w, h)| QRect::new(x as f32, y as f32, w as f32, h as f32))
             .collect()
     }
+
+    // ─── #13: trait coverage for the rest of the rasterised primitives ──
+
+    fn draw_multi_section_view(
+        &mut self,
+        rect: QRect,
+        view: &crate::primitives::multi_section_view::MultiSectionView,
+    ) {
+        let line_height = self.current_line_height;
+        let theme = self.current_theme;
+        let nerd_fonts = self.nerd_fonts_enabled;
+        let (cr, layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_multi_section_view called outside enter_frame_scope");
+        crate::gtk::draw_multi_section_view(
+            cr,
+            layout,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            view,
+            &theme,
+            line_height,
+            nerd_fonts,
+        );
+    }
+
+    fn msv_layout(
+        &self,
+        rect: QRect,
+        view: &crate::primitives::multi_section_view::MultiSectionView,
+    ) -> crate::primitives::multi_section_view::MultiSectionViewLayout {
+        crate::gtk::gtk_msv_layout(view, rect, self.current_line_height)
+    }
+
+    fn tree_layout(&self, rect: QRect, tree: &TreeView) -> crate::primitives::tree::TreeViewLayout {
+        crate::gtk::gtk_tree_layout(tree, rect, self.current_line_height)
+    }
+
+    fn draw_editor(
+        &mut self,
+        rect: QRect,
+        editor: &crate::primitives::editor::Editor,
+    ) -> crate::backend::EditorPaintResult {
+        let line_height = self.current_line_height;
+        let char_width = self.current_char_width;
+        let theme = self.current_theme;
+        let (cr, pango_layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_editor called outside enter_frame_scope");
+        // GTK draw_editor needs FontMetrics; resolve from the layout's
+        // font description. The TUI return type carries a TUI-specific
+        // cursor cell — GTK paints its own caret, so we return the
+        // default. Future GTK refinement can populate fields if hosts
+        // need GTK-side cursor pixel coordinates.
+        let pango_ctx = pango_layout.context();
+        let font_desc = pango_layout
+            .font_description()
+            .or_else(|| pango_ctx.font_description());
+        let metrics = pango_ctx.metrics(font_desc.as_ref(), None);
+        crate::gtk::draw_editor(
+            cr,
+            pango_layout,
+            &metrics,
+            editor,
+            &theme,
+            char_width,
+            line_height,
+        );
+        let _ = rect;
+        crate::backend::EditorPaintResult::default()
+    }
+
+    fn draw_message_list(
+        &mut self,
+        rect: QRect,
+        list: &crate::primitives::message_list::MessageList,
+    ) {
+        let line_height = self.current_line_height;
+        let (cr, pango_layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_message_list called outside enter_frame_scope");
+        crate::gtk::draw_message_list(
+            cr,
+            pango_layout,
+            list,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            (rect.y + rect.height) as f64,
+            line_height,
+        );
+    }
+
+    fn draw_rich_text_popup(
+        &mut self,
+        popup: &crate::primitives::rich_text_popup::RichTextPopup,
+        layout_arg: &crate::primitives::rich_text_popup::RichTextPopupLayout,
+    ) {
+        let theme = self.current_theme;
+        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let (cr, pango_layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_rich_text_popup called outside enter_frame_scope");
+        // GTK rasteriser returns link bounds; for trait parity we
+        // discard them. Hosts that need link hit-testing query the
+        // primitive's own `popup.layout(...).hit_test(...)` API.
+        let _ = crate::gtk::draw_rich_text_popup(
+            cr,
+            pango_layout,
+            &ui_font_desc,
+            popup,
+            layout_arg,
+            &theme,
+        );
+    }
+
+    fn draw_find_replace(
+        &mut self,
+        rect: QRect,
+        panel: &crate::primitives::find_replace::FindReplacePanel,
+    ) {
+        let line_height = self.current_line_height;
+        let char_width = self.current_char_width;
+        let theme = self.current_theme;
+        let (cr, pango_layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_find_replace called outside enter_frame_scope");
+        // GTK rasteriser positions the panel via its own anchor logic;
+        // `rect` parameter is currently unused (forward-compat for a
+        // host-resolved layout per BACKEND_TRAIT_PROPOSAL §6.2).
+        let _ = rect;
+        crate::gtk::draw_find_replace(cr, pango_layout, panel, &theme, line_height, char_width);
+    }
+
+    fn draw_completions(
+        &mut self,
+        completions: &crate::primitives::completions::Completions,
+        layout_arg: &crate::primitives::completions::CompletionsLayout,
+    ) {
+        let theme = self.current_theme;
+        let (cr, pango_layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_completions called outside enter_frame_scope");
+        crate::gtk::draw_completions(cr, pango_layout, completions, layout_arg, &theme);
+    }
+
+    fn draw_scrollbar(
+        &mut self,
+        _rect: QRect,
+        scrollbar: &crate::primitives::scrollbar::Scrollbar,
+    ) {
+        let theme = self.current_theme;
+        let (cr, _layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_scrollbar called outside enter_frame_scope");
+        crate::gtk::draw_scrollbar(cr, scrollbar, &theme);
+    }
 }
 
 // ─── Cross-backend validation tests ──────────────────────────────────────────

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -18,16 +18,14 @@
 //! The pointer is null outside the scope, so the safe accessor
 //! returns `None` and `draw_*` methods can detect misuse.
 //!
-//! ### What the trait covers vs. what stays inherent
+//! ### What the trait covers
 //!
-//! Drawing methods for the migrated primitives — `draw_palette`,
-//! `draw_list`, `draw_tree`, `draw_form` — go through the trait so
-//! the same generic `<B: Backend>` paint function works against
-//! `TuiBackend`, `MockBackend` (see the `tests` module), and future
-//! GTK/Win-GUI/macOS backends. The other five `draw_*` methods stay
-//! stubbed pending a quadraui-side trait change to thread
-//! pre-computed `*Layout` parameters (see
-//! `BACKEND_TRAIT_PROPOSAL.md` §6.2).
+//! As of #13 the `Backend` trait covers every primitive that has
+//! TUI + GTK rasterisers. New primitives must add a trait method as
+//! part of the same change that adds the rasteriser (see CLAUDE.md
+//! Primitive Authoring Rule #7). Generic `<B: Backend>` render code
+//! works against `TuiBackend`, `GtkBackend`, the test `MockBackend`,
+//! and any future Win-GUI / macOS backend implementer.
 //!
 //! Drag-state observation is deliberately not on the trait — only
 //! `crate::dispatch::*` needs to inspect it, and the backend keeps
@@ -587,6 +585,123 @@ impl Backend for TuiBackend {
             .map(|vis| vis.bounds)
             .collect()
     }
+
+    // ─── #13: trait coverage for the rest of the rasterised primitives ──
+
+    fn draw_multi_section_view(
+        &mut self,
+        rect: QRect,
+        view: &crate::primitives::multi_section_view::MultiSectionView,
+    ) {
+        let area = q_rect_to_ratatui(rect);
+        let theme = self.current_theme;
+        let nerd_fonts = self.nerd_fonts_enabled;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_multi_section_view called outside enter_frame_scope");
+        crate::tui::draw_multi_section_view(frame.buffer_mut(), area, view, &theme, nerd_fonts);
+    }
+
+    fn msv_layout(
+        &self,
+        rect: QRect,
+        view: &crate::primitives::multi_section_view::MultiSectionView,
+    ) -> crate::primitives::multi_section_view::MultiSectionViewLayout {
+        let area = q_rect_to_ratatui(rect);
+        crate::tui::tui_msv_layout(view, area)
+    }
+
+    fn tree_layout(&self, rect: QRect, tree: &TreeView) -> crate::primitives::tree::TreeViewLayout {
+        let area = q_rect_to_ratatui(rect);
+        crate::tui::tui_tree_layout(tree, area)
+    }
+
+    fn draw_editor(
+        &mut self,
+        rect: QRect,
+        editor: &crate::primitives::editor::Editor,
+    ) -> crate::backend::EditorPaintResult {
+        let area = q_rect_to_ratatui(rect);
+        let theme = self.current_theme;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_editor called outside enter_frame_scope");
+        let tui_result = crate::tui::draw_editor(frame.buffer_mut(), area, editor, &theme);
+        crate::backend::EditorPaintResult {
+            cursor_position: tui_result.cursor_position,
+        }
+    }
+
+    fn draw_message_list(
+        &mut self,
+        rect: QRect,
+        list: &crate::primitives::message_list::MessageList,
+    ) {
+        let area = q_rect_to_ratatui(rect);
+        let panel_bg = self.current_theme.background;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_message_list called outside enter_frame_scope");
+        crate::tui::draw_message_list(frame.buffer_mut(), area, list, panel_bg);
+    }
+
+    fn draw_rich_text_popup(
+        &mut self,
+        popup: &crate::primitives::rich_text_popup::RichTextPopup,
+        layout: &crate::primitives::rich_text_popup::RichTextPopupLayout,
+    ) {
+        let theme = self.current_theme;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_rich_text_popup called outside enter_frame_scope");
+        crate::tui::draw_rich_text_popup(frame.buffer_mut(), popup, layout, &theme);
+    }
+
+    fn draw_find_replace(
+        &mut self,
+        rect: QRect,
+        panel: &crate::primitives::find_replace::FindReplacePanel,
+    ) {
+        let area = q_rect_to_ratatui(rect);
+        let theme = self.current_theme;
+        // TUI free function takes `editor_left: u16` for editor-relative
+        // positioning. The trait abstraction passes the panel's full
+        // rect; downstream consumers that want a non-zero editor offset
+        // should compose into a sub-rect.
+        let editor_left = area.x;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_find_replace called outside enter_frame_scope");
+        crate::tui::draw_find_replace(frame.buffer_mut(), area, panel, &theme, editor_left);
+    }
+
+    fn draw_completions(
+        &mut self,
+        completions: &crate::primitives::completions::Completions,
+        layout: &crate::primitives::completions::CompletionsLayout,
+    ) {
+        let theme = self.current_theme;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_completions called outside enter_frame_scope");
+        crate::tui::draw_completions(frame.buffer_mut(), completions, layout, &theme);
+    }
+
+    fn draw_scrollbar(
+        &mut self,
+        _rect: QRect,
+        scrollbar: &crate::primitives::scrollbar::Scrollbar,
+    ) {
+        let theme = self.current_theme;
+        let cell_bg = theme.background;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_scrollbar called outside enter_frame_scope");
+        // The standalone TUI scrollbar primitive paints from its own
+        // `track` bounds; `rect` is unused (the primitive owns layout).
+        // Forward-compat parameter for backends that need a clip rect.
+        crate::tui::draw_scrollbar(frame.buffer_mut(), scrollbar, &theme, cell_bg);
+    }
 }
 
 // ─── Cross-backend validation tests ──────────────────────────────────────────
@@ -746,6 +861,73 @@ mod tests {
         ) -> Vec<QRect> {
             Vec::new()
         }
+
+        // ── #13: stubs for the trait methods added with this issue ──
+
+        fn draw_multi_section_view(
+            &mut self,
+            _r: QRect,
+            _v: &crate::primitives::multi_section_view::MultiSectionView,
+        ) {
+        }
+
+        fn msv_layout(
+            &self,
+            r: QRect,
+            v: &crate::primitives::multi_section_view::MultiSectionView,
+        ) -> crate::primitives::multi_section_view::MultiSectionViewLayout {
+            // Mock returns the primitive's natural layout with default
+            // metrics — sufficient for cross-backend compile checks.
+            v.layout(
+                r,
+                crate::primitives::multi_section_view::LayoutMetrics::default(),
+                |_| crate::primitives::multi_section_view::SectionMeasure::default(),
+            )
+        }
+
+        fn tree_layout(&self, r: QRect, t: &TreeView) -> crate::primitives::tree::TreeViewLayout {
+            t.layout(r.width, r.height, |_| {
+                crate::primitives::tree::TreeRowMeasure::new(1.0)
+            })
+        }
+
+        fn draw_editor(
+            &mut self,
+            _r: QRect,
+            _e: &crate::primitives::editor::Editor,
+        ) -> crate::backend::EditorPaintResult {
+            crate::backend::EditorPaintResult::default()
+        }
+
+        fn draw_message_list(
+            &mut self,
+            _r: QRect,
+            _l: &crate::primitives::message_list::MessageList,
+        ) {
+        }
+
+        fn draw_rich_text_popup(
+            &mut self,
+            _p: &crate::primitives::rich_text_popup::RichTextPopup,
+            _l: &crate::primitives::rich_text_popup::RichTextPopupLayout,
+        ) {
+        }
+
+        fn draw_find_replace(
+            &mut self,
+            _r: QRect,
+            _p: &crate::primitives::find_replace::FindReplacePanel,
+        ) {
+        }
+
+        fn draw_completions(
+            &mut self,
+            _c: &crate::primitives::completions::Completions,
+            _l: &crate::primitives::completions::CompletionsLayout,
+        ) {
+        }
+
+        fn draw_scrollbar(&mut self, _r: QRect, _s: &crate::primitives::scrollbar::Scrollbar) {}
     }
 
     /// Generic helper — the minimal "app render code" that consumes


### PR DESCRIPTION
Closes #13.

## Summary

Backfills `Backend` trait methods for every primitive that has TUI + GTK rasterisers but wasn't reachable through the trait. The gap is what made #12 (`gtk_multi_tree`) cost ~500 lines of GTK4 boilerplate per backend instead of ~10 lines through `quadraui::gtk::run`.

`BACKEND_TRAIT_PROPOSAL.md` §4 already mandated per-primitive trait coverage (*"Adding a primitive is a breaking change to this trait. That's intentional"*). This PR catches the 7 primitives that drifted off, plus 2 layout helpers consumer click routers need to stay backend-agnostic.

## What's added

### Trait methods (9 total)

```rust
fn draw_multi_section_view(&mut self, rect: Rect, view: &MultiSectionView);
fn msv_layout(&self, rect: Rect, view: &MultiSectionView) -> MultiSectionViewLayout;
fn tree_layout(&self, rect: Rect, tree: &TreeView) -> TreeViewLayout;
fn draw_editor(&mut self, rect: Rect, editor: &Editor) -> EditorPaintResult;
fn draw_message_list(&mut self, rect: Rect, list: &MessageList);
fn draw_rich_text_popup(&mut self, popup: &RichTextPopup, layout: &RichTextPopupLayout);
fn draw_find_replace(&mut self, rect: Rect, panel: &FindReplacePanel);
fn draw_completions(&mut self, completions: &Completions, layout: &CompletionsLayout);
fn draw_scrollbar(&mut self, rect: Rect, scrollbar: &Scrollbar);
```

### New public struct

`backend::EditorPaintResult { cursor_position: Option<(u16, u16)> }` — carries cursor pixel position for hosts that drive their own caret blink overlay (TUI populates; GTK paints its own caret and returns default).

## Trait shape decisions worth flagging for review

These are the points where I made calls you might want to weigh in on:

1. **`msv_layout` / `tree_layout` are `&self`, not `&mut self`.** They're pure layout computations; nothing on the backend mutates. Existing `&self` precedent: `viewport()`, `services()`. Existing `&mut self` precedent: every `draw_*` (because they consume a frame). Layout helpers are closer in spirit to `viewport()`.

2. **`EditorPaintResult` lives on the trait, not in `tui::editor`.** Both backends conform to a shared shape; the field set is currently TUI-driven (just `cursor_position`). GTK populates default. Future Win-GUI / macOS would populate per their own caret model. Alternative: keep it TUI-internal and have the trait method be `(rect, editor) -> Option<(u16, u16)>` — less typed but less coupling. I picked the struct for forward-compat (more fields can be added without breaking the trait).

3. **`draw_rich_text_popup` discards the GTK link-bounds return.** Hosts that need link hit-testing query the primitive's `popup.layout(...).hit_test(...)` API today. Cleaner long-term: a `popup_layout` helper returning hit data, mirroring `msv_layout` / `tree_layout`. Out of scope here; would be a follow-up if real consumers need it.

4. **TUI-specific extras (`panel_bg: Color`, `cell_bg: Color`, `editor_left: u16`) derive from theme / rect inside the impl.** Hosts that need non-default behaviour drop to the free function. The trait stays portable.

5. **Doc comment update in `tui/backend.rs`.** The stale "five `draw_*` methods stay stubbed pending trait change" comment is removed — the trait is now complete for every rasterised primitive.

## Test plan

- [x] `cargo build -p quadraui --features tui --features gtk` clean
- [x] `cargo test -p quadraui --features tui --features gtk --lib` — 342 pass
- [x] `cargo clippy -p quadraui --features tui --features gtk --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build -p kubeui` + `cargo build -p kubeui-gtk` both build (no consumer-API breakage)
- [ ] `cargo run --example msv_multi_tree --features tui` — should be byte-identical to current behaviour
- [ ] `cargo run --example gtk_multi_tree --features gtk` — same

## What this unblocks

- **#14** (shared `AppLogic` refactor for `msv_multi_tree` + `gtk_multi_tree`) — was blocked on `Backend::draw_multi_section_view`; now ready to start.
- **Future Win-GUI / macOS backends** — can now implement the trait against Direct2D / Core Graphics with no consumer-side changes. CLAUDE.md *Cross-backend portability commitment* is now genuinely load-bearing.

## Out of scope

- Adding rasterisers for the 7 primitives that don't have any (`panel`, `progress`, `spinner`, `split`, `toast`, `modal`, `menu_bar`) — tracked in #6 / #8.
- Refactoring existing examples — tracked in #14.
- New backend implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)