### PR TITLE
fix(quadraui): Form click dispatches to individual ToggleGroup/ButtonRow items (#112)

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -116,6 +116,16 @@ path = "examples/gtk_search_panel.rs"
 required-features = ["gtk"]
 
 [[example]]
+name = "tui_sidebar_search"
+path = "examples/tui_sidebar_search.rs"
+required-features = ["tui"]
+
+[[example]]
+name = "gtk_sidebar_search"
+path = "examples/gtk_sidebar_search.rs"
+required-features = ["gtk"]
+
+[[example]]
 name = "tui_form_groups"
 path = "examples/tui_form_groups.rs"
 required-features = ["tui"]

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -33,6 +33,7 @@ pub mod mini_app;
 pub mod multi_tree;
 pub mod panel_app;
 pub mod search_panel;
+pub mod sidebar_search;
 pub mod split_app;
 pub mod toast_app;
 
@@ -44,5 +45,6 @@ pub use mini_app::MiniApp;
 pub use multi_tree::DebugSidebar;
 pub use panel_app::PanelApp;
 pub use search_panel::SearchPanelApp;
+pub use sidebar_search::SidebarSearchApp;
 pub use split_app::SplitApp;
 pub use toast_app::ToastApp;

--- a/quadraui/examples/common/sidebar_search.rs
+++ b/quadraui/examples/common/sidebar_search.rs
@@ -1,0 +1,298 @@
+//! SidebarSystem-based search panel — manual smoke test for Form
+//! sections with ToggleGroup/ButtonRow items (#105, #112) and
+//! Header-decorated tree rows (#110).
+//!
+//! Structure:
+//! - Section 0 (Form): query TextInput + toggle flags (Aa, .*, W)
+//! - Section 1 (Tree): search results grouped by file
+//!   (`Decoration::Header` file rows + `Normal` match rows)
+//!
+//! Controls:
+//! - Click toggles to flip (status bar shows the event)
+//! - Click file headers to collapse/expand
+//! - Click match rows to "jump"
+//! - Tab cycles sections
+//! - q / Esc to quit
+
+use quadraui::primitives::form::{FieldKind, FormField, ToggleGroupItem};
+use quadraui::{
+    AppLogic, Backend, Color, Decoration, Form, FormEvent, Key, NamedKey, NavigationMode, Reaction,
+    Rect, SectionKind, SectionSize, SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBar,
+    StatusBarSegment, StyledText, TreeRow, UiEvent, WidgetId,
+};
+
+const STATUS_BAR_LINES: f32 = 1.5;
+
+pub struct SidebarSearchApp {
+    sidebar: SidebarSystem,
+    case_sensitive: bool,
+    regex: bool,
+    whole_word: bool,
+    query: String,
+    expanded: Vec<bool>,
+    last_event: String,
+}
+
+impl SidebarSearchApp {
+    pub fn new() -> Self {
+        let mut sidebar = SidebarSystem::new(vec![
+            SidebarSectionDef::form("search", "SEARCH"),
+            SidebarSectionDef::new("results", "RESULTS"),
+        ]);
+        sidebar.set_navigation_mode(NavigationMode::Selection);
+        sidebar.set_active_section(Some(0));
+
+        let expanded = vec![true; 3];
+        let mut app = Self {
+            sidebar,
+            case_sensitive: false,
+            regex: false,
+            whole_word: false,
+            query: String::new(),
+            expanded,
+            last_event: "Click toggles, headers, or match rows".into(),
+        };
+        app.update_form();
+        app.update_results();
+        app
+    }
+
+    fn update_form(&mut self) {
+        let form = Form {
+            id: WidgetId::new("search-form"),
+            fields: vec![
+                FormField {
+                    id: WidgetId::new("query"),
+                    label: StyledText::plain("Find"),
+                    kind: FieldKind::TextInput {
+                        value: self.query.clone(),
+                        placeholder: "Search...".into(),
+                        cursor: Some(self.query.len()),
+                        selection_anchor: None,
+                    },
+                    hint: StyledText::default(),
+                    disabled: false,
+                },
+                FormField {
+                    id: WidgetId::new("toggles"),
+                    label: StyledText::plain(""),
+                    kind: FieldKind::ToggleGroup {
+                        toggles: vec![
+                            ToggleGroupItem {
+                                id: WidgetId::new("case"),
+                                label: "Aa".into(),
+                                value: self.case_sensitive,
+                            },
+                            ToggleGroupItem {
+                                id: WidgetId::new("regex"),
+                                label: ".*".into(),
+                                value: self.regex,
+                            },
+                            ToggleGroupItem {
+                                id: WidgetId::new("word"),
+                                label: "W".into(),
+                                value: self.whole_word,
+                            },
+                        ],
+                    },
+                    hint: StyledText::default(),
+                    disabled: false,
+                },
+            ],
+            focused_field: Some(WidgetId::new("query")),
+            scroll_offset: 0,
+            has_focus: self.sidebar.active_section() == Some(0),
+        };
+        self.sidebar.set_form(0, form);
+    }
+
+    fn update_results(&mut self) {
+        let files: &[(&str, &[&str])] = &[
+            (
+                "src/main.rs",
+                &["fn main() {", "    let config = Config::load();"],
+            ),
+            (
+                "src/config.rs",
+                &["pub struct Config {", "    pub fn load() -> Self {"],
+            ),
+            (
+                "src/app.rs",
+                &[
+                    "use crate::config::Config;",
+                    "    pub fn run(&mut self) {",
+                    "        Config::default()",
+                ],
+            ),
+        ];
+
+        let mut rows = Vec::new();
+        for (fi, (path, matches)) in files.iter().enumerate() {
+            let expanded = self.expanded.get(fi).copied().unwrap_or(true);
+            rows.push(TreeRow {
+                path: vec![fi as u16],
+                indent: 0,
+                icon: None,
+                text: StyledText {
+                    spans: vec![
+                        quadraui::StyledSpan::plain(*path),
+                        quadraui::StyledSpan {
+                            text: format!(" ({})", matches.len()),
+                            fg: Some(Color::rgb(120, 120, 120)),
+                            bg: None,
+                            bold: false,
+                            italic: false,
+                            underline: false,
+                        },
+                    ],
+                },
+                badge: None,
+                is_expanded: Some(expanded),
+                decoration: Decoration::Header,
+                edit: None,
+            });
+            if expanded {
+                for (mi, text) in matches.iter().enumerate() {
+                    rows.push(TreeRow {
+                        path: vec![fi as u16, mi as u16],
+                        indent: 1,
+                        icon: None,
+                        text: StyledText::plain((*text).to_string()),
+                        badge: None,
+                        is_expanded: None,
+                        decoration: Decoration::Normal,
+                        edit: None,
+                    });
+                }
+            }
+        }
+        self.sidebar.set_rows(1, rows);
+    }
+
+    fn sidebar_rect(backend: &dyn Backend) -> Rect {
+        let vp = backend.viewport();
+        let status_h = backend.line_height() * STATUS_BAR_LINES;
+        Rect::new(0.0, 0.0, vp.width, (vp.height - status_h).max(0.0))
+    }
+
+    fn status_rect(backend: &dyn Backend) -> Rect {
+        let vp = backend.viewport();
+        let status_h = backend.line_height() * STATUS_BAR_LINES;
+        Rect::new(0.0, (vp.height - status_h).max(0.0), vp.width, status_h)
+    }
+
+    fn build_status_bar(&self) -> StatusBar {
+        let flags = format!(
+            "Aa:{} .*:{} W:{}",
+            if self.case_sensitive { "on" } else { "off" },
+            if self.regex { "on" } else { "off" },
+            if self.whole_word { "on" } else { "off" },
+        );
+        StatusBar {
+            id: WidgetId::new("status"),
+            left_segments: vec![StatusBarSegment {
+                text: format!(" {} ", self.last_event),
+                fg: Color::rgb(220, 220, 220),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+            right_segments: vec![StatusBarSegment {
+                text: format!(" {flags} "),
+                fg: Color::rgb(180, 180, 180),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+        }
+    }
+}
+
+impl Default for SidebarSearchApp {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppLogic for SidebarSearchApp {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let sidebar_rect = Self::sidebar_rect(backend);
+        let status_rect = Self::status_rect(backend);
+        self.sidebar.render(backend, sidebar_rect);
+        let _ = backend.draw_status_bar(status_rect, &self.build_status_bar(), None, None);
+    }
+
+    fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+        let rect = Self::sidebar_rect(backend);
+        match self.sidebar.handle(&event, backend, rect) {
+            SidebarEvent::FormEvent { event, .. } => {
+                match &event {
+                    FormEvent::ToggleChanged { id, value } => {
+                        let name = id.as_str();
+                        match name {
+                            "case" => self.case_sensitive = *value,
+                            "regex" => self.regex = *value,
+                            "word" => self.whole_word = *value,
+                            _ => {}
+                        }
+                        self.last_event = format!("ToggleChanged {name}={value}");
+                    }
+                    FormEvent::FocusChanged { id } => {
+                        self.last_event = format!("FocusChanged {}", id.as_str());
+                    }
+                    FormEvent::ButtonClicked { id } => {
+                        self.last_event = format!("ButtonClicked {}", id.as_str());
+                    }
+                    other => {
+                        self.last_event = format!("{other:?}");
+                    }
+                }
+                self.update_form();
+                Reaction::Redraw
+            }
+            SidebarEvent::RowSelected { section, path } => {
+                if section == 1 && path.len() == 1 {
+                    let fi = path[0] as usize;
+                    if fi < self.expanded.len() {
+                        self.expanded[fi] = !self.expanded[fi];
+                        self.last_event = format!(
+                            "{} file {}",
+                            if self.expanded[fi] {
+                                "Expanded"
+                            } else {
+                                "Collapsed"
+                            },
+                            fi
+                        );
+                        self.update_results();
+                    }
+                } else {
+                    self.last_event = format!("row→{section} {path:?}");
+                }
+                Reaction::Redraw
+            }
+            SidebarEvent::HeaderActivated { section } => {
+                self.last_event = format!("header→{section}");
+                Reaction::Redraw
+            }
+            SidebarEvent::StateChanged
+            | SidebarEvent::Consumed
+            | SidebarEvent::ScrollChanged { .. } => Reaction::Redraw,
+            SidebarEvent::Ignored => match event {
+                UiEvent::KeyPressed {
+                    key: Key::Char('q'),
+                    ..
+                }
+                | UiEvent::KeyPressed {
+                    key: Key::Named(NamedKey::Escape),
+                    ..
+                } => Reaction::Exit,
+                UiEvent::WindowResized { .. } => Reaction::Redraw,
+                _ => Reaction::Continue,
+            },
+            _ => Reaction::Redraw,
+        }
+    }
+}

--- a/quadraui/examples/gtk_sidebar_search.rs
+++ b/quadraui/examples/gtk_sidebar_search.rs
@@ -1,0 +1,15 @@
+//! SidebarSystem search panel — Form (ToggleGroup) + Tree (Header rows).
+//!
+//! Click individual toggle items, click file headers to collapse,
+//! click match rows to select. Status bar shows received events.
+//!
+//! ```sh
+//! cargo run --example gtk_sidebar_search --features gtk
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::gtk::run(common::SidebarSearchApp::new())
+}

--- a/quadraui/examples/tui_sidebar_search.rs
+++ b/quadraui/examples/tui_sidebar_search.rs
@@ -1,0 +1,15 @@
+//! SidebarSystem search panel — Form (ToggleGroup) + Tree (Header rows).
+//!
+//! Click individual toggle items, click file headers to collapse,
+//! click match rows to select. Status bar shows received events.
+//!
+//! ```sh
+//! cargo run --example tui_sidebar_search --features tui
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::io::Result<()> {
+    quadraui::tui::run(common::SidebarSearchApp::new())
+}

--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -388,7 +388,7 @@ impl SidebarSystem {
     ) -> SidebarEvent {
         let lh = backend.line_height();
         let metrics = backend.msv_metrics();
-        self.handle_inner(event, rect, lh, &metrics)
+        self.handle_inner(event, rect, lh, &metrics, Some(&*backend))
     }
 
     /// Backend-free event handler. Requires [`Self::set_backend_info`]
@@ -400,7 +400,7 @@ impl SidebarSystem {
         };
         let lh = info.line_height;
         let metrics = info.metrics;
-        self.handle_inner(event, rect, lh, &metrics)
+        self.handle_inner(event, rect, lh, &metrics, None)
     }
 
     fn handle_inner(
@@ -409,6 +409,7 @@ impl SidebarSystem {
         rect: Rect,
         lh: f32,
         metrics: &LayoutMetrics,
+        backend: Option<&dyn Backend>,
     ) -> SidebarEvent {
         self.cached_viewport_rows = None;
 
@@ -427,7 +428,7 @@ impl SidebarSystem {
                 button: MouseButton::Left,
                 position,
                 ..
-            } => self.click(rect, position.x, position.y, lh, metrics),
+            } => self.click(rect, position.x, position.y, lh, metrics, backend),
 
             // ── Right-click ──────────────────────────────────────
             UiEvent::MouseDown {
@@ -887,6 +888,7 @@ impl SidebarSystem {
         y: f32,
         lh: f32,
         metrics: &LayoutMetrics,
+        backend: Option<&dyn Backend>,
     ) -> SidebarEvent {
         let (layout, map) = self.compute_layout(rect, metrics, lh);
         let (view, _) = self.build_view();
@@ -923,11 +925,15 @@ impl SidebarSystem {
                         }
                     }
                     SectionBody::Form(f) => {
-                        let row_h = (lh * 1.4).round();
-                        let char_w = lh * 0.6;
-                        let form_layout = f.layout(body_b.width, body_b.height, |i| {
-                            form_field_measure(&f.fields[i], row_h, char_w)
-                        });
+                        let form_layout = if let Some(be) = backend {
+                            be.form_layout(body_b, f)
+                        } else {
+                            let row_h = (lh * 1.4).round();
+                            let char_w = lh * 0.6;
+                            f.layout(body_b.width, body_b.height, |i| {
+                                form_field_measure(&f.fields[i], row_h, char_w)
+                            })
+                        };
                         match form_layout.hit_test(x - body_b.x, y - body_b.y) {
                             crate::primitives::form::FormHit::Field(id) => {
                                 let event = form_click_event(f, &id);

--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -27,7 +27,7 @@ use super::focus_group::FocusGroup;
 use super::form_controller::FormController;
 use super::tree_controller::TreeController;
 use super::tree_controller::TreeControllerEvent;
-use crate::primitives::form::{FieldKind, Form, FormEvent};
+use crate::primitives::form::{FieldKind, Form, FormEvent, FormFieldMeasure, FormItemMeasure};
 use crate::primitives::multi_section_view::{
     LayoutMetrics, MultiSectionViewLayout, SectionMeasure,
 };
@@ -923,8 +923,10 @@ impl SidebarSystem {
                         }
                     }
                     SectionBody::Form(f) => {
-                        let form_layout = f.layout(body_b.width, body_b.height, |_| {
-                            crate::primitives::form::FormFieldMeasure::new((lh * 1.4).round())
+                        let row_h = (lh * 1.4).round();
+                        let char_w = lh * 0.6;
+                        let form_layout = f.layout(body_b.width, body_b.height, |i| {
+                            form_field_measure(&f.fields[i], row_h, char_w)
                         });
                         match form_layout.hit_test(x - body_b.x, y - body_b.y) {
                             crate::primitives::form::FormHit::Field(id) => {
@@ -1194,6 +1196,48 @@ impl SidebarSystem {
             tc.set_selected_path(Some(path));
             tc.set_scroll_offset(0);
         }
+    }
+}
+
+fn form_field_measure(
+    field: &crate::primitives::form::FormField,
+    row_h: f32,
+    char_w: f32,
+) -> FormFieldMeasure {
+    match &field.kind {
+        FieldKind::ToggleGroup { toggles } => {
+            let label_w = field.label.visible_width() as f32 * char_w;
+            let start_x = if label_w > 0.0 {
+                label_w + char_w * 2.0
+            } else {
+                char_w
+            };
+            let items = toggles
+                .iter()
+                .map(|t| FormItemMeasure {
+                    id: t.id.clone(),
+                    width: (t.label.chars().count() as f32 + 2.0) * char_w,
+                })
+                .collect();
+            FormFieldMeasure::with_items(row_h, start_x, char_w, items)
+        }
+        FieldKind::ButtonRow { buttons } => {
+            let label_w = field.label.visible_width() as f32 * char_w;
+            let start_x = if label_w > 0.0 {
+                label_w + char_w * 2.0
+            } else {
+                char_w
+            };
+            let items = buttons
+                .iter()
+                .map(|b| FormItemMeasure {
+                    id: b.id.clone(),
+                    width: (b.label.chars().count() as f32 + 2.0) * char_w,
+                })
+                .collect();
+            FormFieldMeasure::with_items(row_h, start_x, char_w, items)
+        }
+        _ => FormFieldMeasure::new(row_h),
     }
 }
 
@@ -1983,5 +2027,144 @@ mod tests {
                 other
             ),
         }
+    }
+
+    // ── Form item-level click dispatch (#112) ──────────────────────────
+
+    #[test]
+    fn form_field_measure_populates_toggle_group_items() {
+        use crate::primitives::form::{FormField, ToggleGroupItem};
+        let field = FormField {
+            id: WidgetId::new("flags"),
+            label: StyledText::plain("Flags"),
+            kind: FieldKind::ToggleGroup {
+                toggles: vec![
+                    ToggleGroupItem {
+                        id: WidgetId::new("case"),
+                        label: "Aa".into(),
+                        value: false,
+                    },
+                    ToggleGroupItem {
+                        id: WidgetId::new("regex"),
+                        label: ".*".into(),
+                        value: false,
+                    },
+                ],
+            },
+            hint: StyledText::default(),
+            disabled: false,
+        };
+        let m = form_field_measure(&field, 20.0, 10.0);
+        assert_eq!(m.item_measures.len(), 2);
+        assert_eq!(m.item_measures[0].id, WidgetId::new("case"));
+        assert_eq!(m.item_measures[1].id, WidgetId::new("regex"));
+        assert!(m.items_start_x > 0.0);
+    }
+
+    #[test]
+    fn form_field_measure_populates_button_row_items() {
+        use crate::primitives::form::{ButtonRowItem, FormField};
+        let field = FormField {
+            id: WidgetId::new("actions"),
+            label: StyledText::plain(""),
+            kind: FieldKind::ButtonRow {
+                buttons: vec![
+                    ButtonRowItem {
+                        id: WidgetId::new("replace"),
+                        label: "Replace".into(),
+                        disabled: false,
+                    },
+                    ButtonRowItem {
+                        id: WidgetId::new("replace-all"),
+                        label: "Replace All".into(),
+                        disabled: false,
+                    },
+                ],
+            },
+            hint: StyledText::default(),
+            disabled: false,
+        };
+        let m = form_field_measure(&field, 20.0, 10.0);
+        assert_eq!(m.item_measures.len(), 2);
+        assert_eq!(m.item_measures[0].id, WidgetId::new("replace"));
+        assert_eq!(m.item_measures[1].id, WidgetId::new("replace-all"));
+    }
+
+    #[test]
+    fn form_layout_hit_test_returns_individual_toggle_id() {
+        use crate::primitives::form::{FormField, FormHit, ToggleGroupItem};
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("flags"),
+                label: StyledText::plain(""),
+                kind: FieldKind::ToggleGroup {
+                    toggles: vec![
+                        ToggleGroupItem {
+                            id: WidgetId::new("case"),
+                            label: "Aa".into(),
+                            value: false,
+                        },
+                        ToggleGroupItem {
+                            id: WidgetId::new("regex"),
+                            label: ".*".into(),
+                            value: false,
+                        },
+                    ],
+                },
+                hint: StyledText::default(),
+                disabled: false,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        let lh: f32 = 16.0;
+        let row_h = (lh * 1.4).round();
+        let char_w = lh * 0.6;
+        let layout = form.layout(200.0, 100.0, |i| {
+            form_field_measure(&form.fields[i], row_h, char_w)
+        });
+        let m = &layout.visible_fields[0];
+        assert!(
+            !m.item_bounds.is_empty(),
+            "item_bounds should be populated for ToggleGroup"
+        );
+        let (first_id, first_rect) = &m.item_bounds[0];
+        assert_eq!(first_id, &WidgetId::new("case"));
+        let hit = layout.hit_test(first_rect.x + 1.0, first_rect.y + 1.0);
+        assert_eq!(hit, FormHit::Field(WidgetId::new("case")));
+    }
+
+    #[test]
+    fn form_click_event_dispatches_individual_toggle() {
+        use crate::primitives::form::{FormField, ToggleGroupItem};
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("flags"),
+                label: StyledText::plain(""),
+                kind: FieldKind::ToggleGroup {
+                    toggles: vec![ToggleGroupItem {
+                        id: WidgetId::new("case"),
+                        label: "Aa".into(),
+                        value: true,
+                    }],
+                },
+                hint: StyledText::default(),
+                disabled: false,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        let ev = form_click_event(&form, &WidgetId::new("case"));
+        assert_eq!(
+            ev,
+            FormEvent::ToggleChanged {
+                id: WidgetId::new("case"),
+                value: false,
+            }
+        );
     }
 }

--- a/quadraui/src/tui/multi_section_view.rs
+++ b/quadraui/src/tui/multi_section_view.rs
@@ -2325,6 +2325,77 @@ mod tests {
     }
 
     #[test]
+    fn form_toggle_group_items_individually_clickable_in_msv() {
+        use crate::primitives::form::{FormHit, ToggleGroupItem};
+
+        let area = TuiRect::new(0, 0, 40, 6);
+        let mut buf = Buffer::empty(area);
+
+        let fields = vec![FormField {
+            id: WidgetId::new("flags"),
+            label: StyledText::plain(""),
+            kind: FieldKind::ToggleGroup {
+                toggles: vec![
+                    ToggleGroupItem {
+                        id: WidgetId::new("case"),
+                        label: "Aa".into(),
+                        value: false,
+                    },
+                    ToggleGroupItem {
+                        id: WidgetId::new("regex"),
+                        label: ".*".into(),
+                        value: true,
+                    },
+                ],
+            },
+            hint: StyledText::default(),
+            disabled: false,
+        }];
+
+        let v = view_with(vec![form_section("opts", fields, SectionSize::EqualShare)]);
+        let layout = paint_then_layout(&mut buf, area, &v, &Theme::default(), false);
+
+        let s = &layout.sections[0];
+        let body_b = s.body_bounds;
+
+        // Find the row with the toggles — scan for "Aa" painted text.
+        let toggle_y = find_row_with(&buf, "Aa").expect("ToggleGroup items not painted");
+
+        // The click should land in the body.
+        let hit = layout.hit_test(5.0, toggle_y as f32);
+        assert!(
+            matches!(hit, MultiSectionViewHit::Body { section: 0 }),
+            "click at toggle row returned {:?}, expected Body{{0}}",
+            hit
+        );
+
+        // Now hit-test the Form layout inside the body to verify
+        // individual items are reachable.
+        if let SectionBody::Form(f) = &v.sections[0].body {
+            let form_layout = crate::tui::form::tui_form_layout(
+                f,
+                TuiRect::new(0, 0, body_b.width as u16, body_b.height as u16),
+            );
+            // First item should be individually hit-testable.
+            let vis = &form_layout.visible_fields[0];
+            assert!(
+                !vis.item_bounds.is_empty(),
+                "ToggleGroup should have per-item bounds in form layout"
+            );
+            let (first_id, first_rect) = &vis.item_bounds[0];
+            assert_eq!(first_id, &WidgetId::new("case"));
+            let hit = form_layout.hit_test(first_rect.x + 0.5, first_rect.y + 0.5);
+            assert_eq!(
+                hit,
+                FormHit::Field(WidgetId::new("case")),
+                "hit-test at first toggle item should return its individual ID"
+            );
+        } else {
+            panic!("expected Form body");
+        }
+    }
+
+    #[test]
     fn form_toggle_value_paints_correctly() {
         let area = TuiRect::new(0, 0, 40, 6);
         let mut buf = Buffer::empty(area);


### PR DESCRIPTION
## Summary

- Add `form_field_measure()` that inspects `FieldKind` and populates `item_measures` with per-item IDs and estimated widths for `ToggleGroup` and `ButtonRow` fields
- `Form::layout()` now creates per-item hit regions, so `hit_test()` returns individual toggle/button IDs instead of the field-level ID
- `form_click_event()` correctly dispatches individual item IDs to `ToggleChanged`/`ButtonClicked`

## Root cause

The generic `FormFieldMeasure::new(row_h)` created empty `item_measures`, so the form layout only had field-level hit regions. When clicking a toggle group item, `hit_test` returned the field ID (e.g. `"flags"`), which `form_click_event` matched as the field itself and returned `FocusChanged` — never reaching the per-item lookup.

## Test plan

- [x] `form_field_measure_populates_toggle_group_items` — verifies item IDs and count
- [x] `form_field_measure_populates_button_row_items` — same for ButtonRow
- [x] `form_layout_hit_test_returns_individual_toggle_id` — end-to-end: layout → hit_test → individual ID
- [x] `form_click_event_dispatches_individual_toggle` — verifies the event is `ToggleChanged` with flipped value
- [x] Full quality gate: 556 tests, clippy, fmt — all green

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)