### PR TITLE
fix(quadraui): enforce scroll delta sign convention (#79)

### DIFF
--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -14,6 +14,10 @@
 //! Apps define section structure via [`SidebarSectionDef`], set row data
 //! per frame via [`SidebarSystem::set_rows`], and match on
 //! [`SidebarEvent`] for semantic actions.
+//!
+//! Scroll-wheel events follow the [`ScrollDelta`](crate::ScrollDelta)
+//! sign convention: positive `delta.y` = scroll content up (decrease
+//! offset). Backends normalise their native direction before emitting.
 
 use super::focus_group::FocusGroup;
 use super::tree_controller::TreeController;

--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -17,6 +17,11 @@
 //! - `End`               — last row
 //! - `PageUp` / `PageDown` — jump by viewport rows
 //! - `Enter`             — emit [`TreeControllerEvent::RowActivated`]
+//! - Double-click        — emit [`TreeControllerEvent::RowActivated`]
+//!
+//! Scroll-wheel events follow the [`ScrollDelta`](crate::ScrollDelta)
+//! sign convention: positive `delta.y` = scroll content up (decrease
+//! offset). Backends normalise their native direction before emitting.
 
 use crate::{
     Backend, ButtonMask, Key, MouseButton, NamedKey, Rect, Scrollbar, SelectionMode, TreePath,

--- a/quadraui/src/dispatch.rs
+++ b/quadraui/src/dispatch.rs
@@ -356,6 +356,15 @@ pub struct ScrollSurface {
 /// Translate a raw scroll-wheel event into a `Vec<UiEvent>`, consulting
 /// the modal stack first, then the registered scroll surfaces.
 ///
+/// # Scroll delta sign convention
+///
+/// Positive `delta.y` = scroll content **up** (toward the top of the
+/// document). Backends normalise their native direction before
+/// constructing [`ScrollDelta`] — see [`ScrollDelta`] for the
+/// canonical definition. Compose helpers ([`TreeController`],
+/// [`SidebarSystem`]) consume the delta directly without per-call-site
+/// negation.
+///
 /// # Returns
 ///
 /// Three cases:

--- a/quadraui/src/tui/events.rs
+++ b/quadraui/src/tui/events.rs
@@ -106,12 +106,12 @@ pub fn crossterm_mouse_to_uievent(event: MouseEvent) -> Option<UiEvent> {
         }),
         MouseEventKind::ScrollUp => Some(UiEvent::Scroll {
             widget: None,
-            delta: ScrollDelta { x: 0.0, y: -1.0 },
+            delta: ScrollDelta { x: 0.0, y: 1.0 },
             position,
         }),
         MouseEventKind::ScrollDown => Some(UiEvent::Scroll {
             widget: None,
-            delta: ScrollDelta { x: 0.0, y: 1.0 },
+            delta: ScrollDelta { x: 0.0, y: -1.0 },
             position,
         }),
         MouseEventKind::ScrollLeft => Some(UiEvent::Scroll {
@@ -312,9 +312,9 @@ pub fn synth_mouseevent(ev: &UiEvent) -> Option<MouseEvent> {
         UiEvent::Scroll {
             delta, position, ..
         } => {
-            let kind = if delta.y < 0.0 {
+            let kind = if delta.y > 0.0 {
                 MouseEventKind::ScrollUp
-            } else if delta.y > 0.0 {
+            } else if delta.y < 0.0 {
                 MouseEventKind::ScrollDown
             } else if delta.x < 0.0 {
                 MouseEventKind::ScrollLeft
@@ -520,11 +520,11 @@ mod tests {
     }
 
     #[test]
-    fn mouse_scroll_up_translates_to_negative_y() {
+    fn mouse_scroll_up_translates_to_positive_y() {
         let ev = crossterm_mouse_to_uievent(mouse(MouseEventKind::ScrollUp, 0, 0)).unwrap();
         match ev {
             UiEvent::Scroll { delta, .. } => {
-                assert_eq!(delta.y, -1.0);
+                assert_eq!(delta.y, 1.0);
                 assert_eq!(delta.x, 0.0);
             }
             other => panic!("unexpected variant: {:?}", other),
@@ -532,10 +532,10 @@ mod tests {
     }
 
     #[test]
-    fn mouse_scroll_down_translates_to_positive_y() {
+    fn mouse_scroll_down_translates_to_negative_y() {
         let ev = crossterm_mouse_to_uievent(mouse(MouseEventKind::ScrollDown, 0, 0)).unwrap();
         match ev {
-            UiEvent::Scroll { delta, .. } => assert_eq!(delta.y, 1.0),
+            UiEvent::Scroll { delta, .. } => assert_eq!(delta.y, -1.0),
             other => panic!("unexpected variant: {:?}", other),
         }
     }


### PR DESCRIPTION
## Summary

- Fix TUI backend scroll translation: `ScrollDown` now produces `delta.y: -1.0` and `ScrollUp` produces `delta.y: +1.0`, matching the documented `ScrollDelta` convention (positive y = scroll content up). GTK backend was already correct.
- Add doc comments referencing the `ScrollDelta` sign convention on `dispatch_scroll`, `TreeController`, and `SidebarSystem` so consumers don't need to discover it by reading the struct doc.

This eliminates the per-call-site `delta.y` negation that vimcode and other consumers needed when passing TUI scroll events to compose helpers.

Closes #79

## Test plan

- [x] TUI scroll translation tests updated to match new convention
- [x] All 501 tests pass on `--features tui` and `--features gtk`
- [x] Clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)