### PR TITLE
feat(quadraui): Palette preview pane + tree-indented items (#122)

### DIFF
--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -177,7 +177,7 @@ pub use primitives::multi_section_view::{
 };
 pub use primitives::palette::{
     Palette, PaletteEvent, PaletteHit, PaletteItem, PaletteItemMeasure, PaletteLayout,
-    VisiblePaletteItem,
+    PalettePreview, VisiblePaletteItem,
 };
 pub use primitives::panel::{
     Panel, PanelAction, PanelEvent, PanelHit, PanelLayout, PanelMeasure, VisiblePanelAction,
@@ -455,18 +455,25 @@ mod tests {
                     detail: Some(StyledText::plain("Ctrl+O")),
                     icon: None,
                     match_positions: vec![0, 1, 2, 3],
+                    depth: 0,
+                    expandable: false,
+                    expanded: false,
                 },
                 PaletteItem {
                     text: StyledText::plain("Open Recent"),
                     detail: None,
                     icon: None,
                     match_positions: vec![0, 1, 2, 3],
+                    depth: 0,
+                    expandable: false,
+                    expanded: false,
                 },
             ],
             selected_idx: 0,
             scroll_offset: 0,
             total_count: 42,
             has_focus: true,
+            preview: None,
         };
         let json = serde_json::to_string(&palette).unwrap();
         let back: Palette = serde_json::from_str(&json).unwrap();
@@ -2801,6 +2808,9 @@ mod tests {
             detail: None,
             icon: None,
             match_positions: vec![],
+            depth: 0,
+            expandable: false,
+            expanded: false,
         }
     }
 
@@ -2821,6 +2831,7 @@ mod tests {
             scroll_offset: scroll,
             total_count: 0,
             has_focus: true,
+            preview: None,
         }
     }
 
@@ -2901,6 +2912,66 @@ mod tests {
         assert_eq!(layout.query_bounds.unwrap().height, 40.0);
         assert_eq!(layout.visible_items[0].bounds.y, 72.0);
         assert_eq!(layout.visible_items[0].bounds.height, 24.0);
+    }
+
+    #[test]
+    fn palette_layout_with_preview_splits_width() {
+        let mut p = make_palette("Files", "", vec![make_palette_item("main.rs")], 0, 0);
+        p.preview = Some(primitives::palette::PalettePreview {
+            lines: vec![StyledText::plain("fn main() {}")],
+            title: Some("main.rs".into()),
+            scroll_offset: 0,
+            highlight_line: None,
+        });
+        let layout = p.layout(100.0, 50.0, 1.0, 1.0, |_| PaletteItemMeasure::new(1.0));
+        assert_eq!(layout.item_list_width, 40.0);
+        assert_eq!(layout.visible_items[0].bounds.width, 40.0);
+        let pb = layout.preview_bounds.unwrap();
+        assert_eq!(pb.x, 40.0);
+        assert_eq!(pb.width, 60.0);
+        assert_eq!(pb.y, 2.0);
+        assert_eq!(pb.height, 48.0);
+    }
+
+    #[test]
+    fn palette_layout_without_preview_full_width() {
+        let p = make_palette("Cmd", "", vec![make_palette_item("foo")], 0, 0);
+        let layout = p.layout(100.0, 50.0, 1.0, 1.0, |_| PaletteItemMeasure::new(1.0));
+        assert_eq!(layout.item_list_width, 100.0);
+        assert!(layout.preview_bounds.is_none());
+        assert_eq!(layout.visible_items[0].bounds.width, 100.0);
+    }
+
+    #[test]
+    fn palette_preview_hit_test() {
+        let mut p = make_palette("Files", "", vec![make_palette_item("a.rs")], 0, 0);
+        p.preview = Some(primitives::palette::PalettePreview {
+            lines: vec![],
+            title: None,
+            scroll_offset: 0,
+            highlight_line: None,
+        });
+        let layout = p.layout(100.0, 50.0, 1.0, 1.0, |_| PaletteItemMeasure::new(1.0));
+        assert_eq!(layout.hit_test(50.0, 10.0), PaletteHit::Preview);
+        assert_eq!(layout.hit_test(10.0, 2.5), PaletteHit::Item(0));
+    }
+
+    #[test]
+    fn palette_tree_item_serde_round_trip() {
+        let item = primitives::palette::PaletteItem {
+            text: StyledText::plain("src/"),
+            detail: None,
+            icon: None,
+            match_positions: vec![],
+            depth: 2,
+            expandable: true,
+            expanded: true,
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        let back: primitives::palette::PaletteItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.depth, 2);
+        assert!(back.expandable);
+        assert!(back.expanded);
     }
 
     // ── D6 ActivityBar layout API tests ───────────────────────────────

