### PR TITLE
feat(quadraui): TextArea, PasswordInput, SegmentedControl + ValidationState (#53)

### DIFF
--- a/quadraui/examples/common/form_groups.rs
+++ b/quadraui/examples/common/form_groups.rs
@@ -61,6 +61,7 @@ impl FormGroupsApp {
                     },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("toggles"),
@@ -86,6 +87,7 @@ impl FormGroupsApp {
                     },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("replace"),
@@ -98,6 +100,7 @@ impl FormGroupsApp {
                     },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("buttons"),
@@ -123,6 +126,7 @@ impl FormGroupsApp {
                     },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
             ],
             focused_field: self.focus.current().cloned(),

--- a/quadraui/examples/common/sidebar_search.rs
+++ b/quadraui/examples/common/sidebar_search.rs
@@ -334,15 +334,31 @@ impl AppLogic for SidebarSearchApp {
             | SidebarEvent::Consumed
             | SidebarEvent::ScrollChanged { .. } => Reaction::Redraw,
             SidebarEvent::Ignored => match event {
-                UiEvent::CharTyped(ch) => {
+                UiEvent::CharTyped(ch)
+                | UiEvent::KeyPressed {
+                    key: Key::Char(ch), ..
+                } => {
                     if self.sidebar.active_section() == Some(0) {
                         match self.focused_field.as_deref() {
-                            Some("query") => self.query.push(ch),
-                            Some("password") => self.password.push(ch),
-                            _ => return Reaction::Continue,
+                            Some("query") => {
+                                if ch == 'q' || !ch.is_control() {
+                                    self.query.push(ch);
+                                    self.update_form();
+                                    return Reaction::Redraw;
+                                }
+                            }
+                            Some("password") => {
+                                if !ch.is_control() {
+                                    self.password.push(ch);
+                                    self.update_form();
+                                    return Reaction::Redraw;
+                                }
+                            }
+                            _ => {}
                         }
-                        self.update_form();
-                        Reaction::Redraw
+                    }
+                    if ch == 'q' {
+                        Reaction::Exit
                     } else {
                         Reaction::Continue
                     }
@@ -365,18 +381,6 @@ impl AppLogic for SidebarSearchApp {
                         Reaction::Redraw
                     } else {
                         Reaction::Continue
-                    }
-                }
-                UiEvent::KeyPressed {
-                    key: Key::Char('q'),
-                    ..
-                } => {
-                    if self.focused_field.as_deref() == Some("query")
-                        || self.focused_field.as_deref() == Some("password")
-                    {
-                        Reaction::Continue
-                    } else {
-                        Reaction::Exit
                     }
                 }
                 UiEvent::KeyPressed {

--- a/quadraui/examples/common/sidebar_search.rs
+++ b/quadraui/examples/common/sidebar_search.rs
@@ -14,7 +14,7 @@
 //! - Tab cycles sections
 //! - q / Esc to quit
 
-use quadraui::primitives::form::{FieldKind, FormField, ToggleGroupItem};
+use quadraui::primitives::form::{FieldKind, FormField, ToggleGroupItem, ValidationState};
 use quadraui::{
     AppLogic, Backend, Color, Decoration, Form, FormEvent, Key, NamedKey, NavigationMode, Reaction,
     Rect, SectionKind, SectionSize, SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBar,
@@ -29,6 +29,8 @@ pub struct SidebarSearchApp {
     regex: bool,
     whole_word: bool,
     query: String,
+    password: String,
+    scope_idx: usize,
     expanded: Vec<bool>,
     last_event: String,
 }
@@ -49,6 +51,8 @@ impl SidebarSearchApp {
             regex: false,
             whole_word: false,
             query: String::new(),
+            password: String::new(),
+            scope_idx: 0,
             expanded,
             last_event: "Click toggles, headers, or match rows".into(),
         };
@@ -72,7 +76,11 @@ impl SidebarSearchApp {
                     },
                     hint: StyledText::default(),
                     disabled: false,
-                    validation: None,
+                    validation: if self.query.is_empty() {
+                        Some(ValidationState::Error("Query required".into()))
+                    } else {
+                        None
+                    },
                 },
                 FormField {
                     id: WidgetId::new("toggles"),
@@ -99,6 +107,34 @@ impl SidebarSearchApp {
                     hint: StyledText::default(),
                     disabled: false,
                     validation: None,
+                },
+                FormField {
+                    id: WidgetId::new("scope"),
+                    label: StyledText::plain("Scope"),
+                    kind: FieldKind::SegmentedControl {
+                        options: vec!["Workspace".into(), "File".into(), "Selection".into()],
+                        selected_idx: self.scope_idx,
+                    },
+                    hint: StyledText::default(),
+                    disabled: false,
+                    validation: None,
+                },
+                FormField {
+                    id: WidgetId::new("password"),
+                    label: StyledText::plain("Token"),
+                    kind: FieldKind::PasswordInput {
+                        value: self.password.clone(),
+                        placeholder: "API key...".into(),
+                        cursor: Some(self.password.len()),
+                        mask_char: '•',
+                    },
+                    hint: StyledText::default(),
+                    disabled: false,
+                    validation: if self.password.len() > 0 && self.password.len() < 4 {
+                        Some(ValidationState::Warning("Token too short".into()))
+                    } else {
+                        None
+                    },
                 },
             ],
             focused_field: Some(WidgetId::new("query")),
@@ -184,11 +220,13 @@ impl SidebarSearchApp {
     }
 
     fn build_status_bar(&self) -> StatusBar {
+        let scope = ["Workspace", "File", "Selection"][self.scope_idx.min(2)];
         let flags = format!(
-            "Aa:{} .*:{} W:{}",
+            "Aa:{} .*:{} W:{} scope:{}",
             if self.case_sensitive { "on" } else { "off" },
             if self.regex { "on" } else { "off" },
             if self.whole_word { "on" } else { "off" },
+            scope,
         );
         StatusBar {
             id: WidgetId::new("status"),
@@ -240,6 +278,13 @@ impl AppLogic for SidebarSearchApp {
                             _ => {}
                         }
                         self.last_event = format!("ToggleChanged {name}={value}");
+                    }
+                    FormEvent::SegmentedControlChanged { id, selected_idx } => {
+                        if id.as_str() == "scope" {
+                            self.scope_idx = *selected_idx;
+                        }
+                        self.last_event =
+                            format!("SegmentedControl {}={selected_idx}", id.as_str());
                     }
                     FormEvent::FocusChanged { id } => {
                         self.last_event = format!("FocusChanged {}", id.as_str());

--- a/quadraui/examples/common/sidebar_search.rs
+++ b/quadraui/examples/common/sidebar_search.rs
@@ -72,6 +72,7 @@ impl SidebarSearchApp {
                     },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("toggles"),
@@ -97,6 +98,7 @@ impl SidebarSearchApp {
                     },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
             ],
             focused_field: Some(WidgetId::new("query")),

--- a/quadraui/examples/common/sidebar_search.rs
+++ b/quadraui/examples/common/sidebar_search.rs
@@ -31,6 +31,7 @@ pub struct SidebarSearchApp {
     query: String,
     password: String,
     scope_idx: usize,
+    focused_field: Option<String>,
     expanded: Vec<bool>,
     last_event: String,
 }
@@ -53,6 +54,7 @@ impl SidebarSearchApp {
             query: String::new(),
             password: String::new(),
             scope_idx: 0,
+            focused_field: Some("query".into()),
             expanded,
             last_event: "Click toggles, headers, or match rows".into(),
         };
@@ -137,7 +139,10 @@ impl SidebarSearchApp {
                     },
                 },
             ],
-            focused_field: Some(WidgetId::new("query")),
+            focused_field: self
+                .focused_field
+                .as_ref()
+                .map(|f| WidgetId::new(f.clone())),
             scroll_offset: 0,
             has_focus: self.sidebar.active_section() == Some(0),
         };
@@ -287,6 +292,7 @@ impl AppLogic for SidebarSearchApp {
                             format!("SegmentedControl {}={selected_idx}", id.as_str());
                     }
                     FormEvent::FocusChanged { id } => {
+                        self.focused_field = Some(id.as_str().to_string());
                         self.last_event = format!("FocusChanged {}", id.as_str());
                     }
                     FormEvent::ButtonClicked { id } => {
@@ -328,11 +334,52 @@ impl AppLogic for SidebarSearchApp {
             | SidebarEvent::Consumed
             | SidebarEvent::ScrollChanged { .. } => Reaction::Redraw,
             SidebarEvent::Ignored => match event {
+                UiEvent::CharTyped(ch) => {
+                    if self.sidebar.active_section() == Some(0) {
+                        match self.focused_field.as_deref() {
+                            Some("query") => self.query.push(ch),
+                            Some("password") => self.password.push(ch),
+                            _ => return Reaction::Continue,
+                        }
+                        self.update_form();
+                        Reaction::Redraw
+                    } else {
+                        Reaction::Continue
+                    }
+                }
+                UiEvent::KeyPressed {
+                    key: Key::Named(NamedKey::Backspace),
+                    ..
+                } => {
+                    if self.sidebar.active_section() == Some(0) {
+                        match self.focused_field.as_deref() {
+                            Some("query") => {
+                                self.query.pop();
+                            }
+                            Some("password") => {
+                                self.password.pop();
+                            }
+                            _ => return Reaction::Continue,
+                        }
+                        self.update_form();
+                        Reaction::Redraw
+                    } else {
+                        Reaction::Continue
+                    }
+                }
                 UiEvent::KeyPressed {
                     key: Key::Char('q'),
                     ..
+                } => {
+                    if self.focused_field.as_deref() == Some("query")
+                        || self.focused_field.as_deref() == Some("password")
+                    {
+                        Reaction::Continue
+                    } else {
+                        Reaction::Exit
+                    }
                 }
-                | UiEvent::KeyPressed {
+                UiEvent::KeyPressed {
                     key: Key::Named(NamedKey::Escape),
                     ..
                 } => Reaction::Exit,

--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -1275,6 +1275,26 @@ fn form_field_measure(
                 .collect();
             FormFieldMeasure::with_items(row_h, start_x, char_w, items)
         }
+        FieldKind::SegmentedControl { options, .. } => {
+            let label_w = field.label.visible_width() as f32 * char_w;
+            let start_x = if label_w > 0.0 {
+                label_w + char_w * 2.0
+            } else {
+                char_w
+            };
+            let items = options
+                .iter()
+                .enumerate()
+                .map(|(idx, opt)| FormItemMeasure {
+                    id: WidgetId::new(format!("{}__seg_{idx}", field.id.as_str())),
+                    width: (opt.chars().count() as f32 + 2.0) * char_w,
+                })
+                .collect();
+            FormFieldMeasure::with_items(row_h, start_x, 0.0, items)
+        }
+        FieldKind::TextArea { visible_rows, .. } => {
+            FormFieldMeasure::new(row_h * *visible_rows as f32)
+        }
         _ => FormFieldMeasure::new(row_h),
     }
 }
@@ -1308,6 +1328,17 @@ fn form_click_event(form: &Form, clicked_id: &WidgetId) -> FormEvent {
                 return FormEvent::ButtonClicked {
                     id: clicked_id.clone(),
                 };
+            }
+        }
+        if let FieldKind::SegmentedControl { .. } = &field.kind {
+            let prefix = format!("{}__seg_", field.id.as_str());
+            if clicked_id.as_str().starts_with(&prefix) {
+                if let Ok(idx) = clicked_id.as_str()[prefix.len()..].parse::<usize>() {
+                    return FormEvent::SegmentedControlChanged {
+                        id: field.id.clone(),
+                        selected_idx: idx,
+                    };
+                }
             }
         }
     }
@@ -1746,6 +1777,7 @@ mod tests {
                     },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("case-sensitive"),
@@ -1753,6 +1785,7 @@ mod tests {
                     kind: FieldKind::Toggle { value: false },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
             ],
             focused_field: None,
@@ -1901,6 +1934,7 @@ mod tests {
                 kind: FieldKind::Button,
                 hint: StyledText::default(),
                 disabled: false,
+                validation: None,
             }],
             focused_field: None,
             scroll_offset: 0,
@@ -1939,6 +1973,7 @@ mod tests {
                 },
                 hint: StyledText::default(),
                 disabled: false,
+                validation: None,
             }],
             focused_field: None,
             scroll_offset: 0,
