### PR TITLE
feat(quadraui): Palette create_label for branch-picker pattern (#164)

### DIFF
--- a/quadraui/src/gtk/palette.rs
+++ b/quadraui/src/gtk/palette.rs
@@ -77,7 +77,9 @@ pub fn draw_palette(
         let s = y + line_height;
         (s, s)
     };
-    let rows_h_raw = ((y + h) - rows_y - BOTTOM_INSET).max(0.0);
+    let has_create = palette.create_label.is_some();
+    let create_reserved = if has_create { line_height } else { 0.0 };
+    let rows_h_raw = ((y + h) - rows_y - BOTTOM_INSET - create_reserved).max(0.0);
     let visible_rows = (rows_h_raw / line_height) as usize;
     let rows_h = visible_rows as f64 * line_height;
     let total = palette.items.len();
@@ -324,6 +326,26 @@ pub fn draw_palette(
         cr.set_source_rgb(border.0, border.1, border.2);
         cr.rectangle(sb_x + 1.0, thumb_y, SB_W - 2.0, thumb_h);
         cr.fill().ok();
+    }
+
+    // ── Create action row (pinned below items) ────────────────────────
+    if let Some(ref label) = palette.create_label {
+        let create_y = rows_y + rows_h;
+        let accent = cairo_rgb(theme.accent_fg);
+        let prefix = "+ ";
+        cr.set_source_rgb(accent.0, accent.1, accent.2);
+        layout.set_attributes(None);
+        layout.set_text(prefix);
+        let (pw, ph) = layout.pixel_size();
+        cr.move_to(x + 8.0, create_y + (line_height - ph as f64) / 2.0);
+        pcfn::show_layout(cr, layout);
+        layout.set_text(label);
+        let (_, lh) = layout.pixel_size();
+        cr.move_to(
+            x + 8.0 + pw as f64,
+            create_y + (line_height - lh as f64) / 2.0,
+        );
+        pcfn::show_layout(cr, layout);
     }
 
     // ── Preview pane ───────────────────────────────────────────────────

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -481,6 +481,7 @@ mod tests {
             total_count: 42,
             has_focus: true,
             show_query: true,
+            create_label: None,
             preview: None,
         };
         let json = serde_json::to_string(&palette).unwrap();
@@ -2878,6 +2879,7 @@ mod tests {
             total_count: 0,
             has_focus: true,
             show_query: true,
+            create_label: None,
             preview: None,
         }
     }

