### PR TITLE
feat(quadraui): Backend::draw_status_bar returns StatusBarLayout (#140)

### DIFF
--- a/quadraui/examples/common/multi_tree.rs
+++ b/quadraui/examples/common/multi_tree.rs
@@ -132,13 +132,13 @@ impl AppLogic for DebugSidebar {
         let sidebar = Self::sidebar_rect(backend);
         let status = Self::status_rect(backend);
         self.sidebar.render(backend, sidebar);
-        let regions = backend.draw_status_bar(
+        let layout = backend.draw_status_bar(
             status,
             &self.build_status_bar(),
             self.status_interaction.hovered_id(),
             self.status_interaction.pressed_id(),
         );
-        self.status_interaction.set_hit_regions(regions);
+        self.status_interaction.set_layout(layout);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -31,7 +31,7 @@ use crate::primitives::rich_text_popup::{RichTextPopup, RichTextPopupLayout};
 use crate::primitives::scrollbar::Scrollbar;
 use crate::primitives::spinner::{Spinner, SpinnerLayout};
 use crate::primitives::split::{Split, SplitLayout};
-use crate::primitives::status_bar::StatusBarHitRegion;
+use crate::primitives::status_bar::StatusBarLayout;
 use crate::primitives::tab_bar::TabBarHits;
 use crate::primitives::text_display::TextDisplayLayout;
 use crate::primitives::toast::{ToastStack, ToastStackLayout};
@@ -150,7 +150,7 @@ pub trait Backend {
         bar: &StatusBar,
         hovered_id: Option<&WidgetId>,
         pressed_id: Option<&WidgetId>,
-    ) -> Vec<StatusBarHitRegion>;
+    ) -> StatusBarLayout;
     /// Draw a tab bar. `hovered_close_tab` carries per-frame hover
     /// state so the rasteriser can paint a hover background behind the
     /// hovered tab's close glyph (the primitive itself carries no

--- a/quadraui/src/compose/status_bar_interaction.rs
+++ b/quadraui/src/compose/status_bar_interaction.rs
@@ -12,13 +12,13 @@
 use std::cell::RefCell;
 
 use crate::event::{MouseButton, Point, Rect, UiEvent};
-use crate::primitives::status_bar::StatusBarHitRegion;
+use crate::primitives::status_bar::{StatusBarHit, StatusBarLayout};
 use crate::types::WidgetId;
 
 /// Tracks hover and pressed state for a status bar's clickable segments.
 #[derive(Debug, Clone, Default)]
 pub struct StatusBarInteraction {
-    hit_regions: RefCell<Vec<StatusBarHitRegion>>,
+    layout: RefCell<Option<StatusBarLayout>>,
     hovered: Option<WidgetId>,
     pressed: Option<WidgetId>,
 }
@@ -39,11 +39,11 @@ impl StatusBarInteraction {
         Self::default()
     }
 
-    /// Update the stored hit regions. Call this after each `draw_status_bar`
-    /// with the returned `Vec<StatusBarHitRegion>`. Takes `&self` so it can
+    /// Update the stored layout. Call this after each `draw_status_bar`
+    /// with the returned `StatusBarLayout`. Takes `&self` so it can
     /// be called from render paths where only a shared reference is available.
-    pub fn set_hit_regions(&self, regions: Vec<StatusBarHitRegion>) {
-        *self.hit_regions.borrow_mut() = regions;
+    pub fn set_layout(&self, layout: StatusBarLayout) {
+        *self.layout.borrow_mut() = Some(layout);
     }
 
     pub fn hovered_id(&self) -> Option<&WidgetId> {
@@ -110,12 +110,13 @@ impl StatusBarInteraction {
         {
             return None;
         }
-        let local_x = (position.x - bar_rect.x) as u16;
-        self.hit_regions
-            .borrow()
-            .iter()
-            .find(|r| local_x >= r.col && local_x < r.col + r.width)
-            .map(|r| r.id.clone())
+        let local_x = position.x - bar_rect.x;
+        let local_y = position.y - bar_rect.y;
+        let guard = self.layout.borrow();
+        match guard.as_ref().map(|l| l.hit_test(local_x, local_y)) {
+            Some(StatusBarHit::Segment(id)) => Some(id),
+            _ => None,
+        }
     }
 }
 
@@ -127,25 +128,29 @@ mod tests {
         Rect::new(0.0, 100.0, 80.0, 1.0)
     }
 
-    fn regions() -> Vec<StatusBarHitRegion> {
-        vec![
-            StatusBarHitRegion {
-                col: 0,
-                width: 10,
-                id: WidgetId::new("run"),
-            },
-            StatusBarHitRegion {
-                col: 10,
-                width: 10,
-                id: WidgetId::new("stop"),
-            },
-        ]
+    fn test_layout() -> StatusBarLayout {
+        StatusBarLayout {
+            bar_width: 80.0,
+            bar_height: 1.0,
+            visible_segments: Vec::new(),
+            hit_regions: vec![
+                (
+                    crate::event::Rect::new(0.0, 0.0, 10.0, 1.0),
+                    StatusBarHit::Segment(WidgetId::new("run")),
+                ),
+                (
+                    crate::event::Rect::new(10.0, 0.0, 10.0, 1.0),
+                    StatusBarHit::Segment(WidgetId::new("stop")),
+                ),
+            ],
+            resolved_right_start: 0,
+        }
     }
 
     #[test]
     fn hover_sets_hovered_id() {
         let mut sbi = StatusBarInteraction::new();
-        sbi.set_hit_regions(regions());
+        sbi.set_layout(test_layout());
         let ev = UiEvent::MouseMoved {
             position: Point { x: 5.0, y: 100.5 },
             buttons: Default::default(),
@@ -158,7 +163,7 @@ mod tests {
     #[test]
     fn hover_outside_clears() {
         let mut sbi = StatusBarInteraction::new();
-        sbi.set_hit_regions(regions());
+        sbi.set_layout(test_layout());
         // Move into "run" first.
         sbi.handle(
             &UiEvent::MouseMoved {
@@ -182,7 +187,7 @@ mod tests {
     #[test]
     fn click_emits_clicked() {
         let mut sbi = StatusBarInteraction::new();
-        sbi.set_hit_regions(regions());
+        sbi.set_layout(test_layout());
         let rect = bar_rect();
         // Mouse down on "stop".
         sbi.handle(
@@ -211,7 +216,7 @@ mod tests {
     #[test]
     fn press_drag_away_does_not_click() {
         let mut sbi = StatusBarInteraction::new();
-        sbi.set_hit_regions(regions());
+        sbi.set_layout(test_layout());
         let rect = bar_rect();
         // Mouse down on "run".
         sbi.handle(

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -674,7 +674,7 @@ impl Backend for GtkBackend {
         bar: &StatusBar,
         hovered_id: Option<&crate::types::WidgetId>,
         pressed_id: Option<&crate::types::WidgetId>,
-    ) -> Vec<crate::StatusBarHitRegion> {
+    ) -> crate::StatusBarLayout {
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_status_bar called outside enter_frame_scope");

--- a/quadraui/src/gtk/status_bar.rs
+++ b/quadraui/src/gtk/status_bar.rs
@@ -18,7 +18,7 @@ use pangocairo::functions as pcfn;
 
 use super::{cairo_rgb, set_source};
 use crate::primitives::status_bar::{
-    StatusBar, StatusBarHitRegion, StatusBarSegment, StatusSegmentMeasure, StatusSegmentSide,
+    StatusBar, StatusBarLayout, StatusBarSegment, StatusSegmentMeasure, StatusSegmentSide,
 };
 use crate::theme::Theme;
 use crate::types::WidgetId;
@@ -59,7 +59,7 @@ pub fn draw_status_bar(
     theme: &Theme,
     hovered_id: Option<&WidgetId>,
     pressed_id: Option<&WidgetId>,
-) -> Vec<StatusBarHitRegion> {
+) -> StatusBarLayout {
     // Reset layout state.
     layout.set_attributes(None);
     layout.set_width(-1);
@@ -101,8 +101,6 @@ pub fn draw_status_bar(
     };
     let bar_layout = bar.layout(width as f32, line_height as f32, MIN_GAP_PX, measure);
 
-    // Paint visible segments + build hit regions in a single pass.
-    let mut regions: Vec<StatusBarHitRegion> = Vec::new();
     for vs in &bar_layout.visible_segments {
         let seg = match vs.side {
             StatusSegmentSide::Left => &bar.left_segments[vs.segment_idx],
@@ -138,19 +136,10 @@ pub fn draw_status_bar(
         set_source(cr, seg.fg);
         cr.move_to(seg_x, y);
         pcfn::show_layout(cr, layout);
-
-        // Hit region for clickable segments.
-        if let Some(ref id) = seg.action_id {
-            regions.push(StatusBarHitRegion {
-                col: (vs.bounds.x.round() as i64).clamp(0, u16::MAX as i64) as u16,
-                width: (vs.bounds.width.round() as i64).clamp(0, u16::MAX as i64) as u16,
-                id: id.clone(),
-            });
-        }
     }
 
     layout.set_attributes(None);
     cr.restore().ok();
 
-    regions
+    bar_layout
 }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -483,10 +483,9 @@ impl Backend for TuiBackend {
         bar: &StatusBar,
         hovered_id: Option<&crate::types::WidgetId>,
         pressed_id: Option<&crate::types::WidgetId>,
-    ) -> Vec<crate::StatusBarHitRegion> {
+    ) -> crate::StatusBarLayout {
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
-        // Cell-unit measurer: each char counts as one cell.
         let layout = bar.layout(area.width as f32, 1.0, MIN_GAP_CELLS, |seg| {
             crate::StatusSegmentMeasure::new(seg.text.chars().count() as f32)
         });
@@ -1031,8 +1030,14 @@ mod tests {
             _b: &StatusBar,
             _hovered_id: Option<&crate::types::WidgetId>,
             _pressed_id: Option<&crate::types::WidgetId>,
-        ) -> Vec<crate::StatusBarHitRegion> {
-            Vec::new()
+        ) -> crate::StatusBarLayout {
+            crate::StatusBarLayout {
+                bar_width: 0.0,
+                bar_height: 0.0,
+                visible_segments: Vec::new(),
+                hit_regions: Vec::new(),
+                resolved_right_start: 0,
+            }
         }
         fn draw_tab_bar(
             &mut self,

--- a/quadraui/src/tui/status_bar.rs
+++ b/quadraui/src/tui/status_bar.rs
@@ -12,9 +12,7 @@ use ratatui::layout::{Position, Rect};
 use ratatui::style::{Modifier, Style};
 
 use super::{ratatui_color, set_cell};
-use crate::primitives::status_bar::{
-    StatusBar, StatusBarHitRegion, StatusBarLayout, StatusSegmentSide,
-};
+use crate::primitives::status_bar::{StatusBar, StatusBarLayout, StatusSegmentSide};
 use crate::theme::Theme;
 use crate::types::WidgetId;
 
@@ -48,9 +46,15 @@ pub fn draw_status_bar(
     theme: &Theme,
     hovered_id: Option<&WidgetId>,
     pressed_id: Option<&WidgetId>,
-) -> Vec<StatusBarHitRegion> {
+) -> StatusBarLayout {
     if area.width == 0 || area.height == 0 {
-        return Vec::new();
+        return StatusBarLayout {
+            bar_width: 0.0,
+            bar_height: 0.0,
+            visible_segments: Vec::new(),
+            hit_regions: Vec::new(),
+            resolved_right_start: 0,
+        };
     }
     let y = area.y;
 
@@ -64,7 +68,6 @@ pub fn draw_status_bar(
         set_cell(buf, area.x + col, y, ' ', fill_bg, fill_bg);
     }
 
-    let mut regions: Vec<StatusBarHitRegion> = Vec::new();
     for vs in &layout.visible_segments {
         let seg = match vs.side {
             StatusSegmentSide::Left => &bar.left_segments[vs.segment_idx],
@@ -102,16 +105,8 @@ pub fn draw_status_bar(
             }
             cx += 1;
         }
-
-        if let Some(ref id) = seg.action_id {
-            regions.push(StatusBarHitRegion {
-                col: (vs.bounds.x.round() as i64).clamp(0, u16::MAX as i64) as u16,
-                width: (vs.bounds.width.round() as i64).clamp(0, u16::MAX as i64) as u16,
-                id: id.clone(),
-            });
-        }
     }
-    regions
+    layout.clone()
 }
 
 #[cfg(test)]
@@ -257,8 +252,8 @@ mod tests {
             StatusSegmentMeasure::new(seg.text.chars().count() as f32)
         });
         // Zero-width area: function must return without panicking, without
-        // touching the buffer, and with an empty hit-region list.
-        let regions = draw_status_bar(
+        // touching the buffer, and with an empty layout.
+        let result = draw_status_bar(
             &mut buf,
             Rect::new(0, 0, 0, 1),
             &bar,
@@ -268,7 +263,7 @@ mod tests {
             None,
         );
         assert_eq!(cell_char(&buf, 0, 0), ' ');
-        assert!(regions.is_empty());
+        assert!(result.hit_regions.is_empty());
     }
 
     #[test]
@@ -298,7 +293,7 @@ mod tests {
             StatusSegmentMeasure::new(seg.text.chars().count() as f32)
         });
         let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
-        let regions = draw_status_bar(
+        let result = draw_status_bar(
             &mut buf,
             Rect::new(0, 0, 20, 1),
             &bar,
@@ -308,13 +303,17 @@ mod tests {
             None,
         );
 
-        // One region for the segment with action_id.
-        assert_eq!(regions.len(), 1);
-        assert_eq!(regions[0].id.as_str(), "middle-action");
-        // Region is in bar-local cell coords: starts after "AAA" (col 3)
-        // and is 4 cells wide ("BBBB").
-        assert_eq!(regions[0].col, 3);
-        assert_eq!(regions[0].width, 4);
+        // One hit region for the segment with action_id.
+        assert_eq!(result.hit_regions.len(), 1);
+        use crate::primitives::status_bar::StatusBarHit;
+        match &result.hit_regions[0].1 {
+            StatusBarHit::Segment(id) => assert_eq!(id.as_str(), "middle-action"),
+            other => panic!("expected Segment, got {:?}", other),
+        }
+        // Region starts after "AAA" (x=3.0) and is 4 cells wide ("BBBB").
+        let r = &result.hit_regions[0].0;
+        assert_eq!(r.x, 3.0);
+        assert_eq!(r.width, 4.0);
     }
 
     fn make_clickable_bar() -> StatusBar {

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -48,7 +48,7 @@ use crate::primitives::rich_text_popup::{RichTextPopup, RichTextPopupLayout};
 use crate::primitives::scrollbar::Scrollbar;
 use crate::primitives::spinner::{Spinner, SpinnerLayout};
 use crate::primitives::split::{Split, SplitLayout};
-use crate::primitives::status_bar::StatusBarHitRegion;
+use crate::primitives::status_bar::StatusBarLayout;
 use crate::primitives::tab_bar::TabBarHits;
 use crate::primitives::text_display::TextDisplayLayout;
 use crate::primitives::toast::{ToastStack, ToastStackLayout};
@@ -174,7 +174,7 @@ impl Backend for WinBackend {
         _bar: &StatusBar,
         _hovered_id: Option<&crate::types::WidgetId>,
         _pressed_id: Option<&crate::types::WidgetId>,
-    ) -> Vec<StatusBarHitRegion> {
+    ) -> StatusBarLayout {
         todo!("Direct2D status bar rasteriser")
     }
 


### PR DESCRIPTION
## Summary
- `Backend::draw_status_bar` returns `StatusBarLayout` instead of `Vec<StatusBarHitRegion>`
- Both TUI and GTK rasterisers return the computed layout directly (no conversion to the flatter format)
- `StatusBarInteraction` updated: stores `Option<StatusBarLayout>`, uses `StatusBarLayout::hit_test()` for native-unit click resolution
- `set_hit_regions()` replaced with `set_layout()`

Closes #140

## Migration for consumers
- `draw_status_bar` now returns `StatusBarLayout` — callers that discard the result (`let _ = ...`) need no changes
- `StatusBarInteraction::set_hit_regions(regions)` → `StatusBarInteraction::set_layout(layout)`
- Click resolution via `StatusBarLayout::hit_test(x, y)` works in native units (cells for TUI, pixels for GTK)

## Test plan
- [x] Full quality gate: 611 tests, clippy, fmt
- [x] Smoke test: `multi_tree` example — Run/Stop button clicks produce correct `StatusBarAction::Clicked` on both TUI and GTK

🤖 Generated with [Claude Code](https://claude.com/claude-code)