--- a/quadraui/src/primitives/palette.rs
+++ b/quadraui/src/primitives/palette.rs
@@ -61,6 +61,10 @@ pub struct Palette {
     pub total_count: usize,
     #[serde(default)]
     pub has_focus: bool,
+    /// When present, the palette renders a split layout: item list on
+    /// the left, preview content on the right.
+    #[serde(default)]
+    pub preview: Option<PalettePreview>,
 }
 
 /// One row in a `Palette`'s filtered result list.
@@ -81,6 +85,33 @@ pub struct PaletteItem {
     /// text. Empty means "no fuzzy-match highlighting".
     #[serde(default)]
     pub match_positions: Vec<usize>,
+    /// Indentation level for tree-structured items. `0` = top level.
+    /// Backends render `depth * indent_width` leading space.
+    #[serde(default)]
+    pub depth: usize,
+    /// Whether this item shows an expand/collapse arrow.
+    #[serde(default)]
+    pub expandable: bool,
+    /// Arrow direction when `expandable` is true (`▾` vs `▸`).
+    #[serde(default)]
+    pub expanded: bool,
+}
+
+/// Preview pane content shown alongside the item list when the palette
+/// operates in split-layout mode (file pickers, symbol pickers).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PalettePreview {
+    /// Syntax-highlighted content lines.
+    pub lines: Vec<StyledText>,
+    /// Optional title shown above the preview content (e.g. file path).
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Scroll offset into `lines`.
+    #[serde(default)]
+    pub scroll_offset: usize,
+    /// Line to visually highlight (e.g. the matched line in a search).
+    #[serde(default)]
+    pub highlight_line: Option<usize>,
 }
 
 // ── D6 Layout API ───────────────────────────────────────────────────────────