--- a/quadraui/src/primitives/palette.rs
+++ b/quadraui/src/primitives/palette.rs
@@ -66,6 +66,12 @@ pub struct Palette {
     /// Default `true`.
     #[serde(default = "default_true")]
     pub show_query: bool,
+    /// When set, a pinned "create" action row is rendered below the
+    /// scrollable item list (e.g. `"Create branch '{query}'"` in a
+    /// branch picker). The string is the display label — apps
+    /// typically interpolate the query themselves each frame.
+    #[serde(default)]
+    pub create_label: Option<String>,
     /// When present, the palette renders a split layout: item list on
     /// the left, preview content on the right.
     #[serde(default)]
@@ -162,6 +168,8 @@ pub enum PaletteHit {
     Item(usize),
     /// Click landed on the expand/collapse arrow of a tree item.
     ExpandToggle(usize),
+    /// Click landed on the pinned "create" action row.
+    CreateAction,
     /// Click landed on the preview pane area.
     Preview,
     /// Click landed outside any region.
@@ -185,6 +193,8 @@ pub struct PaletteLayout {
     /// Width of the item list column. Equals `viewport_width` when no
     /// preview is present; narrower (~40%) when a preview pane is shown.
     pub item_list_width: f32,
+    /// Pinned create-action row bounds, present when `Palette.create_label` is `Some`.
+    pub create_bounds: Option<Rect>,
     /// Preview pane bounds, present when `Palette.preview` is `Some`.
     pub preview_bounds: Option<Rect>,
 }
@@ -256,6 +266,13 @@ impl Palette {
 
         let items_top = y;
 
+        let create_row_h = if self.create_label.is_some() {
+            measure_item(0).height
+        } else {
+            0.0
+        };
+        let items_bottom = viewport_height - create_row_h;
+
         let resolved_scroll_offset = if self.items.is_empty() {
             0
         } else {
@@ -263,11 +280,11 @@ impl Palette {
         };
 
         for i in resolved_scroll_offset..self.items.len() {
-            if y >= viewport_height {
+            if y >= items_bottom {
                 break;
             }
             let m = measure_item(i);
-            let remaining = viewport_height - y;
+            let remaining = items_bottom - y;
             let height = m.height.min(remaining).max(0.0);
             if height <= 0.0 {
                 break;
@@ -280,6 +297,14 @@ impl Palette {
             hit_regions.push((bounds, PaletteHit::Item(i)));
             y += m.height;
         }
+
+        let create_bounds = if self.create_label.is_some() && items_bottom < viewport_height {
+            let bounds = Rect::new(0.0, items_bottom, item_list_width, create_row_h);
+            hit_regions.push((bounds, PaletteHit::CreateAction));
+            Some(bounds)
+        } else {
+            None
+        };
 
         let preview_bounds = if has_preview {
             let preview_x = item_list_width;
@@ -299,6 +324,7 @@ impl Palette {
             query_bounds,
             visible_items,
             hit_regions,
+            create_bounds,
             resolved_scroll_offset,
             item_list_width,
             preview_bounds,

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1495,6 +1495,7 @@ mod tests {
             total_count: 2,
             has_focus: true,
             show_query: true,
+            create_label: None,
             preview: None,
         }
     }

--- a/quadraui/src/tui/palette.rs
+++ b/quadraui/src/tui/palette.rs
@@ -163,7 +163,9 @@ pub fn draw_palette(
     };
 
     // Result rows.
-    let items_row_end = y_end - 1;
+    let has_create = palette.create_label.is_some();
+    let create_reserved = if has_create { 1u16 } else { 0 };
+    let items_row_end = (y_end - 1).saturating_sub(create_reserved);
     let visible_rows = items_row_end.saturating_sub(items_row0) as usize;
     let total = palette.items.len();
     let has_scrollbar = total > visible_rows;
@@ -302,6 +304,38 @@ pub fn draw_palette(
         }
     }
 
+    // ── Create action row (pinned below items) ────────────────────────
+    if let Some(ref label) = palette.create_label {
+        let create_row = items_row_end;
+        if create_row < y_end - 1 {
+            let accent_fg = ratatui_color(theme.accent_fg);
+            set_cell(buf, x0, create_row, '│', border_fg, bg);
+            if !has_preview && w >= 2 {
+                set_cell(buf, x0 + w - 1, create_row, '│', border_fg, bg);
+            }
+            let end_col = if has_preview { list_w } else { w - 1 };
+            for col in 1..end_col {
+                set_cell(buf, x0 + col, create_row, ' ', fg, bg);
+            }
+            let prefix = "+ ";
+            let mut col = 1u16;
+            for ch in prefix.chars() {
+                if col >= end_col {
+                    break;
+                }
+                set_cell(buf, x0 + col, create_row, ch, accent_fg, bg);
+                col += 1;
+            }
+            for ch in label.chars() {
+                if col >= end_col {
+                    break;
+                }
+                set_cell(buf, x0 + col, create_row, ch, accent_fg, bg);
+                col += 1;
+            }
+        }
+    }
+
     // ── Preview pane ─────────────────────────────────────────────────
     if let Some(ref preview) = palette.preview {
         let sep_col = preview_x0;
@@ -415,6 +449,7 @@ mod tests {
             scroll_offset: 0,
             has_focus: true,
             show_query: true,
+            create_label: None,
             total_count: 3,
             preview: None,
         }
@@ -575,6 +610,28 @@ mod tests {
         assert!(has_item, "expected item text at row 1 when query hidden");
         // No separator row (├─┤) should exist at row 2.
         assert_ne!(cell_char(&buf, 0, 2), '├');
+    }
+
+    #[test]
+    fn create_label_renders_pinned_row() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 30, 10));
+        let mut p = make_palette();
+        p.create_label = Some("Create 'foo'".into());
+        draw_palette(
+            &mut buf,
+            Rect::new(0, 0, 30, 10),
+            &p,
+            &Theme::default(),
+            false,
+        );
+        // Create row is pinned at items_row_end (y_end - 1 - 1 = row 8).
+        // It should show "+ Create 'foo'" with accent_fg.
+        let create_row = 8u16;
+        let row_text: String = (1..20).map(|x| cell_char(&buf, x, create_row)).collect();
+        assert!(
+            row_text.contains("+ Create"),
+            "expected create label at pinned row, got: {row_text:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `create_label: Option<String>` to `Palette` (serde default `None`)
- Add `PaletteHit::CreateAction` variant for hit-testing the create row
- Add `PaletteLayout::create_bounds` for layout-resolved create row position
- Layout reserves one row at the bottom for the create action, reducing scrollable item space
- TUI: renders `+ <label>` with `accent_fg`, pinned below items
- GTK: renders `+ <label>` with accent color via Pango, pinned below items

Closes #164

## Test plan

- [x] 674 tests pass (1 new: `create_label_renders_pinned_row`)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)