### PR TITLE
feat(quadraui): DataTable v2 — separators, cell colors, scrollbar interaction, h-scroll (#146)

### DIFF
--- a/quadraui/examples/common/data_table_app.rs
+++ b/quadraui/examples/common/data_table_app.rs
@@ -7,6 +7,7 @@
 //! - `d` — toggle sort direction
 //! - `q` / `Esc` — quit
 
+use quadraui::primitives::scrollbar::fit_thumb;
 use quadraui::{
     AppLogic, Backend, Color, Column, ColumnAlign, ColumnWidth, DataRow, DataTable, DataTableEvent,
     DataTableHit, DataTableLayout, Key, NamedKey, Reaction, Rect, SortDirection, StatusBar,
@@ -20,6 +21,11 @@ pub struct DataTableApp {
     sort_col: Option<usize>,
     sort_asc: bool,
     resize_col: Option<usize>,
+    /// Vertical scrollbar thumb drag: (track_start_y, track_height, thumb_length, grab_offset)
+    sb_drag: Option<(f32, f32, f32, f32)>,
+    /// Horizontal scrollbar thumb drag: (track_start_x, track_width, thumb_length, grab_offset)
+    h_sb_drag: Option<(f32, f32, f32, f32)>,
+    h_scroll: f32,
 }
 
 impl DataTableApp {
@@ -31,6 +37,9 @@ impl DataTableApp {
             sort_col: Some(0),
             sort_asc: true,
             resize_col: None,
+            sb_drag: None,
+            h_sb_drag: None,
+            h_scroll: 0.0,
         }
     }
 
@@ -141,6 +150,8 @@ impl DataTableApp {
             }),
             has_focus: true,
             show_scrollbar: true,
+            min_total_width: None,
+            h_scroll: self.h_scroll,
         }
     }
 
