### PR TITLE
feat(quadraui): Palette preview pane rendering (#161)

### DIFF
--- a/quadraui/src/gtk/palette.rs
+++ b/quadraui/src/gtk/palette.rs
@@ -66,6 +66,9 @@ pub fn draw_palette(
 
     layout.set_attributes(None);
 
+    let has_preview = palette.preview.is_some();
+    let list_w = if has_preview { (w * 0.4).round() } else { w };
+
     const BOTTOM_INSET: f64 = 4.0;
     let sep_y = y + 2.0 * line_height;
     let rows_y = sep_y + 1.0;
@@ -75,7 +78,7 @@ pub fn draw_palette(
     let total = palette.items.len();
     let has_scrollbar = total > visible_rows;
     const SB_W: f64 = 6.0;
-    let content_w = if has_scrollbar { w - SB_W } else { w };
+    let content_w = if has_scrollbar { list_w - SB_W } else { list_w };
 
     // Clamp so the selected item stays visible AND the visible window
     // stays full when there are enough items above to fill it (mirrors
@@ -288,7 +291,7 @@ pub fn draw_palette(
 
     // ── Scrollbar ─────────────────────────────────────────────────────
     if has_scrollbar && visible_rows > 0 {
-        let sb_x = x + w - SB_W;
+        let sb_x = x + list_w - SB_W;
         let sb_track_y = rows_y;
         let sb_track_h = rows_h;
 
@@ -309,6 +312,76 @@ pub fn draw_palette(
         cr.set_source_rgb(border.0, border.1, border.2);
         cr.rectangle(sb_x + 1.0, thumb_y, SB_W - 2.0, thumb_h);
         cr.fill().ok();
+    }
+
+    // ── Preview pane ───────────────────────────────────────────────────
+    if let Some(ref preview) = palette.preview {
+        let preview_x = x + list_w;
+        let preview_w = w - list_w;
+
+        // Vertical separator between items and preview.
+        cr.set_source_rgb(border.0, border.1, border.2);
+        cr.set_line_width(1.0);
+        cr.move_to(preview_x, rows_y);
+        cr.line_to(preview_x, rows_y + rows_h);
+        cr.stroke().ok();
+
+        // Clip to preview area.
+        cr.save().ok();
+        cr.rectangle(preview_x, rows_y, preview_w, rows_h);
+        cr.clip();
+
+        let content_x = preview_x + 8.0;
+        let content_right = x + w - 8.0;
+        let mut cursor_y = rows_y;
+
+        // Preview title.
+        if let Some(ref title_text) = preview.title {
+            cr.set_source_rgb(dim.0, dim.1, dim.2);
+            layout.set_attributes(None);
+            layout.set_text(title_text);
+            let (_, th) = layout.pixel_size();
+            cr.move_to(content_x, cursor_y + (line_height - th as f64) / 2.0);
+            pcfn::show_layout(cr, layout);
+            cursor_y += line_height;
+        }
+
+        // Preview content lines.
+        let sel_rgb = cairo_rgb(theme.selected_bg);
+        let preview_visible = ((rows_y + rows_h - cursor_y) / line_height) as usize;
+        for (vi, line_idx) in (preview.scroll_offset..).take(preview_visible).enumerate() {
+            let row_y = cursor_y + vi as f64 * line_height;
+            if row_y + line_height > rows_y + rows_h + 0.5 {
+                break;
+            }
+
+            let is_highlight = preview.highlight_line == Some(line_idx);
+            if is_highlight {
+                cr.set_source_rgb(sel_rgb.0, sel_rgb.1, sel_rgb.2);
+                cr.rectangle(preview_x, row_y, preview_w, line_height);
+                cr.fill().ok();
+            }
+
+            if line_idx < preview.lines.len() {
+                let line = &preview.lines[line_idx];
+                let mut cx = content_x;
+                for span in &line.spans {
+                    let span_rgb = span.fg.map(cairo_rgb).unwrap_or(fg);
+                    cr.set_source_rgb(span_rgb.0, span_rgb.1, span_rgb.2);
+                    layout.set_attributes(None);
+                    layout.set_text(&span.text);
+                    let (sw, sh) = layout.pixel_size();
+                    cr.move_to(cx, row_y + (line_height - sh as f64) / 2.0);
+                    pcfn::show_layout(cr, layout);
+                    cx += sw as f64;
+                    if cx > content_right {
+                        break;
+                    }
+                }
+            }
+        }
+
+        cr.restore().ok();
     }
 
     cr.restore().ok();

--- a/quadraui/src/tui/palette.rs
+++ b/quadraui/src/tui/palette.rs
@@ -132,21 +132,6 @@ pub fn draw_palette(
         }
     }
 
-    // Separator row beneath the query.
-    if h >= 4 {
-        let row = y0 + 2;
-        for col in 0..w {
-            let ch = if col == 0 {
-                '├'
-            } else if col == w - 1 {
-                '┤'
-            } else {
-                '─'
-            };
-            set_cell(buf, x0 + col, row, ch, border_fg, bg);
-        }
-    }
-
     // Preview pane splits the popup horizontally when present.
     let has_preview = palette.preview.is_some();
     let list_w = if has_preview {
@@ -155,6 +140,23 @@ pub fn draw_palette(
         w
     };
     let preview_x0 = x0 + list_w;
+
+    // Separator row beneath the query.
+    if h >= 4 {
+        let row = y0 + 2;
+        for col in 0..w {
+            let ch = if col == 0 {
+                '├'
+            } else if col == w - 1 {
+                '┤'
+            } else if has_preview && x0 + col == preview_x0 {
+                '┬'
+            } else {
+                '─'
+            };
+            set_cell(buf, x0 + col, row, ch, border_fg, bg);
+        }
+    }
 
     // Result rows.
     let items_row0 = y0 + 3;
@@ -309,12 +311,6 @@ pub fn draw_palette(
             set_cell(buf, x0 + w - 1, row, '│', border_fg, bg);
         }
 
-        // Separator on the separator row (y0+2) — extend across preview.
-        let sep_row = y0 + 2;
-        if sep_col < x0 + w {
-            set_cell(buf, sep_col, sep_row, '┬', border_fg, bg);
-        }
-
         // Preview title row (reuses separator row area in the preview
         // half, or first content row if no title).
         let mut preview_row0 = items_row0;
@@ -367,12 +363,6 @@ pub fn draw_palette(
                 }
             }
         }
-
-        // Bottom border separator junction.
-        let bottom_row = y_end - 1;
-        if sep_col < x0 + w {
-            set_cell(buf, sep_col, bottom_row, '┴', border_fg, bg);
-        }
     }
 
     // Bottom border.
@@ -382,6 +372,8 @@ pub fn draw_palette(
             '╰'
         } else if col == w - 1 {
             '╯'
+        } else if has_preview && x0 + col == preview_x0 {
+            '┴'
         } else {
             '─'
         };
@@ -483,6 +475,79 @@ mod tests {
         // 'o' at byte 2 of "foo" → second 'o' → f_col + 2.
         let fg2 = buf[(f_col + 2, 3u16)].fg;
         assert_eq!(fg2, ratatui::style::Color::Rgb(99, 99, 99));
+    }
+
+    #[test]
+    fn preview_pane_paints_content_and_separator() {
+        use crate::primitives::palette::PalettePreview;
+        // Wide enough for 40/60 split: 40 cells → list_w=16, preview=24.
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 12));
+        let mut p = make_palette();
+        p.preview = Some(PalettePreview {
+            lines: vec![
+                StyledText::plain("line one"),
+                StyledText::plain("line two"),
+                StyledText::plain("line three"),
+            ],
+            title: Some("preview.rs".into()),
+            scroll_offset: 0,
+            highlight_line: Some(1),
+        });
+        draw_palette(
+            &mut buf,
+            Rect::new(0, 0, 40, 12),
+            &p,
+            &Theme::default(),
+            false,
+        );
+        let list_w = ((40.0_f32) * 0.4).round() as u16; // 16
+                                                        // Vertical separator on item rows.
+        assert_eq!(cell_char(&buf, list_w, 3), '│');
+        // Separator junction on the separator row.
+        assert_eq!(cell_char(&buf, list_w, 2), '┬');
+        // Bottom border junction.
+        assert_eq!(cell_char(&buf, list_w, 11), '┴');
+        // Preview title painted (first char of "preview.rs").
+        let title_col = list_w + 2;
+        assert_eq!(cell_char(&buf, title_col, 3), 'p');
+        // Preview content line 0 ("line one") at row 4 (after title).
+        let content_row = 4;
+        let content_col = list_w + 2;
+        assert_eq!(cell_char(&buf, content_col, content_row), 'l');
+        // Highlight line (line 1) uses selected_bg.
+        let highlight_row = 5;
+        let highlight_bg = buf[(content_col, highlight_row)].bg;
+        let sel_bg_color = ratatui_color(Theme::default().selected_bg);
+        assert_eq!(highlight_bg, sel_bg_color);
+    }
+
+    #[test]
+    fn preview_pane_respects_scroll_offset() {
+        use crate::primitives::palette::PalettePreview;
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 12));
+        let mut p = make_palette();
+        p.preview = Some(PalettePreview {
+            lines: vec![
+                StyledText::plain("line zero"),
+                StyledText::plain("line one"),
+                StyledText::plain("visible"),
+            ],
+            title: None,
+            scroll_offset: 2,
+            highlight_line: None,
+        });
+        draw_palette(
+            &mut buf,
+            Rect::new(0, 0, 40, 12),
+            &p,
+            &Theme::default(),
+            false,
+        );
+        let list_w = ((40.0_f32) * 0.4).round() as u16;
+        let content_col = list_w + 2;
+        // No title → content starts at items_row0 (row 3).
+        // scroll_offset=2 → first visible line is "visible".
+        assert_eq!(cell_char(&buf, content_col, 3), 'v');
     }
 
     #[test]