@@ -1971,6 +2006,7 @@ mod tests {
                 },
                 hint: StyledText::default(),
                 disabled: false,
+                validation: None,
             }],
             focused_field: None,
             scroll_offset: 0,
@@ -2091,6 +2127,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         };
         let m = form_field_measure(&field, 20.0, 10.0);
         assert_eq!(m.item_measures.len(), 2);
@@ -2121,6 +2158,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         };
         let m = form_field_measure(&field, 20.0, 10.0);
         assert_eq!(m.item_measures.len(), 2);
@@ -2152,6 +2190,7 @@ mod tests {
                 },
                 hint: StyledText::default(),
                 disabled: false,
+                validation: None,
             }],
             focused_field: None,
             scroll_offset: 0,
@@ -2191,6 +2230,7 @@ mod tests {
                 },
                 hint: StyledText::default(),
                 disabled: false,
+                validation: None,
             }],
             focused_field: None,
             scroll_offset: 0,

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -923,6 +923,30 @@ impl Backend for GtkBackend {
                         row_h, start_x, gap, items,
                     )
                 }
+                crate::primitives::form::FieldKind::SegmentedControl { options, .. } => {
+                    let label_w = self.pango_text_width(&pango_layout, &field.label, char_w);
+                    let start_x = 6.0 + label_w + 12.0;
+                    let items = options
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, opt)| {
+                            let bracketed = format!("[{opt}]");
+                            crate::primitives::form::FormItemMeasure {
+                                id: crate::WidgetId::new(format!(
+                                    "{}__seg_{idx}",
+                                    field.id.as_str()
+                                )),
+                                width: self.pango_str_width(&pango_layout, &bracketed, char_w),
+                            }
+                        })
+                        .collect();
+                    crate::primitives::form::FormFieldMeasure::with_items(
+                        row_h, start_x, 0.0, items,
+                    )
+                }
+                crate::primitives::form::FieldKind::TextArea { visible_rows, .. } => {
+                    crate::primitives::form::FormFieldMeasure::new(row_h * *visible_rows as f32)
+                }
                 _ => crate::primitives::form::FormFieldMeasure::new(row_h),
             }
         })

