### PR TITLE
feat(quadraui): Backend::char_width() + monospace default + Pango-measured width

### DIFF
--- a/quadraui/examples/common/hscroll_editor.rs
+++ b/quadraui/examples/common/hscroll_editor.rs
@@ -1,0 +1,215 @@
+//! Smoke test for horizontal scrolling: a single-line 500-char editor.
+//!
+//! Keys:
+//! - `$` / `End` — jump cursor to end of line, scroll to show it
+//! - `0` / `Home` — jump cursor to start of line
+//! - `l` / `Right` — move cursor right
+//! - `h` / `Left` — move cursor left
+//! - `q` / `Esc` — quit
+
+use quadraui::{
+    AppLogic, Backend, Color, Editor, EditorCursor, EditorCursorPos, EditorCursorShape, EditorLine,
+    EditorStyle, EditorStyledSpan, Key, NamedKey, Reaction, Rect, StatusBar, StatusBarSegment,
+    UiEvent, WidgetId,
+};
+
+const LINE_LEN: usize = 500;
+
+pub struct HScrollEditor {
+    cursor_col: usize,
+    scroll_left: usize,
+}
+
+impl HScrollEditor {
+    pub fn new() -> Self {
+        Self {
+            cursor_col: 0,
+            scroll_left: 0,
+        }
+    }
+
+    fn line_text(&self) -> String {
+        let mut s = String::with_capacity(LINE_LEN);
+        for i in 0..LINE_LEN {
+            let digit = (i % 10).to_string();
+            s.push_str(&digit);
+        }
+        s
+    }
+
+    fn viewport_cols(&self, backend: &dyn Backend) -> usize {
+        let vp = backend.viewport();
+        let cw = backend.char_width();
+        let gutter_chars = 4;
+        let gutter_w = gutter_chars as f32 * cw;
+        ((vp.width - gutter_w) / cw).floor().max(1.0) as usize
+    }
+
+    fn ensure_cursor_visible(&mut self, viewport_cols: usize) {
+        if self.cursor_col < self.scroll_left {
+            self.scroll_left = self.cursor_col;
+        } else if self.cursor_col >= self.scroll_left + viewport_cols {
+            self.scroll_left = self.cursor_col + 1 - viewport_cols;
+        }
+    }
+
+    fn build_editor(&self, backend: &dyn Backend) -> Editor {
+        let vp = backend.viewport();
+        let lh = backend.line_height();
+        let bar_h = if lh > 1.5 { lh * 1.5 } else { lh };
+        let editor_h = vp.height - bar_h;
+        let text = self.line_text();
+        let text_len = text.len();
+        let fg = Color::rgb(220, 220, 220);
+
+        let line = EditorLine {
+            raw_text: text,
+            gutter_text: "   1".into(),
+            spans: vec![EditorStyledSpan {
+                start_byte: 0,
+                end_byte: text_len,
+                style: EditorStyle {
+                    fg,
+                    bg: None,
+                    bold: false,
+                    italic: false,
+                    font_scale: 1.0,
+                },
+            }],
+            line_idx: 0,
+            is_current_line: true,
+            is_fold_header: false,
+            folded_line_count: 0,
+            git_diff: None,
+            diff_status: None,
+            diagnostics: vec![],
+            spell_errors: vec![],
+            is_breakpoint: false,
+            is_conditional_bp: false,
+            is_dap_current: false,
+            is_wrap_continuation: false,
+            segment_col_offset: 0,
+            annotation: None,
+            ghost_suffix: None,
+            is_ghost_continuation: false,
+            indent_guides: vec![],
+            colorcolumns: vec![],
+        };
+
+        Editor {
+            id: WidgetId::new("editor"),
+            rect: Rect::new(0.0, 0.0, vp.width, editor_h),
+            lines: vec![line],
+            cursor: Some(EditorCursor {
+                pos: EditorCursorPos {
+                    view_line: 0,
+                    col: self.cursor_col.saturating_sub(self.scroll_left),
+                },
+                shape: EditorCursorShape::Block,
+            }),
+            extra_cursors: vec![],
+            selection: None,
+            extra_selections: vec![],
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: self.scroll_left,
+            total_lines: 1,
+            max_col: LINE_LEN,
+            gutter_char_width: 4,
+            is_active: true,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: Default::default(),
+            code_action_lines: Default::default(),
+            bracket_match_positions: vec![],
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: true,
+            lightbulb_glyph: '\0',
+        }
+    }
+
+    fn status_bar(&self, viewport_cols: usize) -> StatusBar {
+        let info = format!(
+            " col {} / {}  scroll_left {}  viewport_cols {} ",
+            self.cursor_col + 1,
+            LINE_LEN,
+            self.scroll_left,
+            viewport_cols,
+        );
+        StatusBar {
+            id: WidgetId::new("status"),
+            left_segments: vec![StatusBarSegment {
+                text: " h-scroll smoke test ".into(),
+                fg: Color::rgb(255, 255, 255),
+                bg: Color::rgb(40, 80, 120),
+                bold: true,
+                action_id: None,
+            }],
+            right_segments: vec![StatusBarSegment {
+                text: info,
+                fg: Color::rgb(220, 220, 220),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+        }
+    }
+}
+
+impl Default for HScrollEditor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppLogic for HScrollEditor {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let editor = self.build_editor(backend);
+        backend.draw_editor(editor.rect, &editor);
+
+        let vp = backend.viewport();
+        let lh = backend.line_height();
+        let bar_h = if lh > 1.5 { lh * 1.5 } else { lh };
+        let bar_rect = Rect::new(0.0, vp.height - bar_h, vp.width, bar_h);
+        let vpc = self.viewport_cols(backend);
+        let bar = self.status_bar(vpc);
+        let _ = backend.draw_status_bar(bar_rect, &bar, None, None);
+    }
+
+    fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+        let vpc = self.viewport_cols(backend);
+        match event {
+            UiEvent::KeyPressed { key, .. } => {
+                match key {
+                    Key::Char('q') | Key::Named(NamedKey::Escape) => return Reaction::Exit,
+                    Key::Char('$') | Key::Named(NamedKey::End) => {
+                        self.cursor_col = LINE_LEN - 1;
+                    }
+                    Key::Char('0') | Key::Named(NamedKey::Home) => {
+                        self.cursor_col = 0;
+                    }
+                    Key::Char('l') | Key::Named(NamedKey::Right) => {
+                        if self.cursor_col < LINE_LEN - 1 {
+                            self.cursor_col += 1;
+                        }
+                    }
+                    Key::Char('h') | Key::Named(NamedKey::Left) => {
+                        self.cursor_col = self.cursor_col.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+                self.ensure_cursor_visible(vpc);
+                Reaction::Redraw
+            }
+            UiEvent::WindowResized { .. } => {
+                self.ensure_cursor_visible(vpc);
+                Reaction::Redraw
+            }
+            _ => Reaction::Continue,
+        }
+    }
+}

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod demo;
 pub mod form_groups;
+pub mod hscroll_editor;
 pub mod indicators_app;
 pub mod menu_bar_app;
 pub mod mini_app;
@@ -39,6 +40,7 @@ pub mod toast_app;
 
 pub use demo::AppState;
 pub use form_groups::FormGroupsApp;
+pub use hscroll_editor::HScrollEditor;
 pub use indicators_app::IndicatorsApp;
 pub use menu_bar_app::MenuBarApp;
 pub use mini_app::MiniApp;

--- a/quadraui/examples/gtk_hscroll.rs
+++ b/quadraui/examples/gtk_hscroll.rs
@@ -1,0 +1,14 @@
+//! GTK horizontal-scroll smoke test.
+//!
+//! 500-char line editor — press `$` to jump to end, `0` to jump to start.
+//!
+//! ```sh
+//! cargo run --example gtk_hscroll --features gtk
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::gtk::run(common::HScrollEditor::new())
+}

--- a/quadraui/examples/tui_hscroll.rs
+++ b/quadraui/examples/tui_hscroll.rs
@@ -1,0 +1,14 @@
+//! TUI horizontal-scroll smoke test.
+//!
+//! 500-char line editor — press `$` to jump to end, `0` to jump to start.
+//!
+//! ```sh
+//! cargo run --example tui_hscroll --features tui
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::io::Result<()> {
+    quadraui::tui::run(common::HScrollEditor::new())
+}

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -99,6 +99,15 @@ pub trait Backend {
     /// Win-GUI — all from the same code path.
     fn line_height(&self) -> f32;
 
+    /// Approximate monospace character width in surface-native units.
+    /// TUI returns `1.0` (one cell); GTK returns the Pango
+    /// `approximate_char_width` in DIPs.
+    ///
+    /// Apps use this alongside [`Self::line_height`] for portable
+    /// horizontal layout. Example:
+    /// `let viewport_cols = ((rect.width - gutter) / backend.char_width()).floor();`
+    fn char_width(&self) -> f32;
+
     // ─── Drawing — one method per primitive ────────────────────────────
     //
     // Implementations are thin wrappers around each backend crate's

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -573,6 +573,10 @@ impl Backend for GtkBackend {
         self.current_line_height as f32
     }
 
+    fn char_width(&self) -> f32 {
+        self.current_char_width as f32
+    }
+
     fn draw_tree(&mut self, rect: QRect, tree: &TreeView) {
         let (cr, layout) = self
             .current_frame_refs()

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -143,21 +143,28 @@ fn activate<A: AppLogic + 'static>(
         da.set_draw_func(move |da, cr, w, h| {
             let pango_ctx = pcfn::create_context(cr);
             let layout = pg::Layout::new(&pango_ctx);
-            // Default font — system sans, size 11. Resolves to whatever
-            // GTK's default theme provides (Cantarell on GNOME, Segoe UI
-            // on Windows, etc).
-            let font_desc = pg::FontDescription::from_string("Sans 11");
+            // Default font — system monospace, size 11. Monospace is
+            // required because `draw_editor`'s scroll formula
+            // (`scroll_left * char_width`) assumes uniform glyph
+            // width. Resolves to the fontconfig monospace alias
+            // (DejaVu Sans Mono, JetBrains Mono, etc).
+            let font_desc = pg::FontDescription::from_string("Monospace 11");
             layout.set_font_description(Some(&font_desc));
             // Single-line, no wrap. Belt-and-braces over the rasterisers
             // that also call `set_width(-1)` themselves.
             layout.set_width(-1);
 
             // Resolve font metrics for the default font and seed the
-            // backend's per-frame state. Cheap; the font metrics call
-            // is sub-microsecond after Pango caches it.
+            // backend's per-frame state.
             let metrics = pango_ctx.metrics(Some(&font_desc), None);
             let line_h = (metrics.ascent() + metrics.descent()) as f64 / pg::SCALE as f64;
-            let char_w = metrics.approximate_char_width() as f64 / pg::SCALE as f64;
+            // Measure actual laid-out character width instead of
+            // `approximate_char_width()` — the approximate value
+            // doesn't account for font hinting and drifts over long
+            // lines (e.g. 9 chars short at 500-char scroll).
+            layout.set_text("0");
+            let (char_w_px, _) = layout.pixel_size();
+            let char_w = char_w_px as f64;
 
             let mut backend_mut = backend.borrow_mut();
             backend_mut.begin_frame(crate::Viewport::new(w as f32, h as f32, 1.0));

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -413,6 +413,10 @@ impl Backend for TuiBackend {
         1.0
     }
 
+    fn char_width(&self) -> f32 {
+        1.0
+    }
+
     // ─── Drawing ───────────────────────────────────────────────────────────
     //
     // Implementations call into the public `crate::tui::draw_*` free
@@ -1073,6 +1077,9 @@ mod tests {
             Vec::new()
         }
 
+        fn char_width(&self) -> f32 {
+            1.0
+        }
         fn line_height(&self) -> f32 {
             1.0
         }

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -146,6 +146,10 @@ impl Backend for WinBackend {
         self.current_line_height
     }
 
+    fn char_width(&self) -> f32 {
+        self.current_char_width
+    }
+
     // ─── Drawing ──────────────────────────────────────────────────────
 
     fn draw_tree(&mut self, _rect: Rect, _tree: &TreeView) {


### PR DESCRIPTION
## Summary
- Add `Backend::char_width()` to the trait — TUI returns 1.0, GTK returns Pango-measured width, Win returns stored value
- GTK runner default font changed from `Sans 11` (proportional) to `Monospace 11` — required because `draw_editor`'s scroll formula (`scroll_left * char_width`) assumes uniform glyph width
- GTK char_width now measured via `layout.set_text("0"); layout.pixel_size()` instead of `metrics.approximate_char_width()` — the approximate value drifts due to font hinting (~9 chars short at 500-char scroll)
- Consumers override with `GtkBackend::set_current_char_width()` for custom fonts

## Smoke test
Paired `tui_hscroll` / `gtk_hscroll` example: 500-char line, `$` jumps to end, `0` to start. Verified last character visible on both backends.

```sh
cargo run --example tui_hscroll --features tui
cargo run --example gtk_hscroll --features gtk
```

## Test plan
- [x] Full quality gate: 611 tests, clippy, fmt
- [x] Manual smoke test: both backends show col 500 at right edge after `$`

🤖 Generated with [Claude Code](https://claude.com/claude-code)