### PR TITLE
macOS chrome rasterisers + example wiring (#38)

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -185,6 +185,11 @@ path = "examples/gtk_chart.rs"
 required-features = ["gtk"]
 
 [[example]]
+name = "macos_app"
+path = "examples/macos_app.rs"
+required-features = ["macos"]
+
+[[example]]
 name = "macos_demo"
 path = "examples/macos_demo.rs"
 required-features = ["macos"]

--- a/quadraui/examples/macos_app.rs
+++ b/quadraui/examples/macos_app.rs
@@ -1,0 +1,15 @@
+//! `cargo run --example macos_app --features macos`
+//!
+//! macOS port of `tui_app.rs` / `gtk_app.rs`. Same `MiniApp`
+//! `AppLogic` impl in `examples/common/mod.rs`; only the runner call
+//! differs. Opens a native AppKit window with a single bottom-anchored
+//! `StatusBar`.
+//!
+//! Press any key to bump the counter; `q` or Esc to quit.
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::macos::run(common::MiniApp::new())
+}

--- a/quadraui/examples/macos_demo.rs
+++ b/quadraui/examples/macos_demo.rs
@@ -1,50 +1,23 @@
 //! `cargo run --example macos_demo --features macos`
 //!
-//! Smoke harness for the macOS backend through #35. Drives an
-//! `AppLogic` implementation (`MiniApp` below) against
-//! [`quadraui::macos::run`].
-//!
-//! `MiniApp` is intentionally trivial: its `render` is a no-op
-//! (every `MacBackend::draw_*` is still `unimplemented!()` until
-//! #38–#43 fill them in), and its `handle` returns `Reaction::Exit`
-//! when Esc is pressed. The window's visible content for now comes
-//! from `QuadraView::drawRect:` painting a debug background +
-//! the #34 Menlo smoke label.
-//!
-//! Once the first chrome rasteriser ships (#38), this example will
-//! switch to the shared `examples/common/AppState` so paired examples
-//! across TUI / GTK / macOS demonstrate the milestone promise: one
-//! `AppLogic` impl, every backend.
+//! macOS port of `tui_demo.rs` / `gtk_demo.rs`. Paints both a `TabBar`
+//! (top) and a `StatusBar` (bottom) and exercises tab navigation +
+//! status-segment focus cycling. The whole `AppLogic` impl lives in
+//! `examples/common/mod.rs::AppState` so the TUI and GTK twins render
+//! byte-identical app code — the only difference between them is the
+//! runner call.
 //!
 //! Controls:
-//! - **Esc**       — quit
-//! - **Close button** — quit (via `QuadraAppDelegate`)
+//! - `←` / `→`           switch active tab
+//! - `n`                 open a new tab
+//! - `x`                 close the active tab
+//! - `Tab` / `Shift-Tab` focus next / previous status segment
+//! - `Return`            activate the focused status segment
+//! - `q` / `Esc`         quit
 
-use quadraui::runner::{AppLogic, Reaction};
-use quadraui::{Backend, Key, NamedKey, UiEvent};
-
-struct MiniApp;
-
-impl AppLogic for MiniApp {
-    type AreaId = ();
-
-    fn render(&self, _backend: &mut dyn Backend, _area: Self::AreaId) {
-        // No-op: `MacBackend::draw_*` are all `unimplemented!` until
-        // #38–#43 land. The visible content comes from
-        // `QuadraView::drawRect:`'s debug paint + #34 smoke label.
-    }
-
-    fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
-        match event {
-            UiEvent::KeyPressed {
-                key: Key::Named(NamedKey::Escape),
-                ..
-            } => Reaction::Exit,
-            _ => Reaction::Continue,
-        }
-    }
-}
+#[path = "common/mod.rs"]
+mod common;
 
 fn main() -> std::process::ExitCode {
-    quadraui::macos::run(MiniApp)
+    quadraui::macos::run(common::AppState::new())
 }

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -1,0 +1,304 @@
+//! macOS rasteriser for [`crate::ActivityBar`].
+//!
+//! Vertical strip of icon rows. Top items render from the top edge
+//! downward at `ACTIVITY_ROW_PX` per row; bottom items pin to the
+//! bottom edge upward. Mirrors [`crate::gtk::activity_bar`] in
+//! geometry, but uses the backend's active `CTFont` directly for
+//! icon rendering instead of GTK's hardcoded "Symbols Nerd Font" —
+//! apps that want Nerd-Font icons install a glyph-bearing font via
+//! [`super::MacBackend::set_current_font`] in `setup()`.
+//!
+//! Returns per-row [`ActivityBarRowHit`]s so callers can route clicks
+//! and query tooltips against the same frame's painted positions.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::primitives::activity_bar::{ActivityBar, ActivityBarRowHit, ActivityItem};
+use crate::theme::Theme;
+use crate::types::Color;
+
+/// Fixed row height in points. Matches `crate::gtk::activity_bar::ACTIVITY_ROW_PX`
+/// (= the vimcode native-button height baked into the GTK CSS).
+pub const ACTIVITY_ROW_PX: f64 = 48.0;
+
+/// Paint `bar` into `(0, 0, width, height)` on `ctx`.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+pub unsafe fn draw_activity_bar(
+    ctx: CGContextRef,
+    font: &CTFont,
+    width: f64,
+    height: f64,
+    bar: &ActivityBar,
+    theme: &Theme,
+    hovered_idx: Option<usize>,
+) -> Vec<ActivityBarRowHit> {
+    CGContextSaveGState(ctx);
+
+    // Background.
+    fill_rect(ctx, 0.0, 0.0, width, height, theme.tab_bar_bg);
+    // Right-edge separator (1 point).
+    fill_rect(ctx, width - 1.0, 0.0, 1.0, height, theme.separator);
+
+    let accent_col = bar.active_accent.unwrap_or(theme.accent_fg);
+    let inactive_fg = theme.inactive_fg;
+    let active_fg = theme.foreground;
+    let hover_bg = theme.tab_bar_bg.lighten(0.10);
+
+    let rows_total = ((height / ACTIVITY_ROW_PX).floor() as usize).max(1);
+    let bottom_count = bar.bottom_items.len().min(rows_total);
+    let top_capacity = rows_total.saturating_sub(bottom_count);
+    let mut regions: Vec<ActivityBarRowHit> = Vec::new();
+
+    let draw_row = |y: f64, item: &ActivityItem, row_idx: usize, regions: &mut Vec<_>| {
+        let is_hovered = hovered_idx == Some(row_idx);
+
+        if is_hovered {
+            fill_rect(ctx, 0.0, y, width, ACTIVITY_ROW_PX, hover_bg);
+        }
+        if item.is_active {
+            fill_rect(ctx, 0.0, y, 2.0, ACTIVITY_ROW_PX, accent_col);
+        }
+
+        let (iw, ih) = measure_text(font, &item.icon);
+        let fg = if item.is_active || is_hovered {
+            active_fg
+        } else {
+            inactive_fg
+        };
+        draw_text(
+            ctx,
+            font,
+            &item.icon,
+            (width - iw) / 2.0,
+            y + (ACTIVITY_ROW_PX - ih) / 2.0,
+            color_to_cg(fg),
+        );
+
+        regions.push(ActivityBarRowHit {
+            y_start: y,
+            y_end: y + ACTIVITY_ROW_PX,
+            id: item.id.clone(),
+            tooltip: item.tooltip.clone(),
+        });
+    };
+
+    for (row_idx, item) in bar.top_items.iter().take(top_capacity).enumerate() {
+        draw_row(
+            row_idx as f64 * ACTIVITY_ROW_PX,
+            item,
+            row_idx,
+            &mut regions,
+        );
+    }
+
+    for (k, item) in bar.bottom_items.iter().rev().take(bottom_count).enumerate() {
+        let y = height - (k + 1) as f64 * ACTIVITY_ROW_PX;
+        if y < 0.0 {
+            break;
+        }
+        let row_idx = regions.len();
+        draw_row(y, item, row_idx, &mut regions);
+    }
+
+    CGContextRestoreGState(ctx);
+    regions
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    use core_graphics::geometry::{CGPoint, CGSize};
+    CGContextFillRect(ctx, CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h)));
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::activity_bar::ActivityItem;
+    use crate::theme::Theme;
+    use crate::types::{Color, WidgetId};
+    use crate::Backend;
+
+    const W: u32 = 48;
+    const H: u32 = 240; // 5 rows × 48px
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn sample_bar() -> ActivityBar {
+        ActivityBar {
+            id: WidgetId::new("activity"),
+            top_items: vec![
+                ActivityItem {
+                    id: WidgetId::new("activity:explorer"),
+                    icon: "E".into(),
+                    tooltip: "Explorer".into(),
+                    is_active: true,
+                    is_keyboard_selected: false,
+                },
+                ActivityItem {
+                    id: WidgetId::new("activity:search"),
+                    icon: "S".into(),
+                    tooltip: "Search".into(),
+                    is_active: false,
+                    is_keyboard_selected: false,
+                },
+            ],
+            bottom_items: vec![ActivityItem {
+                id: WidgetId::new("activity:settings"),
+                icon: "G".into(),
+                tooltip: "Settings".into(),
+                is_active: false,
+                is_keyboard_selected: false,
+            }],
+            active_accent: Some(Color::rgb(80, 140, 255)),
+            selection_bg: None,
+        }
+    }
+
+    fn paint_via_backend(
+        bar: &ActivityBar,
+        hovered: Option<usize>,
+    ) -> (BitmapSurface, Vec<ActivityBarRowHit>) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let regions = std::cell::RefCell::new(Vec::new());
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let r = b.draw_activity_bar(QRect::new(0.0, 0.0, W as f32, H as f32), bar, hovered);
+            *regions.borrow_mut() = r;
+        });
+        backend.end_frame();
+        (surface, regions.into_inner())
+    }
+
+    #[test]
+    fn background_is_tab_bar_bg() {
+        let bar = sample_bar();
+        let (surface, _) = paint_via_backend(&bar, None);
+        let theme = Theme::default();
+        // Probe deep inside the second (non-active) row, well away
+        // from any glyph centre.
+        let (r, g, b, _) = surface.pixel(W - 6, (ACTIVITY_ROW_PX as u32) + 4);
+        assert_eq!(
+            (r, g, b),
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+        );
+    }
+
+    #[test]
+    fn active_item_paints_accent_strip_on_left_edge() {
+        // 2-px accent strip at x ∈ [0, 2). Probe column 0 inside the
+        // first row (active) and assert accent colour.
+        let bar = sample_bar();
+        let (surface, _) = paint_via_backend(&bar, None);
+        let accent = bar.active_accent.unwrap();
+        // y = ACTIVITY_ROW_PX/2 sits mid-row inside the first
+        // (active) item.
+        let probe_y = (ACTIVITY_ROW_PX as u32) / 2;
+        let (r, g, b, _) = surface.pixel(0, probe_y);
+        assert_eq!((r, g, b), (accent.r, accent.g, accent.b));
+        let (r2, g2, b2, _) = surface.pixel(1, probe_y);
+        assert_eq!((r2, g2, b2), (accent.r, accent.g, accent.b));
+
+        // x = 2 should already be off the accent strip — proves the
+        // strip is exactly 2 points wide. Probe at row top to dodge
+        // any wide-glyph render.
+        let (r3, g3, b3, _) = surface.pixel(2, 2);
+        let theme = Theme::default();
+        assert_eq!(
+            (r3, g3, b3),
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+            "x=2 should be tab_bar_bg, not accent",
+        );
+    }
+
+    #[test]
+    fn row_hits_cover_painted_rows() {
+        // Round-trip: returned regions must point at where the icon
+        // was painted. Verify each region's y-span matches the
+        // ACTIVITY_ROW_PX grid AND its id matches the item.
+        let bar = sample_bar();
+        let (_surface, regions) = paint_via_backend(&bar, None);
+        // 2 top + 1 bottom = 3 visible rows.
+        assert_eq!(regions.len(), 3);
+        assert_eq!(regions[0].y_start, 0.0);
+        assert_eq!(regions[0].y_end, ACTIVITY_ROW_PX);
+        assert_eq!(regions[0].id, WidgetId::new("activity:explorer"));
+
+        assert_eq!(regions[1].y_start, ACTIVITY_ROW_PX);
+        assert_eq!(regions[1].y_end, 2.0 * ACTIVITY_ROW_PX);
+        assert_eq!(regions[1].id, WidgetId::new("activity:search"));
+
+        // Bottom-pinned item.
+        assert_eq!(regions[2].y_start, H as f64 - ACTIVITY_ROW_PX);
+        assert_eq!(regions[2].y_end, H as f64);
+        assert_eq!(regions[2].id, WidgetId::new("activity:settings"));
+    }
+
+    #[test]
+    fn right_edge_has_separator_pixel() {
+        let bar = sample_bar();
+        let (surface, _) = paint_via_backend(&bar, None);
+        let theme = Theme::default();
+        let (r, g, b, _) = surface.pixel(W - 1, H / 2);
+        assert_eq!(
+            (r, g, b),
+            (theme.separator.r, theme.separator.g, theme.separator.b),
+        );
+    }
+
+    #[test]
+    fn hover_lightens_row_background() {
+        let bar = sample_bar();
+        // Hover second row (index 1) — currently non-active so hover
+        // tint is the only thing painting bg there.
+        let (surface, _) = paint_via_backend(&bar, Some(1));
+        let theme = Theme::default();
+        let expected = theme.tab_bar_bg.lighten(0.10);
+        // Probe deep into row 1, away from glyph centre.
+        let (r, g, b, _) = surface.pixel(W - 6, (ACTIVITY_ROW_PX as u32) + 4);
+        assert_eq!(
+            (r, g, b),
+            (expected.r, expected.g, expected.b),
+            "hovered row should paint the lightened bg",
+        );
+    }
+}

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -285,6 +285,24 @@ mod tests {
         );
     }
 
