### PR TITLE
fix(quadraui): GTK empty TextInput cursor + header row click drift (#109, #110)

### DIFF
--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -1914,4 +1914,74 @@ mod tests {
             }
         );
     }
+
+    // ── Header row click precision (#110) ──────────────────────────────
+
+    #[test]
+    fn header_row_bottom_pixel_hits_header_not_child() {
+        let lh: f32 = 16.0;
+        let header_h = (lh * 1.2).round(); // 19.0
+
+        let tree = TreeView {
+            id: WidgetId::new("t"),
+            rows: vec![
+                TreeRow {
+                    path: vec![0],
+                    indent: 0,
+                    icon: None,
+                    text: StyledText::plain("src/"),
+                    badge: None,
+                    is_expanded: Some(true),
+                    decoration: Decoration::Header,
+                    edit: None,
+                },
+                TreeRow {
+                    path: vec![0, 0],
+                    indent: 1,
+                    icon: None,
+                    text: StyledText::plain("main.rs"),
+                    badge: None,
+                    is_expanded: None,
+                    decoration: Decoration::Normal,
+                    edit: None,
+                },
+            ],
+            selection_mode: SelectionMode::Single,
+            selected_path: None,
+            scroll_offset: 0,
+            style: Default::default(),
+            has_focus: true,
+        };
+
+        let body_b = Rect::new(0.0, 0.0, 200.0, 200.0);
+        let ss = SidebarSystem::new(vec![SidebarSectionDef::new("t", "T")]);
+        let layout = ss.compute_tree_layout(body_b, &tree, lh);
+
+        // Header row spans [0, header_h). Click at header_h - 0.5 (bottom pixel)
+        // should still land on the header (row 0), not the child (row 1).
+        let bottom_of_header = header_h - 0.5;
+        match layout.hit_test(5.0, bottom_of_header) {
+            TreeViewHit::Row(idx) => assert_eq!(
+                idx, 0,
+                "click at y={bottom_of_header} (bottom of header row) hit row {idx}, expected 0"
+            ),
+            other => panic!(
+                "click at y={bottom_of_header} returned {:?}, expected Row(0)",
+                other
+            ),
+        }
+
+        // First pixel of child row should hit row 1.
+        let top_of_child = header_h + 0.5;
+        match layout.hit_test(5.0, top_of_child) {
+            TreeViewHit::Row(idx) => assert_eq!(
+                idx, 1,
+                "click at y={top_of_child} (top of child row) hit row {idx}, expected 1"
+            ),
+            other => panic!(
+                "click at y={top_of_child} returned {:?}, expected Row(1)",
+                other
+            ),
+        }
+    }
 }

--- a/quadraui/src/gtk/form.rs
+++ b/quadraui/src/gtk/form.rs
@@ -182,15 +182,13 @@ pub fn draw_form(
                     pcfn::show_layout(cr, layout);
 
                     if let Some(cur) = cursor {
-                        if !value.is_empty() {
-                            let prefix = &shown[..(*cur).min(shown.len())];
-                            layout.set_text(prefix);
-                            let (prefix_w, _) = layout.pixel_size();
-                            let cx = ix + 8.0 + prefix_w as f64;
-                            cr.set_source_rgb(accent.0, accent.1, accent.2);
-                            cr.rectangle(cx, y_off + 3.0, 1.5, row_h - 6.0);
-                            cr.fill().ok();
-                        }
+                        let prefix = &shown[..(*cur).min(shown.len())];
+                        layout.set_text(prefix);
+                        let (prefix_w, _) = layout.pixel_size();
+                        let cx = ix + 8.0 + prefix_w as f64;
+                        cr.set_source_rgb(accent.0, accent.1, accent.2);
+                        cr.rectangle(cx, y_off + 3.0, 1.5, row_h - 6.0);
+                        cr.fill().ok();
                     }
                 }
             }

--- a/quadraui/src/gtk/multi_section_view.rs
+++ b/quadraui/src/gtk/multi_section_view.rs
@@ -76,16 +76,11 @@ fn body_measure(body: &SectionBody, aux: &Option<SectionAux>, line_height: f64) 
     let item_h = (line_height * 1.4) as f32;
     let content_size = match body {
         SectionBody::Tree(t) => {
-            // Mirror the GTK tree row convention: headers 1.0×,
-            // others 1.4×.
+            let header_h = (line_height * 1.2).round() as f32;
             let mut total = 0.0_f32;
             for row in &t.rows {
                 let is_header = matches!(row.decoration, crate::types::Decoration::Header);
-                total += if is_header {
-                    line_height as f32
-                } else {
-                    item_h
-                };
+                total += if is_header { header_h } else { item_h };
             }
             total
         }


### PR DESCRIPTION
## Summary

Two GTK rendering/click fixes:

- **#109 — Empty TextInput cursor:** Remove `!value.is_empty()` guard so the cursor draws at the left bracket position when value is empty and `cursor: Some(0)`. Matches VS Code behavior.
- **#110 — Header row click drift:** GTK `body_measure` was using `1.0× line_height` for `Decoration::Header` rows, but `gtk_tree_layout` uses `(line_height × 1.2).round()`. The mismatch caused the MSV to allocate less body space than the tree layout needed, shifting painted rows relative to hit-test regions. Fixed by aligning GTK `body_measure` header height with `gtk_tree_layout`.

## Root cause (#110)

`gtk/multi_section_view.rs:body_measure` line 84 used `line_height as f32` (1.0x) for header rows. `gtk/tree.rs:gtk_tree_layout` line 31 used `(line_height * 1.2).round()` (1.2x). The sidebar_system's own `body_measure` correctly used `(lh * 1.2).round()`. The GTK paint path computed a shorter body than the click handler expected, causing row positions to disagree.

## Test plan

- [x] New unit test `header_row_bottom_pixel_hits_header_not_child` verifying tree layout hit-test precision at header/child boundary with GTK-typical line_height
- [x] Full quality gate: 552 tests, clippy, fmt — all green on TUI + GTK

Closes #109
Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)