--- a/quadraui/src/gtk/form.rs
+++ b/quadraui/src/gtk/form.rs
@@ -14,7 +14,7 @@ use gtk4::pango;
 use pangocairo::functions as pcfn;
 
 use super::cairo_rgb;
-use crate::primitives::form::{FieldKind, Form};
+use crate::primitives::form::{FieldKind, Form, ValidationState};
 use crate::theme::Theme;
 
 /// Draw a [`Form`] into `(x, y, w, h)` on `cr` using `layout` for text
@@ -45,6 +45,8 @@ pub fn draw_form(
     let dim = cairo_rgb(theme.muted_fg);
     let sel = cairo_rgb(theme.selected_bg);
     let accent = cairo_rgb(theme.accent_fg);
+    let error = cairo_rgb(theme.error_fg);
+    let warning = cairo_rgb(theme.warning_fg);
 
     cr.set_source_rgb(bg.0, bg.1, bg.2);
     cr.rectangle(x, y, w, h);
@@ -295,6 +297,193 @@ pub fn draw_form(
                     pcfn::show_layout(cr, layout);
                     ix += rw as f64 + 8.0;
                 }
+            }
+            FieldKind::PasswordInput {
+                value,
+                placeholder,
+                cursor,
+                mask_char,
+            } => {
+                let masked: String = value.chars().map(|_| *mask_char).collect();
+                let shown = if value.is_empty() {
+                    placeholder.as_str()
+                } else {
+                    masked.as_str()
+                };
+                let input_fg = if value.is_empty() { dim } else { field_fg };
+
+                layout.set_text(shown);
+                let (shown_w, shown_h) = layout.pixel_size();
+
+                let (ix, _, bracket_right) = if no_label {
+                    let ix = label_x;
+                    let bracket_r = input_right - 4.0;
+                    let avail = bracket_r - ix - 8.0;
+                    let dw = (shown_w as f64).min(avail.max(0.0));
+                    (ix, dw, bracket_r)
+                } else {
+                    let max_width = (w * 0.6).max(80.0);
+                    let dw = (shown_w as f64).min(max_width);
+                    let ix = input_right - dw - 14.0;
+                    (ix, dw, ix + 8.0 + dw + 2.0)
+                };
+                if no_label || ix > label_right + 8.0 {
+                    cr.set_source_rgb(dim.0, dim.1, dim.2);
+                    layout.set_text("[");
+                    cr.move_to(ix, (y_off + (row_h - shown_h as f64) / 2.0).round());
+                    pcfn::show_layout(cr, layout);
+
+                    cr.set_source_rgb(input_fg.0, input_fg.1, input_fg.2);
+                    layout.set_text(shown);
+                    cr.move_to(ix + 8.0, (y_off + (row_h - shown_h as f64) / 2.0).round());
+                    pcfn::show_layout(cr, layout);
+
+                    cr.set_source_rgb(dim.0, dim.1, dim.2);
+                    layout.set_text("]");
+                    cr.move_to(
+                        bracket_right,
+                        (y_off + (row_h - shown_h as f64) / 2.0).round(),
+                    );
+                    pcfn::show_layout(cr, layout);
+
+                    if let Some(cur) = cursor {
+                        // Cursor position: each original char maps to one
+                        // mask char, so measure the masked prefix up to
+                        // the byte-offset translated cursor.
+                        let char_pos = value[..(*cur).min(value.len())].chars().count();
+                        let mask_prefix: String = masked.chars().take(char_pos).collect();
+                        layout.set_text(&mask_prefix);
+                        let (prefix_w, _) = layout.pixel_size();
+                        let cx = ix + 8.0 + prefix_w as f64;
+                        cr.set_source_rgb(accent.0, accent.1, accent.2);
+                        cr.rectangle(cx, y_off + 3.0, 1.5, row_h - 6.0);
+                        cr.fill().ok();
+                    }
+                }
+            }
+            FieldKind::TextArea {
+                value,
+                placeholder,
+                cursor,
+                ..
+            } => {
+                // For now, render as a single-line input showing the
+                // first line of value. Multi-row GTK rendering is a
+                // future enhancement.
+                let first_line = value.lines().next().unwrap_or("");
+                let shown = if value.is_empty() {
+                    placeholder.as_str()
+                } else {
+                    first_line
+                };
+                let input_fg = if value.is_empty() { dim } else { field_fg };
+
+                layout.set_text(shown);
+                let (shown_w, shown_h) = layout.pixel_size();
+
+                let (ix, _, bracket_right) = if no_label {
+                    let ix = label_x;
+                    let bracket_r = input_right - 4.0;
+                    let avail = bracket_r - ix - 8.0;
+                    let dw = (shown_w as f64).min(avail.max(0.0));
+                    (ix, dw, bracket_r)
+                } else {
+                    let max_width = (w * 0.6).max(80.0);
+                    let dw = (shown_w as f64).min(max_width);
+                    let ix = input_right - dw - 14.0;
+                    (ix, dw, ix + 8.0 + dw + 2.0)
+                };
+                if no_label || ix > label_right + 8.0 {
+                    cr.set_source_rgb(dim.0, dim.1, dim.2);
+                    layout.set_text("[");
+                    cr.move_to(ix, (y_off + (row_h - shown_h as f64) / 2.0).round());
+                    pcfn::show_layout(cr, layout);
+
+                    cr.set_source_rgb(input_fg.0, input_fg.1, input_fg.2);
+                    layout.set_text(shown);
+                    cr.move_to(ix + 8.0, (y_off + (row_h - shown_h as f64) / 2.0).round());
+                    pcfn::show_layout(cr, layout);
+
+                    cr.set_source_rgb(dim.0, dim.1, dim.2);
+                    layout.set_text("]");
+                    cr.move_to(
+                        bracket_right,
+                        (y_off + (row_h - shown_h as f64) / 2.0).round(),
+                    );
+                    pcfn::show_layout(cr, layout);
+
+                    if let Some(cur) = cursor {
+                        // Clamp cursor to first line length for display.
+                        let clamped = (*cur).min(first_line.len());
+                        let prefix = &shown[..clamped.min(shown.len())];
+                        layout.set_text(prefix);
+                        let (prefix_w, _) = layout.pixel_size();
+                        let cx = ix + 8.0 + prefix_w as f64;
+                        cr.set_source_rgb(accent.0, accent.1, accent.2);
+                        cr.rectangle(cx, y_off + 3.0, 1.5, row_h - 6.0);
+                        cr.fill().ok();
+                    }
+                }
+            }
+            FieldKind::SegmentedControl {
+                options,
+                selected_idx,
+            } => {
+                let mut ix = label_right + 12.0;
+                // Opening bracket.
+                cr.set_source_rgb(dim.0, dim.1, dim.2);
+                layout.set_text("[");
+                let (bw, bh) = layout.pixel_size();
+                cr.move_to(ix, (y_off + (row_h - bh as f64) / 2.0).round());
+                pcfn::show_layout(cr, layout);
+                ix += bw as f64;
+
+                for (i, opt) in options.iter().enumerate() {
+                    if i > 0 {
+                        cr.set_source_rgb(dim.0, dim.1, dim.2);
+                        layout.set_text("|");
+                        let (sw, sh) = layout.pixel_size();
+                        cr.move_to(ix, (y_off + (row_h - sh as f64) / 2.0).round());
+                        pcfn::show_layout(cr, layout);
+                        ix += sw as f64;
+                    }
+                    let opt_fg = if i == *selected_idx { accent } else { dim };
+                    cr.set_source_rgb(opt_fg.0, opt_fg.1, opt_fg.2);
+                    layout.set_text(opt);
+                    let (ow, oh) = layout.pixel_size();
+                    cr.move_to(ix, (y_off + (row_h - oh as f64) / 2.0).round());
+                    pcfn::show_layout(cr, layout);
+                    ix += ow as f64;
+                }
+
+                // Closing bracket.
+                cr.set_source_rgb(dim.0, dim.1, dim.2);
+                layout.set_text("]");
+                let (_, rh) = layout.pixel_size();
+                cr.move_to(ix, (y_off + (row_h - rh as f64) / 2.0).round());
+                pcfn::show_layout(cr, layout);
+            }
+        }
+
+        // ── Validation indicator ────────────────────────────────────────
+        if let Some(ref vs) = field.validation {
+            let (indicator_color, msg) = match vs {
+                ValidationState::Error(msg) => (error, msg.as_str()),
+                ValidationState::Warning(msg) => (warning, msg.as_str()),
+            };
+            // Small 3x3 px colored rectangle at the left edge, vertically centered.
+            cr.set_source_rgb(indicator_color.0, indicator_color.1, indicator_color.2);
+            cr.rectangle(x + 2.0, y_off + (row_h - 3.0) / 2.0, 3.0, 3.0);
+            cr.fill().ok();
+
+            // Render error/warning message text in the indicator color.
+            if !msg.is_empty() {
+                layout.set_text(msg);
+                let (_, msg_h) = layout.pixel_size();
+                let msg_x = x + 8.0;
+                let msg_y = (y_off + (row_h + msg_h as f64) / 2.0 + 1.0).round();
+                cr.move_to(msg_x, msg_y);
+                pcfn::show_layout(cr, layout);
             }
         }
 

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -153,7 +153,7 @@ pub use primitives::find_replace::{
 };
 pub use primitives::form::{
     ButtonRowItem, FieldKind, Form, FormEvent, FormField, FormFieldMeasure, FormHit,
-    FormItemMeasure, FormLayout, ToggleGroupItem, VisibleFormField,
+    FormItemMeasure, FormLayout, ToggleGroupItem, ValidationState, VisibleFormField,
 };
 pub use primitives::list::{
     ListItem, ListItemMeasure, ListView, ListViewEvent, ListViewHit, ListViewLayout,
@@ -334,6 +334,7 @@ mod tests {
                     kind: FieldKind::Label,
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("line-numbers"),
@@ -341,6 +342,7 @@ mod tests {
                     kind: FieldKind::Toggle { value: true },
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("tabstop"),
@@ -353,6 +355,7 @@ mod tests {
                     },
                     hint: StyledText::plain("Number of spaces per tab"),
                     disabled: false,
+                    validation: None,
                 },
                 FormField {
                     id: WidgetId::new("save"),
@@ -360,6 +363,7 @@ mod tests {
                     kind: FieldKind::Button,
                     hint: StyledText::default(),
                     disabled: false,
+                    validation: None,
                 },
             ],
             focused_field: Some(WidgetId::new("line-numbers")),
@@ -1573,6 +1577,7 @@ mod tests {
             },
             hint: StyledText::plain("Editor font size in px"),
             disabled: false,
+            validation: None,
         };
         let json = serde_json::to_string(&field).unwrap();
         let back: FormField = serde_json::from_str(&json).unwrap();
@@ -1589,6 +1594,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         };
         let json = serde_json::to_string(&field).unwrap();
         let back: FormField = serde_json::from_str(&json).unwrap();