@@ -116,12 +147,14 @@ pub struct VisiblePaletteItem {
 pub enum PaletteHit {
     /// Click landed on the title chrome row (typically no-op).
     Title,
-    /// Click landed on the query input row. Apps typically focus the
-    /// query and may use the local x-offset (click_x - query_bounds.x)
-    /// to place the caret; the primitive doesn't resolve that in v1.
+    /// Click landed on the query input row.
     Query,
     /// Click landed on an item row.
     Item(usize),
+    /// Click landed on the expand/collapse arrow of a tree item.
+    ExpandToggle(usize),
+    /// Click landed on the preview pane area.
+    Preview,
     /// Click landed outside any region.
     Empty,
 }
@@ -140,6 +173,11 @@ pub struct PaletteLayout {
     pub hit_regions: Vec<(Rect, PaletteHit)>,
     /// Scroll offset actually used, clamped to `[0, items.len())`.
     pub resolved_scroll_offset: usize,
+    /// Width of the item list column. Equals `viewport_width` when no
+    /// preview is present; narrower (~40%) when a preview pane is shown.
+    pub item_list_width: f32,
+    /// Preview pane bounds, present when `Palette.preview` is `Some`.
+    pub preview_bounds: Option<Rect>,
 }
 
 impl PaletteLayout {
@@ -175,12 +213,18 @@ impl Palette {
     where
         F: Fn(usize) -> PaletteItemMeasure,
     {
+        let has_preview = self.preview.is_some();
+        let item_list_width = if has_preview {
+            (viewport_width * 0.4).round()
+        } else {
+            viewport_width
+        };
+
         let mut visible_items: Vec<VisiblePaletteItem> = Vec::new();
         let mut hit_regions: Vec<(Rect, PaletteHit)> = Vec::new();
 
         let mut y = 0.0_f32;
 
-        // Title row (optional).
         let title_bounds = if title_height > 0.0 && y < viewport_height {
             let h = title_height.min(viewport_height - y);
             let bounds = Rect::new(0.0, y, viewport_width, h);
@@ -191,7 +235,6 @@ impl Palette {
             None
         };
 
-        // Query input row (optional but usually present).
         let query_bounds = if query_height > 0.0 && y < viewport_height {
             let h = query_height.min(viewport_height - y);
             let bounds = Rect::new(0.0, y, viewport_width, h);
@@ -202,14 +245,14 @@ impl Palette {
             None
         };
 
-        // Clamp scroll_offset.
+        let items_top = y;
+
         let resolved_scroll_offset = if self.items.is_empty() {
             0
         } else {
             self.scroll_offset.min(self.items.len() - 1)
         };
 
-        // Items list.
         for i in resolved_scroll_offset..self.items.len() {
             if y >= viewport_height {
                 break;
@@ -220,7 +263,7 @@ impl Palette {
             if height <= 0.0 {
                 break;
             }
-            let bounds = Rect::new(0.0, y, viewport_width, height);
+            let bounds = Rect::new(0.0, y, item_list_width, height);
             visible_items.push(VisiblePaletteItem {
                 item_idx: i,
                 bounds,
@@ -228,6 +271,17 @@ impl Palette {
             hit_regions.push((bounds, PaletteHit::Item(i)));
             y += m.height;
         }
+
+        let preview_bounds = if has_preview {
+            let preview_x = item_list_width;
+            let preview_w = (viewport_width - item_list_width).max(0.0);
+            let preview_h = (viewport_height - items_top).max(0.0);
+            let bounds = Rect::new(preview_x, items_top, preview_w, preview_h);
+            hit_regions.push((bounds, PaletteHit::Preview));
+            Some(bounds)
+        } else {
+            None
+        };
 
         PaletteLayout {
             viewport_width,
@@ -237,6 +291,8 @@ impl Palette {
             visible_items,
             hit_regions,
             resolved_scroll_offset,
+            item_list_width,
+            preview_bounds,
         }
     }
 }
@@ -250,6 +306,8 @@ pub enum PaletteEvent {
     SelectionChanged { idx: usize },
     /// User confirmed the highlighted row (Enter or double-click).
     ItemConfirmed { idx: usize },
+    /// User toggled a tree item's expand/collapse state.
+    ExpandToggled { idx: usize, expanded: bool },
     /// Palette was dismissed (Escape, click outside, etc.).
     Closed,
     /// A key was pressed while the palette had focus and the primitive

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1325,6 +1325,9 @@ mod tests {
                     detail: None,
                     icon: None,
                     match_positions: Vec::new(),
+                    depth: 0,
+                    expandable: false,
+                    expanded: false,
                 },
                 PaletteItem {
                     text: StyledText {
@@ -1333,12 +1336,16 @@ mod tests {
                     detail: None,
                     icon: None,
                     match_positions: Vec::new(),
+                    depth: 0,
+                    expandable: false,
+                    expanded: false,
                 },
             ],
             selected_idx: 0,
             scroll_offset: 0,
             total_count: 2,
             has_focus: true,
+            preview: None,
         }
     }
 

--- a/quadraui/src/tui/palette.rs
+++ b/quadraui/src/tui/palette.rs
@@ -310,6 +310,9 @@ mod tests {
             detail: None,
             icon: None,
             match_positions: Vec::new(),
+            depth: 0,
+            expandable: false,
+            expanded: false,
         }
     }
 
@@ -324,6 +327,7 @@ mod tests {
             scroll_offset: 0,
             has_focus: true,
             total_count: 3,
+            preview: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `PalettePreview` struct (styled lines, title, scroll offset, highlight line)
- Add `preview: Option<PalettePreview>` to `Palette` — when present, layout splits 40/60 (item list / preview)
- Add `depth`, `expandable`, `expanded` fields to `PaletteItem` for tree-structured pickers (symbol picker, file tree)
- Add `PaletteHit::ExpandToggle(usize)` and `PaletteHit::Preview` hit variants
- Add `PaletteEvent::ExpandToggled { idx, expanded }` event variant
- `PaletteLayout` gains `item_list_width` and `preview_bounds: Option<Rect>`
- All new fields use `#[serde(default)]` for backward compatibility
- `match_positions` was already implemented — no change needed there

## Test plan

- [x] `palette_layout_with_preview_splits_width` — item list gets 40%, preview gets 60%
- [x] `palette_layout_without_preview_full_width` — no regression: items span full width
- [x] `palette_preview_hit_test` — click routing to Preview vs Item
- [x] `palette_tree_item_serde_round_trip` — depth/expandable/expanded survive JSON round-trip
- [x] All 11 existing palette tests pass unchanged

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)