### PR TITLE
feat(quadraui): TerminalScrollbar inverted mode + configurable width (#131)

### DIFF
--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -741,7 +741,10 @@ impl Backend for GtkBackend {
             .current_frame_refs()
             .expect("GtkBackend::draw_terminal called outside enter_frame_scope");
 
-        let sb_width = if term.scrollbar.is_some() { lh } else { 0.0 };
+        let sb_width = match &term.scrollbar {
+            Some(sb) => sb.width.map(|w| w as f64).unwrap_or(8.0),
+            None => 0.0,
+        };
         let cell_area_w = (rect.width as f64 - sb_width).max(0.0);
 
         crate::gtk::draw_terminal_cells(
@@ -765,7 +768,7 @@ impl Backend for GtkBackend {
                     sb_width as f32,
                     rect.height,
                 ),
-                sb_state.scroll_offset as f32,
+                sb_state.effective_scroll_offset() as f32,
                 sb_state.total_lines as f32,
                 sb_state.visible_lines as f32,
                 lh as f32,

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -897,6 +897,8 @@ mod tests {
                 total_lines: 500,
                 visible_lines: 24,
                 scroll_offset: 100,
+                inverted: false,
+                width: None,
             }),
         };
         let json = serde_json::to_string(&term).unwrap();

--- a/quadraui/src/primitives/terminal.rs
+++ b/quadraui/src/primitives/terminal.rs
@@ -59,6 +59,31 @@ pub struct TerminalScrollbar {
     pub total_lines: usize,
     pub visible_lines: usize,
     pub scroll_offset: usize,
+    /// When `true`, `scroll_offset = 0` means "at the bottom" (live
+    /// view) and increasing offset scrolls up into history. The
+    /// rasteriser flips the offset before constructing the visual
+    /// scrollbar so the thumb sits at the bottom when offset is 0.
+    #[serde(default)]
+    pub inverted: bool,
+    /// Scrollbar width in surface-native units (pixels for GTK, cells
+    /// for TUI). When `None`, the rasteriser picks a default (8px GTK,
+    /// 1 cell TUI).
+    #[serde(default)]
+    pub width: Option<u16>,
+}
+
+impl TerminalScrollbar {
+    /// Scroll offset suitable for `Scrollbar::vertical`. When
+    /// `inverted`, flips so offset 0 maps to the track bottom.
+    pub fn effective_scroll_offset(&self) -> usize {
+        if self.inverted {
+            self.total_lines
+                .saturating_sub(self.visible_lines)
+                .saturating_sub(self.scroll_offset)
+        } else {
+            self.scroll_offset
+        }
+    }
 }
 
 /// One styled cell in a `Terminal`. Carries the rendered character, RGB
@@ -351,5 +376,68 @@ mod tests {
         assert_eq!(sl.hit_test(50.0, 5.0), TerminalSplitHit::Right);
         assert_eq!(sl.hit_test(50.0, 30.0), TerminalSplitHit::Outside);
         assert_eq!(sl.hit_test(-1.0, 5.0), TerminalSplitHit::Outside);
+    }
+
+    #[test]
+    fn effective_scroll_offset_non_inverted() {
+        let sb = TerminalScrollbar {
+            total_lines: 500,
+            visible_lines: 24,
+            scroll_offset: 100,
+            inverted: false,
+            width: None,
+        };
+        assert_eq!(sb.effective_scroll_offset(), 100);
+    }
+
+    #[test]
+    fn effective_scroll_offset_inverted_at_bottom() {
+        let sb = TerminalScrollbar {
+            total_lines: 500,
+            visible_lines: 24,
+            scroll_offset: 0,
+            inverted: true,
+            width: None,
+        };
+        // offset 0 = live view → thumb at bottom → effective = max
+        assert_eq!(sb.effective_scroll_offset(), 476);
+    }
+
+    #[test]
+    fn effective_scroll_offset_inverted_at_top() {
+        let sb = TerminalScrollbar {
+            total_lines: 500,
+            visible_lines: 24,
+            scroll_offset: 476,
+            inverted: true,
+            width: None,
+        };
+        // fully scrolled into history → thumb at top → effective = 0
+        assert_eq!(sb.effective_scroll_offset(), 0);
+    }
+
+    #[test]
+    fn effective_scroll_offset_inverted_midpoint() {
+        let sb = TerminalScrollbar {
+            total_lines: 500,
+            visible_lines: 24,
+            scroll_offset: 200,
+            inverted: true,
+            width: None,
+        };
+        assert_eq!(sb.effective_scroll_offset(), 276);
+    }
+
+    #[test]
+    fn effective_scroll_offset_inverted_no_overflow() {
+        let sb = TerminalScrollbar {
+            total_lines: 24,
+            visible_lines: 24,
+            scroll_offset: 0,
+            inverted: true,
+            width: None,
+        };
+        // total == visible → no scrollable range
+        assert_eq!(sb.effective_scroll_offset(), 0);
     }
 }

--- a/quadraui/src/tui/terminal.rs
+++ b/quadraui/src/tui/terminal.rs
@@ -22,7 +22,10 @@ pub fn draw_terminal(buf: &mut Buffer, area: Rect, term: &Terminal, theme: &Them
         return;
     }
 