@@ -1610,6 +1616,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         };
         let json = serde_json::to_string(&field).unwrap();
         let back: FormField = serde_json::from_str(&json).unwrap();
@@ -1653,6 +1660,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         };
         let json = serde_json::to_string(&field).unwrap();
         let back: FormField = serde_json::from_str(&json).unwrap();
@@ -1680,6 +1688,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         };
         let json = serde_json::to_string(&field).unwrap();
         let back: FormField = serde_json::from_str(&json).unwrap();
@@ -2672,6 +2681,7 @@ mod tests {
             kind,
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         }
     }
 
@@ -3989,6 +3999,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         };
         let json = serde_json::to_string(&field).unwrap();
         let back: FormField = serde_json::from_str(&json).unwrap();

--- a/quadraui/src/primitives/form.rs
+++ b/quadraui/src/primitives/form.rs
@@ -63,6 +63,13 @@ pub struct Form {
     pub has_focus: bool,
 }
 
+/// Validation state rendered as a colored indicator + message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ValidationState {
+    Error(String),
+    Warning(String),
+}
+
 /// One row in a `Form`: a label + an input.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FormField {
@@ -78,6 +85,10 @@ pub struct FormField {
     /// When true, the field is rendered dimmed and will not emit events.
     #[serde(default)]
     pub disabled: bool,
+    /// When set, backends render a red/yellow indicator + message.
+    /// Overrides `hint` visually when present.
+    #[serde(default)]
+    pub validation: Option<ValidationState>,
 }
 
 /// The input variant carried by a `FormField`.