@@ -204,10 +215,36 @@ impl DataTableApp {
     fn table_layout(&self, backend: &dyn Backend) -> DataTableLayout {
         let vp = backend.viewport();
         let lh = backend.line_height();
+        let cw = backend.char_width();
         let bar_h = if lh > 1.5 { lh * 1.5 } else { lh };
         let table_rect = Rect::new(0.0, 0.0, vp.width, vp.height - bar_h);
-        let table = self.build_table();
+        let mut table = self.build_table();
+        table.min_total_width = Some(80.0 * cw);
         backend.data_table_layout(table_rect, &table)
+    }
+
+    fn scrollbar_geometry(&self, backend: &dyn Backend) -> Option<(f32, f32, f32, f32, f32)> {
+        let total = Self::rows().len();
+        let layout = self.table_layout(backend);
+        if !self.build_table().show_scrollbar
+            || total <= layout.visible_rows
+            || layout.scrollbar_width <= 0.0
+        {
+            return None;
+        }
+        let vp = backend.viewport();
+        let lh = backend.line_height();
+        let sb_x = vp.width - layout.scrollbar_width;
+        let track_y = layout.header_height;
+        let track_h = (vp.height - lh.max(1.0) * 1.5 - layout.header_height).max(1.0);
+        let (thumb_start, thumb_len) = fit_thumb(
+            self.scroll_offset as f32,
+            total as f32,
+            layout.visible_rows as f32,
+            track_h,
+            if lh > 1.5 { lh } else { 1.0 },
+        );
+        Some((sb_x, track_y, track_h, thumb_start, thumb_len))
     }
 
     fn ensure_visible(&mut self, backend: &dyn Backend) {
@@ -234,9 +271,11 @@ impl AppLogic for DataTableApp {
     fn render(&self, backend: &mut dyn Backend, _area: ()) {
         let vp = backend.viewport();
         let lh = backend.line_height();
+        let cw = backend.char_width();
         let bar_h = if lh > 1.5 { lh * 1.5 } else { lh };
         let table_rect = Rect::new(0.0, 0.0, vp.width, vp.height - bar_h);
-        let table = self.build_table();
+        let mut table = self.build_table();
+        table.min_total_width = Some(80.0 * cw);
         let _layout = backend.draw_data_table(table_rect, &table);
 
         let bar_rect = Rect::new(0.0, vp.height - bar_h, vp.width, bar_h);
@@ -275,12 +314,78 @@ impl AppLogic for DataTableApp {
                     Key::Named(NamedKey::End) => {
                         self.selected = Some(total.saturating_sub(1));
                     }
+                    Key::Char('H') | Key::Named(NamedKey::Left) => {
+                        self.h_scroll = (self.h_scroll - 5.0).max(0.0);
+                    }
+                    Key::Char('L') | Key::Named(NamedKey::Right) => {
+                        let layout = self.table_layout(backend);
+                        let max_h = (layout.content_width - layout.viewport_width
+                            + layout.scrollbar_width)
+                            .max(0.0);
+                        self.h_scroll = (self.h_scroll + 5.0).min(max_h);
+                    }
                     _ => return Reaction::Continue,
                 }
                 self.ensure_visible(backend);
                 Reaction::Redraw
             }
             UiEvent::MouseDown { position, .. } => {
+                // Check h-scrollbar first.
+                let layout = self.table_layout(backend);
+                if layout.h_scrollbar_height > 0.0 && layout.content_width > 0.0 {
+                    let vp = backend.viewport();
+                    let lh = backend.line_height();
+                    let bar_h = if lh > 1.5 { lh * 1.5 } else { lh };
+                    let table_h = vp.height - bar_h;
+                    let hsb_y = table_h - layout.h_scrollbar_height;
+                    if position.y >= hsb_y && position.y < table_h {
+                        let track_w = (vp.width - layout.scrollbar_width).max(1.0);
+                        let visible_w = track_w;
+                        let max_h_scroll = (layout.content_width - visible_w).max(0.0);
+                        let (thumb_start, thumb_len) = fit_thumb(
+                            self.h_scroll,
+                            layout.content_width,
+                            visible_w,
+                            track_w,
+                            if lh > 1.5 { lh } else { 1.0 },
+                        );
+                        let local_x = position.x;
+                        if local_x >= thumb_start && local_x < thumb_start + thumb_len {
+                            self.h_sb_drag = Some((0.0, track_w, thumb_len, local_x - thumb_start));
+                            return Reaction::Continue;
+                        }
+                        // Track click — page left/right.
+                        let page = visible_w;
+                        if local_x < thumb_start {
+                            self.h_scroll = (self.h_scroll - page).max(0.0);
+                        } else {
+                            self.h_scroll = (self.h_scroll + page).min(max_h_scroll);
+                        }
+                        return Reaction::Redraw;
+                    }
+                }
+                // Check v-scrollbar.
+                if let Some((sb_x, track_y, track_h, thumb_start, thumb_len)) =
+                    self.scrollbar_geometry(backend)
+                {
+                    let vis = self.visible_rows(backend);
+                    let max_scroll = total.saturating_sub(vis);
+                    if position.x >= sb_x {
+                        let local_y = position.y - track_y;
+                        if local_y >= thumb_start && local_y < thumb_start + thumb_len {
+                            self.sb_drag =
+                                Some((track_y, track_h, thumb_len, local_y - thumb_start));
+                            return Reaction::Continue;
+                        }
+                        // Track click — page up/down.
+                        if local_y < thumb_start {
+                            self.scroll_offset = self.scroll_offset.saturating_sub(vis);
+                        } else {
+                            self.scroll_offset = (self.scroll_offset + vis).min(max_scroll);
+                        }
+                        return Reaction::Redraw;
+                    }
+                }
                 let layout = self.table_layout(backend);
                 match layout.hit_test(position.x, position.y, self.scroll_offset, total) {
                     DataTableHit::Header { col } => {
@@ -304,6 +409,23 @@ impl AppLogic for DataTableApp {
                 }
             }
             UiEvent::MouseMoved { position, .. } => {
+                if let Some((track_x, track_w, thumb_len, grab_off)) = self.h_sb_drag {
+                    let lay = self.table_layout(backend);
+                    let visible_w = (lay.viewport_width - lay.scrollbar_width).max(1.0);
+                    let max_h_scroll = (lay.content_width - visible_w).max(0.0);
+                    let effective = (track_w - thumb_len).max(1.0);
+                    let rel = ((position.x - track_x - grab_off) / effective).clamp(0.0, 1.0);
+                    self.h_scroll = (rel * max_h_scroll).round().min(max_h_scroll);
+                    return Reaction::Redraw;
+                }
+                if let Some((track_y, track_h, thumb_len, grab_off)) = self.sb_drag {
+                    let vis = self.visible_rows(backend);
+                    let max_scroll = total.saturating_sub(vis);
+                    let effective = (track_h - thumb_len).max(1.0);
+                    let rel = ((position.y - track_y - grab_off) / effective).clamp(0.0, 1.0);
+                    self.scroll_offset = (rel * max_scroll as f32).round() as usize;
+                    return Reaction::Redraw;
+                }
                 if let Some(col) = self.resize_col {
                     let layout = self.table_layout(backend);
                     if col < layout.columns.len() {
@@ -316,12 +438,22 @@ impl AppLogic for DataTableApp {
                 Reaction::Continue
             }
             UiEvent::MouseUp { .. } => {
-                if self.resize_col.take().is_some() {
+                let had_drag = self.resize_col.take().is_some()
+                    || self.sb_drag.take().is_some()
+                    || self.h_sb_drag.take().is_some();
+                if had_drag {
                     return Reaction::Redraw;
                 }
                 Reaction::Continue
             }
             UiEvent::Scroll { delta, .. } => {
+                if delta.x.abs() > 0.01 {
+                    let layout = self.table_layout(backend);
+                    let max_h = (layout.content_width - layout.viewport_width
+                        + layout.scrollbar_width)
+                        .max(0.0);
+                    self.h_scroll = (self.h_scroll - delta.x * 10.0).clamp(0.0, max_h);
+                }
                 let vis = self.visible_rows(backend);
                 if delta.y < 0.0 {
                     self.scroll_offset = self

--- a/quadraui/src/gtk/data_table.rs
+++ b/quadraui/src/gtk/data_table.rs
@@ -58,6 +58,7 @@ pub fn draw_data_table(
     cr.fill().ok();
 
     // ── Header text ───────────────────────────────────────────────────
+    let h_off = table.h_scroll as f64;
     set_source(cr, theme.foreground);
     let bold_attrs = pango::AttrList::new();
     bold_attrs.insert(pango::AttrInt::new_weight(pango::Weight::Bold));
@@ -79,7 +80,7 @@ pub fn draw_data_table(
         pango_layout.set_attributes(Some(&bold_attrs));
         let (text_w, _) = pango_layout.pixel_size();
 
-        let col_x = x + rc.x as f64;
+        let col_x = x + rc.x as f64 - h_off;
         let col_w = rc.width as f64;
 
         cr.save().ok();
@@ -96,6 +97,17 @@ pub fn draw_data_table(
         cr.restore().ok();
     }
     pango_layout.set_attributes(None);
+
+    // ── Header column separators ──────────────────────────────────────
+    set_source(cr, theme.separator);
+    for (col_idx, rc) in layout.columns.iter().enumerate() {
+        if col_idx + 1 >= layout.columns.len() {
+            break;
+        }
+        let sep_x = x + (rc.x + rc.width) as f64 - h_off;
+        cr.rectangle(sep_x - 0.5, y, 1.0, header_height);
+        cr.fill().ok();
+    }
 
     // ── Body rows ─────────────────────────────────────────────────────
     let body_y = y + header_height;
@@ -117,24 +129,24 @@ pub fn draw_data_table(
         }
 
         for (col_idx, rc) in layout.columns.iter().enumerate() {
-            let cell_text: String = row
-                .cells
-                .get(col_idx)
-                .map(|c| c.spans.iter().map(|s| s.text.as_str()).collect())
-                .unwrap_or_default();
-            let text = cell_text.as_str();
-            if text.is_empty() || rc.width <= 0.0 {
+            let styled = match row.cells.get(col_idx) {
+                Some(c) if !c.spans.is_empty() => c,
+                _ => continue,
+            };
+            if rc.width <= 0.0 {
                 continue;
             }
 
             let col_w = rc.width as f64;
-            let col_x = x + rc.x as f64;
+            let col_x = x + rc.x as f64 - h_off;
+            let is_muted = row.decoration == crate::types::Decoration::Muted;
 
             cr.save().ok();
             cr.rectangle(col_x, row_y, col_w, line_height);
             cr.clip();
 
-            pango_layout.set_text(text);
+            let full_text: String = styled.spans.iter().map(|s| s.text.as_str()).collect();
+            pango_layout.set_text(&full_text);
             pango_layout.set_attributes(None);
             let (text_w, _) = pango_layout.pixel_size();
 
@@ -149,13 +161,34 @@ pub fn draw_data_table(
                 ColumnAlign::Right => col_x + col_w - text_w as f64,
             };
 
-            if row.decoration == crate::types::Decoration::Muted {
+            // Per-span colored text via Pango attributes.
+            let attrs = pango::AttrList::new();
+            let mut byte_offset = 0u32;
+            for span in &styled.spans {
+                let span_bytes = span.text.len() as u32;
+                if !is_muted {
+                    if let Some(fg) = span.fg {
+                        let mut color_attr = pango::AttrColor::new_foreground(
+                            fg.r as u16 * 257,
+                            fg.g as u16 * 257,
+                            fg.b as u16 * 257,
+                        );
+                        color_attr.set_start_index(byte_offset);
+                        color_attr.set_end_index(byte_offset + span_bytes);
+                        attrs.insert(color_attr);
+                    }
+                }
+                byte_offset += span_bytes;
+            }
+            if is_muted {
                 set_source(cr, theme.muted_fg);
             } else {
                 set_source(cr, theme.foreground);
             }
+            pango_layout.set_attributes(Some(&attrs));
             cr.move_to(text_x, row_y);
             pcfn::show_layout(cr, pango_layout);
+            pango_layout.set_attributes(None);
             cr.restore().ok();
         }
     }
@@ -181,6 +214,28 @@ pub fn draw_data_table(
             line_height as f32,
         );
         super::draw_scrollbar(cr, &sb, theme);
+    }
+
+    // ── Horizontal scrollbar ─────────────────────────────────────────
+    if layout.h_scrollbar_height > 0.0 && layout.content_width > 0.0 {
+        let hsb_y = y + height - layout.h_scrollbar_height as f64;
+        let track_w = (width - layout.scrollbar_width as f64).max(1.0);
+        let hsb_track = crate::event::Rect::new(
+            x as f32,
+            hsb_y as f32,
+            track_w as f32,
+            layout.h_scrollbar_height,
+        );
+        let visible_w = track_w as f32;
+        let hsb = crate::primitives::scrollbar::Scrollbar::horizontal(
+            table.id.clone(),
+            hsb_track,
+            table.h_scroll,
+            layout.content_width,
+            visible_w,
+            line_height as f32,
+        );
+        super::draw_scrollbar(cr, &hsb, theme);
     }
 
     cr.restore().ok();

--- a/quadraui/src/primitives/data_table.rs
+++ b/quadraui/src/primitives/data_table.rs
@@ -95,6 +95,16 @@ pub struct DataTable {
     /// Show a vertical scrollbar when rows exceed the viewport.
     #[serde(default)]
     pub show_scrollbar: bool,
+    /// Minimum total width for all columns. When the viewport is
+    /// narrower, columns are laid out at this width and a horizontal
+    /// scrollbar appears. `None` = columns squeeze to fit.
+    #[serde(default)]
+    pub min_total_width: Option<f32>,
+    /// Horizontal scroll offset in surface-native units (pixels for
+    /// GTK, cells for TUI). Only meaningful when `min_total_width`
+    /// causes the content to be wider than the viewport.
+    #[serde(default)]
+    pub h_scroll: f32,
 }
 
 /// Events a `DataTable` emits back to the app.
@@ -156,8 +166,14 @@ pub struct DataTableLayout {
     pub visible_rows: usize,
     pub viewport_width: f32,
     pub viewport_height: f32,
-    /// Width reserved for the scrollbar (0 when hidden).
+    /// Width reserved for the vertical scrollbar (0 when hidden).
     pub scrollbar_width: f32,
+    /// Total content width after column layout. When this exceeds
+    /// `viewport_width`, horizontal scrolling is active.
+    pub content_width: f32,
+    /// Height reserved for the horizontal scrollbar (0 when not
+    /// scrolling horizontally).
+    pub h_scrollbar_height: f32,
 }
 
 /// Grab zone half-width for column divider detection (surface units).
@@ -234,9 +250,24 @@ impl DataTable {
         } else {
             0.0
         };
-        let col_area = (viewport_width - sb_w).max(0.0);
-        let resolved = resolve_columns(&self.columns, col_area, &measure);
-        let body_height = (viewport_height - header_height).max(0.0);
+        let visible_col_area = (viewport_width - sb_w).max(0.0);
+        let layout_width = match self.min_total_width {
+            Some(min) if min > visible_col_area => min,
+            _ => visible_col_area,
+        };
+        let resolved = resolve_columns(&self.columns, layout_width, &measure);
+        let content_width = resolved.last().map(|c| c.x + c.width).unwrap_or(0.0);
+        let h_scrolling = content_width > visible_col_area + 0.5;
+        let h_sb_h = if h_scrolling {
+            if row_height > 1.5 {
+                (row_height * 0.5).round()
+            } else {
+                row_height
+            }
+        } else {
+            0.0
+        };
+        let body_height = (viewport_height - header_height - h_sb_h).max(0.0);
         let visible_rows = if row_height > 0.0 {
             (body_height / row_height).floor() as usize
         } else {
@@ -250,6 +281,8 @@ impl DataTable {
             viewport_width,
             viewport_height,
             scrollbar_width: sb_w,
+            content_width,
+            h_scrollbar_height: h_sb_h,
         }
     }
 }
@@ -340,6 +373,8 @@ mod tests {
             sort: None,
             has_focus: false,
             show_scrollbar: false,
+            min_total_width: None,
+            h_scroll: 0.0,
         }
     }
 

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1047,6 +1047,8 @@ mod tests {
                 viewport_width: 0.0,
                 viewport_height: 0.0,
                 scrollbar_width: 0.0,
+                content_width: 0.0,
+                h_scrollbar_height: 0.0,
             }
         }
         fn data_table_layout(
@@ -1062,6 +1064,8 @@ mod tests {
                 viewport_width: 0.0,
                 viewport_height: 0.0,
                 scrollbar_width: 0.0,
+                content_width: 0.0,
+                h_scrollbar_height: 0.0,
             }
         }
         fn draw_palette(&mut self, rect: QRect, palette: &Palette) {

--- a/quadraui/src/tui/data_table.rs
+++ b/quadraui/src/tui/data_table.rs
@@ -49,15 +49,30 @@ pub fn draw_data_table(
         set_cell(buf, area.x + x, header_y, ' ', header_fg, header_bg);
     }
 
+    let sep_fg = ratatui_color(theme.separator);
+    let h_off = table.h_scroll.round() as i16;
+
     for (col_idx, rc) in layout.columns.iter().enumerate() {
         if col_idx >= table.columns.len() {
             break;
         }
         let col = &table.columns[col_idx];
-        let col_x = area.x + rc.x.round() as u16;
+        let col_x_raw = area.x as i32 + rc.x.round() as i32 - h_off as i32;
+        let col_x_end = col_x_raw + rc.width.round() as i32;
+        if col_x_end <= area.x as i32 || col_x_raw >= (area.x + area.width) as i32 {
+            continue;
+        }
         let col_w = rc.width.round() as u16;
         if col_w == 0 {
             continue;
+        }
+
+        // Column separator on the right edge (skip last column).
+        if col_idx + 1 < table.columns.len() {
+            let sep_cx = col_x_raw + col_w as i32 - 1;
+            if sep_cx >= area.x as i32 && sep_cx < (area.x + area.width) as i32 {
+                set_cell(buf, sep_cx as u16, header_y, '│', sep_fg, header_bg);
+            }
         }
 
         let sort_suffix = match &table.sort {
@@ -68,17 +83,26 @@ pub fn draw_data_table(
             _ => "",
         };
         let title = format!("{}{}", col.title, sort_suffix);
-        let text_len = title.chars().count() as u16;
-        let start = align_offset(col.align, text_len, col_w);
+        let text_len = title.chars().count() as i32;
+        let usable_w = if col_idx + 1 < table.columns.len() {
+            col_w.saturating_sub(1) as i32
+        } else {
+            col_w as i32
+        };
+        let start = align_offset(col.align, text_len as u16, usable_w as u16) as i32;
 
         for (i, ch) in title.chars().enumerate() {
-            let cx = col_x + start + i as u16;
-            if cx >= area.x + area.width {
+            let cx = col_x_raw + start + i as i32;
+            if cx >= col_x_raw + usable_w || cx >= (area.x + area.width) as i32 {
                 break;
             }
-            set_cell(buf, cx, header_y, ch, header_fg, header_bg);
-            if let Some(cell) = buf.cell_mut(ratatui::prelude::Position::new(cx, header_y)) {
-                cell.set_style(ratatui::style::Style::default().add_modifier(Modifier::BOLD));
+            if cx >= area.x as i32 {
+                set_cell(buf, cx as u16, header_y, ch, header_fg, header_bg);
+                if let Some(cell) =
+                    buf.cell_mut(ratatui::prelude::Position::new(cx as u16, header_y))
+                {
+                    cell.set_style(ratatui::style::Style::default().add_modifier(Modifier::BOLD));
+                }
             }
         }
     }
@@ -107,15 +131,18 @@ pub fn draw_data_table(
         }
 
         for (col_idx, rc) in layout.columns.iter().enumerate() {
-            let cell_text: String = row
-                .cells
-                .get(col_idx)
-                .map(|c| c.spans.iter().map(|s| s.text.as_str()).collect())
-                .unwrap_or_default();
-            let text = cell_text.as_str();
-            let col_x = area.x + rc.x.round() as u16;
+            let styled = match row.cells.get(col_idx) {
+                Some(c) if !c.spans.is_empty() => c,
+                _ => continue,
+            };
+            let full_text: String = styled.spans.iter().map(|s| s.text.as_str()).collect();
+            let col_x_raw = area.x as i32 + rc.x.round() as i32 - h_off as i32;
+            let col_x_end = col_x_raw + rc.width.round() as i32;
+            if col_x_end <= area.x as i32 || col_x_raw >= (area.x + area.width) as i32 {
+                continue;
+            }
             let col_w = rc.width.round() as u16;
-            if col_w == 0 || text.is_empty() {
+            if col_w == 0 || full_text.is_empty() {
                 continue;
             }
 
@@ -124,21 +151,27 @@ pub fn draw_data_table(
                 .get(col_idx)
                 .map(|c| c.align)
                 .unwrap_or(ColumnAlign::Left);
-            let text_len = text.chars().count() as u16;
-            let start = align_offset(align, text_len, col_w);
+            let text_len = full_text.chars().count() as u16;
+            let start = align_offset(align, text_len, col_w) as i32;
 
-            let cell_fg = if row.decoration == crate::types::Decoration::Muted {
-                muted_fg
-            } else {
-                row_fg
-            };
-
-            for (i, ch) in text.chars().enumerate() {
-                let cx = col_x + start + i as u16;
-                if cx >= area.x + area.width {
-                    break;
+            let is_muted = row.decoration == crate::types::Decoration::Muted;
+            let mut char_offset = 0i32;
+            for span in &styled.spans {
+                let span_fg = if is_muted {
+                    muted_fg
+                } else {
+                    span.fg.map(ratatui_color).unwrap_or(row_fg)
+                };
+                for ch in span.text.chars() {
+                    let cx = col_x_raw + start + char_offset;
+                    if cx >= (area.x + area.width) as i32 {
+                        break;
+                    }
+                    if cx >= area.x as i32 {
+                        set_cell(buf, cx as u16, y, ch, span_fg, row_bg);
+                    }
+                    char_offset += 1;
                 }
-                set_cell(buf, cx, y, ch, cell_fg, row_bg);
             }
         }
     }
@@ -164,6 +197,23 @@ pub fn draw_data_table(
             1.0,
         );
         super::draw_scrollbar(buf, &sb, theme, theme.background);
+    }
+
+    // ── Horizontal scrollbar ─────────────────────────────────────────
+    if layout.h_scrollbar_height > 0.0 && layout.content_width > 0.0 {
+        let hsb_y = area.y + area.height - layout.h_scrollbar_height.round() as u16;
+        let track_w = (area.width as f32 - layout.scrollbar_width).max(1.0);
+        let hsb_track = crate::event::Rect::new(area.x as f32, hsb_y as f32, track_w, 1.0);
+        let visible_w = (area.width as f32 - layout.scrollbar_width).max(1.0);
+        let hsb = crate::primitives::scrollbar::Scrollbar::horizontal(
+            table.id.clone(),
+            hsb_track,
+            table.h_scroll,
+            layout.content_width,
+            visible_w,
+            1.0,
+        );
+        super::draw_scrollbar(buf, &hsb, theme, theme.background);
     }
 
     layout
@@ -226,6 +276,8 @@ mod tests {
             sort: Some((0, SortDirection::Ascending)),
             has_focus: true,
             show_scrollbar: false,
+            min_total_width: None,
+            h_scroll: 0.0,
         }
     }
 


### PR DESCRIPTION
## Summary
Follow-up to DataTable v1 (#145). Addresses all items from #146:

1. **Column header separators** — TUI: `│` between columns; GTK: 1px Cairo lines
2. **Per-cell colored text** — both rasterisers iterate `StyledText` spans and apply per-span `fg` color (green Running, red CrashLoopBackOff, yellow Pending)
3. **Scrollbar thumb drag + track page** — vertical scrollbar fully interactive in the example
4. **Horizontal scroll** — `min_total_width: Option<f32>` + `h_scroll: f32` on `DataTable`; columns laid out at min width when viewport is narrower; h-scrollbar at half line_height (GTK) / 1 cell (TUI); thumb drag + track page + `H`/`L` keys + scroll wheel
5. **TUI h-scroll clipping** — columns correctly scroll off-screen left using i32 coordinate math

Closes #146

## Test plan
- [x] Full quality gate: 626 tests, clippy, fmt
- [x] Manual smoke test both backends: sort, select, v-scroll, h-scroll, column resize, colored cells, header separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)