### PR TITLE
feat(quadraui): TUI double-click synthesis from repeated MouseDown (#147)

### DIFF
--- a/quadraui/examples/common/multi_tree.rs
+++ b/quadraui/examples/common/multi_tree.rs
@@ -158,9 +158,12 @@ impl AppLogic for DebugSidebar {
                 self.last_action = format!("header→{section}");
                 Reaction::Redraw
             }
-            SidebarEvent::RowSelected { section, path }
-            | SidebarEvent::RowActivated { section, path } => {
-                self.last_action = format!("row→{section} {path:?}");
+            SidebarEvent::RowSelected { section, path } => {
+                self.last_action = format!("sel→{section} {path:?}");
+                Reaction::Redraw
+            }
+            SidebarEvent::RowActivated { section, path } => {
+                self.last_action = format!("dblclick→{section} {path:?}");
                 Reaction::Redraw
             }
             SidebarEvent::ContextMenuRequested {

--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -463,6 +463,11 @@ impl SidebarSystem {
                 ..
             } => self.right_click(rect, *position, lh, metrics),
 
+            // ── Double-click → forward to TreeController for RowActivated
+            UiEvent::DoubleClick { position, .. } => {
+                self.double_click(rect, position.x, position.y, lh, metrics, backend)
+            }
+
             // ── Mouse drag ────────────────────────────────────────
             UiEvent::MouseMoved {
                 position,
@@ -1069,6 +1074,40 @@ impl SidebarSystem {
                 let max_scroll = (total - rect.height).max(0.0);
                 self.panel_scroll = (self.panel_scroll + rect.height).clamp(0.0, max_scroll);
                 SidebarEvent::Consumed
+            }
+            _ => SidebarEvent::Ignored,
+        }
+    }
+
+    fn double_click(
+        &mut self,
+        rect: Rect,
+        x: f32,
+        y: f32,
+        lh: f32,
+        metrics: &LayoutMetrics,
+        _backend: Option<&dyn Backend>,
+    ) -> SidebarEvent {
+        let (layout, map) = self.compute_layout(rect, metrics, lh);
+        let (view, _) = self.build_view();
+        match layout.hit_test(x, y) {
+            MultiSectionViewHit::Body {
+                section: msv_idx, ..
+            } => {
+                let section = map[msv_idx];
+                let body_b = layout.sections[msv_idx].body_bounds;
+                if let SectionBody::Tree(t) = &view.sections[msv_idx].body {
+                    let tree = t.clone();
+                    let inner = self.compute_tree_layout(body_b, &tree, lh);
+                    if let TreeViewHit::Row(idx) = inner.hit_test(x - body_b.x, y - body_b.y) {
+                        let path = tree.rows[idx].path.clone();
+                        if let SectionController::Tree(tc) = &mut self.sections[section] {
+                            tc.set_selected_path(Some(path.clone()));
+                        }
+                        return SidebarEvent::RowActivated { section, path };
+                    }
+                }
+                SidebarEvent::Ignored
             }
             _ => SidebarEvent::Ignored,
         }

--- a/quadraui/src/event.rs
+++ b/quadraui/src/event.rs
@@ -88,8 +88,9 @@ pub enum NamedKey {
 }
 
 /// Mouse button identity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum MouseButton {
+    #[default]
     Left,
     Right,
     Middle,

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -225,10 +225,17 @@ fn activate<A: AppLogic + 'static>(
         let app = app.clone();
         let da_for_redraw = da.clone();
         let window_for_close = window.clone();
-        click.connect_pressed(move |gesture, _n_press, x, y| {
+        click.connect_pressed(move |gesture, n_press, x, y| {
             let button = gesture.current_button();
             let modifier = gesture.current_event_state();
-            let ev = gdk_button_to_mouse_down(button, x, y, modifier);
+            let ev = if n_press == 2 {
+                crate::UiEvent::DoubleClick {
+                    widget: None,
+                    position: crate::Point::new(x as f32, y as f32),
+                }
+            } else {
+                gdk_button_to_mouse_down(button, x, y, modifier)
+            };
             let reaction = {
                 let mut backend_mut = backend.borrow_mut();
                 let mut app_mut = app.borrow_mut();

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -95,6 +95,7 @@ pub struct TuiBackend {
     /// or ASCII fallbacks (`false`). Apps set this from their own
     /// settings via [`Self::set_nerd_fonts`]; defaults to `true`.
     nerd_fonts_enabled: bool,
+    double_click: super::events::DoubleClickDetector,
 }
 
 impl TuiBackend {
@@ -115,6 +116,7 @@ impl TuiBackend {
             current_frame_ptr: Cell::new(std::ptr::null_mut()),
             current_theme: crate::Theme::default(),
             nerd_fonts_enabled: true,
+            double_click: super::events::DoubleClickDetector::new(),
         }
     }
 
@@ -363,6 +365,7 @@ impl Backend for TuiBackend {
             }
         }
         self.apply_accelerators(&mut out);
+        self.double_click.process(&mut out);
         out
     }
 
@@ -379,6 +382,7 @@ impl Backend for TuiBackend {
             if let Ok(ev) = ratatui::crossterm::event::read() {
                 let mut out = super::events::crossterm_to_uievents(ev);
                 self.apply_accelerators(&mut out);
+                self.double_click.process(&mut out);
                 return out;
             }
         }

--- a/quadraui/src/tui/events.rs
+++ b/quadraui/src/tui/events.rs
@@ -127,6 +127,61 @@ pub fn crossterm_mouse_to_uievent(event: MouseEvent) -> Option<UiEvent> {
     }
 }
 
+// ── Double-click synthesis ───────────────────────────────────────────────
+
+use std::time::{Duration, Instant};
+
+const DOUBLE_CLICK_MS: u64 = 400;
+const DOUBLE_CLICK_RADIUS: f32 = 1.5;
+
+/// Detects double-clicks from repeated `MouseDown` events within a
+/// time window at the same position. Stateful — lives on `TuiBackend`.
+#[derive(Default)]
+pub struct DoubleClickDetector {
+    last_click_time: Option<Instant>,
+    last_click_pos: Point,
+    last_click_button: MouseButton,
+}
+
+impl DoubleClickDetector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process a batch of translated events. Replaces `MouseDown` with
+    /// `DoubleClick` when the same button clicks at the same position
+    /// within the time window.
+    pub fn process(&mut self, events: &mut [UiEvent]) {
+        let now = Instant::now();
+        for ev in events.iter_mut() {
+            if let UiEvent::MouseDown {
+                button, position, ..
+            } = ev
+            {
+                let is_double = self
+                    .last_click_time
+                    .map(|t| now.duration_since(t) < Duration::from_millis(DOUBLE_CLICK_MS))
+                    .unwrap_or(false)
+                    && *button == self.last_click_button
+                    && (position.x - self.last_click_pos.x).abs() <= DOUBLE_CLICK_RADIUS
+                    && (position.y - self.last_click_pos.y).abs() <= DOUBLE_CLICK_RADIUS;
+
+                if is_double {
+                    *ev = UiEvent::DoubleClick {
+                        widget: None,
+                        position: *position,
+                    };
+                    self.last_click_time = None;
+                } else {
+                    self.last_click_time = Some(now);
+                    self.last_click_pos = *position;
+                    self.last_click_button = *button;
+                }
+            }
+        }
+    }
+}
+
 fn crossterm_keycode_to_key(code: KeyCode) -> Option<Key> {
     let named = match code {
         KeyCode::Char(c) => return Some(Key::Char(c)),
@@ -664,5 +719,64 @@ mod tests {
         let ui = crossterm_mouse_to_uievent(original).unwrap();
         let round = synth_mouseevent(&ui).unwrap();
         assert!(matches!(round.kind, MouseEventKind::ScrollUp));
+    }
+
+    // ── DoubleClickDetector tests ────────────────────────────────────
+
+    fn mouse_down(x: f32, y: f32) -> UiEvent {
+        UiEvent::MouseDown {
+            widget: None,
+            button: MouseButton::Left,
+            position: Point::new(x, y),
+            modifiers: Modifiers::default(),
+        }
+    }
+
+    #[test]
+    fn double_click_detected_on_same_position() {
+        let mut det = DoubleClickDetector::new();
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(matches!(events[0], UiEvent::MouseDown { .. }));
+
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(
+            matches!(events[0], UiEvent::DoubleClick { .. }),
+            "second click at same position should be DoubleClick"
+        );
+    }
+
+    #[test]
+    fn no_double_click_at_different_position() {
+        let mut det = DoubleClickDetector::new();
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+
+        let mut events = vec![mouse_down(20.0, 10.0)];
+        det.process(&mut events);
+        assert!(
+            matches!(events[0], UiEvent::MouseDown { .. }),
+            "click at different position should NOT be DoubleClick"
+        );
+    }
+
+    #[test]
+    fn triple_click_resets_to_single() {
+        let mut det = DoubleClickDetector::new();
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(matches!(events[0], UiEvent::DoubleClick { .. }));
+
+        // Third click at same position — resets to single (no triple-click).
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(
+            matches!(events[0], UiEvent::MouseDown { .. }),
+            "third click should reset to MouseDown"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `DoubleClickDetector` on `TuiBackend` tracks last click time + position + button
- When `MouseDown` arrives within 400ms at the same cell (±1.5 unit radius), replaced with `UiEvent::DoubleClick`
- Third click resets to single (no triple-click)
- Wired into both `poll_events` and `wait_events`
- Also adds `Default` derive to `MouseButton` (needed by detector)

Closes #147

## Migration for consumers
- TUI consumers that handle `UiEvent::DoubleClick` now get it automatically — remove manual double-click timers
- `TreeController::handle()` RowActivated on double-click now works on TUI

## Test plan
- [x] 3 new tests: double-click detected, different position rejected, triple resets
- [x] Full quality gate: 629 tests, clippy, fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)