@@ -153,6 +164,37 @@ pub enum FieldKind {
         options: Vec<StyledText>,
         selected_idx: usize,
     },
+    /// Multi-line text editing area. `visible_rows` controls the height
+    /// hint (number of rows rendered). Emits `FormEvent::TextInputChanged`
+    /// and `TextInputCommitted` like `TextInput`.
+    TextArea {
+        value: String,
+        #[serde(default)]
+        placeholder: String,
+        #[serde(default)]
+        cursor: Option<usize>,
+        #[serde(default = "textarea_default_rows")]
+        visible_rows: usize,
+    },
+    /// Masked single-line text input. Characters display as `mask_char`
+    /// (default `'•'`). Value is stored in plaintext; only rendering is
+    /// masked. Emits the same events as `TextInput`.
+    PasswordInput {
+        value: String,
+        #[serde(default)]
+        placeholder: String,
+        #[serde(default)]
+        cursor: Option<usize>,
+        #[serde(default = "password_default_mask")]
+        mask_char: char,
+    },
+    /// Horizontal row of N options where exactly one is selected.
+    /// All options are visible (unlike Dropdown). Click selects; emits
+    /// `FormEvent::SegmentedControlChanged`.
+    SegmentedControl {
+        options: Vec<String>,
+        selected_idx: usize,
+    },
     /// Horizontal row of named boolean toggles. Each toggle has its own
     /// `WidgetId`, label, and value. Click toggles the value; emits
     /// `FormEvent::ToggleChanged { id, value }` with the individual
