### PR TITLE
feat(quadraui): add placeholder to TreeRowEditState

### DIFF
--- a/quadraui/examples/common/multi_tree.rs
+++ b/quadraui/examples/common/multi_tree.rs
@@ -157,7 +157,7 @@ impl AppLogic for DebugSidebar {
                     if let Some(section) = self.sidebar.active_section() {
                         if let Some(path) = self.sidebar.selected_path(section).cloned() {
                             let label = format!("item{}", path.last().unwrap_or(&0));
-                            self.sidebar.start_editing(section, path, label);
+                            self.sidebar.start_editing(section, path, label, None);
                         }
                     }
                     Reaction::Redraw

--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -207,9 +207,15 @@ impl SidebarSystem {
 
     // ── Inline editing ───────────────────────────────────────────────
 
-    pub fn start_editing(&mut self, section: usize, path: TreePath, initial_text: String) {
+    pub fn start_editing(
+        &mut self,
+        section: usize,
+        path: TreePath,
+        initial_text: String,
+        placeholder: Option<String>,
+    ) {
         if let Some(tc) = self.sections.get_mut(section) {
-            tc.start_editing(path, initial_text);
+            tc.start_editing(path, initial_text, placeholder);
         }
     }
 
@@ -561,6 +567,7 @@ impl SidebarSystem {
                                     text: tc.editing_text().unwrap_or("").to_string(),
                                     cursor: tc.editing_cursor(),
                                     selection_anchor: tc.editing_selection_anchor(),
+                                    placeholder: tc.editing_placeholder().map(String::from),
                                 });
                             }
                         }

