### PR TITLE
feat(quadraui): gtk::wire_da_events helper (#101)

### DIFF
--- a/quadraui/src/gtk/events.rs
+++ b/quadraui/src/gtk/events.rs
@@ -23,6 +23,8 @@
 //! standalone (no Rc/RefCell), so they're trivially testable.
 
 use gtk4::gdk;
+use gtk4::glib;
+use gtk4::prelude::*;
 
 use crate::{Key, Modifiers, MouseButton, NamedKey, Point, UiEvent};
 
@@ -200,6 +202,77 @@ pub fn gdk_button_to_quadraui(button: u32) -> MouseButton {
         9 => MouseButton::X2,
         n => MouseButton::Other(n.min(255) as u8),
     }
+}
+
+/// Attach mouse, scroll, and click event controllers to a
+/// `DrawingArea` and translate all native events to [`UiEvent`].
+///
+/// The `on_event` callback fires for every translated event. The
+/// consumer routes it (e.g. to `SidebarSystem::handle_cached`) and
+/// triggers a redraw if needed.
+///
+/// Covers: MouseDown (left+right), MouseUp, DoubleClick, MouseMoved
+/// (with button mask for drag detection), and Scroll (with correct
+/// sign convention).
+///
+/// This eliminates ~40 lines of per-DrawingArea signal wiring that
+/// every GTK consumer otherwise needs to write manually.
+pub fn wire_da_events<F>(da: &gtk4::DrawingArea, on_event: F)
+where
+    F: Fn(UiEvent) + Clone + 'static,
+{
+    use gtk4::{
+        EventControllerMotion, EventControllerScroll, EventControllerScrollFlags, GestureClick,
+    };
+
+    let click = GestureClick::builder().button(0).build();
+    {
+        let on_event = on_event.clone();
+        click.connect_pressed(move |gesture, n_press, x, y| {
+            let button = gesture.current_button();
+            let modifier = gesture.current_event_state();
+            if n_press == 2 {
+                on_event(UiEvent::DoubleClick {
+                    widget: None,
+                    position: Point::new(x as f32, y as f32),
+                });
+            } else {
+                on_event(gdk_button_to_mouse_down(button, x, y, modifier));
+            }
+        });
+    }
+    {
+        let on_event = on_event.clone();
+        click.connect_released(move |gesture, _n_press, x, y| {
+            on_event(gdk_button_to_mouse_up(gesture.current_button(), x, y));
+        });
+    }
+    da.add_controller(click);
+
+    let motion = EventControllerMotion::new();
+    {
+        let on_event = on_event.clone();
+        motion.connect_motion(move |ctrl, x, y| {
+            let modifier = ctrl.current_event_state();
+            let buttons = crate::ButtonMask {
+                left: modifier.contains(gdk::ModifierType::BUTTON1_MASK),
+                middle: modifier.contains(gdk::ModifierType::BUTTON2_MASK),
+                right: modifier.contains(gdk::ModifierType::BUTTON3_MASK),
+            };
+            on_event(gdk_motion_to_uievent(x, y, buttons));
+        });
+    }
+    da.add_controller(motion);
+
+    let scroll = EventControllerScroll::new(EventControllerScrollFlags::BOTH_AXES);
+    {
+        let on_event = on_event.clone();
+        scroll.connect_scroll(move |_ctrl, dx, dy| {
+            on_event(gdk_scroll_to_uievent(dx, dy, 0.0, 0.0));
+            glib::Propagation::Stop
+        });
+    }
+    da.add_controller(scroll);
 }
 
 #[cfg(test)]

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -64,6 +64,7 @@ pub use completions::draw_completions;
 pub use context_menu::draw_context_menu;
 pub use dialog::draw_dialog;
 pub use editor::draw_editor;
+pub use events::wire_da_events;
 pub use find_replace::draw_find_replace;
 pub use form::{draw_form, draw_settings_chrome};
 pub use list::draw_list;


### PR DESCRIPTION
## Summary

Adds `quadraui::gtk::wire_da_events(da, callback)` — attaches all needed GTK event controllers to a DrawingArea and translates native events to `UiEvent` via a callback.

**Covers:** MouseDown (left+right), MouseUp, DoubleClick (n_press==2), MouseMoved (with button mask for drag detection), Scroll (with correct sign convention).

**Consumer usage:**
```rust
quadraui::gtk::wire_da_events(&da, move |event: UiEvent| {
    let mut engine = engine.borrow_mut();
    engine.handle_sidebar_event(event, rect);
    da_clone.queue_draw();
});
```

Eliminates ~40 lines of per-DA signal wiring boilerplate. Fixes the class of bug where a consumer DA is missing MouseMoved/MouseUp handlers (which broke scrollbar thumb drag in vimcode's extensions sidebar).

Closes #101

## Test plan

- [x] 527 tests pass, no regressions
- [x] Quality gate clean (build, clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)