@@ -189,6 +231,14 @@ pub struct ButtonRowItem {
 
 fn slider_default_step() -> f32 {
     1.0
+}
+
+fn textarea_default_rows() -> usize {
+    3
+}
+
+fn password_default_mask() -> char {
+    '•'
 }
 
 // ── D6 Layout API ───────────────────────────────────────────────────────────
@@ -388,6 +438,8 @@ pub enum FormEvent {
     ColorChanged { id: WidgetId, value: crate::Color },
     /// A `Dropdown` field committed a new selection.
     DropdownChanged { id: WidgetId, selected_idx: usize },
+    /// A `SegmentedControl` field committed a new selection.
+    SegmentedControlChanged { id: WidgetId, selected_idx: usize },
     /// Keyboard focus moved to a different field.
     FocusChanged { id: WidgetId },
     /// A `Button` was clicked or activated with Enter / Space.

--- a/quadraui/src/tui/form.rs
+++ b/quadraui/src/tui/form.rs
@@ -1126,4 +1126,222 @@ mod tests {
         let bracket_fg = buf[(all_col, 0u16)].fg;
         assert_eq!(bracket_fg, ratatui::style::Color::Rgb(80, 80, 80));
     }
+
+    // ── PasswordInput round-trip ──────────────────────────────────────
+
+    #[test]
+    fn password_input_paints_mask_chars() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 3));
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("pw"),
+                label: label("Token"),
+                kind: FieldKind::PasswordInput {
+                    value: "secret".into(),
+                    placeholder: String::new(),
+                    cursor: None,
+                    mask_char: '•',
+                },
+                hint: label(""),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        draw_form(&mut buf, Rect::new(0, 0, 40, 3), &form, &Theme::default());
+        let row: String = (0..40).map(|x| cell_char(&buf, x, 0)).collect();
+        assert!(
+            row.contains("••••••"),
+            "password should show mask chars, got: {row:?}"
+        );
+        assert!(
+            !row.contains("secret"),
+            "password should NOT show plaintext, got: {row:?}"
+        );
+    }
+
+    #[test]
+    fn password_input_shows_placeholder_when_empty() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 3));
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("pw"),
+                label: label(""),
+                kind: FieldKind::PasswordInput {
+                    value: String::new(),
+                    placeholder: "Enter key".into(),
+                    cursor: None,
+                    mask_char: '•',
+                },
+                hint: label(""),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        draw_form(&mut buf, Rect::new(0, 0, 40, 3), &form, &Theme::default());
+        let row: String = (0..40).map(|x| cell_char(&buf, x, 0)).collect();
+        assert!(
+            row.contains("Enter key"),
+            "empty password should show placeholder, got: {row:?}"
+        );
+    }
+
+    // ── SegmentedControl round-trip ───────────────────────────────────
+
+    #[test]
+    fn segmented_control_paints_all_options() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 3));
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("scope"),
+                label: label(""),
+                kind: FieldKind::SegmentedControl {
+                    options: vec!["Ws".into(), "File".into(), "Sel".into()],
+                    selected_idx: 1,
+                },
+                hint: label(""),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        draw_form(&mut buf, Rect::new(0, 0, 40, 3), &form, &Theme::default());
+        let row: String = (0..40).map(|x| cell_char(&buf, x, 0)).collect();
+        assert!(row.contains("Ws"), "should paint 'Ws', got: {row:?}");
+        assert!(row.contains("File"), "should paint 'File', got: {row:?}");
+        assert!(row.contains("Sel"), "should paint 'Sel', got: {row:?}");
+    }
+
+    #[test]
+    fn segmented_control_hit_test_returns_item_id() {
+        use crate::primitives::form::FormHit;
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("scope"),
+                label: label(""),
+                kind: FieldKind::SegmentedControl {
+                    options: vec!["Ws".into(), "File".into()],
+                    selected_idx: 0,
+                },
+                hint: label(""),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        let layout = tui_form_layout(&form, Rect::new(0, 0, 40, 3));
+        let vis = &layout.visible_fields[0];
+        assert!(
+            vis.item_bounds.len() >= 2,
+            "SegmentedControl should have per-item bounds"
+        );
+        let (id0, rect0) = &vis.item_bounds[0];
+        assert_eq!(id0, &WidgetId::new("scope__seg_0"));
+        let hit = layout.hit_test(rect0.x + 1.0, rect0.y + 0.5);
+        assert_eq!(hit, FormHit::Field(WidgetId::new("scope__seg_0")));
+    }
+
+    // ── TextArea round-trip ──────────────────────────────────────────
+
+    #[test]
+    fn textarea_paints_multi_row() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 6));
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("desc"),
+                label: label("Desc"),
+                kind: FieldKind::TextArea {
+                    value: "line one content here".into(),
+                    placeholder: String::new(),
+                    cursor: None,
+                    visible_rows: 3,
+                },
+                hint: label(""),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        draw_form(&mut buf, Rect::new(0, 0, 40, 6), &form, &Theme::default());
+        let layout = tui_form_layout(&form, Rect::new(0, 0, 40, 6));
+        assert_eq!(
+            layout.visible_fields[0].bounds.height, 3.0,
+            "TextArea with visible_rows=3 should be 3 cells tall"
+        );
+    }
+
+    // ── ValidationState round-trip ───────────────────────────────────
+
+    #[test]
+    fn validation_error_paints_indicator() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 3));
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("name"),
+                label: label("Name"),
+                kind: FieldKind::TextInput {
+                    value: String::new(),
+                    placeholder: String::new(),
+                    cursor: None,
+                    selection_anchor: None,
+                },
+                hint: label(""),
+                disabled: false,
+                validation: Some(ValidationState::Error("Required".into())),
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        draw_form(&mut buf, Rect::new(0, 0, 40, 3), &form, &Theme::default());
+        let col0 = cell_char(&buf, 0, 0);
+        assert_eq!(col0, '!', "error validation should paint '!' at col 0");
+    }
+
+    #[test]
+    fn validation_warning_paints_indicator() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 3));
+        let form = Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("name"),
+                label: label("Name"),
+                kind: FieldKind::TextInput {
+                    value: "ab".into(),
+                    placeholder: String::new(),
+                    cursor: None,
+                    selection_anchor: None,
+                },
+                hint: label(""),
+                disabled: false,
+                validation: Some(ValidationState::Warning("Too short".into())),
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        draw_form(&mut buf, Rect::new(0, 0, 40, 3), &form, &Theme::default());
+        let col0 = cell_char(&buf, 0, 0);
+        assert_eq!(
+            col0, '\u{26A0}',
+            "warning validation should paint warning sign at col 0"
+        );
+    }
 }

--- a/quadraui/src/tui/form.rs
+++ b/quadraui/src/tui/form.rs
@@ -8,9 +8,11 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 
 use super::{draw_styled_text, ratatui_color, set_cell};
-use crate::primitives::form::{FieldKind, Form, FormFieldMeasure, FormItemMeasure};
+use crate::primitives::form::{
+    FieldKind, Form, FormFieldMeasure, FormItemMeasure, ValidationState,
+};
 use crate::theme::Theme;
-use crate::types::Decoration;
+use crate::types::{Decoration, WidgetId};
 
 /// Compute the form layout using TUI cell metrics (1 cell per row,
 /// char-count item widths).
@@ -42,6 +44,20 @@ pub fn tui_form_layout(form: &Form, area: Rect) -> crate::primitives::form::Form
                     .collect();
                 FormFieldMeasure::with_items(1.0, start_x as f32, 1.0, items)
             }
+            FieldKind::TextArea { visible_rows, .. } => FormFieldMeasure::new(*visible_rows as f32),
+            FieldKind::SegmentedControl { options, .. } => {
+                let label_w = field.label.visible_width();
+                let start_x = if label_w > 0 { label_w + 2 } else { 1 };
+                let items = options
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, opt)| FormItemMeasure {
+                        id: WidgetId::new(format!("{}__seg_{}", field.id.as_str(), idx)),
+                        width: opt.chars().count() as f32,
+                    })
+                    .collect();
+                FormFieldMeasure::with_items(1.0, start_x as f32, 1.0, items)
+            }
             _ => FormFieldMeasure::new(1.0),
         }
     })
