### PR TITLE
fix(quadraui): visible selection highlight in inline tree editing (#89)

### DIFF
--- a/quadraui/src/gtk/tree.rs
+++ b/quadraui/src/gtk/tree.rs
@@ -87,6 +87,7 @@ pub fn draw_tree(
     let fg = cairo_rgb(theme.foreground);
     let dim = cairo_rgb(theme.muted_fg);
     let sel = cairo_rgb(theme.selected_bg);
+    let text_sel = cairo_rgb(theme.selection_bg);
 
     cr.set_source_rgb(bg.0, bg.1, bg.2);
     cr.rectangle(x, y, w, h);
@@ -178,7 +179,7 @@ pub fn draw_tree(
                 x + w,
                 edit,
                 def_fg,
-                sel,
+                text_sel,
                 dim,
             );
         } else {

--- a/quadraui/src/tui/tree.rs
+++ b/quadraui/src/tui/tree.rs
@@ -56,6 +56,7 @@ pub fn draw_tree(
     let hdr_fg = ratatui_color(theme.header_fg);
     let item_fg = ratatui_color(theme.foreground);
     let sel_bg = ratatui_color(theme.selected_bg);
+    let text_sel_bg = ratatui_color(theme.selection_bg);
     let dim_fg = ratatui_color(theme.muted_fg);
 
     let indent_cells = tree.style.indent as usize;
@@ -131,7 +132,7 @@ pub fn draw_tree(
         }
 
         if let Some(ref edit) = row.edit {
-            paint_edit_input(buf, area, y, col, edit, default_fg, bg, sel_bg, dim_fg);
+            paint_edit_input(buf, area, y, col, edit, default_fg, bg, text_sel_bg, dim_fg);
         } else {
             let text_start = col;
             let text_end = draw_styled_text(


### PR DESCRIPTION
## Summary

- TUI and GTK inline edit selection highlights were using `theme.selected_bg` (the row-selected background), making them invisible since the editing row is always selected
- Switched to `theme.selection_bg` (text selection color, distinct from row highlight) in both rasterisers

2-line fix. The selection rendering code was already correct — it was just using the wrong color.

Closes #89

## Test plan

- [x] 519 tests pass, no regressions
- [x] Quality gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)