### PR TITLE
feat(quadraui): Dialog multi-line body text (#165)

### DIFF
--- a/quadraui/src/gtk/dialog.rs
+++ b/quadraui/src/gtk/dialog.rs
@@ -89,12 +89,13 @@ pub fn draw_dialog(
 
     let body_b = dialog_layout.body_bounds;
     cr.set_source_rgb(fg.0, fg.1, fg.2);
-    for (i, line) in flatten(&dialog.body).split('\n').enumerate() {
+    for (i, line) in dialog.body.iter().enumerate() {
         let row_y = body_b.y as f64 + i as f64 * line_height;
         if row_y + line_height > body_b.y as f64 + body_b.height as f64 {
             break;
         }
-        pango_layout.set_text(line);
+        let text = flatten(line);
+        pango_layout.set_text(&text);
         pango_layout.set_attributes(None);
         cr.move_to(body_b.x as f64, row_y);
         pcfn::show_layout(cr, pango_layout);

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -1446,7 +1446,7 @@ mod tests {
         let d = Dialog {
             id: WidgetId::new("confirm"),
             title: StyledText::plain("Close unsaved file?"),
-            body: StyledText::plain("You have unsaved changes. Close anyway?"),
+            body: vec![StyledText::plain("You have unsaved changes. Close anyway?")],
             buttons: vec![cancel, ok],
             severity: Some(DialogSeverity::Question),
             vertical_buttons: false,
@@ -1485,7 +1485,7 @@ mod tests {
         let d = Dialog {
             id: WidgetId::new("code-actions"),
             title: StyledText::plain("Code actions"),
-            body: StyledText::default(),
+            body: vec![StyledText::default()],
             buttons: vec![
                 mk_dialog_button("a1", "Add import"),
                 mk_dialog_button("a2", "Use fully qualified path"),
@@ -1522,7 +1522,7 @@ mod tests {
         let d = Dialog {
             id: WidgetId::new("confirm"),
             title: StyledText::plain("T"),
-            body: StyledText::plain("B"),
+            body: vec![StyledText::plain("B")],
             buttons: vec![
                 mk_dialog_button("cancel", "Cancel"),
                 mk_dialog_button("ok", "OK"),
@@ -1568,7 +1568,7 @@ mod tests {
         let d = Dialog {
             id: WidgetId::new("rename"),
             title: StyledText::plain("Rename"),
-            body: StyledText::plain("New name:"),
+            body: vec![StyledText::plain("New name:")],
             buttons: vec![cancel, ok],
             severity: None,
             vertical_buttons: false,
@@ -1608,7 +1608,7 @@ mod tests {
         let d = Dialog {
             id: WidgetId::new("d"),
             title: StyledText::default(),
-            body: StyledText::default(),
+            body: vec![StyledText::default()],
             buttons: vec![cancel, ok],
             severity: None,
             vertical_buttons: false,

--- a/quadraui/src/primitives/dialog.rs
+++ b/quadraui/src/primitives/dialog.rs
@@ -24,7 +24,10 @@ use serde::{Deserialize, Serialize};
 pub struct Dialog {
     pub id: WidgetId,
     pub title: StyledText,
-    pub body: StyledText,
+    /// Body content lines. Each entry is one line rendered top-to-bottom.
+    /// Supports per-line styled spans for keybinding references, help
+    /// text, and other multi-line content.
+    pub body: Vec<StyledText>,
     pub buttons: Vec<DialogButton>,
     /// Optional severity tint — backends may add an icon or edge
     /// accent. `None` = neutral.

--- a/quadraui/src/tui/dialog.rs
+++ b/quadraui/src/tui/dialog.rs
@@ -79,17 +79,17 @@ pub fn draw_dialog(buf: &mut Buffer, dialog: &Dialog, layout: &DialogLayout, the
         set_cell(buf, x + col, y + h - 1, ch, border_fg, bg);
     }
 
-    // Body text — split on \n.
+    // Body text — one StyledText per line.
     let body_x = layout.body_bounds.x.round() as u16;
     let body_y = layout.body_bounds.y.round() as u16;
     let body_w = layout.body_bounds.width.round() as u16;
-    let body_text = flatten(&dialog.body);
-    for (i, line) in body_text.split('\n').enumerate() {
+    for (i, line) in dialog.body.iter().enumerate() {
         let row = body_y + i as u16;
         if row >= body_y + layout.body_bounds.height.round() as u16 {
             break;
         }
-        for (j, ch) in line.chars().enumerate() {
+        let text = flatten(line);
+        for (j, ch) in text.chars().enumerate() {
             let col = body_x + j as u16;
             if col >= body_x + body_w {
                 break;
@@ -151,9 +151,9 @@ mod tests {
             title: StyledText {
                 spans: vec![StyledSpan::plain("Confirm")],
             },
-            body: StyledText {
+            body: vec![StyledText {
                 spans: vec![StyledSpan::plain("Save before quitting?")],
-            },
+            }],
             buttons: vec![
                 DialogButton {
                     id: WidgetId::new("save"),


### PR DESCRIPTION
## Summary

- Change `Dialog.body` from `StyledText` to `Vec<StyledText>`
- Each entry is one line, rendered top-to-bottom with per-line styled spans
- TUI rasteriser: iterates `dialog.body` directly instead of `flatten(&body).split('\n')`
- GTK rasteriser: same iteration change
- All existing Dialog constructions updated to `vec![StyledText::plain(...)]`

Closes #165

## Test plan

- [x] 674 tests pass (`cargo test --features tui --features gtk`)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)