### PR TITLE
feat(quadraui): Palette show_query flag for popup-style lists (#162)

### DIFF
--- a/quadraui/src/gtk/palette.rs
+++ b/quadraui/src/gtk/palette.rs
@@ -70,8 +70,13 @@ pub fn draw_palette(
     let list_w = if has_preview { (w * 0.4).round() } else { w };
 
     const BOTTOM_INSET: f64 = 4.0;
-    let sep_y = y + 2.0 * line_height;
-    let rows_y = sep_y + 1.0;
+    let (sep_y, rows_y) = if palette.show_query {
+        let s = y + 2.0 * line_height;
+        (s, s + 1.0)
+    } else {
+        let s = y + line_height;
+        (s, s)
+    };
     let rows_h_raw = ((y + h) - rows_y - BOTTOM_INSET).max(0.0);
     let visible_rows = (rows_h_raw / line_height) as usize;
     let rows_h = visible_rows as f64 * line_height;
@@ -99,11 +104,16 @@ pub fn draw_palette(
     // visibility-clamped effective value without mutating the caller.
     let mut palette_local = palette.clone();
     palette_local.scroll_offset = effective_offset;
+    let query_h = if palette.show_query {
+        line_height as f32
+    } else {
+        0.0
+    };
     let palette_layout = palette_local.layout(
         w as f32,
         (rows_y + rows_h - y) as f32,
         line_height as f32,
-        line_height as f32,
+        query_h,
         |_| PaletteItemMeasure::new(line_height as f32),
     );
 
@@ -173,11 +183,13 @@ pub fn draw_palette(
     }
 
     // ── Separator row ─────────────────────────────────────────────────
-    cr.set_source_rgb(border.0, border.1, border.2);
-    cr.set_line_width(1.0);
-    cr.move_to(x, sep_y);
-    cr.line_to(x + w, sep_y);
-    cr.stroke().ok();
+    if palette.show_query {
+        cr.set_source_rgb(border.0, border.1, border.2);
+        cr.set_line_width(1.0);
+        cr.move_to(x, sep_y);
+        cr.line_to(x + w, sep_y);
+        cr.stroke().ok();
+    }
 
     // ── Result rows ───────────────────────────────────────────────────
     cr.save().ok();

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -480,6 +480,7 @@ mod tests {
             scroll_offset: 0,
             total_count: 42,
             has_focus: true,
+            show_query: true,
             preview: None,
         };
         let json = serde_json::to_string(&palette).unwrap();
@@ -2874,6 +2875,7 @@ mod tests {
             scroll_offset: scroll,
             total_count: 0,
             has_focus: true,
+            show_query: true,
             preview: None,
         }
     }

--- a/quadraui/src/primitives/palette.rs
+++ b/quadraui/src/primitives/palette.rs
@@ -61,6 +61,11 @@ pub struct Palette {
     pub total_count: usize,
     #[serde(default)]
     pub has_focus: bool,
+    /// When `false`, the query input row and separator are hidden —
+    /// producing a popup-style list (tab switcher, branch picker).
+    /// Default `true`.
+    #[serde(default = "default_true")]
+    pub show_query: bool,
     /// When present, the palette renders a split layout: item list on
     /// the left, preview content on the right.
     #[serde(default)]
@@ -95,6 +100,10 @@ pub struct PaletteItem {
     /// Arrow direction when `expandable` is true (`▾` vs `▸`).
     #[serde(default)]
     pub expanded: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Preview pane content shown alongside the item list when the palette

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1494,6 +1494,7 @@ mod tests {
             scroll_offset: 0,
             total_count: 2,
             has_focus: true,
+            show_query: true,
             preview: None,
         }
     }

--- a/quadraui/src/tui/palette.rs
+++ b/quadraui/src/tui/palette.rs
@@ -91,47 +91,6 @@ pub fn draw_palette(
         set_cell(buf, x0 + col, y0, ch, title_fg, bg);
     }
 
-    // Query line.
-    if h >= 3 {
-        let row = y0 + 1;
-        set_cell(buf, x0, row, '│', border_fg, bg);
-        if w >= 2 {
-            set_cell(buf, x0 + w - 1, row, '│', border_fg, bg);
-        }
-        let prompt = "> ";
-        let mut col = 1u16;
-        for ch in prompt.chars() {
-            if col + 1 >= w {
-                break;
-            }
-            set_cell(buf, x0 + col, row, ch, query_fg, bg);
-            col += 1;
-        }
-        let query_start = col;
-        for ch in palette.query.chars() {
-            if col + 1 >= w {
-                break;
-            }
-            set_cell(buf, x0 + col, row, ch, query_fg, bg);
-            col += 1;
-        }
-        // Cursor block: byte-offset → visible column.
-        let mut byte = 0usize;
-        let mut char_idx = 0usize;
-        for ch in palette.query.chars() {
-            if byte >= palette.query_cursor {
-                break;
-            }
-            byte += ch.len_utf8();
-            char_idx += 1;
-        }
-        let cursor_col = query_start + char_idx as u16;
-        if cursor_col + 1 < w {
-            let ch = palette.query.chars().nth(char_idx).unwrap_or(' ');
-            set_cell(buf, x0 + cursor_col, row, ch, bg, query_fg);
-        }
-    }
-
     // Preview pane splits the popup horizontally when present.
     let has_preview = palette.preview.is_some();
     let list_w = if has_preview {
@@ -141,25 +100,69 @@ pub fn draw_palette(
     };
     let preview_x0 = x0 + list_w;
 
-    // Separator row beneath the query.
-    if h >= 4 {
-        let row = y0 + 2;
-        for col in 0..w {
-            let ch = if col == 0 {
-                '├'
-            } else if col == w - 1 {
-                '┤'
-            } else if has_preview && x0 + col == preview_x0 {
-                '┬'
-            } else {
-                '─'
-            };
-            set_cell(buf, x0 + col, row, ch, border_fg, bg);
+    // Query line + separator (skipped when show_query is false).
+    let items_row0 = if palette.show_query {
+        if h >= 3 {
+            let row = y0 + 1;
+            set_cell(buf, x0, row, '│', border_fg, bg);
+            if w >= 2 {
+                set_cell(buf, x0 + w - 1, row, '│', border_fg, bg);
+            }
+            let prompt = "> ";
+            let mut col = 1u16;
+            for ch in prompt.chars() {
+                if col + 1 >= w {
+                    break;
+                }
+                set_cell(buf, x0 + col, row, ch, query_fg, bg);
+                col += 1;
+            }
+            let query_start = col;
+            for ch in palette.query.chars() {
+                if col + 1 >= w {
+                    break;
+                }
+                set_cell(buf, x0 + col, row, ch, query_fg, bg);
+                col += 1;
+            }
+            let mut byte = 0usize;
+            let mut char_idx = 0usize;
+            for ch in palette.query.chars() {
+                if byte >= palette.query_cursor {
+                    break;
+                }
+                byte += ch.len_utf8();
+                char_idx += 1;
+            }
+            let cursor_col = query_start + char_idx as u16;
+            if cursor_col + 1 < w {
+                let ch = palette.query.chars().nth(char_idx).unwrap_or(' ');
+                set_cell(buf, x0 + cursor_col, row, ch, bg, query_fg);
+            }
         }
-    }
+
+        if h >= 4 {
+            let row = y0 + 2;
+            for col in 0..w {
+                let ch = if col == 0 {
+                    '├'
+                } else if col == w - 1 {
+                    '┤'
+                } else if has_preview && x0 + col == preview_x0 {
+                    '┬'
+                } else {
+                    '─'
+                };
+                set_cell(buf, x0 + col, row, ch, border_fg, bg);
+            }
+        }
+
+        y0 + 3
+    } else {
+        y0 + 1
+    };
 
     // Result rows.
-    let items_row0 = y0 + 3;
     let items_row_end = y_end - 1;
     let visible_rows = items_row_end.saturating_sub(items_row0) as usize;
     let total = palette.items.len();
@@ -411,6 +414,7 @@ mod tests {
             selected_idx: 0,
             scroll_offset: 0,
             has_focus: true,
+            show_query: true,
             total_count: 3,
             preview: None,
         }
@@ -548,6 +552,29 @@ mod tests {
         // No title → content starts at items_row0 (row 3).
         // scroll_offset=2 → first visible line is "visible".
         assert_eq!(cell_char(&buf, content_col, 3), 'v');
+    }
+
+    #[test]
+    fn show_query_false_hides_query_and_separator() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 10));
+        let mut p = make_palette();
+        p.show_query = false;
+        draw_palette(
+            &mut buf,
+            Rect::new(0, 0, 20, 10),
+            &p,
+            &Theme::default(),
+            false,
+        );
+        // Row 1 should be items, not the query prompt.
+        // With show_query=false, items start at y0+1 (right after title).
+        let row1_chars: String = (1..6).map(|x| cell_char(&buf, x, 1)).collect();
+        assert_ne!(row1_chars, "> fo ");
+        // First item "foo" should appear at row 1 (with selection prefix).
+        let has_item = (0..20).any(|x| cell_char(&buf, x, 1) == 'f');
+        assert!(has_item, "expected item text at row 1 when query hidden");
+        // No separator row (├─┤) should exist at row 2.
+        assert_ne!(cell_char(&buf, 0, 2), '├');
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `show_query: bool` field to `Palette` (serde default `true`)
- When `false`, query input row and separator are hidden — items start directly below the title
- TUI: `items_row0` adjusts from `y0+3` to `y0+1`; query/separator rendering skipped
- GTK: `rows_y` adjusts from `sep_y+1` to `y+line_height`; query/separator rendering skipped; layout receives `query_height: 0.0`

Closes #162

## Test plan

- [x] 673 tests pass (1 new: `show_query_false_hides_query_and_separator`)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)