### PR TITLE
feat(quadraui): macOS AppKit window + Core Graphics bootstrap (#32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,11 +47,11 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.59.0",
@@ -78,6 +78,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -89,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -121,7 +136,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -252,6 +267,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,7 +314,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -291,7 +330,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -400,8 +439,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
- "objc2",
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -487,6 +526,33 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -711,7 +777,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1422,6 +1488,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,14 +1514,42 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags",
- "objc2",
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1448,9 +1558,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1459,11 +1569,23 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1474,12 +1596,24 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
- "objc2",
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -1489,9 +1623,34 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
- "objc2",
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1678,7 +1837,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1749,8 +1908,12 @@ name = "quadraui"
 version = "0.0.1"
 dependencies = [
  "arboard",
+ "core-graphics",
  "crossterm 0.29.0",
  "gtk4",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "pangocairo",
  "ratatui",
  "serde",
@@ -1778,7 +1941,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -1799,7 +1962,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1860,7 +2023,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1873,7 +2036,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1991,7 +2154,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2004,7 +2167,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2449,7 +2612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "http",
  "http-body",

--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -27,6 +27,16 @@ win = []
 # forward — both gtk_demo and gtk_app now go through `quadraui::gtk::run`.
 gtk-example = ["gtk"]
 
+# Public macOS rasterisers in `quadraui::macos` (AppKit + Core Graphics + Core Text).
+# The objc2-family deps are platform-gated below so this flag is a no-op on
+# non-macOS hosts — `cargo check --features macos` still type-checks on Linux/CI.
+macos = [
+    "dep:objc2",
+    "dep:objc2-app-kit",
+    "dep:objc2-foundation",
+    "dep:core-graphics",
+]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 # Optional — pulled in by the `gtk` / `gtk-example` features.
@@ -36,6 +46,28 @@ pangocairo = { version = "0.18", optional = true }
 ratatui = { version = "0.29", optional = true }
 # Optional — pulled in by `tui` and `gtk` for system clipboard access.
 arboard = { version = "3", optional = true }
+
+# macOS-only optional deps. Gated on `target_os = "macos"` so the `macos`
+# feature is a no-op on other platforms — keeps cross-platform CI green.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { version = "0.5", optional = true }
+objc2-app-kit = { version = "0.2", optional = true, features = [
+    "NSApplication",
+    "NSWindow",
+    "NSView",
+    "NSResponder",
+    "NSRunningApplication",
+    "NSGraphicsContext",
+    "NSGraphics",
+    "NSColor",
+] }
+objc2-foundation = { version = "0.2", optional = true, features = [
+    "NSGeometry",
+    "NSObject",
+    "NSString",
+    "NSThread",
+] }
+core-graphics = { version = "0.23", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -146,3 +178,8 @@ required-features = ["tui"]
 name = "gtk_chart"
 path = "examples/gtk_chart.rs"
 required-features = ["gtk"]
+
+[[example]]
+name = "macos_demo"
+path = "examples/macos_demo.rs"
+required-features = ["macos"]

--- a/quadraui/examples/macos_demo.rs
+++ b/quadraui/examples/macos_demo.rs
@@ -1,0 +1,15 @@
+//! `cargo run --example macos_demo --features macos`
+//!
+//! Smoke-test for the macOS backend bootstrap (issue #32). Opens an
+//! AppKit window, paints a flat dark grey through Core Graphics on
+//! every `drawRect:`, and proves the Retina backing factor flows into
+//! `Viewport::scale`.
+//!
+//! Once #35 lands this example will be rewritten to share the
+//! `common::AppState` AppLogic that the TUI and GTK demos already
+//! drive, matching the milestone promise that every `AppLogic`
+//! example runs unchanged across backends.
+
+fn main() -> std::process::ExitCode {
+    quadraui::macos::run()
+}

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -94,6 +94,8 @@ pub mod types;
 // at a time so external apps stop reimplementing the same draw functions.
 #[cfg(feature = "gtk")]
 pub mod gtk;
+#[cfg(all(feature = "macos", target_os = "macos"))]
+pub mod macos;
 #[cfg(feature = "tui")]
 pub mod tui;
 #[cfg(feature = "win")]

--- a/quadraui/src/macos/mod.rs
+++ b/quadraui/src/macos/mod.rs
@@ -1,0 +1,25 @@
+//! Public macOS (AppKit + Core Graphics + Core Text) rasterisers for
+//! `quadraui` primitives.
+//!
+//! Enabled via the `macos` Cargo feature on a macOS host. Apps depend
+//! on `quadraui` with `features = ["macos"]` and call into this module
+//! to open an AppKit window and paint primitives onto a `CGContextRef`
+//! that the runner sets up inside the view's `drawRect:` override.
+//!
+//! Mirrors the layout of [`crate::gtk`] and [`crate::tui`]: a `run`
+//! entry point owns window + run-loop bootstrap, and per-primitive
+//! rasterisers live as sibling modules. This pre-foundation milestone
+//! (#32) only ships the bootstrap — events (#33), Core Text (#34), the
+//! `MacBackend` trait impl (#35), and the per-primitive rasterisers
+//! (#38–#43) land in follow-up issues.
+//!
+//! Per the [milestone description][milestone]: "Every existing
+//! `AppLogic`-driven example runs on macOS unchanged once this
+//! milestone ships." The trait integration that delivers that promise
+//! lands in #35; #32 proves the AppKit + CG plumbing in isolation.
+//!
+//! [milestone]: https://github.com/JDonaghy/quadraui/milestone/4
+
+mod run;
+
+pub use run::run;

--- a/quadraui/src/macos/run.rs
+++ b/quadraui/src/macos/run.rs
@@ -1,0 +1,280 @@
+//! macOS runner — opens an AppKit window, installs a custom `NSView`
+//! subclass that forwards each `drawRect:` to a Core Graphics fill of
+//! the bounds, and pumps the AppKit run loop.
+//!
+//! Smoke-only for issue #32: there is no `AppLogic` integration, no
+//! event translation, no Core Text. Subsequent tickets layer those on:
+//!
+//! - #33 — `NSEvent → UiEvent` translation (overrides on `QuadraView`).
+//! - #34 — Core Text font metrics + `draw_text`.
+//! - #35 — `MacBackend` struct, `Backend` trait impl, and the final
+//!   `pub fn run<A: AppLogic + 'static>(app: A) -> ExitCode` shape that
+//!   threads `app.render(backend, AreaId::default())` through this
+//!   draw callback.
+//!
+//! The retina backing factor is read from the window each frame and
+//! packed into [`crate::Viewport::scale`] — the only piece of state
+//! #32 surfaces to its (currently empty) frame body.
+
+use std::cell::Cell;
+
+use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+use core_graphics::sys::CGContextRef;
+use objc2::declare_class;
+use objc2::encode::{Encoding, RefEncode};
+use objc2::msg_send;
+use objc2::msg_send_id;
+use objc2::mutability;
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2::ClassType;
+use objc2::DeclaredClass;
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSBackingStoreType,
+    NSGraphicsContext, NSView, NSWindow, NSWindowStyleMask,
+};
+use objc2_foundation::{
+    MainThreadMarker, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString,
+};
+
+use crate::event::Viewport;
+
+/// Opaque stand-in for the C type `CGContext`. We only ever hold a
+/// `*mut OpaqueCGContext`, which we then cast to `core-graphics`'
+/// `CGContextRef`. The custom `RefEncode` impl is what makes
+/// `msg_send![gctx, CGContext]` accept the return type — objc2's
+/// debug-mode encoding check matches `^{CGContext=}` exactly, so
+/// `*mut c_void` (encoded as `^v`) panics at runtime.
+#[repr(C)]
+struct OpaqueCGContext {
+    _unused: [u8; 0],
+}
+
+unsafe impl RefEncode for OpaqueCGContext {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct("CGContext", &[]));
+}
+
+// Direct CoreGraphics bindings. `core-graphics::context` exposes safe
+// wrappers that take ownership of a `CGContextRef`; we need to *borrow*
+// the pointer AppKit hands us inside `drawRect:` so we drop to FFI.
+// The CoreGraphics framework is linked by the `core-graphics` crate so
+// no `#[link]` attribute is needed here.
+extern "C" {
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+/// Per-view state tracked across `drawRect:` calls. `last_viewport`
+/// captures the most recent viewport so future tickets (#35) can
+/// inspect it without re-querying AppKit, and so tests can assert
+/// scale plumbing without spinning up a run loop.
+pub(crate) struct QuadraViewIvars {
+    last_viewport: Cell<Viewport>,
+}
+
+declare_class!(
+    /// Quadraui's custom `NSView`. Overrides `drawRect:` to obtain a
+    /// `CGContextRef` from the current [`NSGraphicsContext`] and fill
+    /// the view bounds with a flat background colour.
+    pub(crate) struct QuadraView;
+
+    // SAFETY:
+    // - NSView is documented to be subclassable for custom drawing.
+    // - MainThreadOnly: AppKit views must be created + used on the
+    //   main thread; `QuadraView::new` enforces this via the
+    //   `MainThreadMarker` argument.
+    // - `QuadraView` doesn't implement Drop — ivars are POD-ish
+    //   (`Cell<Viewport>` is `Copy` inside).
+    unsafe impl ClassType for QuadraView {
+        type Super = NSView;
+        type Mutability = mutability::MainThreadOnly;
+        const NAME: &'static str = "QuadraUiView";
+    }
+
+    impl DeclaredClass for QuadraView {
+        type Ivars = QuadraViewIvars;
+    }
+
+    unsafe impl QuadraView {
+        #[method(drawRect:)]
+        fn draw_rect(&self, _dirty: NSRect) {
+            let bounds = self.bounds();
+            let scale = self
+                .window()
+                .map(|w| w.backingScaleFactor())
+                .unwrap_or(1.0);
+
+            let viewport = Viewport::new(
+                bounds.size.width as f32,
+                bounds.size.height as f32,
+                scale as f32,
+            );
+            self.ivars().last_viewport.set(viewport);
+
+            // SAFETY: `drawRect:` is always invoked inside a valid
+            // graphics scope, so `currentContext` returns `Some`.
+            let Some(gctx) = (unsafe { NSGraphicsContext::currentContext() }) else {
+                return;
+            };
+            // The typed wrappers in objc2-app-kit don't expose
+            // `CGContext` (it returns a CoreFoundation pointer that
+            // sits outside the objc2 type system). We drop to
+            // `msg_send!` with a custom opaque return type whose
+            // encoding (`^{CGContext=}`) matches the ObjC method
+            // signature — `*mut c_void` (`^v`) panics under objc2's
+            // debug-mode encoding check.
+            let cg_opaque: *mut OpaqueCGContext = unsafe { msg_send![&*gctx, CGContext] };
+            if cg_opaque.is_null() {
+                return;
+            }
+            let cg_ref: CGContextRef = cg_opaque.cast();
+
+            // `NSRect` (objc2-foundation) and `CGRect` (core-graphics)
+            // are layout-compatible but distinct Rust types — convert
+            // by re-constructing.
+            let rect = CGRect::new(
+                &CGPoint::new(bounds.origin.x, bounds.origin.y),
+                &CGSize::new(bounds.size.width, bounds.size.height),
+            );
+
+            // Flat dark grey — picked to make it obvious the view is
+            // painting (vs. the AppKit default white that would show
+            // through if `drawRect:` no-op'd). The theme integration
+            // proper lands in #35 alongside `MacBackend`.
+            //
+            // We call CoreGraphics directly here rather than wrap the
+            // borrowed pointer — `core_graphics::context`'s safe
+            // wrappers want ownership semantics that don't fit a
+            // pointer AppKit reclaims when `drawRect:` returns.
+            //
+            // SAFETY: `cg_ref` is a non-null `CGContextRef` owned by
+            // AppKit for the duration of this call; CoreGraphics is
+            // linked transitively via the `core-graphics` crate.
+            unsafe {
+                CGContextSetRGBFillColor(cg_ref, 0.12, 0.12, 0.14, 1.0);
+                CGContextFillRect(cg_ref, rect);
+            }
+        }
+
+        /// Use top-left origin to match the rest of the library
+        /// (TUI + GTK both lay out from the top-left).
+        #[method(isFlipped)]
+        fn is_flipped(&self) -> bool {
+            true
+        }
+    }
+);
+
+impl QuadraView {
+    fn new(mtm: MainThreadMarker) -> Retained<Self> {
+        let this = mtm.alloc::<Self>();
+        let this = this.set_ivars(QuadraViewIvars {
+            last_viewport: Cell::new(Viewport::default()),
+        });
+        unsafe { msg_send_id![super(this), init] }
+    }
+}
+
+declare_class!(
+    /// Minimal `NSApplicationDelegate` so the smoke harness terminates
+    /// when the last window closes (red traffic-light button quits the
+    /// process). Without a delegate, `NSApplication::run` keeps
+    /// pumping the loop forever — leaving no exit short of `kill`,
+    /// since #32 doesn't yet wire `[NSApp terminate:]` to a menu or
+    /// keystroke. #35 replaces this with a delegate that bridges
+    /// AppKit notifications into [`crate::Reaction::Exit`].
+    pub(crate) struct QuadraAppDelegate;
+
+    // SAFETY:
+    // - NSObject has no subclassing requirements.
+    // - MainThreadOnly: application delegates must live on the main thread.
+    // - No Drop impl.
+    unsafe impl ClassType for QuadraAppDelegate {
+        type Super = NSObject;
+        type Mutability = mutability::MainThreadOnly;
+        const NAME: &'static str = "QuadraUiAppDelegate";
+    }
+
+    impl DeclaredClass for QuadraAppDelegate {}
+
+    unsafe impl NSObjectProtocol for QuadraAppDelegate {}
+
+    unsafe impl NSApplicationDelegate for QuadraAppDelegate {
+        #[method(applicationShouldTerminateAfterLastWindowClosed:)]
+        fn should_terminate_after_last_window(&self, _sender: &NSApplication) -> bool {
+            true
+        }
+    }
+);
+
+impl QuadraAppDelegate {
+    fn new(mtm: MainThreadMarker) -> Retained<Self> {
+        let this = mtm.alloc::<Self>();
+        // No state, but `set_ivars(())` is still required to advance
+        // the allocation to `PartialInit` before the `super init` call.
+        let this = this.set_ivars(());
+        unsafe { msg_send_id![super(this), init] }
+    }
+}
+
+/// Open an AppKit window, install a `QuadraView`, and run the
+/// `NSApplication` event loop until the user closes the window.
+///
+/// Returns [`std::process::ExitCode::SUCCESS`] when the loop exits
+/// cleanly. **Must be called from the main thread.**
+///
+/// This is the smoke-test entry point for issue #32. Once #35 lands,
+/// this signature will change to `run<A: AppLogic + 'static>(app: A)`
+/// and `drawRect:` will dispatch to `app.render(...)` via
+/// `MacBackend::enter_frame_scope`. Today it paints a flat colour and
+/// proves AppKit / Core Graphics / Retina plumbing all line up.
+pub fn run() -> std::process::ExitCode {
+    let mtm =
+        MainThreadMarker::new().expect("quadraui::macos::run must be called from the main thread");
+
+    let app = NSApplication::sharedApplication(mtm);
+    let _ = app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
+
+    // Install the delegate before run() so the first window-close
+    // triggers terminate. The delegate is retained by NSApp.
+    let delegate = QuadraAppDelegate::new(mtm);
+    let delegate_proto = ProtocolObject::from_ref(&*delegate);
+    app.setDelegate(Some(delegate_proto));
+
+    let content_rect = NSRect::new(NSPoint::new(120.0, 120.0), NSSize::new(800.0, 600.0));
+    let style = NSWindowStyleMask::Titled
+        | NSWindowStyleMask::Closable
+        | NSWindowStyleMask::Resizable
+        | NSWindowStyleMask::Miniaturizable;
+    let window: Retained<NSWindow> = unsafe {
+        msg_send_id![
+            mtm.alloc::<NSWindow>(),
+            initWithContentRect: content_rect,
+            styleMask: style,
+            backing: NSBackingStoreType::NSBackingStoreBuffered,
+            defer: false,
+        ]
+    };
+    window.setTitle(&NSString::from_str("quadraui (macos smoke)"));
+
+    let view = QuadraView::new(mtm);
+    window.setContentView(Some(&view));
+    window.makeKeyAndOrderFront(None);
+
+    // Bring the app to the foreground when launched from a terminal,
+    // otherwise the window opens behind the calling Terminal.
+    #[allow(deprecated)]
+    app.activateIgnoringOtherApps(true);
+
+    // SAFETY: blocks on AppKit run loop; returns when the last
+    // window closes or `[NSApp terminate:]` is invoked.
+    unsafe { app.run() };
+
+    std::process::ExitCode::SUCCESS
+}


### PR DESCRIPTION
## Summary

First issue in the macOS backend milestone (#4). Adds the `macos` Cargo feature, a feature-gated `quadraui::macos` module mirroring `quadraui::gtk`, and a smoke-only `pub fn run() -> ExitCode` that opens an `NSWindow`, paints a flat dark grey via Core Graphics on every `drawRect:`, and plumbs `backingScaleFactor` into `Viewport::scale`.

- `quadraui/src/macos/run.rs` — `QuadraView` (custom `NSView` subclass via `declare_class!`) + `QuadraAppDelegate` (returns `YES` from `applicationShouldTerminateAfterLastWindowClosed:` so the red close button quits the process).
- `quadraui/Cargo.toml` — new `macos` feature with `objc2`, `objc2-app-kit`, `objc2-foundation`, `core-graphics` deps gated on `target_os = "macos"` so the feature is a no-op on Linux/CI.
- `quadraui/examples/macos_demo.rs` — three-line smoke runner.

No `AppLogic` integration, no event translation, no Core Text — those follow in #33 / #34 / #35. The `MacBackend` trait impl arrives with #35 alongside the final `run<A: AppLogic>(app)` signature.

Closes #32.

## Test plan

- [x] `cargo build -p quadraui --features macos` — green
- [x] `cargo build -p quadraui --example macos_demo --features macos` — green
- [x] `cargo test -p quadraui --lib --features tui` — 645 passed, 0 failed (no regression)
- [x] `cargo fmt --check` — clean
- [x] `cargo run -p quadraui --example macos_demo --features macos` — window opens, paints grey, red close-button quits the process cleanly
- [ ] CI confirms cross-platform `cargo check --features macos` is a no-op on non-macOS hosts (the deps live under `[target.'cfg(target_os = "macos")'.dependencies]`)

## Notes

- objc2 0.5 verifies ObjC return-type encodings in debug builds. `[NSGraphicsContext CGContext]` returns `^{CGContext=}`, so the naive `*mut c_void` (encoded as `^v`) panics — we declare a `#[repr(C)] OpaqueCGContext` with a hand-rolled `RefEncode` impl whose encoding matches. The same pattern will be needed for any other CG-pointer-returning ObjC method (`CGImageRef`, `CFRunLoopRef`, etc.) added in later tickets.
- Filed #173 separately: `gtk_hscroll` and `gtk_data_table` examples on develop are missing `required-features = ["gtk"]` declarations, causing `cargo test --features tui` to fail compiling them. Surfaced during rebase but unrelated to #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)