### PR TITLE
fix(quadraui): panel scrollbar click-to-page and thumb drag (#95)

### DIFF
--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -110,12 +110,20 @@ struct ScrollDrag {
     max_offset: usize,
 }
 
+struct PanelScrollDrag {
+    origin_y: f32,
+    origin_scroll: f32,
+    travel: f32,
+    max_scroll: f32,
+}
+
 pub struct SidebarSystem {
     defs: Vec<SidebarSectionDef>,
     sections: Vec<TreeController>,
     focus: FocusGroup,
     collapsed: Vec<bool>,
     scroll_drag: Option<ScrollDrag>,
+    panel_drag: Option<PanelScrollDrag>,
     has_focus: bool,
     allow_collapse: bool,
     navigation_mode: NavigationMode,
@@ -137,6 +145,7 @@ impl SidebarSystem {
             focus: FocusGroup::new(n),
             collapsed: vec![false; n],
             scroll_drag: None,
+            panel_drag: None,
             has_focus: true,
             allow_collapse: false,
             navigation_mode: NavigationMode::default(),
@@ -309,6 +318,7 @@ impl SidebarSystem {
                 ..
             } => {
                 self.scroll_drag = None;
+                self.panel_drag = None;
                 SidebarEvent::Ignored
             }
 
@@ -714,6 +724,42 @@ impl SidebarSystem {
                 self.sections[section].page_scroll(viewport_rows as isize, viewport_rows);
                 SidebarEvent::ScrollChanged { section }
             }
+            MultiSectionViewHit::PanelScrollbar {
+                kind: ScrollbarHit::Thumb,
+            } => {
+                if let Some(sb) = layout.panel_scrollbar {
+                    let total: f32 = layout.sections.iter().map(|s| s.resolved_size).sum();
+                    let max_scroll = (total - rect.height).max(0.0);
+                    let thumb_frac = rect.height / total;
+                    let thumb_h = (sb.height * thumb_frac).max(backend.line_height());
+                    let travel = (sb.height - thumb_h).max(0.0);
+                    self.panel_drag = Some(PanelScrollDrag {
+                        origin_y: y,
+                        origin_scroll: self.panel_scroll,
+                        travel,
+                        max_scroll,
+                    });
+                    SidebarEvent::Consumed
+                } else {
+                    SidebarEvent::Ignored
+                }
+            }
+            MultiSectionViewHit::PanelScrollbar {
+                kind: ScrollbarHit::TrackBefore,
+            } => {
+                let total: f32 = layout.sections.iter().map(|s| s.resolved_size).sum();
+                let max_scroll = (total - rect.height).max(0.0);
+                self.panel_scroll = (self.panel_scroll - rect.height).clamp(0.0, max_scroll);
+                SidebarEvent::Consumed
+            }
+            MultiSectionViewHit::PanelScrollbar {
+                kind: ScrollbarHit::TrackAfter,
+            } => {
+                let total: f32 = layout.sections.iter().map(|s| s.resolved_size).sum();
+                let max_scroll = (total - rect.height).max(0.0);
+                self.panel_scroll = (self.panel_scroll + rect.height).clamp(0.0, max_scroll);
+                SidebarEvent::Consumed
+            }
             _ => SidebarEvent::Ignored,
         }
     }
@@ -769,6 +815,19 @@ impl SidebarSystem {
     }
 
     fn drag_to(&mut self, y: f32) -> SidebarEvent {
+        if let Some(drag) = &self.panel_drag {
+            if drag.travel <= 0.0 || drag.max_scroll <= 0.0 {
+                return SidebarEvent::Ignored;
+            }
+            let dy = y - drag.origin_y;
+            let new = drag.origin_scroll + dy / drag.travel * drag.max_scroll;
+            let new = new.clamp(0.0, drag.max_scroll);
+            if (new - self.panel_scroll).abs() < 0.5 {
+                return SidebarEvent::Ignored;
+            }
+            self.panel_scroll = new;
+            return SidebarEvent::Consumed;
+        }
         let Some(drag) = &self.scroll_drag else {
             return SidebarEvent::Ignored;
         };

--- a/quadraui/src/primitives/multi_section_view.rs
+++ b/quadraui/src/primitives/multi_section_view.rs
@@ -621,6 +621,18 @@ impl MultiSectionView {
         let mut dividers = Vec::new();
         let mut hit_regions: Vec<(Rect, MultiSectionViewHit)> = Vec::new();
 
+        let panel_sb_w = match self.scroll_mode {
+            ScrollMode::WholePanel => {
+                let total: f32 = resolved.iter().sum::<f32>() + dividers_total;
+                if total > bounds.height {
+                    metrics.scrollbar_size
+                } else {
+                    0.0
+                }
+            }
+            ScrollMode::PerSection => 0.0,
+        };
+
         // For WholePanel mode, sections stack at content size and the
         // viewport scrolls the whole panel. `panel_scroll` shifts every
         // section's y upward; the layout clamps the value internally to
@@ -645,7 +657,12 @@ impl MultiSectionView {
             let s_main = resolved[i];
             let s_top = y;
 
-            let header_bounds = Rect::new(bounds.x, s_top, bounds.width, metrics.header_size);
+            let header_bounds = Rect::new(
+                bounds.x,
+                s_top,
+                (bounds.width - panel_sb_w).max(0.0),
+                metrics.header_size,
+            );
 
             let mut content_top = s_top + metrics.header_size;
 
@@ -681,7 +698,7 @@ impl MultiSectionView {
             } else {
                 0.0
             };
-            let body_w = (bounds.width - scrollbar_w).max(0.0);
+            let body_w = (bounds.width - scrollbar_w - panel_sb_w).max(0.0);
 
             let body_bounds = Rect::new(bounds.x, content_top, body_w, body_main);
             let scrollbar_bounds = if needs_scrollbar {
@@ -830,12 +847,41 @@ impl MultiSectionView {
                         sb_w,
                         bounds.height,
                     );
+                    let thumb_frac = bounds.height / total_content;
+                    let min_thumb = metrics.scrollbar_size.max(8.0);
+                    let thumb_h = (r.height * thumb_frac).max(min_thumb).min(r.height);
+                    let max_scroll = (total_content - bounds.height).max(0.0);
+                    let scroll_frac = if max_scroll > 0.0 {
+                        self.panel_scroll.clamp(0.0, max_scroll) / max_scroll
+                    } else {
+                        0.0
+                    };
+                    let travel = (r.height - thumb_h).max(0.0);
+                    let thumb_y = r.y + travel * scroll_frac;
+                    if thumb_y > r.y {
+                        hit_regions.push((
+                            Rect::new(r.x, r.y, r.width, thumb_y - r.y),
+                            MultiSectionViewHit::PanelScrollbar {
+                                kind: ScrollbarHit::TrackBefore,
+                            },
+                        ));
+                    }
                     hit_regions.push((
-                        r,
+                        Rect::new(r.x, thumb_y, r.width, thumb_h),
                         MultiSectionViewHit::PanelScrollbar {
                             kind: ScrollbarHit::Thumb,
                         },
                     ));
+                    let thumb_bottom = thumb_y + thumb_h;
+                    let track_bottom = r.y + r.height;
+                    if thumb_bottom < track_bottom {
+                        hit_regions.push((
+                            Rect::new(r.x, thumb_bottom, r.width, track_bottom - thumb_bottom),
+                            MultiSectionViewHit::PanelScrollbar {
+                                kind: ScrollbarHit::TrackAfter,
+                            },
+                        ));
+                    }
                     Some(r)
                 } else {
                     None


### PR DESCRIPTION
## Summary

- **MSV primitive**: panel scrollbar now splits into TrackBefore/Thumb/TrackAfter hit regions based on `panel_scroll` position (was a single Thumb region covering the entire track)
- **SidebarSystem**: added `PanelScrollDrag` for float-based thumb drag, TrackBefore/TrackAfter handlers for page-scroll, and panel_drag clearing on mouse-up

The previous PR (#94) merged before the scrollbar fix was pushed. This PR applies the fix properly to develop.

Closes #95

## Test plan

- [x] 527 tests pass, no regressions
- [x] Quality gate clean
- [ ] Smoke test: `cargo run --features tui --example msv_multi_tree` — click track above/below thumb to page, drag thumb to scrub

🤖 Generated with [Claude Code](https://claude.com/claude-code)