### PR TITLE
feat(quadraui): dimmed selection highlight for unfocused trees (#159)

### DIFF
--- a/quadraui/src/gtk/tree.rs
+++ b/quadraui/src/gtk/tree.rs
@@ -87,6 +87,7 @@ pub fn draw_tree(
     let fg = cairo_rgb(theme.foreground);
     let dim = cairo_rgb(theme.muted_fg);
     let sel = cairo_rgb(theme.selected_bg);
+    let inactive_sel = cairo_rgb(theme.inactive_selected_bg);
     let text_sel = cairo_rgb(theme.selection_bg);
 
     cr.set_source_rgb(bg.0, bg.1, bg.2);
@@ -118,11 +119,14 @@ pub fn draw_tree(
             continue;
         }
 
-        let is_selected =
-            tree.has_focus && tree.selected_path.as_ref().is_some_and(|p| p == &row.path);
+        let path_selected = tree.selected_path.as_ref().is_some_and(|p| p == &row.path);
+        let is_selected = tree.has_focus && path_selected;
+        let is_inactive_selected = !tree.has_focus && path_selected;
 
         let (def_fg, row_bg) = if is_selected {
             (hdr_fg, sel)
+        } else if is_inactive_selected {
+            (fg, inactive_sel)
         } else if is_header {
             (hdr_fg, hdr_bg)
         } else if matches!(row.decoration, Decoration::Muted) {

--- a/quadraui/src/theme.rs
+++ b/quadraui/src/theme.rs
@@ -68,6 +68,10 @@ pub struct Theme {
     pub surface_fg: Color,
     /// Background of the selected row in a `ListView`.
     pub selected_bg: Color,
+    /// Dimmed selection background for unfocused trees / lists. Indicates
+    /// the selected row without implying keyboard focus (e.g. explorer
+    /// tree highlighting the file matching the active editor tab).
+    pub inactive_selected_bg: Color,
     /// Border-glyph colour for bordered surfaces.
     pub border_fg: Color,
     /// Title text colour drawn over a top border (bordered `ListView`).
@@ -267,6 +271,7 @@ impl Default for Theme {
             surface_bg: Color::rgb(28, 32, 44),
             surface_fg: fg,
             selected_bg: Color::rgb(50, 60, 90),
+            inactive_selected_bg: Color::rgb(35, 40, 58),
             border_fg: Color::rgb(120, 160, 200),
             title_fg: Color::rgb(180, 200, 230),
             header_bg: Color::rgb(40, 44, 56),

--- a/quadraui/src/tui/tree.rs
+++ b/quadraui/src/tui/tree.rs
@@ -56,6 +56,7 @@ pub fn draw_tree(
     let hdr_fg = ratatui_color(theme.header_fg);
     let item_fg = ratatui_color(theme.foreground);
     let sel_bg = ratatui_color(theme.selected_bg);
+    let inactive_sel_bg = ratatui_color(theme.inactive_selected_bg);
     let text_sel_bg = ratatui_color(theme.selection_bg);
     let dim_fg = ratatui_color(theme.muted_fg);
 
@@ -71,13 +72,15 @@ pub fn draw_tree(
         }
 
         let is_header = matches!(row.decoration, Decoration::Header);
-        let is_selected =
-            tree.has_focus && tree.selected_path.as_ref().is_some_and(|p| p == &row.path);
+        let path_selected = tree.selected_path.as_ref().is_some_and(|p| p == &row.path);
+        let is_selected = tree.has_focus && path_selected;
+        let is_inactive_selected = !tree.has_focus && path_selected;
 
-        let (default_fg, bg) = match (is_header, is_selected) {
-            (_, true) => (hdr_fg, sel_bg),
-            (true, false) => (hdr_fg, hdr_bg),
-            (false, false) => (item_fg, row_bg),
+        let (default_fg, bg) = match (is_header, is_selected, is_inactive_selected) {
+            (_, true, _) => (hdr_fg, sel_bg),
+            (_, _, true) => (item_fg, inactive_sel_bg),
+            (true, _, _) => (hdr_fg, hdr_bg),
+            _ => (item_fg, row_bg),
         };
 
         for x in area.x..area.x + area.width {


### PR DESCRIPTION
## Summary

- Add `inactive_selected_bg` to `Theme` — a dimmed selection background for unfocused trees/lists (default: `rgb(35, 40, 58)`, midway between `tab_bar_bg` and `selected_bg`)
- Update TUI `draw_tree_view` — ternary selection: focused → `selected_bg`, unfocused → `inactive_selected_bg`, none → normal bg
- Update GTK `draw_tree_view` — same ternary logic, unfocused uses `default_fg` (not `header_fg`) to avoid implying focus

Closes #159

## Test plan

- [x] 670 tests pass (`cargo test --features tui --features gtk`)
- [x] Clippy clean, fmt clean
- [ ] Visual: run vimcode with updated quadraui, verify explorer tree shows dimmed highlight on the active tab's file when editor has focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)