### PR TITLE
feat(quadraui): StatusBar hover/pressed visual feedback (#45)

### DIFF
--- a/kubeui-gtk/src/main.rs
+++ b/kubeui-gtk/src/main.rs
@@ -259,7 +259,18 @@ fn paint(cr: &Cairo, w: f64, h: f64, state: &AppState, da: &DrawingArea) {
 
     // ── Status bar ─────────────────────────────────────────────
     let bar = build_status_bar(state);
-    quadraui::gtk::draw_status_bar(cr, &layout, 0.0, h - line_h, w, line_h, &bar, &theme());
+    quadraui::gtk::draw_status_bar(
+        cr,
+        &layout,
+        0.0,
+        h - line_h,
+        w,
+        line_h,
+        &bar,
+        &theme(),
+        None,
+        None,
+    );
 
     // ── Picker overlay (optional) ──────────────────────────────
     if let Some(picker) = state.picker.as_ref() {

--- a/kubeui/src/main.rs
+++ b/kubeui/src/main.rs
@@ -119,6 +119,8 @@ fn run(
                 &bar,
                 &bar_layout,
                 &theme(),
+                None,
+                None,
             );
             if let Some(picker) = state.picker.as_ref() {
                 let viewport = quadraui::Rect::new(0.0, 0.0, area.width as f32, area.height as f32);

--- a/quadraui/examples/common/demo.rs
+++ b/quadraui/examples/common/demo.rs
@@ -263,7 +263,7 @@ impl AppLogic for AppState {
         let status_bar = build_status_bar(self, focused.as_deref());
         let status_h = 28.0;
         let status_rect = Rect::new(0.0, viewport.height - status_h, viewport.width, status_h);
-        let _hits = backend.draw_status_bar(status_rect, &status_bar);
+        let _hits = backend.draw_status_bar(status_rect, &status_bar, None, None);
     }
 
     fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/form_groups.rs
+++ b/quadraui/examples/common/form_groups.rs
@@ -212,7 +212,7 @@ impl AppLogic for FormGroupsApp {
         let form_rect = Self::form_rect(backend);
         let status_rect = Self::status_rect(backend);
         backend.draw_form(form_rect, &self.build_form());
-        let _hits = backend.draw_status_bar(status_rect, &self.build_status_bar());
+        let _hits = backend.draw_status_bar(status_rect, &self.build_status_bar(), None, None);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/indicators_app.rs
+++ b/quadraui/examples/common/indicators_app.rs
@@ -109,7 +109,7 @@ impl AppLogic for IndicatorsApp {
 
         // Status bar at bottom.
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
-        let _ = backend.draw_status_bar(status_rect, &self.status_bar());
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/menu_bar_app.rs
+++ b/quadraui/examples/common/menu_bar_app.rs
@@ -130,7 +130,7 @@ impl AppLogic for MenuBarApp {
         self.menu_system.render(backend, bar_rect);
 
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
-        let _ = backend.draw_status_bar(status_rect, &self.status_bar());
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/mini_app.rs
+++ b/quadraui/examples/common/mini_app.rs
@@ -75,7 +75,7 @@ impl AppLogic for MiniApp {
         let viewport = backend.viewport();
         let row_h = 28.0;
         let rect = Rect::new(0.0, viewport.height - row_h, viewport.width, row_h);
-        let _ = backend.draw_status_bar(rect, &bar);
+        let _ = backend.draw_status_bar(rect, &bar, None, None);
     }
 
     fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/multi_tree.rs
+++ b/quadraui/examples/common/multi_tree.rs
@@ -109,7 +109,7 @@ impl AppLogic for DebugSidebar {
         let sidebar = Self::sidebar_rect(backend);
         let status = Self::status_rect(backend);
         self.sidebar.render(backend, sidebar);
-        let _hits = backend.draw_status_bar(status, &self.build_status_bar());
+        let _hits = backend.draw_status_bar(status, &self.build_status_bar(), None, None);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/panel_app.rs
+++ b/quadraui/examples/common/panel_app.rs
@@ -91,7 +91,7 @@ impl PanelApp {
             }],
             right_segments: vec![],
         };
-        let _ = backend.draw_status_bar(label_rect, &bar);
+        let _ = backend.draw_status_bar(label_rect, &bar, None, None);
     }
 }
 
@@ -114,7 +114,7 @@ impl AppLogic for PanelApp {
         self.fill_content(backend, layout.content_bounds);
 
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
-        let _ = backend.draw_status_bar(status_rect, &self.status_bar());
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/search_panel.rs
+++ b/quadraui/examples/common/search_panel.rs
@@ -200,7 +200,7 @@ impl AppLogic for SearchPanelApp {
         backend.draw_multi_section_view(panel_rect, &view);
 
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
-        let _ = backend.draw_status_bar(status_rect, &self.status_bar());
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/split_app.rs
+++ b/quadraui/examples/common/split_app.rs
@@ -83,7 +83,7 @@ impl SplitApp {
             }],
             right_segments: vec![],
         };
-        let _ = backend.draw_status_bar(bounds, &bar);
+        let _ = backend.draw_status_bar(bounds, &bar, None, None);
     }
 }
 
@@ -132,7 +132,7 @@ impl AppLogic for SplitApp {
         );
 
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
-        let _ = backend.draw_status_bar(status_rect, &self.status_bar());
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/toast_app.rs
+++ b/quadraui/examples/common/toast_app.rs
@@ -102,7 +102,7 @@ impl AppLogic for ToastApp {
 
         // Status bar at bottom.
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
-        let _ = backend.draw_status_bar(status_rect, &self.status_bar());
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
 
         // Toast stack overlays the viewport.
         let overlay_rect = Rect::new(0.0, 0.0, viewport.width, viewport.height - lh);

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -126,11 +126,20 @@ pub trait Backend {
     // Methods that produce hit-region data (clickable segments,
     // close-button rects, link rects) return it directly so callers
     // route clicks against the same data the rasteriser used to paint.
-    /// Draw a status bar. Returns hit regions in **bar-local
-    /// coordinates** (relative to `rect.x` / `rect.y`) for each segment
-    /// carrying an `action_id`. Caller dispatches clicks against the
-    /// returned list.
-    fn draw_status_bar(&mut self, rect: Rect, bar: &StatusBar) -> Vec<StatusBarHitRegion>;
+    /// Draw a status bar. `hovered_id` and `pressed_id` carry per-frame
+    /// interaction state so the rasteriser can tint the background of the
+    /// matching clickable segment (the primitive itself carries no mouse
+    /// state — same pattern as `ActivityBar`'s `hovered_idx`). Returns
+    /// hit regions in **bar-local coordinates** (relative to `rect.x` /
+    /// `rect.y`) for each segment carrying an `action_id`. Caller
+    /// dispatches clicks against the returned list.
+    fn draw_status_bar(
+        &mut self,
+        rect: Rect,
+        bar: &StatusBar,
+        hovered_id: Option<&WidgetId>,
+        pressed_id: Option<&WidgetId>,
+    ) -> Vec<StatusBarHitRegion>;
     /// Draw a tab bar. `hovered_close_tab` carries per-frame hover
     /// state so the rasteriser can paint a hover background behind the
     /// hovered tab's close glyph (the primitive itself carries no

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -664,7 +664,13 @@ impl Backend for GtkBackend {
     // impls stay as stubs and the GTK call sites continue to use the
     // legacy shims directly.
 
-    fn draw_status_bar(&mut self, rect: QRect, bar: &StatusBar) -> Vec<crate::StatusBarHitRegion> {
+    fn draw_status_bar(
+        &mut self,
+        rect: QRect,
+        bar: &StatusBar,
+        hovered_id: Option<&crate::types::WidgetId>,
+        pressed_id: Option<&crate::types::WidgetId>,
+    ) -> Vec<crate::StatusBarHitRegion> {
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_status_bar called outside enter_frame_scope");
@@ -677,6 +683,8 @@ impl Backend for GtkBackend {
             self.current_line_height,
             bar,
             &self.current_theme,
+            hovered_id,
+            pressed_id,
         )
     }
 

--- a/quadraui/src/gtk/status_bar.rs
+++ b/quadraui/src/gtk/status_bar.rs
@@ -21,6 +21,7 @@ use crate::primitives::status_bar::{
     StatusBar, StatusBarHitRegion, StatusBarSegment, StatusSegmentMeasure, StatusSegmentSide,
 };
 use crate::theme::Theme;
+use crate::types::WidgetId;
 
 /// 16-pixel minimum gap between left and right segment groups, matching
 /// the existing vimcode GTK behaviour. Right segments are dropped from
@@ -56,6 +57,8 @@ pub fn draw_status_bar(
     line_height: f64,
     bar: &StatusBar,
     theme: &Theme,
+    hovered_id: Option<&WidgetId>,
+    pressed_id: Option<&WidgetId>,
 ) -> Vec<StatusBarHitRegion> {
     // Reset layout state.
     layout.set_attributes(None);
@@ -111,8 +114,23 @@ pub fn draw_status_bar(
         let seg_x = x + vs.bounds.x as f64;
         let seg_w = vs.bounds.width as f64;
 
-        // Segment background fill.
-        set_source(cr, seg.bg);
+        // Segment background fill (with hover/pressed tint for interactive segments).
+        let effective_bg = if seg
+            .action_id
+            .as_ref()
+            .is_some_and(|id| Some(id) == pressed_id)
+        {
+            seg.bg.darken(0.05)
+        } else if seg
+            .action_id
+            .as_ref()
+            .is_some_and(|id| Some(id) == hovered_id)
+        {
+            seg.bg.lighten(0.05)
+        } else {
+            seg.bg
+        };
+        set_source(cr, effective_bg);
         cr.rectangle(seg_x, y, seg_w, line_height);
         cr.fill().ok();
 

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -473,7 +473,13 @@ impl Backend for TuiBackend {
     // are now thin pass-throughs, mirroring the GTK impls in
     // `gtk/backend.rs`.
 
-    fn draw_status_bar(&mut self, rect: QRect, bar: &StatusBar) -> Vec<crate::StatusBarHitRegion> {
+    fn draw_status_bar(
+        &mut self,
+        rect: QRect,
+        bar: &StatusBar,
+        hovered_id: Option<&crate::types::WidgetId>,
+        pressed_id: Option<&crate::types::WidgetId>,
+    ) -> Vec<crate::StatusBarHitRegion> {
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
         // Cell-unit measurer: each char counts as one cell.
@@ -483,7 +489,15 @@ impl Backend for TuiBackend {
         let frame = self
             .current_frame_mut()
             .expect("TuiBackend::draw_status_bar called outside enter_frame_scope");
-        crate::tui::draw_status_bar(frame.buffer_mut(), area, bar, &layout, &theme)
+        crate::tui::draw_status_bar(
+            frame.buffer_mut(),
+            area,
+            bar,
+            &layout,
+            &theme,
+            hovered_id,
+            pressed_id,
+        )
     }
 
     fn draw_tab_bar(
@@ -993,7 +1007,13 @@ mod tests {
         // records the ones the cross-backend test actually exercises.
         fn draw_tree(&mut self, _r: QRect, _t: &TreeView) {}
         fn draw_form(&mut self, _r: QRect, _f: &Form) {}
-        fn draw_status_bar(&mut self, _r: QRect, _b: &StatusBar) -> Vec<crate::StatusBarHitRegion> {
+        fn draw_status_bar(
+            &mut self,
+            _r: QRect,
+            _b: &StatusBar,
+            _hovered_id: Option<&crate::types::WidgetId>,
+            _pressed_id: Option<&crate::types::WidgetId>,
+        ) -> Vec<crate::StatusBarHitRegion> {
             Vec::new()
         }
         fn draw_tab_bar(

--- a/quadraui/src/tui/status_bar.rs
+++ b/quadraui/src/tui/status_bar.rs
@@ -16,6 +16,7 @@ use crate::primitives::status_bar::{
     StatusBar, StatusBarHitRegion, StatusBarLayout, StatusSegmentSide,
 };
 use crate::theme::Theme;
+use crate::types::WidgetId;
 
 /// Draw a [`StatusBar`] into `area` on `buf`. Returns hit regions in
 /// **bar-local cell coordinates** (relative to `area.x`) for each
@@ -45,6 +46,8 @@ pub fn draw_status_bar(
     bar: &StatusBar,
     layout: &StatusBarLayout,
     theme: &Theme,
+    hovered_id: Option<&WidgetId>,
+    pressed_id: Option<&WidgetId>,
 ) -> Vec<StatusBarHitRegion> {
     if area.width == 0 || area.height == 0 {
         return Vec::new();
@@ -68,7 +71,22 @@ pub fn draw_status_bar(
             StatusSegmentSide::Right => &bar.right_segments[vs.segment_idx],
         };
         let fg = ratatui_color(seg.fg);
-        let bg = ratatui_color(seg.bg);
+        let effective_bg = if seg
+            .action_id
+            .as_ref()
+            .is_some_and(|id| Some(id) == pressed_id)
+        {
+            seg.bg.darken(0.05)
+        } else if seg
+            .action_id
+            .as_ref()
+            .is_some_and(|id| Some(id) == hovered_id)
+        {
+            seg.bg.lighten(0.05)
+        } else {
+            seg.bg
+        };
+        let bg = ratatui_color(effective_bg);
         let start_x = area.x + vs.bounds.x.round() as u16;
         let bar_end = area.x + area.width;
         let mut cx = start_x;
@@ -148,6 +166,8 @@ mod tests {
             &bar,
             &layout,
             &Theme::default(),
+            None,
+            None,
         );
 
         // Left side starts at column 0: "NORMAL main.rs "
@@ -175,7 +195,15 @@ mod tests {
             foreground: Color::rgb(255, 255, 255),
             ..Theme::default()
         };
-        draw_status_bar(&mut buf, Rect::new(0, 0, 10, 1), &bar, &layout, &theme);
+        draw_status_bar(
+            &mut buf,
+            Rect::new(0, 0, 10, 1),
+            &bar,
+            &layout,
+            &theme,
+            None,
+            None,
+        );
 
         // Whole bar painted with theme.background as bg.
         for x in 0..10 {
@@ -201,6 +229,8 @@ mod tests {
             &bar,
             &layout,
             &Theme::default(),
+            None,
+            None,
         );
 
         // "NORMAL" was the bold segment — first 6 cells should carry BOLD.
@@ -234,6 +264,8 @@ mod tests {
             &bar,
             &layout,
             &Theme::default(),
+            None,
+            None,
         );
         assert_eq!(cell_char(&buf, 0, 0), ' ');
         assert!(regions.is_empty());
@@ -272,6 +304,8 @@ mod tests {
             &bar,
             &layout,
             &Theme::default(),
+            None,
+            None,
         );
 
         // One region for the segment with action_id.
@@ -281,5 +315,127 @@ mod tests {
         // and is 4 cells wide ("BBBB").
         assert_eq!(regions[0].col, 3);
         assert_eq!(regions[0].width, 4);
+    }
+
+    fn make_clickable_bar() -> StatusBar {
+        StatusBar {
+            id: WidgetId::new("click-bar"),
+            left_segments: vec![StatusBarSegment {
+                text: "BTN".into(),
+                fg: Color::rgb(255, 255, 255),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: Some(WidgetId::new("btn")),
+            }],
+            right_segments: vec![],
+        }
+    }
+
+    #[test]
+    fn hovered_segment_uses_lightened_bg() {
+        let bar = make_clickable_bar();
+        let base_bg = bar.left_segments[0].bg;
+        let hover_id = WidgetId::new("btn");
+        let layout = bar.layout(20.0, 1.0, 0.0, |seg| {
+            StatusSegmentMeasure::new(seg.text.chars().count() as f32)
+        });
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
+        draw_status_bar(
+            &mut buf,
+            Rect::new(0, 0, 20, 1),
+            &bar,
+            &layout,
+            &Theme::default(),
+            Some(&hover_id),
+            None,
+        );
+
+        let expected = ratatui_color(base_bg.lighten(0.05));
+        assert_eq!(
+            buf[(0, 0)].bg,
+            expected,
+            "hovered segment bg should be lightened"
+        );
+    }
+
+    #[test]
+    fn pressed_segment_uses_darkened_bg() {
+        let bar = make_clickable_bar();
+        let base_bg = bar.left_segments[0].bg;
+        let press_id = WidgetId::new("btn");
+        let layout = bar.layout(20.0, 1.0, 0.0, |seg| {
+            StatusSegmentMeasure::new(seg.text.chars().count() as f32)
+        });
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
+        draw_status_bar(
+            &mut buf,
+            Rect::new(0, 0, 20, 1),
+            &bar,
+            &layout,
+            &Theme::default(),
+            None,
+            Some(&press_id),
+        );
+
+        let expected = ratatui_color(base_bg.darken(0.05));
+        assert_eq!(
+            buf[(0, 0)].bg,
+            expected,
+            "pressed segment bg should be darkened"
+        );
+    }
+
+    #[test]
+    fn pressed_takes_precedence_over_hovered() {
+        let bar = make_clickable_bar();
+        let base_bg = bar.left_segments[0].bg;
+        let id = WidgetId::new("btn");
+        let layout = bar.layout(20.0, 1.0, 0.0, |seg| {
+            StatusSegmentMeasure::new(seg.text.chars().count() as f32)
+        });
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
+        draw_status_bar(
+            &mut buf,
+            Rect::new(0, 0, 20, 1),
+            &bar,
+            &layout,
+            &Theme::default(),
+            Some(&id),
+            Some(&id),
+        );
+
+        let expected = ratatui_color(base_bg.darken(0.05));
+        assert_eq!(buf[(0, 0)].bg, expected, "pressed should win over hovered");
+    }
+
+    #[test]
+    fn non_clickable_segment_ignores_hover() {
+        let bar = make_bar();
+        let base_bg = bar.left_segments[0].bg;
+        let fake_id = WidgetId::new("no-match");
+        let layout = bar.layout(40.0, 1.0, 2.0, |seg| {
+            StatusSegmentMeasure::new(seg.text.chars().count() as f32)
+        });
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 1));
+        draw_status_bar(
+            &mut buf,
+            Rect::new(0, 0, 40, 1),
+            &bar,
+            &layout,
+            &Theme::default(),
+            Some(&fake_id),
+            None,
+        );
+
+        let expected = ratatui_color(base_bg);
+        assert_eq!(
+            buf[(0, 0)].bg,
+            expected,
+            "non-clickable segment bg should be unchanged"
+        );
     }
 }

--- a/quadraui/src/types.rs
+++ b/quadraui/src/types.rs
@@ -63,6 +63,18 @@ impl Color {
             a: self.a,
         }
     }
+
+    /// Linearly interpolate each channel toward black by `amount`
+    /// (clamped to `[0.0, 1.0]`). Symmetric counterpart of [`Self::lighten`].
+    pub fn darken(self, amount: f64) -> Self {
+        let f = amount.clamp(0.0, 1.0);
+        Self {
+            r: (self.r as f64 * (1.0 - f)) as u8,
+            g: (self.g as f64 * (1.0 - f)) as u8,
+            b: (self.b as f64 * (1.0 - f)) as u8,
+            a: self.a,
+        }
+    }
 }
 
 /// A contiguous run of text sharing a single style.

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -162,7 +162,13 @@ impl Backend for WinBackend {
         todo!("Direct2D palette rasteriser")
     }
 
-    fn draw_status_bar(&mut self, _rect: Rect, _bar: &StatusBar) -> Vec<StatusBarHitRegion> {
+    fn draw_status_bar(
+        &mut self,
+        _rect: Rect,
+        _bar: &StatusBar,
+        _hovered_id: Option<&crate::types::WidgetId>,
+        _pressed_id: Option<&crate::types::WidgetId>,
+    ) -> Vec<StatusBarHitRegion> {
         todo!("Direct2D status bar rasteriser")
     }
 


### PR DESCRIPTION
## Summary

- Add `hovered_id` / `pressed_id` parameters to `Backend::draw_status_bar` and both TUI + GTK rasterisers, following the established pattern (ActivityBar `hovered_idx`, TabBar `hovered_close_tab`) of passing per-frame interaction state alongside the primitive rather than inside it.
- Hovered clickable segments render with `bg.lighten(0.05)`; pressed with `bg.darken(0.05)` (pressed takes precedence). Non-clickable segments are unaffected.
- Add `Color::darken(amount)` as a symmetric counterpart to `Color::lighten`.

Closes #45

## Test plan

- [x] 4 new TUI tests: hover paint, pressed paint, pressed-over-hover precedence, non-clickable ignores hover
- [x] All 501 existing tests pass on both `--features tui` and `--features gtk`
- [x] `cargo clippy --features tui -- -D warnings` clean
- [x] `cargo clippy --features gtk -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)