@@ -60,6 +76,8 @@ pub fn draw_form(buf: &mut Buffer, area: Rect, form: &Form, theme: &Theme) {
     let sel_bg = ratatui_color(theme.selected_bg);
     let dim_fg = ratatui_color(theme.muted_fg);
     let accent_fg = ratatui_color(theme.accent_fg);
+    let error_fg = ratatui_color(theme.error_fg);
+    let warning_fg = ratatui_color(theme.warning_fg);
 
     let layout = tui_form_layout(form, area);
 
@@ -391,6 +409,209 @@ pub fn draw_form(buf: &mut Buffer, area: Rect, form: &Form, theme: &Theme) {
                     }
                 }
             }
+            FieldKind::TextArea {
+                value,
+                placeholder,
+                cursor,
+                visible_rows,
+            } => {
+                let shown = if value.is_empty() {
+                    placeholder.as_str()
+                } else {
+                    value.as_str()
+                };
+                let input_fg = if value.is_empty() { dim_fg } else { field_fg };
+                let rows = *visible_rows;
+
+                // Paint each row of the text area.
+                let avail_w = (area.width as usize).saturating_sub(2); // inside brackets
+                let mut chars_iter = shown.chars();
+                for row in 0..rows {
+                    let row_y = y + row as u16;
+                    if row_y >= area.y + area.height {
+                        break;
+                    }
+                    // Clear the row background (rows > 0 weren't cleared by
+                    // the initial row-clear above).
+                    if row > 0 {
+                        for x in area.x..area.x + area.width {
+                            set_cell(buf, x, row_y, ' ', default_fg, row_bg);
+                        }
+                    }
+
+                    // Left bracket on first column.
+                    set_cell(buf, area.x, row_y, '[', dim_fg, row_bg);
+
+                    // Content characters for this row.
+                    let mut col = 1usize;
+                    for _ in 0..avail_w {
+                        if let Some(ch) = chars_iter.next() {
+                            if col < area.width as usize {
+                                set_cell(buf, area.x + col as u16, row_y, ch, input_fg, row_bg);
+                            }
+                            col += 1;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // Right bracket at last column.
+                    let bracket_col = (area.width as usize).saturating_sub(1);
+                    if bracket_col < area.width as usize {
+                        set_cell(buf, area.x + bracket_col as u16, row_y, ']', dim_fg, row_bg);
+                    }
+                }
+
+                // Cursor rendering on the first row (same logic as TextInput).
+                if let Some(cur) = cursor {
+                    if !value.is_empty() {
+                        let mut byte = 0usize;
+                        let mut char_idx = 0usize;
+                        for ch in value.chars().take(avail_w) {
+                            if byte >= *cur {
+                                break;
+                            }
+                            byte += ch.len_utf8();
+                            char_idx += 1;
+                        }
+                        let cursor_col = 1 + char_idx;
+                        if cursor_col < area.width as usize {
+                            let ch = value.chars().nth(char_idx).unwrap_or(' ');
+                            set_cell(buf, area.x + cursor_col as u16, y, ch, row_bg, field_fg);
+                        }
+                    }
+                }
+            }
+            FieldKind::PasswordInput {
+                value,
+                placeholder,
+                cursor,
+                mask_char,
+            } => {
+                // Mask the value: replace each character with mask_char.
+                let masked: String = value.chars().map(|_| *mask_char).collect();
+                let shown = if value.is_empty() {
+                    placeholder.as_str()
+                } else {
+                    masked.as_str()
+                };
+                let input_fg = if value.is_empty() { dim_fg } else { field_fg };
+
+                let (start_col, desired) = if no_label {
+                    let sc = 1usize;
+                    let avail = (area.width as usize).saturating_sub(sc + 2);
+                    (sc, shown.chars().count().min(avail))
+                } else {
+                    let max_input = (area.width as usize * 2 / 3).max(10);
+                    let d = shown.chars().count().min(max_input);
+                    let sc = (area.width as usize).saturating_sub(d + 2);
+                    (sc, d)
+                };
+
+                if start_col > label_end + 1 || no_label {
+                    if start_col > 0 && start_col - 1 < area.width as usize {
+                        set_cell(buf, area.x + (start_col - 1) as u16, y, '[', dim_fg, row_bg);
+                    }
+                    let mut col = start_col;
+                    for ch in shown.chars().take(desired) {
+                        if col >= area.width as usize {
+                            break;
+                        }
+                        set_cell(buf, area.x + col as u16, y, ch, input_fg, row_bg);
+                        col += 1;
+                    }
+                    let bracket_col = if no_label {
+                        (area.width as usize).saturating_sub(1)
+                    } else {
+                        col
+                    };
+                    if bracket_col < area.width as usize {
+                        set_cell(buf, area.x + bracket_col as u16, y, ']', dim_fg, row_bg);
+                    }
+
+                    // Cursor (byte offset into original value, rendered at
+                    // the masked character position).
+                    if let Some(cur) = cursor {
+                        if !value.is_empty() {
+                            let mut byte = 0usize;
+                            let mut char_idx = 0usize;
+                            for ch in value.chars().take(desired) {
+                                if byte >= *cur {
+                                    break;
+                                }
+                                byte += ch.len_utf8();
+                                char_idx += 1;
+                            }
+                            let cursor_col = start_col + char_idx;
+                            if cursor_col < area.width as usize {
+                                let ch = masked.chars().nth(char_idx).unwrap_or(' ');
+                                set_cell(buf, area.x + cursor_col as u16, y, ch, row_bg, field_fg);
+                            }
+                        }
+                    }
+                }
+            }
+            FieldKind::SegmentedControl {
+                options,
+                selected_idx,
+            } => {
+                // Render as [opt1|opt2|opt3] using item_bounds for positioning.
+                // If item_bounds are available, use them; otherwise fall back to
+                // sequential rendering.
+                if !visible_field.item_bounds.is_empty() {
+                    // Opening bracket before first item.
+                    let first_x = visible_field.item_bounds[0].1.x;
+                    let bracket_x = (area.x as f32 + first_x - 1.0).max(area.x as f32);
+                    if (bracket_x as u16) < area.x + area.width {
+                        set_cell(buf, bracket_x as u16, y, '[', dim_fg, row_bg);
+                    }
+
+                    for (i, (_item_id, item_rect)) in visible_field.item_bounds.iter().enumerate() {
+                        let opt = options.get(i).map(|s| s.as_str()).unwrap_or("");
+                        let opt_fg = if i == *selected_idx {
+                            accent_fg
+                        } else {
+                            dim_fg
+                        };
+                        let col = area.x as f32 + item_rect.x;
+                        for (j, ch) in opt.chars().enumerate() {
+                            let cx = col as u16 + j as u16;
+                            if cx < area.x + area.width {
+                                set_cell(buf, cx, y, ch, opt_fg, row_bg);
+                            }
+                        }
+
+                        // Separator '|' after each option except the last.
+                        if i + 1 < options.len() {
+                            let sep_x = col as u16 + opt.chars().count() as u16;
+                            if sep_x < area.x + area.width {
+                                set_cell(buf, sep_x, y, '|', dim_fg, row_bg);
+                            }
+                        }
+                    }
+
+                    // Closing bracket after last item.
+                    if let Some((_last_id, last_rect)) = visible_field.item_bounds.last() {
+                        let last_opt_len = options.last().map(|s| s.chars().count()).unwrap_or(0);
+                        let close_x = area.x as f32 + last_rect.x + last_opt_len as f32;
+                        if (close_x as u16) < area.x + area.width {
+                            set_cell(buf, close_x as u16, y, ']', dim_fg, row_bg);
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Validation indicator ─────────────────────────────────────
+        // Render a colored prefix character at column 0 on the field's
+        // first row. This avoids adding extra rows that would break TUI
+        // layout (all non-TextArea fields are 1 cell tall).
+        if let Some(ref vs) = field.validation {
+            let (indicator, v_fg) = match vs {
+                ValidationState::Error(_) => ('!', error_fg),
+                ValidationState::Warning(_) => ('\u{26A0}', warning_fg),
+            };
+            set_cell(buf, area.x, y, indicator, v_fg, row_bg);
         }
     }
 }
@@ -505,6 +726,7 @@ mod tests {
                     label: label("Editor"),
                     kind: FieldKind::Label,
                     disabled: false,
+                    validation: None,
                     hint: label(""),
                 },
                 FormField {
@@ -512,6 +734,7 @@ mod tests {
                     label: label("wrap"),
                     kind: FieldKind::Toggle { value: true },
                     disabled: false,
+                    validation: None,
                     hint: label(""),
                 },
             ],
@@ -600,6 +823,7 @@ mod tests {
                     selection_anchor: None,
                 },
                 disabled: false,
+                validation: None,
                 hint: label(""),
             }],
             focused_field: None,
@@ -648,6 +872,7 @@ mod tests {
                     ],
                 },
                 disabled: false,
+                validation: None,
                 hint: label(""),
             }],
             focused_field: None,