--- a/quadraui/src/tui/palette.rs
+++ b/quadraui/src/tui/palette.rs
@@ -147,13 +147,28 @@ pub fn draw_palette(
         }
     }
 
+    // Preview pane splits the popup horizontally when present.
+    let has_preview = palette.preview.is_some();
+    let list_w = if has_preview {
+        ((w as f32) * 0.4).round() as u16
+    } else {
+        w
+    };
+    let preview_x0 = x0 + list_w;
+
     // Result rows.
     let items_row0 = y0 + 3;
     let items_row_end = y_end - 1;
     let visible_rows = items_row_end.saturating_sub(items_row0) as usize;
     let total = palette.items.len();
     let has_scrollbar = total > visible_rows;
-    let item_end_col = if has_scrollbar { w - 2 } else { w - 1 };
+    let item_end_col = if has_scrollbar {
+        list_w - 1
+    } else if has_preview {
+        list_w
+    } else {
+        w - 1
+    };
 
     // Clamp scroll_offset so the selected item is always visible AND
     // the visible window stays full when there are enough items to
@@ -188,7 +203,7 @@ pub fn draw_palette(
         let row_bg = if is_selected { sel_bg } else { bg };
 
         set_cell(buf, x0, row, '│', border_fg, bg);
-        if w >= 2 {
+        if !has_preview && w >= 2 {
             set_cell(buf, x0 + w - 1, row, '│', border_fg, bg);
         }
         for col in 1..item_end_col {
@@ -262,7 +277,7 @@ pub fn draw_palette(
 
         // Scrollbar.
         if has_scrollbar {
-            let sb_col = w - 2;
+            let sb_col = list_w - 1;
             let track_len = visible_rows;
             let thumb_len = (visible_rows * visible_rows / total.max(1)).max(1);
             let thumb_start = effective_offset * track_len / total.max(1);
@@ -277,8 +292,86 @@ pub fn draw_palette(
     let drawn = total.saturating_sub(effective_offset).min(visible_rows) as u16;
     for row in items_row0 + drawn..items_row_end {
         set_cell(buf, x0, row, '│', border_fg, bg);
-        if w >= 2 {
+        if !has_preview && w >= 2 {
             set_cell(buf, x0 + w - 1, row, '│', border_fg, bg);
+        }
+    }
+
+    // ── Preview pane ─────────────────────────────────────────────────
+    if let Some(ref preview) = palette.preview {
+        let sep_col = preview_x0;
+        let preview_content_x = sep_col + 1;
+        let _preview_w = (x0 + w).saturating_sub(preview_content_x + 1);
+
+        // Vertical separator + right border for all item/preview rows.
+        for row in items_row0..items_row_end {
+            set_cell(buf, sep_col, row, '│', border_fg, bg);
+            set_cell(buf, x0 + w - 1, row, '│', border_fg, bg);
+        }
+
+        // Separator on the separator row (y0+2) — extend across preview.
+        let sep_row = y0 + 2;
+        if sep_col < x0 + w {
+            set_cell(buf, sep_col, sep_row, '┬', border_fg, bg);
+        }
+
+        // Preview title row (reuses separator row area in the preview
+        // half, or first content row if no title).
+        let mut preview_row0 = items_row0;
+
+        if let Some(ref title_text) = preview.title {
+            let row = items_row0;
+            if row < items_row_end {
+                for col in preview_content_x..x0 + w - 1 {
+                    set_cell(buf, col, row, ' ', fg, bg);
+                }
+                let mut col = preview_content_x + 1;
+                for ch in title_text.chars() {
+                    if col + 1 >= x0 + w - 1 {
+                        break;
+                    }
+                    set_cell(buf, col, row, ch, dim_fg, bg);
+                    col += 1;
+                }
+                preview_row0 = items_row0 + 1;
+            }
+        }
+
+        // Preview content lines.
+        let highlight_bg = ratatui_color(theme.selected_bg);
+        let preview_visible = items_row_end.saturating_sub(preview_row0) as usize;
+        for (vi, line_idx) in (preview.scroll_offset..).take(preview_visible).enumerate() {
+            let row = preview_row0 + vi as u16;
+            if row >= items_row_end {
+                break;
+            }
+            let is_highlight = preview.highlight_line == Some(line_idx);
+            let line_bg = if is_highlight { highlight_bg } else { bg };
+
+            for col in preview_content_x..x0 + w - 1 {
+                set_cell(buf, col, row, ' ', fg, line_bg);
+            }
+
+            if line_idx < preview.lines.len() {
+                let line = &preview.lines[line_idx];
+                let mut col = preview_content_x + 1;
+                for span in &line.spans {
+                    let span_fg = span.fg.map(ratatui_color).unwrap_or(fg);
+                    for ch in span.text.chars() {
+                        if col + 1 >= x0 + w - 1 {
+                            break;
+                        }
+                        set_cell(buf, col, row, ch, span_fg, line_bg);
+                        col += 1;
+                    }
+                }
+            }
+        }
+
+        // Bottom border separator junction.
+        let bottom_row = y_end - 1;
+        if sep_col < x0 + w {
+            set_cell(buf, sep_col, bottom_row, '┴', border_fg, bg);
         }
     }
 


### PR DESCRIPTION
## Summary

- **TUI rasteriser**: When `Palette.preview` is `Some`, splits the popup 40/60 with a `│` vertical separator. Renders preview lines with `scroll_offset`, optional title (dimmed), and `highlight_line` background (`selected_bg`). Border junctions use `┬`/`┴`.
- **GTK rasteriser**: Same 40/60 split with a 1px vertical separator line. Preview lines rendered per-span with syntax highlighting colors. Highlighted line uses `selected_bg` fill.
- Both backends respect existing `PalettePreview` fields: `lines`, `title`, `scroll_offset`, `highlight_line`
- No primitive or theme changes — all infrastructure was already in place (#155 session)

Closes #161

## Test plan

- [x] 670 tests pass (`cargo test --features tui --features gtk`)
- [x] Clippy clean, fmt clean
- [ ] Visual: vimcode file picker with preview pane enabled on both backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)