--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -61,6 +61,7 @@ struct EditingState {
     text: String,
     cursor: usize,
     selection_anchor: Option<usize>,
+    placeholder: Option<String>,
 }
 
 pub struct TreeController {
@@ -140,14 +141,21 @@ impl TreeController {
     // ── Inline editing ───────────────────────────────────────────────
 
     /// Begin inline editing of the row at `path`. The cursor starts at
-    /// the end with all text selected (select-all).
-    pub fn start_editing(&mut self, path: TreePath, initial_text: String) {
+    /// the end with all text selected (select-all). An optional
+    /// `placeholder` is shown in muted style when the text is empty.
+    pub fn start_editing(
+        &mut self,
+        path: TreePath,
+        initial_text: String,
+        placeholder: Option<String>,
+    ) {
         let cursor = initial_text.len();
         self.editing = Some(EditingState {
             path: path.clone(),
             text: initial_text,
             cursor,
             selection_anchor: Some(0),
+            placeholder,
         });
         self.selected_path = Some(path);
     }
@@ -175,6 +183,10 @@ impl TreeController {
 
     pub fn editing_selection_anchor(&self) -> Option<usize> {
         self.editing.as_ref().and_then(|e| e.selection_anchor)
+    }
+
+    pub fn editing_placeholder(&self) -> Option<&str> {
+        self.editing.as_ref().and_then(|e| e.placeholder.as_deref())
     }
 
     pub fn edit_insert_char_via(&mut self, ch: char) -> TreeControllerEvent {
@@ -701,6 +713,7 @@ impl TreeController {
                     text: editing.text.clone(),
                     cursor: editing.cursor,
                     selection_anchor: editing.selection_anchor,
+                    placeholder: editing.placeholder.clone(),
                 });
             }
         }
@@ -1038,7 +1051,7 @@ mod tests {
     #[test]
     fn start_editing_initializes_state() {
         let mut tc = test_controller();
-        tc.start_editing(vec![2], "hello.rs".into());
+        tc.start_editing(vec![2], "hello.rs".into(), None);
         assert!(tc.is_editing());
         assert_eq!(tc.editing_path(), Some(&vec![2]));
         assert_eq!(tc.editing_text(), Some("hello.rs"));
@@ -1048,7 +1061,7 @@ mod tests {
     #[test]
     fn cancel_editing_clears_state() {
         let mut tc = test_controller();
-        tc.start_editing(vec![0], "a.rs".into());
+        tc.start_editing(vec![0], "a.rs".into(), None);
         tc.cancel_editing();
         assert!(!tc.is_editing());
         assert_eq!(tc.editing_path(), None);
@@ -1057,7 +1070,7 @@ mod tests {
     #[test]
     fn char_key_inserts_during_editing() {
         let mut tc = test_controller();
-        tc.start_editing(vec![0], String::new());
+        tc.start_editing(vec![0], String::new(), None);
         let ev = tc.handle_edit_key_via(&Key::Char('j'), &Modifiers::default());
         assert!(matches!(ev, TreeControllerEvent::EditChanged { .. }));
         assert_eq!(tc.editing_text(), Some("j"));
@@ -1066,7 +1079,7 @@ mod tests {
     #[test]
     fn enter_confirms_editing() {
         let mut tc = test_controller();
-        tc.start_editing(vec![1], "new.txt".into());
+        tc.start_editing(vec![1], "new.txt".into(), None);
         // Select-all is on by default; type to replace.
         tc.handle_edit_key_via(&Key::Char('x'), &Modifiers::default());
         let ev = tc.handle_edit_key_via(&Key::Named(NamedKey::Enter), &Modifiers::default());
@@ -1083,7 +1096,7 @@ mod tests {
     #[test]
     fn escape_cancels_editing() {
         let mut tc = test_controller();
-        tc.start_editing(vec![0], "old.txt".into());
+        tc.start_editing(vec![0], "old.txt".into(), None);
         let ev = tc.handle_edit_key_via(&Key::Named(NamedKey::Escape), &Modifiers::default());
         assert_eq!(ev, TreeControllerEvent::EditCancelled { path: vec![0] });
         assert!(!tc.is_editing());
@@ -1092,7 +1105,7 @@ mod tests {
     #[test]
     fn backspace_deletes_char() {
         let mut tc = test_controller();
-        tc.start_editing(vec![0], "abc".into());
+        tc.start_editing(vec![0], "abc".into(), None);
         // Clear select-all first by pressing Right.
         tc.handle_edit_key_via(&Key::Named(NamedKey::End), &Modifiers::default());
         tc.handle_edit_key_via(&Key::Named(NamedKey::Backspace), &Modifiers::default());
@@ -1102,7 +1115,7 @@ mod tests {
     #[test]
     fn left_right_move_cursor() {
         let mut tc = test_controller();
-        tc.start_editing(vec![0], "ab".into());
+        tc.start_editing(vec![0], "ab".into(), None);
         // End clears select-all and goes to end.
         tc.handle_edit_key_via(&Key::Named(NamedKey::End), &Modifiers::default());
         tc.handle_edit_key_via(&Key::Named(NamedKey::Left), &Modifiers::default());
@@ -1113,7 +1126,7 @@ mod tests {
     #[test]
     fn shift_right_extends_selection_and_backspace_deletes_range() {
         let mut tc = test_controller();
-        tc.start_editing(vec![0], "abcd".into());
+        tc.start_editing(vec![0], "abcd".into(), None);
         // Home to clear select-all, then Shift+Right twice to select "ab".
         tc.handle_edit_key_via(&Key::Named(NamedKey::Home), &Modifiers::default());
         let shift = Modifiers {
@@ -1129,7 +1142,7 @@ mod tests {
     #[test]
     fn build_tree_view_stamps_edit_state() {
         let mut tc = test_controller();
-        tc.start_editing(vec![2], "renamed".into());
+        tc.start_editing(vec![2], "renamed".into(), None);
         let tree = tc.build_tree_view(Rect::new(0.0, 0.0, 40.0, 10.0));
         let row = &tree.rows[2];
         assert!(row.edit.is_some());
@@ -1141,7 +1154,7 @@ mod tests {
     fn nav_keys_suppressed_during_editing() {
         let mut tc = test_controller();
         tc.set_selected_path(Some(vec![2]));
-        tc.start_editing(vec![2], "test".into());
+        tc.start_editing(vec![2], "test".into(), None);
         let ev = tc.handle_edit_key_via(&Key::Named(NamedKey::Down), &Modifiers::default());
         assert_eq!(ev, TreeControllerEvent::Consumed);
         assert_eq!(tc.selected_path(), Some(&vec![2]));
@@ -1150,7 +1163,7 @@ mod tests {
     #[test]
     fn select_all_then_type_replaces() {
         let mut tc = test_controller();
-        tc.start_editing(vec![0], "old".into());
+        tc.start_editing(vec![0], "old".into(), None);
         // start_editing selects all, so typing replaces.
         tc.handle_edit_key_via(&Key::Char('n'), &Modifiers::default());
         assert_eq!(tc.editing_text(), Some("n"));

--- a/quadraui/src/gtk/tree.rs
+++ b/quadraui/src/gtk/tree.rs
@@ -169,7 +169,18 @@ pub fn draw_tree(
         }
 
         if let Some(ref edit) = row.edit {
-            paint_edit_input_gtk(cr, layout, cursor_x, row_y, row_h, x + w, edit, def_fg, sel);
+            paint_edit_input_gtk(
+                cr,
+                layout,
+                cursor_x,
+                row_y,
+                row_h,
+                x + w,
+                edit,
+                def_fg,
+                sel,
+                dim,
+            );
         } else {
             let badge_info = row.badge.as_ref().map(|badge| {
                 layout.set_text(&badge.text);
@@ -248,9 +259,25 @@ fn paint_edit_input_gtk(
     edit: &TreeRowEditState,
     fg: (f64, f64, f64),
     sel_rgb: (f64, f64, f64),
+    dim: (f64, f64, f64),
 ) {
     let text_w = right_edge - text_x - 4.0;
     if text_w <= 0.0 {
+        return;
+    }
+
+    if edit.text.is_empty() {
+        if let Some(ref ph) = edit.placeholder {
+            cr.set_source_rgb(dim.0, dim.1, dim.2);
+            layout.set_text(ph);
+            let (_, th) = layout.pixel_size();
+            cr.move_to(text_x, (row_y + (row_h - th as f64) / 2.0).round());
+            pcfn::show_layout(cr, layout);
+        }
+        // Caret at position 0.
+        cr.set_source_rgb(fg.0, fg.1, fg.2);
+        cr.rectangle(text_x, row_y + 3.0, 1.5, row_h - 6.0);
+        cr.fill().ok();
         return;
     }
 
@@ -623,6 +650,7 @@ mod tests {
                     text: "new-name".into(),
                     cursor: 3, // after "new"
                     selection_anchor: None,
+                    placeholder: None,
                 }),
             },
             leaf(2, "gamma"),

--- a/quadraui/src/primitives/tree.rs
+++ b/quadraui/src/primitives/tree.rs
@@ -83,6 +83,9 @@ pub struct TreeRowEditState {
     /// Selection anchor as a byte offset. When `Some(n)` and `n != cursor`,
     /// the range between anchor and cursor is selected.
     pub selection_anchor: Option<usize>,
+    /// Shown in muted style when `text` is empty (e.g. "New file name...").
+    #[serde(default)]
+    pub placeholder: Option<String>,
 }
 
 // ── D6 Layout API ───────────────────────────────────────────────────────────

--- a/quadraui/src/tui/tree.rs
+++ b/quadraui/src/tui/tree.rs
@@ -131,7 +131,7 @@ pub fn draw_tree(
         }
 
         if let Some(ref edit) = row.edit {
-            paint_edit_input(buf, area, y, col, edit, default_fg, bg, sel_bg);
+            paint_edit_input(buf, area, y, col, edit, default_fg, bg, sel_bg, dim_fg);
         } else {
             let text_start = col;
             let text_end = draw_styled_text(
@@ -179,7 +179,26 @@ fn paint_edit_input(
     fg: ratatui::style::Color,
     bg: ratatui::style::Color,
     sel_bg: ratatui::style::Color,
+    dim_fg: ratatui::style::Color,
 ) {
+    if edit.text.is_empty() {
+        if let Some(ref ph) = edit.placeholder {
+            let mut col = start_col;
+            for ch in ph.chars() {
+                if col >= area.width as usize {
+                    break;
+                }
+                set_cell(buf, area.x + col as u16, y, ch, dim_fg, bg);
+                col += 1;
+            }
+        }
+        // Cursor at position 0 (inverted space).
+        if start_col < area.width as usize {
+            set_cell(buf, area.x + start_col as u16, y, ' ', bg, fg);
+        }
+        return;
+    }
+
     let (sel_lo, sel_hi) = match edit.selection_anchor {
         Some(a) if a != edit.cursor => (a.min(edit.cursor), a.max(edit.cursor)),
         _ => (0, 0),
@@ -584,6 +603,7 @@ mod tests {
             text: "renamed.rs".into(),
             cursor: 10,
             selection_anchor: None,
+            placeholder: None,
         });
         draw_tree(&mut buf, area, &tree, &Theme::default(), false);
 
@@ -618,6 +638,7 @@ mod tests {
                     text: "ab".into(),
                     cursor: 2, // cursor at end (on the space after 'b')
                     selection_anchor: None,
+                    placeholder: None,
                 }),
             }],
             selection_mode: crate::types::SelectionMode::default(),


### PR DESCRIPTION
## Summary

- Adds `placeholder: Option<String>` field to `TreeRowEditState` — shown in muted style when `text` is empty
- Both TUI and GTK rasterisers render the placeholder text (muted fg color) with a cursor overlay when the edit buffer is empty
- `start_editing()` and `SidebarSystem::start_editing()` gain a `placeholder: Option<String>` parameter
- Follows the existing `InlineInput.placeholder` pattern from MSV

This enables the inline "new item" UX: consumer inserts a phantom row, calls `start_editing(path, "", Some("New file name..."))`, and the user sees a dimmed hint until they start typing.

## Test plan

- [x] 518 tests pass (TUI + GTK), no regressions
- [x] Quality gate clean (build, clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)