@@ -765,6 +990,7 @@ mod tests {
                     ],
                 },
                 disabled: false,
+                validation: None,
                 hint: label(""),
             }],
             focused_field: None,

--- a/quadraui/src/tui/multi_section_view.rs
+++ b/quadraui/src/tui/multi_section_view.rs
@@ -2235,6 +2235,7 @@ mod tests {
                 },
                 hint: StyledText::default(),
                 disabled: false,
+                validation: None,
             },
             FormField {
                 id: WidgetId::new("case"),
@@ -2242,6 +2243,7 @@ mod tests {
                 kind: FieldKind::Toggle { value: true },
                 hint: StyledText::default(),
                 disabled: false,
+                validation: None,
             },
         ];
 
@@ -2350,6 +2352,7 @@ mod tests {
             },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         }];
 
         let v = view_with(vec![form_section("opts", fields, SectionSize::EqualShare)]);
@@ -2406,6 +2409,7 @@ mod tests {
             kind: FieldKind::Toggle { value: true },
             hint: StyledText::default(),
             disabled: false,
+            validation: None,
         }];
 
         let v = view_with(vec![form_section("opts", fields, SectionSize::EqualShare)]);


### PR DESCRIPTION
## Summary

Four additions to the Form primitive:

- **`FieldKind::TextArea`** — multi-line text editing with `visible_rows` height hint. TUI renders as bordered multi-row box; GTK renders first line (multi-row GTK is a future enhancement).
- **`FieldKind::PasswordInput`** — masked single-line input. Renders `mask_char` (default `'•'`) instead of value characters. Same events as TextInput.
- **`FieldKind::SegmentedControl`** — horizontal exclusive-choice selector `[opt1|opt2|opt3]`. Selected option in accent color. Emits `FormEvent::SegmentedControlChanged { id, selected_idx }`.
- **`FormField.validation: Option<ValidationState>`** — `Error(msg)` / `Warning(msg)` rendered as colored indicator. TUI: `!` or `⚠` at column 0. GTK: 3px colored dot + message text.

## Changes

| File | What |
|---|---|
| `primitives/form.rs` | New `FieldKind` variants, `ValidationState` enum, `FormEvent::SegmentedControlChanged`, helper fns |
| `tui/form.rs` | TUI rasteriser + layout measurement for all 4 |
| `gtk/form.rs` | GTK rasteriser for all 4 |
| `compose/sidebar_system.rs` | `form_click_event` + `form_field_measure` handle SegmentedControl + TextArea |
| `lib.rs` | Re-export `ValidationState` |
| Examples + tests | `validation: None` added to all existing `FormField` literals |

## Test plan

- [x] 558 tests pass (TUI + GTK)
- [x] Clippy clean, fmt clean
- [x] Existing Form rendering unchanged (all prior tests pass)
- [ ] Manual smoke test with `gtk_sidebar_search` — extend to include new field kinds (follow-up)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)