### PR TITLE
feat(quadraui): StatusBarInteraction compose helper (#91)

### DIFF
--- a/quadraui/examples/common/multi_tree.rs
+++ b/quadraui/examples/common/multi_tree.rs
@@ -18,14 +18,15 @@
 
 use quadraui::{
     AppLogic, Backend, Color, Decoration, Key, NamedKey, NavigationMode, Reaction, Rect,
-    SectionSize, SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBar, StatusBarSegment,
-    StyledText, TreeRow, UiEvent, WidgetId,
+    SectionSize, SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBar, StatusBarAction,
+    StatusBarInteraction, StatusBarSegment, StyledText, TreeRow, UiEvent, WidgetId,
 };
 
 const STATUS_BAR_LINES: f32 = 1.5;
 
 pub struct DebugSidebar {
     sidebar: SidebarSystem,
+    status_interaction: StatusBarInteraction,
     last_action: String,
 }
 
@@ -45,6 +46,7 @@ impl DebugSidebar {
         sidebar.set_active_section(Some(0));
         Self {
             sidebar,
+            status_interaction: StatusBarInteraction::new(),
             last_action: "—".into(),
         }
     }
@@ -78,15 +80,32 @@ impl DebugSidebar {
         };
         let fg = Color::rgb(220, 220, 220);
         let bg = Color::rgb(40, 40, 60);
+        let btn_bg = Color::rgb(60, 60, 90);
         StatusBar {
             id: WidgetId::new("multi-tree-status"),
-            left_segments: vec![StatusBarSegment {
-                text: format!(" active: {active}  last: {} ", self.last_action),
-                fg,
-                bg,
-                bold: false,
-                action_id: None,
-            }],
+            left_segments: vec![
+                StatusBarSegment {
+                    text: format!(" active: {active}  last: {} ", self.last_action),
+                    fg,
+                    bg,
+                    bold: false,
+                    action_id: None,
+                },
+                StatusBarSegment {
+                    text: " ▶ Run ".into(),
+                    fg,
+                    bg: btn_bg,
+                    bold: true,
+                    action_id: Some(WidgetId::new("run")),
+                },
+                StatusBarSegment {
+                    text: " ■ Stop ".into(),
+                    fg,
+                    bg: btn_bg,
+                    bold: true,
+                    action_id: Some(WidgetId::new("stop")),
+                },
+            ],
             right_segments: vec![StatusBarSegment {
                 text: " mouse / Tab / ↑↓ / Enter / r=edit / q ".into(),
                 fg,
@@ -111,10 +130,26 @@ impl AppLogic for DebugSidebar {
         let sidebar = Self::sidebar_rect(backend);
         let status = Self::status_rect(backend);
         self.sidebar.render(backend, sidebar);
-        let _hits = backend.draw_status_bar(status, &self.build_status_bar(), None, None);
+        let regions = backend.draw_status_bar(
+            status,
+            &self.build_status_bar(),
+            self.status_interaction.hovered_id(),
+            self.status_interaction.pressed_id(),
+        );
+        self.status_interaction.set_hit_regions(regions);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+        let status_rect = Self::status_rect(backend);
+        match self.status_interaction.handle(&event, status_rect) {
+            StatusBarAction::Clicked(id) => {
+                self.last_action = format!("btn:{}", id.as_str());
+                return Reaction::Redraw;
+            }
+            StatusBarAction::Redraw => return Reaction::Redraw,
+            StatusBarAction::Ignored => {}
+        }
+
         let rect = Self::sidebar_rect(backend);
         match self.sidebar.handle(&event, backend, rect) {
             SidebarEvent::HeaderActivated { section } => {

--- a/quadraui/src/compose/mod.rs
+++ b/quadraui/src/compose/mod.rs
@@ -17,10 +17,12 @@ pub mod focus_group;
 pub mod focus_ring;
 pub mod menu_system;
 pub mod sidebar_system;
+pub mod status_bar_interaction;
 pub mod tree_controller;
 
 pub use focus_group::FocusGroup;
 pub use focus_ring::FocusRing;
 pub use menu_system::{MenuDef, MenuEvent, MenuSystem};
 pub use sidebar_system::{NavigationMode, SidebarEvent, SidebarSectionDef, SidebarSystem};
+pub use status_bar_interaction::{StatusBarAction, StatusBarInteraction};
 pub use tree_controller::{TreeController, TreeControllerEvent};

--- a/quadraui/src/compose/status_bar_interaction.rs
+++ b/quadraui/src/compose/status_bar_interaction.rs
@@ -1,0 +1,237 @@
+//! Lightweight hover/press state tracker for [`crate::StatusBar`].
+//!
+//! Consumers store a [`StatusBarInteraction`] alongside their status bar,
+//! call [`StatusBarInteraction::handle`] with each mouse event and the
+//! bar's rect, then read [`hovered_id`](StatusBarInteraction::hovered_id)
+//! and [`pressed_id`](StatusBarInteraction::pressed_id) when calling
+//! `Backend::draw_status_bar`.
+//!
+//! This eliminates per-backend mouse routing code for status bar hover —
+//! backends just forward `UiEvent`s uniformly.
+
+use std::cell::RefCell;
+
+use crate::event::{MouseButton, Point, Rect, UiEvent};
+use crate::primitives::status_bar::StatusBarHitRegion;
+use crate::types::WidgetId;
+
+/// Tracks hover and pressed state for a status bar's clickable segments.
+#[derive(Debug, Clone, Default)]
+pub struct StatusBarInteraction {
+    hit_regions: RefCell<Vec<StatusBarHitRegion>>,
+    hovered: Option<WidgetId>,
+    pressed: Option<WidgetId>,
+}
+
+/// What happened after [`StatusBarInteraction::handle`] processed an event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StatusBarAction {
+    /// A clickable segment was clicked (mouse-down + mouse-up on the same segment).
+    Clicked(WidgetId),
+    /// State changed (hover entered/left, press started) — caller should redraw.
+    Redraw,
+    /// Event not relevant to the status bar.
+    Ignored,
+}
+
+impl StatusBarInteraction {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update the stored hit regions. Call this after each `draw_status_bar`
+    /// with the returned `Vec<StatusBarHitRegion>`. Takes `&self` so it can
+    /// be called from render paths where only a shared reference is available.
+    pub fn set_hit_regions(&self, regions: Vec<StatusBarHitRegion>) {
+        *self.hit_regions.borrow_mut() = regions;
+    }
+
+    pub fn hovered_id(&self) -> Option<&WidgetId> {
+        self.hovered.as_ref()
+    }
+
+    pub fn pressed_id(&self) -> Option<&WidgetId> {
+        self.pressed.as_ref()
+    }
+
+    /// Process a mouse event relative to the status bar's rect.
+    /// Returns what action (if any) resulted.
+    pub fn handle(&mut self, event: &UiEvent, bar_rect: Rect) -> StatusBarAction {
+        match event {
+            UiEvent::MouseMoved { position, .. } => {
+                let new_hover = self.hit_test(bar_rect, *position);
+                if new_hover != self.hovered {
+                    self.hovered = new_hover;
+                    StatusBarAction::Redraw
+                } else {
+                    StatusBarAction::Ignored
+                }
+            }
+            UiEvent::MouseDown {
+                button: MouseButton::Left,
+                position,
+                ..
+            } => {
+                let hit = self.hit_test(bar_rect, *position);
+                if hit.is_some() {
+                    self.pressed = hit;
+                    StatusBarAction::Redraw
+                } else {
+                    StatusBarAction::Ignored
+                }
+            }
+            UiEvent::MouseUp {
+                button: MouseButton::Left,
+                position,
+                ..
+            } => {
+                let was_pressed = self.pressed.take();
+                if let Some(ref pressed_id) = was_pressed {
+                    let hit = self.hit_test(bar_rect, *position);
+                    if hit.as_ref() == Some(pressed_id) {
+                        return StatusBarAction::Clicked(pressed_id.clone());
+                    }
+                }
+                if was_pressed.is_some() {
+                    StatusBarAction::Redraw
+                } else {
+                    StatusBarAction::Ignored
+                }
+            }
+            _ => StatusBarAction::Ignored,
+        }
+    }
+
+    fn hit_test(&self, bar_rect: Rect, position: Point) -> Option<WidgetId> {
+        if position.x < bar_rect.x
+            || position.x >= bar_rect.x + bar_rect.width
+            || position.y < bar_rect.y
+            || position.y >= bar_rect.y + bar_rect.height
+        {
+            return None;
+        }
+        let local_x = (position.x - bar_rect.x) as u16;
+        self.hit_regions
+            .borrow()
+            .iter()
+            .find(|r| local_x >= r.col && local_x < r.col + r.width)
+            .map(|r| r.id.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bar_rect() -> Rect {
+        Rect::new(0.0, 100.0, 80.0, 1.0)
+    }
+
+    fn regions() -> Vec<StatusBarHitRegion> {
+        vec![
+            StatusBarHitRegion {
+                col: 0,
+                width: 10,
+                id: WidgetId::new("run"),
+            },
+            StatusBarHitRegion {
+                col: 10,
+                width: 10,
+                id: WidgetId::new("stop"),
+            },
+        ]
+    }
+
+    #[test]
+    fn hover_sets_hovered_id() {
+        let mut sbi = StatusBarInteraction::new();
+        sbi.set_hit_regions(regions());
+        let ev = UiEvent::MouseMoved {
+            position: Point { x: 5.0, y: 100.5 },
+            buttons: Default::default(),
+        };
+        let action = sbi.handle(&ev, bar_rect());
+        assert_eq!(action, StatusBarAction::Redraw);
+        assert_eq!(sbi.hovered_id(), Some(&WidgetId::new("run")));
+    }
+
+    #[test]
+    fn hover_outside_clears() {
+        let mut sbi = StatusBarInteraction::new();
+        sbi.set_hit_regions(regions());
+        // Move into "run" first.
+        sbi.handle(
+            &UiEvent::MouseMoved {
+                position: Point { x: 5.0, y: 100.5 },
+                buttons: Default::default(),
+            },
+            bar_rect(),
+        );
+        // Move outside the bar.
+        let action = sbi.handle(
+            &UiEvent::MouseMoved {
+                position: Point { x: 5.0, y: 50.0 },
+                buttons: Default::default(),
+            },
+            bar_rect(),
+        );
+        assert_eq!(action, StatusBarAction::Redraw);
+        assert_eq!(sbi.hovered_id(), None);
+    }
+
+    #[test]
+    fn click_emits_clicked() {
+        let mut sbi = StatusBarInteraction::new();
+        sbi.set_hit_regions(regions());
+        let rect = bar_rect();
+        // Mouse down on "stop".
+        sbi.handle(
+            &UiEvent::MouseDown {
+                button: MouseButton::Left,
+                position: Point { x: 15.0, y: 100.5 },
+                modifiers: Default::default(),
+                widget: None,
+            },
+            rect,
+        );
+        assert_eq!(sbi.pressed_id(), Some(&WidgetId::new("stop")));
+        // Mouse up on same segment.
+        let action = sbi.handle(
+            &UiEvent::MouseUp {
+                button: MouseButton::Left,
+                position: Point { x: 15.0, y: 100.5 },
+                widget: None,
+            },
+            rect,
+        );
+        assert_eq!(action, StatusBarAction::Clicked(WidgetId::new("stop")));
+        assert_eq!(sbi.pressed_id(), None);
+    }
+
+    #[test]
+    fn press_drag_away_does_not_click() {
+        let mut sbi = StatusBarInteraction::new();
+        sbi.set_hit_regions(regions());
+        let rect = bar_rect();
+        // Mouse down on "run".
+        sbi.handle(
+            &UiEvent::MouseDown {
+                button: MouseButton::Left,
+                position: Point { x: 5.0, y: 100.5 },
+                modifiers: Default::default(),
+                widget: None,
+            },
+            rect,
+        );
+        // Mouse up outside any segment.
+        let action = sbi.handle(
+            &UiEvent::MouseUp {
+                button: MouseButton::Left,
+                position: Point { x: 50.0, y: 100.5 },
+                widget: None,
+            },
+            rect,
+        );
+        assert_eq!(action, StatusBarAction::Redraw);
+    }
+}

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -238,7 +238,8 @@ pub use event::{
 // Phase B.4 re-exports.
 pub use compose::{
     FocusGroup, FocusRing, MenuDef, MenuEvent, MenuSystem, NavigationMode, SidebarEvent,
-    SidebarSectionDef, SidebarSystem, TreeController, TreeControllerEvent,
+    SidebarSectionDef, SidebarSystem, StatusBarAction, StatusBarInteraction, TreeController,
+    TreeControllerEvent,
 };
 pub use dispatch::{
     dispatch_click, dispatch_mouse_down, dispatch_mouse_drag, dispatch_mouse_up, dispatch_scroll,


### PR DESCRIPTION
## Summary

Adds `StatusBarInteraction` — a lightweight hover/press state tracker for `StatusBar` clickable segments. Eliminates per-backend mouse routing code for status bar hover/press.

**Usage:**
```rust
// Store alongside your status bar:
let mut sbi = StatusBarInteraction::new();

// In render: pass hover/press state to draw call
let regions = backend.draw_status_bar(rect, &bar, sbi.hovered_id(), sbi.pressed_id());
sbi.set_hit_regions(regions);

// In handle: forward mouse events
match sbi.handle(&event, status_rect) {
    StatusBarAction::Clicked(id) => { /* dispatch action */ }
    StatusBarAction::Redraw => { /* trigger redraw */ }
    StatusBarAction::Ignored => {}
}
```

Closes #91

## Test plan

- [x] 523 tests pass (+4 new: hover set, hover clear, click, press-drag-away)
- [x] Quality gate clean (build, clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)