+    /// `cargo test -p quadraui --features macos -- --ignored --nocapture macos::activity_bar::tests::dump_smoke_ppm`
+    ///
+    /// Paints the sample bar (2 top items + 1 bottom-pinned) into a
+    /// 48 × 240 surface and writes `/tmp/quadraui_activity_bar.ppm`.
+    /// Hover row 1 so the lightened bg is visible. Open in Preview to
+    /// confirm:
+    /// - Top item (active) has a 2-pt accent strip on the left edge.
+    /// - Middle item shows the hover-lightened bg.
+    /// - Bottom item is pinned to the bottom edge.
+    /// - Right-edge has a 1-pt separator column.
+    #[test]
+    #[ignore = "writes /tmp/quadraui_activity_bar.ppm — opt in with --ignored"]
+    fn dump_smoke_ppm() {
+        let bar = sample_bar();
+        let (surface, _) = paint_via_backend(&bar, Some(1));
+        surface.write_ppm_and_open("/tmp/quadraui_activity_bar.ppm");
+    }
+
     #[test]
     fn hover_lightens_row_background() {
         let bar = sample_bar();

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -303,28 +303,99 @@ impl Backend for MacBackend {
 
     fn draw_status_bar(
         &mut self,
-        _rect: Rect,
-        _bar: &StatusBar,
-        _hovered_id: Option<&WidgetId>,
-        _pressed_id: Option<&WidgetId>,
+        rect: Rect,
+        bar: &StatusBar,
+        hovered_id: Option<&WidgetId>,
+        pressed_id: Option<&WidgetId>,
     ) -> StatusBarLayout {
-        mac_unimpl!("draw_status_bar", "#38")
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_status_bar called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_status_bar requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        // SAFETY: `ctx` is non-null inside the frame scope; the call
+        // chain enforces `enter_frame_scope` via the debug_assert above.
+        unsafe {
+            super::status_bar::draw_status_bar(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                line_height,
+                bar,
+                &theme,
+                hovered_id,
+                pressed_id,
+            )
+        }
     }
     fn draw_tab_bar(
         &mut self,
-        _rect: Rect,
-        _bar: &TabBar,
-        _hovered_close_tab: Option<usize>,
+        rect: Rect,
+        bar: &TabBar,
+        hovered_close_tab: Option<usize>,
     ) -> TabBarHits {
-        mac_unimpl!("draw_tab_bar", "#38")
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_tab_bar called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_tab_bar requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        // SAFETY: `ctx` is non-null inside the frame scope.
+        unsafe {
+            super::tab_bar::draw_tab_bar(
+                ctx,
+                font,
+                rect.width as f64,
+                line_height,
+                rect.y as f64,
+                rect.height as f64,
+                bar,
+                &theme,
+                hovered_close_tab,
+            )
+        }
     }
     fn draw_activity_bar(
         &mut self,
-        _rect: Rect,
-        _bar: &ActivityBar,
-        _hovered_idx: Option<usize>,
+        rect: Rect,
+        bar: &ActivityBar,
+        hovered_idx: Option<usize>,
     ) -> Vec<ActivityBarRowHit> {
-        mac_unimpl!("draw_activity_bar", "#38")
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_activity_bar called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_activity_bar requires set_current_font");
+        let theme = self.current_theme;
+        // SAFETY: ctx non-null inside frame scope.
+        unsafe {
+            super::activity_bar::draw_activity_bar(
+                ctx,
+                font,
+                rect.width as f64,
+                rect.height as f64,
+                bar,
+                &theme,
+                hovered_idx,
+            )
+        }
     }
     fn draw_terminal(&mut self, _rect: Rect, _term: &Terminal) {
         mac_unimpl!("draw_terminal", "#43")
@@ -381,11 +452,44 @@ impl Backend for MacBackend {
     fn draw_scrollbar(&mut self, _rect: Rect, _scrollbar: &Scrollbar) {
         mac_unimpl!("draw_scrollbar", "#40")
     }
-    fn draw_menu_bar(&mut self, _rect: Rect, _bar: &MenuBar) -> MenuBarLayout {
-        mac_unimpl!("draw_menu_bar", "#38")
+    fn draw_menu_bar(&mut self, rect: Rect, bar: &MenuBar) -> MenuBarLayout {
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_menu_bar called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_menu_bar requires set_current_font");
+        let theme = self.current_theme;
+        // SAFETY: ctx non-null inside frame scope.
+        unsafe {
+            super::menu_bar::draw_menu_bar(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                bar,
+                &theme,
+            )
+        }
     }
-    fn menu_bar_layout(&self, _rect: Rect, _bar: &MenuBar) -> MenuBarLayout {
-        mac_unimpl!("menu_bar_layout", "#38")
+    fn menu_bar_layout(&self, rect: Rect, bar: &MenuBar) -> MenuBarLayout {
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::menu_bar_layout requires set_current_font");
+        super::menu_bar::mac_menu_bar_layout(
+            font,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            bar,
+        )
     }
     fn draw_split(&mut self, _rect: Rect, _split: &Split) -> SplitLayout {
         mac_unimpl!("draw_split", "#42")
@@ -417,11 +521,46 @@ impl Backend for MacBackend {
     fn spinner_layout(&self, _rect: Rect, _spinner: &Spinner) -> SpinnerLayout {
         mac_unimpl!("spinner_layout", "#42")
     }
-    fn draw_command_center(&mut self, _rect: Rect, _cc: &CommandCenter) -> CommandCenterLayout {
-        mac_unimpl!("draw_command_center", "#38")
+    fn draw_command_center(&mut self, rect: Rect, cc: &CommandCenter) -> CommandCenterLayout {
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_command_center called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_command_center requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        // SAFETY: ctx non-null inside frame scope.
+        unsafe {
+            super::command_center::draw_command_center(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                cc,
+                &theme,
+                line_height,
+            )
+        }
     }
-    fn command_center_layout(&self, _rect: Rect, _cc: &CommandCenter) -> CommandCenterLayout {
-        mac_unimpl!("command_center_layout", "#38")
+    fn command_center_layout(&self, rect: Rect, cc: &CommandCenter) -> CommandCenterLayout {
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::command_center_layout requires set_current_font");
+        super::command_center::mac_command_center_layout(
+            cc,
+            font,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+        )
     }
     fn draw_chart(
         &mut self,

--- a/quadraui/src/macos/command_center.rs
+++ b/quadraui/src/macos/command_center.rs
@@ -286,6 +286,24 @@ mod tests {
         );
     }
 
+    /// `cargo test -p quadraui --features macos -- --ignored --nocapture macos::command_center::tests::dump_smoke_ppm`
+    ///
+    /// Paints the sample CC (back enabled, forward disabled, "project"
+    /// search) into a 480 × 32 surface and writes
+    /// `/tmp/quadraui_command_center.ppm`. Open in Preview to confirm:
+    /// - Back arrow `◀` is bright (tab_inactive_fg).
+    /// - Forward arrow `▶` is dim (muted_fg).
+    /// - Search box has a 1-pt rectangular border with "project"
+    ///   label inside.
+    /// - Whole strip is centred horizontally within the 480-wide bar.
+    #[test]
+    #[ignore = "writes /tmp/quadraui_command_center.ppm — opt in with --ignored"]
+    fn dump_smoke_ppm() {
+        let cc = sample_cc();
+        let (surface, _) = paint_via_backend(&cc);
+        surface.write_ppm_and_open("/tmp/quadraui_command_center.ppm");
+    }
+
     #[test]
     fn empty_search_label_omits_search_bounds() {
         let cc = CommandCenter {

--- a/quadraui/src/macos/command_center.rs
+++ b/quadraui/src/macos/command_center.rs
@@ -1,0 +1,300 @@
+//! macOS rasteriser for [`crate::CommandCenter`].
+//!
+//! Mirrors [`crate::gtk::command_center`]: back/forward arrows
+//! (`◀` / `▶`) and a rounded-rect bordered search box, centred within
+//! the given area. Returns [`CommandCenterLayout`] for caller click
+//! dispatch.
+//!
+//! ## Scope omissions (follow-up)
+//!
+//! - **Rounded search-box border** — GTK strokes a 4 px-radius
+//!   rounded rect. macOS for #38 draws a 1-pt straight rectangle
+//!   border (CG path API needed for proper rounded corners). Visual
+//!   parity tracked separately; geometry + hit regions identical.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::event::Rect as QRect;
+use crate::primitives::command_center::{CommandCenter, CommandCenterLayout, CommandCenterMeasure};
+use crate::theme::Theme;
+use crate::types::Color;
+
+const ARROW_WIDTH_PX: f32 = 24.0;
+const GAP_PX: f32 = 8.0;
+const SEARCH_PAD_PX: f64 = 8.0;
+const SEARCH_MIN_WIDTH: f32 = 280.0;
+
+/// Compute the pixel-unit layout without painting. Caller routes
+/// clicks against this when it needs the same layout the rasteriser
+/// used.
+pub fn mac_command_center_layout(
+    cc: &CommandCenter,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+) -> CommandCenterLayout {
+    let search_w = if cc.search_label.is_empty() {
+        0.0
+    } else {
+        let (text_w, _) = measure_text(font, &cc.search_label);
+        (text_w as f32 + SEARCH_PAD_PX as f32 * 2.0).max(SEARCH_MIN_WIDTH)
+    };
+    cc.layout(
+        QRect::new(x as f32, y as f32, w as f32, h as f32),
+        CommandCenterMeasure {
+            arrow_width: ARROW_WIDTH_PX,
+            gap: GAP_PX,
+            search_box_width: search_w,
+            height: h as f32,
+        },
+    )
+}
+
+/// Paint `cc` into `(x, y, w, h)` on `ctx`. Returns the layout.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_command_center(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    cc: &CommandCenter,
+    theme: &Theme,
+    line_height: f64,
+) -> CommandCenterLayout {
+    let layout = mac_command_center_layout(cc, font, x, y, w, h);
+
+    CGContextSaveGState(ctx);
+    fill_rect(ctx, x, y, w, h, theme.tab_bar_bg);
+
+    let enabled_fg = theme.tab_inactive_fg;
+    let disabled_fg = theme.muted_fg;
+    let text_y = y + (h - line_height) / 2.0;
+
+    if let Some(bb) = layout.back_bounds {
+        let fg = if cc.back_enabled {
+            enabled_fg
+        } else {
+            disabled_fg
+        };
+        let (tw, _) = measure_text(font, "◀");
+        draw_text(
+            ctx,
+            font,
+            "◀",
+            bb.x as f64 + (bb.width as f64 - tw) / 2.0,
+            text_y,
+            color_to_cg(fg),
+        );
+    }
+    if let Some(fb) = layout.forward_bounds {
+        let fg = if cc.forward_enabled {
+            enabled_fg
+        } else {
+            disabled_fg
+        };
+        let (tw, _) = measure_text(font, "▶");
+        draw_text(
+            ctx,
+            font,
+            "▶",
+            fb.x as f64 + (fb.width as f64 - tw) / 2.0,
+            text_y,
+            color_to_cg(fg),
+        );
+    }
+
+    if let Some(sb) = layout.search_bounds {
+        let bx = sb.x as f64;
+        let by = sb.y as f64 + 2.0;
+        let bw = sb.width as f64;
+        let bh = sb.height as f64 - 4.0;
+
+        // Border — straight 1-pt outline. CG path API needed for
+        // rounded corners; deferred (see module header).
+        stroke_rect(ctx, bx, by, bw, bh, theme.separator, 1.0);
+
+        // Search label.
+        draw_text(
+            ctx,
+            font,
+            &cc.search_label,
+            bx + SEARCH_PAD_PX,
+            text_y,
+            color_to_cg(theme.tab_inactive_fg),
+        );
+    }
+
+    CGContextRestoreGState(ctx);
+    layout
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    use core_graphics::geometry::{CGPoint, CGSize};
+    CGContextFillRect(ctx, CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h)));
+}
+
+unsafe fn stroke_rect(
+    ctx: CGContextRef,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    c: Color,
+    line_width: f64,
+) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBStrokeColor(ctx, r, g, b, a);
+    CGContextSetLineWidth(ctx, line_width);
+    use core_graphics::geometry::{CGPoint, CGSize};
+    CGContextStrokeRect(ctx, CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h)));
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBStrokeColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextSetLineWidth(c: CGContextRef, w: core_graphics::base::CGFloat);
+    fn CGContextStrokeRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::Viewport;
+    use crate::primitives::command_center::CommandCenterHit;
+    use crate::theme::Theme;
+    use crate::types::WidgetId;
+    use crate::Backend;
+
+    const W: u32 = 480;
+    const H: u32 = 32;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn sample_cc() -> CommandCenter {
+        CommandCenter {
+            id: WidgetId::new("cc"),
+            back_enabled: true,
+            forward_enabled: false,
+            search_label: "project".into(),
+        }
+    }
+
+    fn paint_via_backend(cc: &CommandCenter) -> (BitmapSurface, CommandCenterLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_command_center(QRect::new(0.0, 0.0, W as f32, H as f32), cc);
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn background_is_tab_bar_bg() {
+        let cc = sample_cc();
+        let (surface, _) = paint_via_backend(&cc);
+        let theme = Theme::default();
+        // Probe column 0 (well before any arrow) at mid-height.
+        let (r, g, b, _) = surface.pixel(0, H / 2);
+        assert_eq!(
+            (r, g, b),
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+        );
+    }
+
+    #[test]
+    fn layout_centres_content_in_bounds() {
+        let cc = sample_cc();
+        let (_surface, layout) = paint_via_backend(&cc);
+        let back = layout.back_bounds.expect("back arrow has bounds");
+        let search = layout.search_bounds.expect("search bounds present");
+        // Content_width = 24 + 8 + 24 + 8 + max(280, ...) ≥ 344. With
+        // W=480 the centred left edge sits at (480 - content) / 2.
+        // back.x must be > 0 and < W/2.
+        assert!(back.x > 0.0 && back.x < (W as f32) / 2.0);
+        // Search box ends at or before W.
+        assert!(search.x + search.width <= W as f32);
+    }
+
+    #[test]
+    fn hit_test_resolves_back_forward_search() {
+        let cc = sample_cc();
+        let (_surface, layout) = paint_via_backend(&cc);
+        let back = layout.back_bounds.unwrap();
+        let fwd = layout.forward_bounds.unwrap();
+        let search = layout.search_bounds.unwrap();
+
+        assert_eq!(
+            layout.hit_test(back.x + 1.0, back.y + 1.0),
+            CommandCenterHit::Back,
+        );
+        assert_eq!(
+            layout.hit_test(fwd.x + 1.0, fwd.y + 1.0),
+            CommandCenterHit::Forward,
+        );
+        assert_eq!(
+            layout.hit_test(search.x + 5.0, search.y + 5.0),
+            CommandCenterHit::SearchBox,
+        );
+    }
+
+    #[test]
+    fn empty_search_label_omits_search_bounds() {
+        let cc = CommandCenter {
+            search_label: "".into(),
+            ..sample_cc()
+        };
+        let (_surface, layout) = paint_via_backend(&cc);
+        assert!(layout.search_bounds.is_none());
+        assert!(layout.back_bounds.is_some());
+        assert!(layout.forward_bounds.is_some());
+    }
+}

--- a/quadraui/src/macos/headless.rs
+++ b/quadraui/src/macos/headless.rs
@@ -349,9 +349,9 @@ mod tests {
         // immediately obvious.
         let q = 40.0;
         let corners = [
-            (0.0, 0.0, 1.0, 0.0, 0.0),       // top-left, red
-            (W as f64 - q, 0.0, 0.0, 1.0, 0.0), // top-right, green
-            (0.0, H as f64 - q, 0.0, 0.0, 1.0), // bottom-left, blue
+            (0.0, 0.0, 1.0, 0.0, 0.0),                   // top-left, red
+            (W as f64 - q, 0.0, 0.0, 1.0, 0.0),          // top-right, green
+            (0.0, H as f64 - q, 0.0, 0.0, 1.0),          // bottom-left, blue
             (W as f64 - q, H as f64 - q, 1.0, 1.0, 0.0), // bottom-right, yellow
         ];
         // SAFETY: ctx valid for the surface's lifetime.

--- a/quadraui/src/macos/headless.rs
+++ b/quadraui/src/macos/headless.rs
@@ -175,6 +175,32 @@ impl BitmapSurface {
         )
     }
 
+    /// Write the surface to `path` as a P6 PPM (24 bpp RGB, alpha
+    /// dropped) and best-effort launch it via macOS `open` so it shows
+    /// in Preview / Quick Look. Used by `#[ignore]`d smoke tests
+    /// across the chrome rasterisers — the shared visual-confirmation
+    /// path. Failures from `open` (no Preview, sandboxed env) are
+    /// non-fatal; the PPM file is still on disk.
+    pub fn write_ppm_and_open(&self, path: &str) {
+        use std::fs::File;
+        use std::io::Write;
+        let mut f = File::create(path).expect("create ppm file");
+        writeln!(f, "P6").expect("write header");
+        writeln!(f, "{} {}", self.width, self.height).expect("write dims");
+        writeln!(f, "255").expect("write maxval");
+        let bytes = self.bytes();
+        let mut rgb = Vec::with_capacity((self.width * self.height * 3) as usize);
+        for chunk in bytes.chunks_exact(4) {
+            rgb.push(chunk[0]);
+            rgb.push(chunk[1]);
+            rgb.push(chunk[2]);
+        }
+        f.write_all(&rgb).expect("write ppm pixels");
+        drop(f);
+        eprintln!("wrote {} — launching Preview", path);
+        let _ = std::process::Command::new("open").arg(path).status();
+    }
+
     /// Borrow the raw pixel buffer. Row 0 is the **top** scanline
     /// (matches the [`Self::pixel`] coordinate frame and the live
     /// `QuadraView`'s `isFlipped = YES`).
@@ -332,8 +358,6 @@ mod tests {
     #[ignore = "writes /tmp/quadraui_headless.ppm — opt in with --ignored"]
     fn dump_smoke_ppm() {
         use super::super::text::{draw_text, make_font};
-        use std::fs::File;
-        use std::io::Write;
 
         const W: u32 = 200;
         const H: u32 = 120;
@@ -383,26 +407,7 @@ mod tests {
             }
         }
 
-        // Write PPM P6 — Apple Preview reads it natively. Drop the
-        // alpha channel: P6 is RGB only.
-        let path = "/tmp/quadraui_headless.ppm";
-        let mut f = File::create(path).expect("create ppm file");
-        writeln!(f, "P6").unwrap();
-        writeln!(f, "{} {}", W, H).unwrap();
-        writeln!(f, "255").unwrap();
-        let bytes = s.bytes();
-        let mut rgb = Vec::with_capacity((W * H * 3) as usize);
-        for chunk in bytes.chunks_exact(4) {
-            rgb.push(chunk[0]);
-            rgb.push(chunk[1]);
-            rgb.push(chunk[2]);
-        }
-        f.write_all(&rgb).expect("write ppm pixels");
-        drop(f);
-        eprintln!("wrote {} — launching Preview", path);
-        // Best-effort launch via `open`. Failures (no Preview, sandbox)
-        // are non-fatal — the file is on disk either way.
-        let _ = std::process::Command::new("open").arg(path).status();
+        s.write_ppm_and_open("/tmp/quadraui_headless.ppm");
     }
 
     #[test]

--- a/quadraui/src/macos/menu_bar.rs
+++ b/quadraui/src/macos/menu_bar.rs
@@ -1,0 +1,257 @@
+//! macOS rasteriser for [`crate::MenuBar`].
+//!
+//! Horizontal strip of top-level menu labels. Mirrors
+//! [`crate::gtk::menu_bar`]: per-item Core Text measurement,
+//! active-item highlight, label rendering with `&` stripped.
+//!
+//! ## Scope omissions (follow-up)
+//!
+//! - **Alt-key underline** — GTK applies a Pango underline attribute
+//!   to the `&`-marked character. Core Text supports underline via
+//!   `kCTUnderlineStyleAttributeName` but the existing
+//!   [`super::text::draw_text`] path doesn't thread attributes
+//!   through. Deferred with bold/italic to a unified text-attribute
+//!   pass.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::event::Rect as QRect;
+use crate::primitives::menu_bar::{MenuBar, MenuBarItemMeasure, MenuBarLayout};
+use crate::theme::Theme;
+use crate::types::Color;
+
+/// 8-pt padding each side of the menu label inside its hit slot.
+const ITEM_PAD: f32 = 8.0;
+
+/// Compute the macOS pixel-unit layout for `bar` without painting.
+/// Mirrors `crate::gtk::gtk_menu_bar_layout`. Apps call this to route
+/// clicks via the same layout the rasteriser used.
+pub fn mac_menu_bar_layout(
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    bar: &MenuBar,
+) -> MenuBarLayout {
+    let bounds = QRect::new(x as f32, y as f32, width as f32, height as f32);
+    bar.layout(bounds, |i| {
+        let text = display_text(&bar.items[i].label);
+        let (w, _) = measure_text(font, &text);
+        MenuBarItemMeasure::new(w as f32 + ITEM_PAD * 2.0)
+    })
+}
+
+/// Paint `bar` into `(x, y, width, height)` on `ctx`. Returns the
+/// layout for caller click dispatch.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_menu_bar(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    bar: &MenuBar,
+    theme: &Theme,
+) -> MenuBarLayout {
+    CGContextSaveGState(ctx);
+    fill_rect(ctx, x, y, width, height, theme.tab_bar_bg);
+
+    let layout = mac_menu_bar_layout(font, x, y, width, height, bar);
+
+    for vi in &layout.visible_items {
+        let item = &bar.items[vi.item_idx];
+        let is_active = bar.open_item == Some(vi.item_idx) || bar.focused_item == Some(vi.item_idx);
+
+        let (fg_color, bg_color) = if is_active {
+            (theme.tab_active_fg, theme.tab_active_bg)
+        } else if item.disabled {
+            (theme.muted_fg, theme.tab_bar_bg)
+        } else {
+            (theme.tab_inactive_fg, theme.tab_bar_bg)
+        };
+
+        let item_x = x + vi.bounds.x as f64;
+        let item_w = vi.bounds.width as f64;
+
+        if is_active {
+            fill_rect(ctx, item_x, y, item_w, height, bg_color);
+        }
+
+        let text = display_text(&item.label);
+        let (text_w, text_h) = measure_text(font, &text);
+        let text_x = item_x + (item_w - text_w) / 2.0;
+        let text_y = y + (height - text_h) / 2.0;
+        draw_text(ctx, font, &text, text_x, text_y, color_to_cg(fg_color));
+    }
+
+    CGContextRestoreGState(ctx);
+    layout
+}
+
+/// Strip `&` markers from a label for display.
+fn display_text(label: &str) -> String {
+    label.chars().filter(|&c| c != '&').collect()
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    use core_graphics::geometry::{CGPoint, CGSize};
+    CGContextFillRect(ctx, CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h)));
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::Viewport;
+    use crate::primitives::menu_bar::{MenuBar, MenuBarHit, MenuBarItem};
+    use crate::theme::Theme;
+    use crate::types::WidgetId;
+    use crate::Backend;
+
+    const W: u32 = 320;
+    const H: u32 = 24;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn sample_bar() -> MenuBar {
+        MenuBar {
+            id: WidgetId::new("menus"),
+            items: vec![
+                MenuBarItem {
+                    id: WidgetId::new("menu:file"),
+                    label: "&File".into(),
+                    disabled: false,
+                },
+                MenuBarItem {
+                    id: WidgetId::new("menu:edit"),
+                    label: "&Edit".into(),
+                    disabled: false,
+                },
+                MenuBarItem {
+                    id: WidgetId::new("menu:view"),
+                    label: "&View".into(),
+                    disabled: true,
+                },
+            ],
+            open_item: Some(0),
+            focused_item: None,
+        }
+    }
+
+    fn paint_via_backend(bar: &MenuBar) -> (BitmapSurface, MenuBarLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_menu_bar(QRect::new(0.0, 0.0, W as f32, H as f32), bar);
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn open_item_paints_active_bg() {
+        // First item (File) is the open menu — its bg should be
+        // tab_active_bg, distinct from tab_bar_bg.
+        let bar = sample_bar();
+        let (surface, layout) = paint_via_backend(&bar);
+        let theme = Theme::default();
+        let file = &layout.visible_items[0];
+        // Probe column 1 (inside the leading padding so no glyph
+        // ink) at the bottom edge of the bar.
+        let probe_x = (file.bounds.x as u32) + 1;
+        let probe_y = H - 2;
+        let (r, g, b, _) = surface.pixel(probe_x, probe_y);
+        assert_eq!(
+            (r, g, b),
+            (
+                theme.tab_active_bg.r,
+                theme.tab_active_bg.g,
+                theme.tab_active_bg.b
+            ),
+        );
+    }
+
+    #[test]
+    fn inactive_item_paints_bar_bg() {
+        let bar = sample_bar();
+        let (surface, layout) = paint_via_backend(&bar);
+        let theme = Theme::default();
+        // Second item (Edit) is inactive — its bg should still be
+        // tab_bar_bg (not painted over).
+        let edit = &layout.visible_items[1];
+        let probe_x = (edit.bounds.x as u32) + 1;
+        let probe_y = H - 2;
+        let (r, g, b, _) = surface.pixel(probe_x, probe_y);
+        assert_eq!(
+            (r, g, b),
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+        );
+    }
+
+    #[test]
+    fn hit_test_resolves_clickable_items_via_layout() {
+        let bar = sample_bar();
+        let (_surface, layout) = paint_via_backend(&bar);
+        // Clickable items (File, Edit) resolve as Item(i). Disabled
+        // View falls through to Bar — matches the primitive contract.
+        for (i, vi) in layout.visible_items.iter().enumerate() {
+            let cx = vi.bounds.x + vi.bounds.width * 0.5;
+            let cy = vi.bounds.y + vi.bounds.height * 0.5;
+            let expected = if vi.clickable {
+                MenuBarHit::Item(i)
+            } else {
+                MenuBarHit::Bar
+            };
+            assert_eq!(
+                layout.hit_test(cx, cy),
+                expected,
+                "item {} (clickable={})",
+                i,
+                vi.clickable
+            );
+        }
+    }
+}

--- a/quadraui/src/macos/menu_bar.rs
+++ b/quadraui/src/macos/menu_bar.rs
@@ -231,6 +231,24 @@ mod tests {
         );
     }
 
+    /// `cargo test -p quadraui --features macos -- --ignored --nocapture macos::menu_bar::tests::dump_smoke_ppm`
+    ///
+    /// Paints the sample bar (File / Edit / View, File open) into a
+    /// 320 × 24 surface and writes `/tmp/quadraui_menu_bar.ppm`. Open
+    /// in Preview to confirm:
+    /// - "File" reads in `tab_active_fg` over `tab_active_bg` (the
+    ///   open-menu highlight).
+    /// - "Edit" reads in `tab_inactive_fg` over the bar's normal bg.
+    /// - "View" (disabled) reads dimmer (`muted_fg`).
+    /// - `&` markers are stripped from rendered text.
+    #[test]
+    #[ignore = "writes /tmp/quadraui_menu_bar.ppm — opt in with --ignored"]
+    fn dump_smoke_ppm() {
+        let bar = sample_bar();
+        let (surface, _) = paint_via_backend(&bar);
+        surface.write_ppm_and_open("/tmp/quadraui_menu_bar.ppm");
+    }
+
     #[test]
     fn hit_test_resolves_clickable_items_via_layout() {
         let bar = sample_bar();

--- a/quadraui/src/macos/mod.rs
+++ b/quadraui/src/macos/mod.rs
@@ -20,14 +20,24 @@
 //!
 //! [milestone]: https://github.com/JDonaghy/quadraui/milestone/4
 
+pub mod activity_bar;
 pub mod backend;
+pub mod command_center;
 pub mod events;
 #[cfg(test)]
 pub mod headless;
+pub mod menu_bar;
 mod run;
 pub mod services;
+pub mod status_bar;
+pub mod tab_bar;
 pub mod text;
 
+pub use activity_bar::draw_activity_bar;
 pub use backend::MacBackend;
+pub use command_center::{draw_command_center, mac_command_center_layout};
+pub use menu_bar::{draw_menu_bar, mac_menu_bar_layout};
 pub use run::run;
 pub use services::MacPlatformServices;
+pub use status_bar::draw_status_bar;
+pub use tab_bar::draw_tab_bar;

--- a/quadraui/src/macos/run.rs
+++ b/quadraui/src/macos/run.rs
@@ -55,7 +55,7 @@ use objc2_foundation::{
 
 use super::backend::MacBackend;
 use super::events::{ns_key_to_uievent, ns_mouse_down, ns_mouse_moved, ns_mouse_up, ns_scroll};
-use super::text::{draw_text, font_metrics, make_font};
+use super::text::make_font;
 use crate::backend::Backend;
 use crate::event::Viewport;
 use crate::runner::{AppLogic, Reaction};
@@ -172,32 +172,17 @@ declare_class!(
                 &CGSize::new(bounds.size.width, bounds.size.height),
             );
 
-            // Debug background — flat dark grey so the window is
-            // visibly painted before AppLogic renders. The smoke
-            // label below proves the #34 Core Text path. Both
-            // disappear once any chrome rasteriser ships (#38).
+            // Background fill so the area between rasterised chrome
+            // (e.g. tab_bar at the top + status_bar at the bottom) has
+            // a consistent backdrop until content rasterisers (#39+)
+            // fill the middle. Removed once content rasterisers paint
+            // the full client area.
             //
             // SAFETY: `cg_ref` is a non-null `CGContextRef` borrowed
             // for the duration of this call.
             unsafe {
                 CGContextSetRGBFillColor(cg_ref, 0.12, 0.12, 0.14, 1.0);
                 CGContextFillRect(cg_ref, rect);
-            }
-
-            if let Some(font) = make_font("Menlo", 14.0) {
-                let m = font_metrics(&font);
-                let label = format!(
-                    "quadraui · macos · {}×{} @ {:.0}x · line_h {:.1}pt · char_w {:.2}pt",
-                    bounds.size.width as u32,
-                    bounds.size.height as u32,
-                    scale,
-                    m.line_height,
-                    m.char_width,
-                );
-                // SAFETY: same lifetime invariant as the fill above.
-                unsafe {
-                    draw_text(cg_ref, &font, &label, 16.0, 16.0, (0.25, 0.65, 1.0, 1.0));
-                }
             }
 
             // Now run the app's render via the stored closure.

--- a/quadraui/src/macos/run.rs
+++ b/quadraui/src/macos/run.rs
@@ -445,6 +445,18 @@ pub fn run<A: AppLogic + 'static>(app: A) -> std::process::ExitCode {
     let app = Rc::new(RefCell::new(app));
     let backend = Rc::new(RefCell::new(MacBackend::new()));
 
+    // ── Default font ──────────────────────────────────────────────
+    // Install Menlo 14pt before `setup` so backend-trait calls inside
+    // the app's setup or first render frame find a font to measure
+    // against. Apps that want a different family / size override via
+    // `MacBackend::set_current_font` from their own `setup` hook —
+    // but the shared backend-agnostic examples (`MiniApp`, `AppState`,
+    // etc.) work with no per-app font wiring this way, matching the
+    // ergonomics of `tui::run` and `gtk::run`.
+    if let Some(font) = make_font("Menlo", 14.0) {
+        backend.borrow_mut().set_current_font(font);
+    }
+
     // ── App setup hook ────────────────────────────────────────────
     // Run `AppLogic::setup` once before the window opens. Accelerator
     // registration / cache warming happens here.

--- a/quadraui/src/macos/status_bar.rs
+++ b/quadraui/src/macos/status_bar.rs
@@ -1,0 +1,409 @@
+//! macOS rasteriser for [`crate::StatusBar`].
+//!
+//! Mirrors [`crate::gtk::status_bar::draw_status_bar`]: the rasteriser
+//! computes the layout internally because Core Text measurement and
+//! glyph rendering both require the same `CTFont` handle, so splitting
+//! the work across the call boundary would force callers to plumb the
+//! font through twice. The resolved [`StatusBarLayout`] is returned so
+//! the host (or the [`Backend`] adapter on top) can dispatch clicks.
+//!
+//! Per D6: layout policy (priority drop, gap rules, …) lives in
+//! [`StatusBar::layout`]; this rasteriser paints whatever that returns.
+//!
+//! ## Bold segments
+//!
+//! Tracked separately — `bold` on a segment is currently ignored. Bold
+//! support requires materialising a bold variant of the active font
+//! via `CTFontCreateCopyWithSymbolicTraits` and is out of scope for
+//! #38; follow-up after the chrome batch lands.
+//!
+//! [`Backend`]: crate::Backend
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::primitives::status_bar::{
+    StatusBar, StatusBarLayout, StatusBarSegment, StatusSegmentMeasure, StatusSegmentSide,
+};
+use crate::theme::Theme;
+use crate::types::{Color, WidgetId};
+
+/// 16-point minimum gap between left and right segment groups. Matches
+/// the GTK rasteriser and the vimcode native-backend behaviour.
+const MIN_GAP_PX: f32 = 16.0;
+
+/// Paint `bar` into the rect `(x, y, width, line_height)` on `ctx`
+/// using `font` for text measurement + glyph rendering. Returns the
+/// resolved layout — hit regions are in **bar-local coordinates**
+/// (relative to `x`), matching `gtk::draw_status_bar`.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call (typical: the frame-scope pointer stashed on
+/// [`super::MacBackend`]). Calling with a freed or null pointer is UB.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_status_bar(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    width: f64,
+    line_height: f64,
+    bar: &StatusBar,
+    theme: &Theme,
+    hovered_id: Option<&WidgetId>,
+    pressed_id: Option<&WidgetId>,
+) -> StatusBarLayout {
+    // Empty rect — return the layout the primitive would have produced
+    // for a zero-width bar so callers' hit dispatch behaves predictably.
+    if width <= 0.0 || line_height <= 0.0 {
+        return bar.layout(
+            width.max(0.0) as f32,
+            line_height.max(0.0) as f32,
+            MIN_GAP_PX,
+            |_| StatusSegmentMeasure::new(0.0),
+        );
+    }
+
+    CGContextSaveGState(ctx);
+
+    // Clip to the bar rect so right-aligned segments that overflow are
+    // truncated cleanly at the right edge instead of painting past it.
+    CGContextClipToRect(ctx, CGRect::new_xywh(x, y, width, line_height));
+
+    // Background fill: first segment's bg, falling through to theme bg.
+    let fill = bar
+        .left_segments
+        .first()
+        .or(bar.right_segments.first())
+        .map(|s| s.bg)
+        .unwrap_or(theme.background);
+    fill_rect(ctx, x, y, width, line_height, fill);
+
+    // Measure each visible segment via Core Text. `measure_text` returns
+    // (width, height) in points; the primitive only needs the width.
+    let measure = |seg: &StatusBarSegment| -> StatusSegmentMeasure {
+        let (w, _) = measure_text(font, &seg.text);
+        StatusSegmentMeasure::new(w as f32)
+    };
+    let bar_layout = bar.layout(width as f32, line_height as f32, MIN_GAP_PX, measure);
+
+    for vs in &bar_layout.visible_segments {
+        let seg = match vs.side {
+            StatusSegmentSide::Left => &bar.left_segments[vs.segment_idx],
+            StatusSegmentSide::Right => &bar.right_segments[vs.segment_idx],
+        };
+        let seg_x = x + vs.bounds.x as f64;
+        let seg_w = vs.bounds.width as f64;
+
+        // Hover/press tint — applied only to interactive segments to
+        // match the TUI + GTK convention. `action_id.is_some_and(...)`
+        // is false for both non-clickable segments and segments whose
+        // id doesn't match `hovered_id` / `pressed_id`.
+        let effective_bg = if seg
+            .action_id
+            .as_ref()
+            .is_some_and(|id| Some(id) == pressed_id)
+        {
+            seg.bg.darken(0.05)
+        } else if seg
+            .action_id
+            .as_ref()
+            .is_some_and(|id| Some(id) == hovered_id)
+        {
+            seg.bg.lighten(0.05)
+        } else {
+            seg.bg
+        };
+        fill_rect(ctx, seg_x, y, seg_w, line_height, effective_bg);
+
+        let fg = color_to_cg(seg.fg);
+        draw_text(ctx, font, &seg.text, seg_x, y, fg);
+    }
+
+    CGContextRestoreGState(ctx);
+
+    bar_layout
+}
+
+/// Convert a `quadraui::Color` (0–255 RGBA) into CG's normalised
+/// `(r, g, b, a)` tuple expected by [`super::text::draw_text`] and
+/// the local `fill_rect`.
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+/// Set the fill colour and emit a `CGContextFillRect`. Convenience for
+/// the rasteriser's repeated background-fill pattern.
+///
+/// # Safety
+///
+/// Same contract as the caller — `ctx` must be a valid CG context
+/// borrowed for the duration of the call.
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    CGContextFillRect(ctx, CGRect::new_xywh(x, y, w, h));
+}
+
+// Small convenience extension for building `CGRect` in (x, y, w, h)
+// form. Keeps call sites scannable.
+trait CGRectExt {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self;
+}
+impl CGRectExt for CGRect {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self {
+        use core_graphics::geometry::{CGPoint, CGSize};
+        CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h))
+    }
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextClipToRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::status_bar::StatusBarHit;
+    use crate::primitives::status_bar::StatusBarSegment;
+    use crate::theme::Theme;
+    use crate::types::{Color, WidgetId};
+    use crate::Backend;
+
+    const W: u32 = 320;
+    const H: u32 = 24;
+    const FONT_SIZE: f64 = 14.0;
+
+    fn font() -> CTFont {
+        make_font("Menlo", FONT_SIZE).expect("Menlo installed on every macOS host")
+    }
+
+    /// Three-segment bar:
+    /// - Left[0]: "(L) " sentinel with bg `(10, 20, 30)` — sets the
+    ///   bar fill (first segment's bg) to a colour distinct from the
+    ///   clickable segment, so paint-shift mutations can't hide
+    ///   behind a matching bar fill.
+    /// - Left[1]: " Save " clickable, bg `(40, 80, 120)`.
+    /// - Right[0]: " 1:1 " non-clickable, bg `(40, 80, 120)`.
+    ///
+    /// Leading/trailing spaces give glyph-free padding pixels for
+    /// bg-colour probing — same trick the TUI reference tests use.
+    fn sample_bar() -> StatusBar {
+        StatusBar {
+            id: WidgetId::new("status"),
+            left_segments: vec![
+                StatusBarSegment {
+                    text: "(L) ".into(),
+                    fg: Color::rgb(255, 255, 255),
+                    bg: Color::rgb(10, 20, 30),
+                    bold: false,
+                    action_id: None,
+                },
+                StatusBarSegment {
+                    text: " Save ".into(),
+                    fg: Color::rgb(255, 255, 255),
+                    bg: Color::rgb(40, 80, 120),
+                    bold: false,
+                    action_id: Some(WidgetId::new("status:save")),
+                },
+            ],
+            right_segments: vec![StatusBarSegment {
+                text: " 1:1 ".into(),
+                fg: Color::rgb(255, 255, 255),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+        }
+    }
+
+    /// Paint a bar through the full `MacBackend::draw_status_bar`
+    /// path and return both the surface (for pixel inspection) and
+    /// the layout (for hit_test). Establishes the harness shape every
+    /// chrome rasteriser test follows.
+    fn paint_via_backend(bar: &StatusBar) -> (BitmapSurface, StatusBarLayout) {
+        let surface = BitmapSurface::new(W, H);
+        // Clear so we can distinguish "painted by status_bar" from
+        // "untouched memory" cleanly.
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_status_bar(QRect::new(0.0, 0.0, W as f32, H as f32), bar, None, None);
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    /// Probe a column near the leading space of the clickable "Save"
+    /// segment — a glyph-free padding region that exposes the
+    /// segment's bg fill without interference from rasterised text.
+    /// Sample near the top edge where line_height is guaranteed
+    /// painted and glyphs (anchored at the ascent baseline) don't
+    /// reach.
+    fn probe_save_segment_bg(surface: &BitmapSurface, layout: &StatusBarLayout) -> (u8, u8, u8) {
+        let save = layout
+            .visible_segments
+            .iter()
+            .filter(|vs| vs.side == StatusSegmentSide::Left)
+            .nth(1)
+            .expect("save segment visible");
+        let probe_x = (save.bounds.x as u32) + 1;
+        let probe_y = 2;
+        let (r, g, b, _) = surface.pixel(probe_x, probe_y);
+        (r, g, b)
+    }
+
+    #[test]
+    fn paints_segment_backgrounds() {
+        let bar = sample_bar();
+        let (surface, layout) = paint_via_backend(&bar);
+        assert_eq!(
+            probe_save_segment_bg(&surface, &layout),
+            (40, 80, 120),
+            "left-segment bg should match StatusBarSegment.bg",
+        );
+    }
+
+    #[test]
+    fn round_trip_click_hits_clickable_segment() {
+        // Paint the bar, then hit-test a coordinate inside the
+        // clickable "Save" segment's painted bounds. Assert the layout
+        // reports a hit on the segment's action_id.
+        let bar = sample_bar();
+        let (_surface, layout) = paint_via_backend(&bar);
+
+        let save = layout
+            .visible_segments
+            .iter()
+            .filter(|vs| vs.side == StatusSegmentSide::Left)
+            .nth(1)
+            .expect("save segment visible");
+        let hit_x = save.bounds.x + save.bounds.width * 0.5;
+        let hit_y = save.bounds.y + save.bounds.height * 0.5;
+        let hit = layout.hit_test(hit_x, hit_y);
+        assert_eq!(
+            hit,
+            StatusBarHit::Segment(WidgetId::new("status:save")),
+            "expected clickable Save segment hit at ({}, {})",
+            hit_x,
+            hit_y,
+        );
+
+        // Sanity check: the right segment is non-clickable, so a hit
+        // inside its bounds must return Empty.
+        let right = layout
+            .visible_segments
+            .iter()
+            .find(|vs| vs.side == StatusSegmentSide::Right)
+            .expect("right segment visible");
+        let right_hit = layout.hit_test(
+            right.bounds.x + right.bounds.width * 0.5,
+            right.bounds.y + right.bounds.height * 0.5,
+        );
+        assert_eq!(
+            right_hit,
+            StatusBarHit::Empty,
+            "non-clickable right segment must hit Empty",
+        );
+    }
+
+    #[test]
+    fn empty_bar_falls_back_to_theme_background() {
+        // No segments → fill colour comes from theme.background.
+        let bar = StatusBar {
+            id: WidgetId::new("empty"),
+            left_segments: vec![],
+            right_segments: vec![],
+        };
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.set_current_theme(Theme {
+            background: Color::rgb(1, 2, 3),
+            ..Theme::default()
+        });
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            b.draw_status_bar(QRect::new(0.0, 0.0, W as f32, H as f32), &bar, None, None);
+        });
+        backend.end_frame();
+
+        // Every pixel should carry the theme bg.
+        let (r, g, b, _) = surface.pixel(W / 2, H / 2);
+        assert_eq!(
+            (r, g, b),
+            (1, 2, 3),
+            "empty bar should be filled with theme.background",
+        );
+    }
+
+    #[test]
+    fn hover_tint_lightens_clickable_segment_bg() {
+        // Paint with `hovered_id = "status:save"` and assert the bg
+        // sample comes back lighter than the un-tinted version.
+        let bar = sample_bar();
+
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let hovered = WidgetId::new("status:save");
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_status_bar(
+                QRect::new(0.0, 0.0, W as f32, H as f32),
+                &bar,
+                Some(&hovered),
+                None,
+            );
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+
+        let layout = layout.into_inner().unwrap();
+        let (r, g, b) = probe_save_segment_bg(&surface, &layout);
+        // Base colour is (40, 80, 120). `lighten(0.05)` moves each
+        // channel 5% of the way to 255. Each channel should be
+        // strictly greater than the base.
+        assert!(
+            r > 40 && g > 80 && b > 120,
+            "hover-tinted bg ({}, {}, {}) should be lighter than base (40, 80, 120)",
+            r,
+            g,
+            b,
+        );
+    }
+}

--- a/quadraui/src/macos/tab_bar.rs
+++ b/quadraui/src/macos/tab_bar.rs
@@ -1,0 +1,481 @@
+//! macOS rasteriser for [`crate::TabBar`].
+//!
+//! Mirrors [`crate::gtk::tab_bar::draw_tab_bar`]: measures tab widths
+//! via Core Text, lays out left-to-right with active-tab highlighting,
+//! close glyphs (× or ● for dirty), and right-aligned segments.
+//! Returns a [`TabBarHits`] carrying per-tab + per-segment screen
+//! bounds for the caller's click dispatch.
+//!
+//! ## Scope omissions (follow-up after the #38 chrome batch)
+//!
+//! - **Italic preview tabs** — needs an italic-variant `CTFont` via
+//!   `CTFontCreateCopyWithSymbolicTraits`. Same dependency as bold
+//!   support in [`super::status_bar`]; pairs naturally with that
+//!   future change. Until it lands, preview tabs render in the
+//!   active font.
+//! - **Rounded close-button hover background** — the GTK rasteriser
+//!   draws a 3 px rounded rect under the close glyph on hover. macOS
+//!   uses a simpler approach for #38: tint the close glyph itself
+//!   (`theme.foreground`) when hovered. Visual parity with GTK is
+//!   tracked separately.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::primitives::tab_bar::{TabBar, TabBarHits};
+use crate::theme::Theme;
+use crate::types::Color;
+
+/// Per-tab horizontal padding (left + right) inside the tab background fill.
+const TAB_PAD: f64 = 14.0;
+/// Gap between the tab label and the close glyph.
+const TAB_INNER_GAP: f64 = 10.0;
+/// Gap between adjacent tabs.
+const TAB_OUTER_GAP: f64 = 1.0;
+/// Top-edge accent strip height for the active tab (when `active_accent`
+/// is set).
+const ACCENT_HEIGHT: f64 = 2.0;
+/// 15-char sample used to estimate cell width for `available_cols`.
+/// Same string the GTK rasteriser uses, so app-level cell budgets
+/// remain comparable between backends.
+const CELL_WIDTH_SAMPLE: &str = "ABCDabcd0123.:_";
+
+/// Paint `bar` into the rect `(0, y_offset, width, row_height)` on
+/// `ctx`. `line_height` is the *text* line height; `row_height` may be
+/// larger (callers pad file-tab bars). Returns per-tab + per-segment
+/// hit bounds plus the resolved scroll offset.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call (typical: the frame-scope pointer stashed on
+/// [`super::MacBackend`]). Calling with a freed or null pointer is UB.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_tab_bar(
+    ctx: CGContextRef,
+    font: &CTFont,
+    width: f64,
+    line_height: f64,
+    y_offset: f64,
+    row_height: f64,
+    bar: &TabBar,
+    theme: &Theme,
+    hovered_close_tab: Option<usize>,
+) -> TabBarHits {
+    let text_y_offset = y_offset + (row_height - line_height) / 2.0;
+    let tab_pad = if bar.compact { 2.0 } else { TAB_PAD };
+    let tab_inner_gap = if bar.compact { 4.0 } else { TAB_INNER_GAP };
+    let tab_outer_gap = if bar.compact { 0.0 } else { TAB_OUTER_GAP };
+
+    CGContextSaveGState(ctx);
+
+    // Tab-bar background.
+    fill_rect(ctx, 0.0, y_offset, width, row_height, theme.tab_bar_bg);
+
+    // ── Right-segment widths (measure once; paint after tabs) ─────────
+    let mut right_widths: Vec<f64> = Vec::with_capacity(bar.right_segments.len());
+    for seg in &bar.right_segments {
+        let (w, _) = measure_text(font, &seg.text);
+        right_widths.push(w);
+    }
+    let reserved_px: f64 = right_widths.iter().sum();
+    let effective_tab_area = (width - reserved_px).max(0.0);
+
+    // Close-glyph width measured once — every tab pays the same width
+    // for the `×` glyph (the `●` dirty variant is the same width in
+    // Menlo and most monospace fonts).
+    let close_w = if bar.show_tab_close {
+        let (w, _) = measure_text(font, "×");
+        w
+    } else {
+        0.0
+    };
+    let close_extra = if bar.show_tab_close {
+        tab_inner_gap + close_w
+    } else {
+        0.0
+    };
+
+    // Pre-measure every tab's full slot width — used both for scroll
+    // offset resolution and the paint loop.
+    let tab_slot_widths: Vec<f64> = bar
+        .tabs
+        .iter()
+        .map(|tab| {
+            let (name_w, _) = measure_text(font, &tab.label);
+            tab_pad + name_w + close_extra + tab_pad + tab_outer_gap
+        })
+        .collect();
+
+    let active_idx = bar.tabs.iter().position(|t| t.is_active);
+    let correct_scroll_offset = if let Some(active) = active_idx {
+        TabBar::fit_active_scroll_offset(active, bar.tabs.len(), effective_tab_area as usize, |i| {
+            tab_slot_widths[i] as usize
+        })
+    } else {
+        bar.scroll_offset
+    };
+
+    // ── Tabs paint loop ──────────────────────────────────────────────
+    let mut slot_positions: Vec<(f64, f64)> = Vec::with_capacity(bar.tabs.len());
+    let mut close_bounds: Vec<Option<(f64, f64)>> = Vec::with_capacity(bar.tabs.len());
+    for _ in 0..bar.scroll_offset.min(bar.tabs.len()) {
+        slot_positions.push((0.0, 0.0));
+        close_bounds.push(None);
+    }
+
+    let mut x = 0.0_f64;
+    for (tab_idx, tab) in bar.tabs.iter().enumerate().skip(bar.scroll_offset) {
+        let (tab_name_w, _) = measure_text(font, &tab.label);
+        let tab_content_w = tab_pad + tab_name_w + close_extra + tab_pad;
+        let slot_w = tab_content_w + tab_outer_gap;
+        if x + slot_w > effective_tab_area {
+            break;
+        }
+        slot_positions.push((x, x + slot_w));
+
+        let close_x = x + tab_pad + tab_name_w + tab_inner_gap;
+        if bar.show_tab_close {
+            let close_pad = 2.0;
+            close_bounds.push(Some((close_x - close_pad, close_x + close_w + close_pad)));
+        } else {
+            close_bounds.push(None);
+        }
+
+        // Tab background.
+        let bg_col = if tab.is_active {
+            theme.tab_active_bg
+        } else {
+            theme.tab_bar_bg
+        };
+        fill_rect(ctx, x, y_offset, tab_content_w, row_height, bg_col);
+
+        // Top accent line for the active tab.
+        if tab.is_active {
+            if let Some(accent) = bar.active_accent {
+                fill_rect(ctx, x, y_offset, tab_content_w, ACCENT_HEIGHT, accent);
+            }
+        }
+
+        // Tab label.
+        let fg_col = match (tab.is_active, tab.is_preview) {
+            (true, true) => theme.tab_preview_active_fg,
+            (true, false) => theme.tab_active_fg,
+            (false, true) => theme.tab_preview_inactive_fg,
+            (false, false) => theme.tab_inactive_fg,
+        };
+        draw_text(
+            ctx,
+            font,
+            &tab.label,
+            x + tab_pad,
+            text_y_offset,
+            color_to_cg(fg_col),
+        );
+
+        // Close glyph (× or ● for dirty), tinted on hover.
+        if bar.show_tab_close {
+            let is_close_hovered = hovered_close_tab == Some(tab_idx);
+            let close_glyph = if tab.is_dirty && !is_close_hovered {
+                "●"
+            } else {
+                "×"
+            };
+            let close_fg = if tab.is_dirty || is_close_hovered {
+                theme.foreground
+            } else if tab.is_active {
+                theme.tab_inactive_fg
+            } else {
+                theme.separator
+            };
+            draw_text(
+                ctx,
+                font,
+                close_glyph,
+                close_x,
+                text_y_offset,
+                color_to_cg(close_fg),
+            );
+        }
+
+        x += slot_w;
+    }
+
+    // ── Right segments paint loop ────────────────────────────────────
+    let right_base = width - reserved_px;
+    let mut right_segment_bounds: Vec<(f64, f64)> = Vec::with_capacity(bar.right_segments.len());
+    let mut sx = right_base;
+    for (i, seg) in bar.right_segments.iter().enumerate() {
+        let seg_w = right_widths[i];
+        let fg_col = if seg.is_active {
+            theme.tab_active_fg
+        } else {
+            theme.tab_inactive_fg
+        };
+        draw_text(ctx, font, &seg.text, sx, text_y_offset, color_to_cg(fg_col));
+        right_segment_bounds.push((sx, sx + seg_w));
+        sx += seg_w;
+    }
+
+    // Cell-width estimation: 15-char sample width / 15 → average glyph
+    // advance. Matches the GTK convention so app-level char-col math
+    // doesn't diverge across backends.
+    let (sample_px, _) = measure_text(font, CELL_WIDTH_SAMPLE);
+    let char_w = (sample_px / CELL_WIDTH_SAMPLE.chars().count() as f64).max(1.0);
+    let available_cols = (effective_tab_area / char_w).floor().max(0.0) as usize;
+
+    CGContextRestoreGState(ctx);
+
+    TabBarHits {
+        slot_positions,
+        close_bounds,
+        right_segment_bounds,
+        available_cols,
+        correct_scroll_offset,
+    }
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    use core_graphics::geometry::{CGPoint, CGSize};
+    CGContextFillRect(ctx, CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h)));
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::tab_bar::{TabBar, TabItem};
+    use crate::theme::Theme;
+    use crate::types::{Color, WidgetId};
+    use crate::Backend;
+
+    const W: u32 = 480;
+    const H: u32 = 28;
+    const FONT_SIZE: f64 = 14.0;
+
+    fn font() -> CTFont {
+        make_font("Menlo", FONT_SIZE).expect("Menlo installed")
+    }
+
+    fn sample_bar() -> TabBar {
+        TabBar {
+            id: WidgetId::new("tabs"),
+            tabs: vec![
+                TabItem {
+                    label: "main.rs".into(),
+                    is_active: true,
+                    is_dirty: false,
+                    is_preview: false,
+                },
+                TabItem {
+                    label: "lib.rs".into(),
+                    is_active: false,
+                    is_dirty: true,
+                    is_preview: false,
+                },
+            ],
+            scroll_offset: 0,
+            right_segments: vec![],
+            active_accent: Some(Color::rgb(80, 140, 255)),
+            show_tab_close: true,
+            compact: false,
+        }
+    }
+
+    /// Drive a paint through the full `MacBackend::draw_tab_bar` path
+    /// and return `(surface, hits)` for inspection. Mirrors the
+    /// status_bar harness so future chrome tests follow the same
+    /// shape.
+    fn paint_via_backend(
+        bar: &TabBar,
+        hovered_close: Option<usize>,
+    ) -> (BitmapSurface, TabBarHits) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let hits = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let h = b.draw_tab_bar(QRect::new(0.0, 0.0, W as f32, H as f32), bar, hovered_close);
+            *hits.borrow_mut() = Some(h);
+        });
+        backend.end_frame();
+        (surface, hits.into_inner().unwrap())
+    }
+
+    #[test]
+    fn active_tab_paints_active_bg() {
+        // The active tab's bg differs from `tab_bar_bg`. Probe just
+        // above the bottom edge near the left of the active tab's
+        // slot (past the leading padding, before the label glyphs).
+        let bar = sample_bar();
+        let (surface, hits) = paint_via_backend(&bar, None);
+        let theme = Theme::default();
+
+        let (start, end) = hits.slot_positions[0];
+        assert!(end > start, "active tab slot must have non-zero width");
+
+        // Probe near the bottom-left of the slot — past the 14px
+        // padding, below the accent strip, but well outside any glyph
+        // pixels. y = row_height - 2 stays inside the painted row.
+        let probe_x = (start + 2.0) as u32;
+        let probe_y = H - 2;
+        let (r, g, b, _) = surface.pixel(probe_x, probe_y);
+        let expected = theme.tab_active_bg;
+        assert_eq!(
+            (r, g, b),
+            (expected.r, expected.g, expected.b),
+            "active tab bg at ({}, {}) should be tab_active_bg",
+            probe_x,
+            probe_y,
+        );
+    }
+
+    #[test]
+    fn active_accent_paints_at_top_of_active_tab() {
+        // 2-px accent strip at y_offset for the active tab.
+        let bar = sample_bar();
+        let (surface, hits) = paint_via_backend(&bar, None);
+
+        let (start, _) = hits.slot_positions[0];
+        // Top scanline (y=0) inside the active slot — past leading
+        // padding so we don't overlap the second tab.
+        let probe_x = (start + 4.0) as u32;
+        let (r, g, b, _) = surface.pixel(probe_x, 0);
+        let accent = bar.active_accent.unwrap();
+        assert_eq!(
+            (r, g, b),
+            (accent.r, accent.g, accent.b),
+            "accent strip at top edge should match TabBar.active_accent",
+        );
+    }
+
+    #[test]
+    fn close_bounds_round_trip_via_hits_struct() {
+        // Round-trip: paint, then sample a coordinate inside the
+        // reported close-bounds and assert the hits struct's bounds
+        // contain it. This is the "paint and click agree on close
+        // button location" gate.
+        let bar = sample_bar();
+        let (_surface, hits) = paint_via_backend(&bar, None);
+
+        let close = hits.close_bounds[0].expect("active tab has close bounds");
+        let mid_x = (close.0 + close.1) / 2.0;
+        assert!(
+            mid_x >= close.0 && mid_x < close.1,
+            "midpoint must be inside close bounds [{}, {})",
+            close.0,
+            close.1,
+        );
+        // The reported bounds must sit inside the tab slot — a paint
+        // shift on the close glyph would land outside the slot and
+        // catch the drift here.
+        let (slot_start, slot_end) = hits.slot_positions[0];
+        assert!(
+            close.0 >= slot_start && close.1 <= slot_end,
+            "close bounds [{}, {}) must be inside tab slot [{}, {})",
+            close.0,
+            close.1,
+            slot_start,
+            slot_end,
+        );
+    }
+
+    #[test]
+    fn dirty_tab_uses_filled_circle_glyph() {
+        // `is_dirty` swaps the close glyph from `×` to `●`. We can't
+        // easily compare glyph shape pixel-by-pixel, but a row-wise
+        // ink ratio differs noticeably: `●` is mostly filled, `×` is
+        // two thin diagonals. Compare the dirty tab's close column
+        // against the active tab's: dirty should be visibly denser.
+        let bar = sample_bar();
+        let (surface, hits) = paint_via_backend(&bar, None);
+
+        let active_close = hits.close_bounds[0].unwrap();
+        let dirty_close = hits.close_bounds[1].unwrap();
+
+        // Count non-bg pixels in a 1-column strip across the line
+        // height for each close glyph. The dirty (●) column should
+        // have more inked pixels than the × column.
+        fn ink_density(surface: &BitmapSurface, x: u32, bg: Color) -> u32 {
+            (0..H)
+                .filter(|&y| {
+                    let (r, g, b, _) = surface.pixel(x, y);
+                    !(r == bg.r && g == bg.g && b == bg.b)
+                })
+                .count() as u32
+        }
+        let theme = Theme::default();
+        let active_ink = ink_density(
+            &surface,
+            ((active_close.0 + active_close.1) / 2.0) as u32,
+            theme.tab_active_bg,
+        );
+        let dirty_ink = ink_density(
+            &surface,
+            ((dirty_close.0 + dirty_close.1) / 2.0) as u32,
+            theme.tab_bar_bg,
+        );
+        assert!(
+            dirty_ink > active_ink,
+            "dirty `●` glyph should ink more rows ({}) than active `×` ({})",
+            dirty_ink,
+            active_ink,
+        );
+    }
+
+    #[test]
+    fn empty_bar_paints_only_tab_bar_bg() {
+        let bar = TabBar {
+            id: WidgetId::new("empty"),
+            tabs: vec![],
+            scroll_offset: 0,
+            right_segments: vec![],
+            active_accent: None,
+            show_tab_close: true,
+            compact: false,
+        };
+        let (surface, hits) = paint_via_backend(&bar, None);
+        let theme = Theme::default();
+
+        // Whole row should be tab_bar_bg.
+        let (r, g, b, _) = surface.pixel(W / 2, H / 2);
+        assert_eq!(
+            (r, g, b),
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b)
+        );
+        assert!(hits.slot_positions.is_empty());
+        assert!(hits.close_bounds.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #38. Five chrome rasterisers for the macOS backend + the runner-side glue that lets the shared `MiniApp` / `AppState` examples actually run.

- `macos::status_bar` — left/right segments, priority drop, hover/press tint.
- `macos::tab_bar` — left-to-right tabs with active/dirty states, close glyph (× / ●), top accent strip, right-aligned segments, scroll-offset resolution.
- `macos::activity_bar` — vertical icon strip (48 pt rows), top + bottom-pinned items, active accent on left edge, right-edge separator, hover-row tint.
- `macos::command_center` — back/forward arrows + search box, centred; `mac_command_center_layout` companion for caller click routing.
- `macos::menu_bar` — horizontal label strip with active highlight; `mac_menu_bar_layout` companion.

All five flow through the same `MacBackend::enter_frame_scope` + `BitmapSurface` harness that #37 set up. Geometry + hit regions are byte-identical to GTK.

## Runner + examples

- Install Menlo 14pt as `MacBackend.current_font` before `AppLogic::setup` so backend-trait `draw_*` calls work with zero per-app font wiring.
- Drop the `drawRect:` smoke label (descenders were peeking below the tab bar in `macos_demo`); keep the dark-grey debug fill until content rasterisers land in #39+.
- Add `examples/macos_app.rs` (shared `MiniApp`: single StatusBar) and re-point `examples/macos_demo.rs` at the shared `AppState` (TabBar + StatusBar with focus cycling) — same code as the TUI/GTK twins, only the runner call differs.

## Scope omissions (documented in each module header)

All wait on a unified text-attribute pass through `macos::text`:

- Bold segments (`status_bar`).
- Italic preview tabs + rounded close-button hover background (`tab_bar`).
- Alt-key underline (`menu_bar`).
- Rounded search-box border (`command_center`).

## Tests

547 lib tests pass (+17 new chrome tests). Mutation-verified canaries on `status_bar` and `tab_bar` — paint-shift `+30/+50 pt` mutations fail the round-trip tests; revert restored green.

## Test plan

- [ ] `cargo test -p quadraui --features macos --lib` — 547 / 547 passing
- [ ] `cargo run -p quadraui --example macos_app --features macos` — opens AppKit window with bottom status bar, key counter increments
- [ ] `cargo run -p quadraui --example macos_demo --features macos` — tab bar at top, status bar at bottom, `←/→` switches tab, `n` opens, `x` closes, `Tab` cycles status focus, `q`/Esc quits
- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy -p quadraui --features macos --all-targets` clean on macos files

🤖 Generated with [Claude Code](https://claude.com/claude-code)