### PR TITLE
feat(quadraui): add SidebarSystem::has_focus() getter (#97)

### DIFF
--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -202,6 +202,10 @@ impl SidebarSystem {
         }
     }
 
+    pub fn has_focus(&self) -> bool {
+        self.has_focus
+    }
+
     pub fn set_has_focus(&mut self, has_focus: bool) {
         self.has_focus = has_focus;
     }


### PR DESCRIPTION
## Summary

One-line addition: `pub fn has_focus(&self) -> bool` on `SidebarSystem`. Eliminates the need for consumers to maintain a parallel focus-state field.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)