-    let sb_cols: u16 = if term.scrollbar.is_some() { 1 } else { 0 };
+    let sb_cols: u16 = match &term.scrollbar {
+        Some(sb) => sb.width.unwrap_or(1),
+        None => 0,
+    };
     let cell_area_w = area.width.saturating_sub(sb_cols);
 
     for (row_idx, row) in term.cells.iter().enumerate() {
@@ -66,7 +69,7 @@ pub fn draw_terminal(buf: &mut Buffer, area: Rect, term: &Terminal, theme: &Them
         let sb = Scrollbar::vertical(
             term.id.clone(),
             track,
-            sb_state.scroll_offset as f32,
+            sb_state.effective_scroll_offset() as f32,
             sb_state.total_lines as f32,
             sb_state.visible_lines as f32,
             1.0,
@@ -95,6 +98,24 @@ fn resolve_cell_colors(
     }
 }
 
+/// Helper: find the top-most and bottom-most rows containing the thumb
+/// glyph (`█`) in the scrollbar column.
+#[cfg(test)]
+fn find_thumb_extent(buf: &Buffer, sb_col: u16, y0: u16, height: u16) -> Option<(u16, u16)> {
+    let mut first = None;
+    let mut last = None;
+    for dy in 0..height {
+        let y = y0 + dy;
+        if buf[(sb_col, y)].symbol() == "█" {
+            if first.is_none() {
+                first = Some(dy);
+            }
+            last = Some(dy);
+        }
+    }
+    first.zip(last)
+}
+
 /// Draw a vertical divider for a terminal split pane.
 /// Places `│` characters down the column at `x` using
 /// `theme.separator` colour.
@@ -108,5 +129,102 @@ pub fn draw_terminal_divider(buf: &mut Buffer, x: u16, y: u16, height: u16, them
             cell.set_char('│').set_fg(sep_fg).set_bg(sep_bg);
             cell.modifier = Modifier::empty();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::terminal::{TerminalCell, TerminalScrollbar};
+    use crate::types::Color;
+
+    fn blank_cell() -> TerminalCell {
+        TerminalCell {
+            ch: ' ',
+            fg: Color::rgb(200, 200, 200),
+            bg: Color::rgb(0, 0, 0),
+            bold: false,
+            italic: false,
+            underline: false,
+            selected: false,
+            is_cursor: false,
+            is_find_match: false,
+            is_find_active: false,
+        }
+    }
+
+    fn make_terminal(rows: usize, cols: usize, sb: Option<TerminalScrollbar>) -> Terminal {
+        let row = vec![blank_cell(); cols];
+        Terminal {
+            id: "test-term".into(),
+            cells: vec![row; rows],
+            scrollbar: sb,
+        }
+    }
+
+    #[test]
+    fn inverted_offset_zero_thumb_at_bottom() {
+        let sb = TerminalScrollbar {
+            total_lines: 500,
+            visible_lines: 20,
+            scroll_offset: 0,
+            inverted: true,
+            width: None,
+        };
+        let term = make_terminal(20, 39, Some(sb));
+        let area = Rect::new(0, 0, 40, 20);
+        let theme = Theme::default();
+        let mut buf = Buffer::empty(area);
+        draw_terminal(&mut buf, area, &term, &theme);
+
+        let (top, bot) = find_thumb_extent(&buf, 39, 0, 20).expect("thumb should be painted");
+        // effective_scroll_offset = 480 → thumb near track bottom
+        assert!(
+            bot >= 18,
+            "inverted offset=0: thumb bottom ({bot}) should be at/near row 19"
+        );
+        assert!(
+            top > 0,
+            "inverted offset=0: thumb top ({top}) should NOT be at row 0"
+        );
+    }
+
+    #[test]
+    fn inverted_offset_max_thumb_at_top() {
+        let sb = TerminalScrollbar {
+            total_lines: 500,
+            visible_lines: 20,
+            scroll_offset: 480,
+            inverted: true,
+            width: None,
+        };
+        let term = make_terminal(20, 39, Some(sb));
+        let area = Rect::new(0, 0, 40, 20);
+        let theme = Theme::default();
+        let mut buf = Buffer::empty(area);
+        draw_terminal(&mut buf, area, &term, &theme);
+
+        let (top, _bot) = find_thumb_extent(&buf, 39, 0, 20).expect("thumb should be painted");
+        // effective_scroll_offset = 0 → thumb at track top
+        assert_eq!(top, 0, "inverted offset=max: thumb should start at row 0");
+    }
+
+    #[test]
+    fn non_inverted_offset_zero_thumb_at_top() {
+        let sb = TerminalScrollbar {
+            total_lines: 500,
+            visible_lines: 20,
+            scroll_offset: 0,
+            inverted: false,
+            width: None,
+        };
+        let term = make_terminal(20, 39, Some(sb));
+        let area = Rect::new(0, 0, 40, 20);
+        let theme = Theme::default();
+        let mut buf = Buffer::empty(area);
+        draw_terminal(&mut buf, area, &term, &theme);
+
+        let (top, _bot) = find_thumb_extent(&buf, 39, 0, 20).expect("thumb should be painted");
+        assert_eq!(top, 0, "non-inverted offset=0: thumb should start at row 0");
     }
 }


### PR DESCRIPTION
## Summary
- Add `inverted: bool` to `TerminalScrollbar` — when true, `scroll_offset = 0` maps to the bottom (live view) and the rasteriser flips the thumb position via `effective_scroll_offset()`
- Add `width: Option<u16>` to `TerminalScrollbar` — consumers control scrollbar width in surface-native units (pixels for GTK, cells for TUI); defaults to 8px GTK / 1 cell TUI when `None`
- GTK scrollbar narrowed from `line_height` (~18px) to consumer-controlled width, fixing the oversized terminal scrollbar

Closes #131

## Test plan
- [x] 5 unit tests for `effective_scroll_offset()` (normal, inverted-at-bottom, inverted-at-top, midpoint, no-overflow)
- [x] 3 TUI paint round-trip tests verifying thumb position for inverted and non-inverted modes
- [x] Full quality gate (build, test, clippy, fmt) passes for both TUI and GTK features
- [x] Manually tested in vimcode GTK + TUI with `inverted: true` and `width: Some(6)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)