### PR TITLE
macOS content rasterisers (#39)

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -195,6 +195,21 @@ path = "examples/macos_demo.rs"
 required-features = ["macos"]
 
 [[example]]
+name = "macos_data_table"
+path = "examples/macos_data_table.rs"
+required-features = ["macos"]
+
+[[example]]
+name = "macos_chart"
+path = "examples/macos_chart.rs"
+required-features = ["macos"]
+
+[[example]]
+name = "macos_form_groups"
+path = "examples/macos_form_groups.rs"
+required-features = ["macos"]
+
+[[example]]
 name = "tui_data_table"
 path = "examples/tui_data_table.rs"
 required-features = ["tui"]

--- a/quadraui/examples/macos_chart.rs
+++ b/quadraui/examples/macos_chart.rs
@@ -1,0 +1,13 @@
+//! `cargo run --example macos_chart --features macos`
+//!
+//! macOS port of `tui_chart.rs` / `gtk_chart.rs`. Same `ChartApp`
+//! `AppLogic` impl in `examples/common/chart_app.rs`; only the runner
+//! call differs. Demonstrates sparkline / line / bar chart variants
+//! with hover tracking and a vertical crosshair.
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::macos::run(common::ChartApp::new())
+}

--- a/quadraui/examples/macos_data_table.rs
+++ b/quadraui/examples/macos_data_table.rs
@@ -1,0 +1,16 @@
+//! `cargo run --example macos_data_table --features macos`
+//!
+//! macOS port of `tui_data_table.rs` / `gtk_data_table.rs`. Same
+//! `DataTableApp` `AppLogic` impl in `examples/common/data_table_app.rs`;
+//! only the runner call differs. Demonstrates a sortable Kubernetes
+//! pod list with column headers, hover row tint, and row selection.
+//!
+//! j/k or ↑/↓ to navigate, s to cycle sort column, d to flip direction,
+//! click header to sort, click row to select, q to quit.
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::macos::run(common::DataTableApp::new())
+}

--- a/quadraui/examples/macos_form_groups.rs
+++ b/quadraui/examples/macos_form_groups.rs
@@ -1,0 +1,14 @@
+//! `cargo run --example macos_form_groups --features macos`
+//!
+//! macOS port of `tui_form_groups.rs` / `gtk_form_groups.rs`. Same
+//! `FormGroupsApp` `AppLogic` impl in `examples/common/form_groups.rs`;
+//! only the runner call differs. Demonstrates a `Form` with mixed
+//! field kinds (Label, Toggle, TextInput, Button) and Tab focus
+//! cycling.
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::macos::run(common::FormGroupsApp::new())
+}

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -277,25 +277,134 @@ impl Backend for MacBackend {
     // `unimplemented!` so the file stays scannable; the macro
     // ensures the ticket pointer is consistent across primitives.
 
-    fn draw_tree(&mut self, _rect: Rect, _tree: &TreeView) {
-        mac_unimpl!("draw_tree", "#39")
+    fn draw_tree(&mut self, rect: Rect, tree: &TreeView) {
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_tree called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_tree requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        // SAFETY: ctx is non-null inside the frame scope.
+        unsafe {
+            super::tree::draw_tree(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                tree,
+                &theme,
+                line_height,
+            );
+        }
     }
-    fn draw_list(&mut self, _rect: Rect, _list: &ListView) {
-        mac_unimpl!("draw_list", "#39")
+    fn draw_list(&mut self, rect: Rect, list: &ListView) {
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_list called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_list requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        // SAFETY: ctx is non-null inside the frame scope.
+        unsafe {
+            super::list::draw_list(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                list,
+                &theme,
+                line_height,
+            );
+        }
     }
     fn draw_data_table(
         &mut self,
-        _rect: Rect,
-        _table: &DataTable,
-        _hovered_idx: Option<usize>,
+        rect: Rect,
+        table: &DataTable,
+        hovered_idx: Option<usize>,
     ) -> DataTableLayout {
-        mac_unimpl!("draw_data_table", "#39")
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_data_table called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_data_table requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        // SAFETY: ctx is non-null inside the frame scope.
+        unsafe {
+            super::data_table::draw_data_table(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                table,
+                &theme,
+                line_height,
+                hovered_idx,
+            )
+        }
     }
-    fn data_table_layout(&self, _rect: Rect, _table: &DataTable) -> DataTableLayout {
-        mac_unimpl!("data_table_layout", "#39")
+    fn data_table_layout(&self, rect: Rect, table: &DataTable) -> DataTableLayout {
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::data_table_layout requires set_current_font");
+        super::data_table::mac_data_table_layout(
+            table,
+            font,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            self.current_line_height,
+        )
     }
-    fn draw_form(&mut self, _rect: Rect, _form: &Form) {
-        mac_unimpl!("draw_form", "#39")
+    fn draw_form(&mut self, rect: Rect, form: &Form) {
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_form called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_form requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        // SAFETY: ctx is non-null inside the frame scope.
+        unsafe {
+            super::form::draw_form(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                form,
+                &theme,
+                line_height,
+            );
+        }
     }
     fn draw_palette(&mut self, _rect: Rect, _palette: &Palette) {
         mac_unimpl!("draw_palette", "#41")
@@ -428,14 +537,27 @@ impl Backend for MacBackend {
     fn msv_metrics(&self) -> LayoutMetrics {
         mac_unimpl!("msv_metrics", "#40")
     }
-    fn tree_layout(&self, _rect: Rect, _tree: &TreeView) -> TreeViewLayout {
-        mac_unimpl!("tree_layout", "#39")
+    fn tree_layout(&self, rect: Rect, tree: &TreeView) -> TreeViewLayout {
+        super::tree::mac_tree_layout(tree, rect, self.current_line_height)
     }
-    fn form_layout(&self, _rect: Rect, _form: &Form) -> FormLayout {
-        mac_unimpl!("form_layout", "#39")
+    fn form_layout(&self, rect: Rect, form: &Form) -> FormLayout {
+        super::form::mac_form_layout(form, rect, self.current_line_height)
     }
-    fn draw_editor(&mut self, _rect: Rect, _editor: &Editor) -> EditorPaintResult {
-        mac_unimpl!("draw_editor", "#39")
+    fn draw_editor(&mut self, _rect: Rect, editor: &Editor) -> EditorPaintResult {
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_editor called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_editor requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        let char_width = self.current_char_width;
+        // SAFETY: ctx is non-null inside the frame scope.
+        unsafe { super::editor::draw_editor(ctx, font, editor, &theme, char_width, line_height) }
     }
     fn draw_message_list(&mut self, _rect: Rect, _list: &MessageList) {
         mac_unimpl!("draw_message_list", "#43")
@@ -564,15 +686,51 @@ impl Backend for MacBackend {
     }
     fn draw_chart(
         &mut self,
-        _rect: Rect,
-        _chart: &Chart,
-        _hovered_point: Option<(usize, usize)>,
-        _crosshair_x: Option<f64>,
+        rect: Rect,
+        chart: &Chart,
+        hovered_point: Option<(usize, usize)>,
+        crosshair_x: Option<f64>,
     ) -> ChartLayout {
-        mac_unimpl!("draw_chart", "#39")
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_chart called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_chart requires set_current_font");
+        let theme = self.current_theme;
+        let line_height = self.current_line_height;
+        let char_width = self.current_char_width;
+        // SAFETY: ctx is non-null inside the frame scope.
+        unsafe {
+            super::chart::draw_chart(
+                ctx,
+                font,
+                rect.x as f64,
+                rect.y as f64,
+                rect.width as f64,
+                rect.height as f64,
+                chart,
+                &theme,
+                line_height,
+                char_width,
+                hovered_point,
+                crosshair_x,
+            )
+        }
     }
-    fn chart_layout(&self, _rect: Rect, _chart: &Chart) -> ChartLayout {
-        mac_unimpl!("chart_layout", "#39")
+    fn chart_layout(&self, rect: Rect, chart: &Chart) -> ChartLayout {
+        super::chart::mac_chart_layout(
+            chart,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            self.current_line_height,
+            self.current_char_width,
+        )
     }
 }
 

--- a/quadraui/src/macos/chart.rs
+++ b/quadraui/src/macos/chart.rs
@@ -1,0 +1,556 @@
+//! macOS rasteriser for [`crate::Chart`].
+//!
+//! Mirrors [`crate::gtk::chart::draw_chart`] for the three chart kinds:
+//!
+//! - **Sparkline** — single-series polyline (1.5pt) inside the plot area.
+//! - **Line** — multi-series polyline with optional area fill at 20%
+//!   alpha.
+//! - **Bar** — vertical rectangles per data point.
+//!
+//! Hover marker and crosshair overlays are honoured. Axis labels,
+//! ticks, grid, and legend chrome use Core Text.
+
+use core_graphics::base::CGFloat;
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::primitives::chart::{Chart, ChartKind, ChartLayout, ChartMeasure};
+use crate::theme::Theme;
+use crate::types::Color;
+
+/// Default series palette — matches GTK's `SERIES_COLORS`.
+const SERIES_COLORS: [Color; 6] = [
+    Color::rgb(80, 160, 255),
+    Color::rgb(255, 120, 80),
+    Color::rgb(80, 220, 120),
+    Color::rgb(220, 180, 60),
+    Color::rgb(180, 100, 240),
+    Color::rgb(240, 100, 180),
+];
+
+/// Compute the macOS pixel-unit layout for `chart`.
+pub fn mac_chart_layout(
+    chart: &Chart,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    line_height: f64,
+    char_width: f64,
+) -> ChartLayout {
+    chart.layout(
+        x as f32,
+        y as f32,
+        ChartMeasure {
+            width: w as f32,
+            height: h as f32,
+            char_width: char_width as f32,
+            line_height: line_height as f32,
+        },
+    )
+}
+
+/// Draw `chart` onto `ctx`. Returns the layout used for painting.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_chart(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    chart: &Chart,
+    theme: &Theme,
+    line_height: f64,
+    char_width: f64,
+    hovered_point: Option<(usize, usize)>,
+    crosshair_x: Option<f64>,
+) -> ChartLayout {
+    let layout = mac_chart_layout(chart, x, y, w, h, line_height, char_width);
+
+    if w <= 0.0 || h <= 0.0 {
+        return layout;
+    }
+
+    CGContextSaveGState(ctx);
+    CGContextClipToRect(ctx, CGRect::new_xywh(x, y, w, h));
+
+    match chart.kind {
+        ChartKind::Sparkline => paint_sparkline(ctx, &layout, chart, theme),
+        ChartKind::Line => paint_line(ctx, font, &layout, chart, theme),
+        ChartKind::Bar => paint_bar(ctx, font, &layout, chart, theme),
+    }
+
+    if let Some(data_x) = crosshair_x {
+        paint_crosshair(ctx, &layout, chart, theme, data_x);
+    }
+    if let Some((si, di)) = hovered_point {
+        paint_hover_marker(ctx, &layout, si, di, chart);
+    }
+
+    CGContextRestoreGState(ctx);
+    layout
+}
+
+fn series_color(chart: &Chart, idx: usize) -> Color {
+    chart
+        .series
+        .get(idx)
+        .and_then(|s| s.color)
+        .unwrap_or(SERIES_COLORS[idx % SERIES_COLORS.len()])
+}
+
+unsafe fn paint_sparkline(ctx: CGContextRef, layout: &ChartLayout, chart: &Chart, theme: &Theme) {
+    let pa = &layout.plot_area;
+    fill_rect(
+        ctx,
+        pa.x as f64,
+        pa.y as f64,
+        pa.width as f64,
+        pa.height as f64,
+        theme.background,
+    );
+
+    let Some(series) = chart.series.first() else {
+        return;
+    };
+    if series.data.is_empty() || pa.width <= 0.0 || pa.height <= 0.0 {
+        return;
+    }
+    let color = series_color(chart, 0);
+    stroke_polyline(ctx, &layout.data_point_positions, 0, color, 1.5);
+}
+
+unsafe fn paint_line(
+    ctx: CGContextRef,
+    font: &CTFont,
+    layout: &ChartLayout,
+    chart: &Chart,
+    theme: &Theme,
+) {
+    let pa = &layout.plot_area;
+    fill_rect(
+        ctx,
+        pa.x as f64,
+        pa.y as f64,
+        pa.width as f64,
+        pa.height as f64,
+        theme.background,
+    );
+
+    // Grid lines.
+    if chart.show_grid {
+        for &(sy, _) in &layout.y_tick_positions {
+            fill_rect(
+                ctx,
+                pa.x as f64,
+                sy as f64,
+                pa.width as f64,
+                1.0,
+                theme.separator,
+            );
+        }
+    }
+
+    // Per-series strokes.
+    for (si, s) in chart.series.iter().enumerate() {
+        let color = series_color(chart, si);
+        stroke_polyline(ctx, &layout.data_point_positions, si, color, 1.5);
+        // Area fill: approximate with a vertical fan of 1px-wide bars
+        // beneath each segment.
+        if s.fill {
+            let alpha_color = Color {
+                r: color.r,
+                g: color.g,
+                b: color.b,
+                a: 51, // ~20% alpha
+            };
+            for w in layout
+                .data_point_positions
+                .iter()
+                .filter(|(s, _, _, _)| *s == si)
+                .collect::<Vec<_>>()
+                .windows(2)
+            {
+                let (_, _, x0, y0) = w[0];
+                let (_, _, x1, _y1) = w[1];
+                let baseline = pa.y as f64 + pa.height as f64;
+                let bar_w = (*x1 as f64 - *x0 as f64).max(1.0);
+                fill_rect(
+                    ctx,
+                    *x0 as f64,
+                    *y0 as f64,
+                    bar_w,
+                    baseline - *y0 as f64,
+                    alpha_color,
+                );
+            }
+        }
+    }
+
+    paint_axis_labels(ctx, font, layout, chart, theme);
+    paint_legend(ctx, font, layout, chart, theme);
+}
+
+unsafe fn paint_bar(
+    ctx: CGContextRef,
+    font: &CTFont,
+    layout: &ChartLayout,
+    chart: &Chart,
+    theme: &Theme,
+) {
+    let pa = &layout.plot_area;
+    fill_rect(
+        ctx,
+        pa.x as f64,
+        pa.y as f64,
+        pa.width as f64,
+        pa.height as f64,
+        theme.background,
+    );
+
+    let Some(series) = chart.series.first() else {
+        return;
+    };
+    if series.data.is_empty() {
+        return;
+    }
+    let n = series.data.len() as f64;
+    let bar_gap = 2.0_f64;
+    let bar_w = ((pa.width as f64 / n) - bar_gap).max(1.0);
+    let baseline = pa.y as f64 + pa.height as f64;
+    let color = series_color(chart, 0);
+    for (_si, di, sx, sy) in layout
+        .data_point_positions
+        .iter()
+        .filter(|(si, _, _, _)| *si == 0)
+    {
+        let bx = *sx as f64 - bar_w / 2.0;
+        let bh = baseline - *sy as f64;
+        if bh > 0.0 {
+            fill_rect(ctx, bx, *sy as f64, bar_w, bh, color);
+        }
+        let _ = di;
+    }
+
+    paint_axis_labels(ctx, font, layout, chart, theme);
+    paint_legend(ctx, font, layout, chart, theme);
+}
+
+unsafe fn paint_axis_labels(
+    ctx: CGContextRef,
+    font: &CTFont,
+    layout: &ChartLayout,
+    _chart: &Chart,
+    theme: &Theme,
+) {
+    // Y-axis tick labels: render to the left of the plot area.
+    for &(sy, val) in &layout.y_tick_positions {
+        let label = format_tick(val);
+        let (tw, th) = measure_text(font, &label);
+        let lx = (layout.plot_area.x as f64 - tw - 4.0).max(0.0);
+        draw_text(
+            ctx,
+            font,
+            &label,
+            lx,
+            sy as f64 - th / 2.0,
+            color_to_cg(theme.muted_fg),
+        );
+    }
+}
+
+unsafe fn paint_legend(
+    ctx: CGContextRef,
+    font: &CTFont,
+    layout: &ChartLayout,
+    chart: &Chart,
+    _theme: &Theme,
+) {
+    let Some(lb) = layout.legend_bounds else {
+        return;
+    };
+    if chart.series.is_empty() {
+        return;
+    }
+    let entry_w = (lb.width / chart.series.len() as f32).max(1.0);
+    for (i, s) in chart.series.iter().enumerate() {
+        let color = series_color(chart, i);
+        let ex = lb.x + entry_w * i as f32;
+        // Colour swatch.
+        let sw = 10.0_f64;
+        fill_rect(
+            ctx,
+            ex as f64,
+            lb.y as f64 + 2.0,
+            sw,
+            lb.height as f64 - 4.0,
+            color,
+        );
+        // Series label.
+        let (_, th) = measure_text(font, &s.label);
+        draw_text(
+            ctx,
+            font,
+            &s.label,
+            ex as f64 + sw + 4.0,
+            lb.y as f64 + (lb.height as f64 - th) / 2.0,
+            color_to_cg(color),
+        );
+    }
+}
+
+unsafe fn paint_crosshair(
+    ctx: CGContextRef,
+    layout: &ChartLayout,
+    chart: &Chart,
+    theme: &Theme,
+    data_x: f64,
+) {
+    let n = chart.max_data_len();
+    if n == 0 {
+        return;
+    }
+    let sx = layout.data_to_screen_x(data_x, n);
+    fill_rect(
+        ctx,
+        sx as f64 - 0.5,
+        layout.plot_area.y as f64,
+        1.0,
+        layout.plot_area.height as f64,
+        theme.accent_fg,
+    );
+}
+
+unsafe fn paint_hover_marker(
+    ctx: CGContextRef,
+    layout: &ChartLayout,
+    si: usize,
+    di: usize,
+    chart: &Chart,
+) {
+    let Some(&(_, _, sx, sy)) = layout
+        .data_point_positions
+        .iter()
+        .find(|(s, d, _, _)| *s == si && *d == di)
+    else {
+        return;
+    };
+    let color = series_color(chart, si);
+    let radius = 4.0_f64;
+    fill_rect(
+        ctx,
+        sx as f64 - radius,
+        sy as f64 - radius,
+        radius * 2.0,
+        radius * 2.0,
+        color,
+    );
+}
+
+/// Stroke a polyline through every point belonging to `series_idx` in
+/// `points` using CG path API.
+unsafe fn stroke_polyline(
+    ctx: CGContextRef,
+    points: &[(usize, usize, f32, f32)],
+    series_idx: usize,
+    color: Color,
+    line_width: f64,
+) {
+    let pts: Vec<(f64, f64)> = points
+        .iter()
+        .filter_map(|(s, _, x, y)| {
+            if *s == series_idx {
+                Some((*x as f64, *y as f64))
+            } else {
+                None
+            }
+        })
+        .collect();
+    if pts.len() < 2 {
+        return;
+    }
+    let (r, g, b, a) = color_to_cg(color);
+    CGContextSetRGBStrokeColor(ctx, r, g, b, a);
+    CGContextSetLineWidth(ctx, line_width);
+    CGContextBeginPath(ctx);
+    CGContextMoveToPoint(ctx, pts[0].0, pts[0].1);
+    for &(px, py) in &pts[1..] {
+        CGContextAddLineToPoint(ctx, px, py);
+    }
+    CGContextStrokePath(ctx);
+}
+
+fn format_tick(val: f64) -> String {
+    if val.fract().abs() < 1e-9 {
+        format!("{:.0}", val)
+    } else {
+        format!("{:.1}", val)
+    }
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    CGContextFillRect(ctx, CGRect::new_xywh(x, y, w, h));
+}
+
+trait CGRectExt {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self;
+}
+impl CGRectExt for CGRect {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self {
+        use core_graphics::geometry::{CGPoint, CGSize};
+        CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h))
+    }
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextClipToRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBFillColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
+    fn CGContextSetRGBStrokeColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
+    fn CGContextSetLineWidth(c: CGContextRef, w: CGFloat);
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+    fn CGContextBeginPath(c: CGContextRef);
+    fn CGContextMoveToPoint(c: CGContextRef, x: CGFloat, y: CGFloat);
+    fn CGContextAddLineToPoint(c: CGContextRef, x: CGFloat, y: CGFloat);
+    fn CGContextStrokePath(c: CGContextRef);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::chart::{ChartHit, ChartKind, Series};
+    use crate::theme::Theme;
+    use crate::types::WidgetId;
+    use crate::Backend;
+
+    const W: u32 = 200;
+    const H: u32 = 120;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn sample_line() -> Chart {
+        Chart {
+            id: WidgetId::new("ch"),
+            kind: ChartKind::Line,
+            series: vec![Series {
+                label: "x".into(),
+                data: vec![0.0, 1.0, 0.5, 2.0, 1.0],
+                color: Some(Color::rgb(80, 160, 255)),
+                fill: false,
+            }],
+            x_label: None,
+            y_label: None,
+            y_range: Some((0.0, 2.0)),
+            x_range: None,
+            show_legend: false,
+            y_ticks: Some(0),
+            x_ticks: Some(0),
+            show_grid: false,
+        }
+    }
+
+    fn paint_via_backend(
+        chart: &Chart,
+        hovered: Option<(usize, usize)>,
+    ) -> (BitmapSurface, ChartLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_chart(
+                QRect::new(0.0, 0.0, W as f32, H as f32),
+                chart,
+                hovered,
+                None,
+            );
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn plot_area_paints_background() {
+        let chart = sample_line();
+        let (surface, layout) = paint_via_backend(&chart, None);
+        let theme = Theme::default();
+        // Probe a corner of the plot area.
+        let px = (layout.plot_area.x + layout.plot_area.width - 2.0) as u32;
+        let py = (layout.plot_area.y + 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (theme.background.r, theme.background.g, theme.background.b),
+        );
+    }
+
+    #[test]
+    fn line_stroke_paints_series_color() {
+        let chart = sample_line();
+        let (surface, layout) = paint_via_backend(&chart, None);
+        // Sample at data point index 1 (value 1.0 in [0..2] range = mid
+        // plot, comfortably inside bounds — first and last points sit
+        // on the plot edges).
+        let (_, _, sx, sy) = layout.data_point_positions[1];
+        let (r, g, b, _) = surface.pixel(sx as u32, sy as u32);
+        // Series colour blue → blue channel dominant.
+        assert!(
+            b > r,
+            "expected blue dominant at data point 1 ({}, {}), got ({}, {}, {})",
+            sx as u32,
+            sy as u32,
+            r,
+            g,
+            b,
+        );
+    }
+
+    #[test]
+    fn hit_test_inside_plot_area_returns_body() {
+        let chart = sample_line();
+        let (_surface, layout) = paint_via_backend(&chart, None);
+        let cx = layout.plot_area.x + layout.plot_area.width * 0.5;
+        let cy = layout.plot_area.y + layout.plot_area.height * 0.5;
+        assert_eq!(layout.hit_test(cx, cy), ChartHit::Body(WidgetId::new("ch")),);
+    }
+
+    #[test]
+    fn hover_marker_painted_when_set() {
+        let chart = sample_line();
+        let (surface, layout) = paint_via_backend(&chart, Some((0, 2)));
+        // Probe at the centre of the hover marker (data point 2).
+        let (_, _, sx, sy) = layout.data_point_positions[2];
+        let (r, _g, b, _) = surface.pixel(sx as u32, sy as u32);
+        // Marker is the series colour, solid — blue should dominate.
+        assert!(b > r);
+    }
+}

--- a/quadraui/src/macos/data_table.rs
+++ b/quadraui/src/macos/data_table.rs
@@ -1,0 +1,464 @@
+//! macOS rasteriser for [`crate::DataTable`].
+//!
+//! Mirrors [`crate::gtk::data_table::draw_data_table`]: header row at
+//! `(line_height * 1.2)` with bold-ish accent (rendered as the default
+//! font for now — bold lands with the unified text-attribute pass),
+//! sort glyphs (`▲` / `▼`) suffixed onto the active sort column's
+//! title, body rows at `line_height` pitch with hover/select tints,
+//! column separators, and vertical + horizontal scrollbars when
+//! configured.
+//!
+//! ## Scope omissions (follow-up)
+//!
+//! - **Bold header text** — needs `CTFontCreateCopyWithSymbolicTraits`
+//!   bold variant, deferred with the text-attribute pass.
+//! - **Per-row selection alpha blending** — GTK uses `selection_alpha`
+//!   for translucent selection; macOS paints a solid `selection_bg`
+//!   pixel today. Visual parity tracked separately.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::primitives::data_table::{
+    ColumnAlign, ColumnMeasure, DataTable, DataTableLayout, SortDirection,
+};
+use crate::theme::Theme;
+use crate::types::{Color, Decoration};
+
+const SCROLLBAR_WIDTH: f32 = 8.0;
+
+/// Compute the layout the macOS rasteriser would produce for `table`
+/// at `(x, y, w, h)` and `line_height`.
+pub fn mac_data_table_layout(
+    table: &DataTable,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    line_height: f64,
+) -> DataTableLayout {
+    let header_height = (line_height * 1.2).round();
+    let measure = |col: &crate::primitives::data_table::Column| -> ColumnMeasure {
+        let (tw, _) = measure_text(font, &col.title);
+        ColumnMeasure::new(tw.max(0.0) as f32)
+    };
+    let _ = (x, y); // hit_test consumes table-local coords; bounds stay
+                    // relative to the table's origin.
+    table.layout(
+        w as f32,
+        h as f32,
+        line_height as f32,
+        header_height as f32,
+        SCROLLBAR_WIDTH,
+        measure,
+    )
+}
+
+/// Draw `table` into `(x, y, w, h)` on `ctx`. Returns the same layout
+/// `mac_data_table_layout` would produce.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_data_table(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    table: &DataTable,
+    theme: &Theme,
+    line_height: f64,
+    hovered_idx: Option<usize>,
+) -> DataTableLayout {
+    let layout = mac_data_table_layout(table, font, x, y, w, h, line_height);
+    if w <= 0.0 || h <= 0.0 {
+        return layout;
+    }
+
+    CGContextSaveGState(ctx);
+    CGContextClipToRect(ctx, CGRect::new_xywh(x, y, w, h));
+
+    // Header background.
+    fill_rect(ctx, x, y, w, layout.header_height as f64, theme.tab_bar_bg);
+
+    let h_off = table.h_scroll as f64;
+    let header_height = layout.header_height as f64;
+
+    for (col_idx, rc) in layout.columns.iter().enumerate() {
+        if col_idx >= table.columns.len() || rc.width <= 0.0 {
+            break;
+        }
+        let col = &table.columns[col_idx];
+        let sort_suffix = match &table.sort {
+            Some((si, dir)) if *si == col_idx => match dir {
+                SortDirection::Ascending => " ▲",
+                SortDirection::Descending => " ▼",
+            },
+            _ => "",
+        };
+        let title = format!("{}{}", col.title, sort_suffix);
+        let (text_w, _) = measure_text(font, &title);
+        let col_x = x + rc.x as f64 - h_off;
+        let col_w = rc.width as f64;
+
+        let text_x = match col.align {
+            ColumnAlign::Left => col_x,
+            ColumnAlign::Center => col_x + (col_w - text_w) / 2.0,
+            ColumnAlign::Right => col_x + col_w - text_w,
+        };
+        draw_text(
+            ctx,
+            font,
+            &title,
+            text_x,
+            y + (header_height - measure_text(font, &title).1) / 2.0,
+            color_to_cg(theme.foreground),
+        );
+    }
+
+    // Header column separators.
+    for (col_idx, rc) in layout.columns.iter().enumerate() {
+        if col_idx + 1 >= layout.columns.len() {
+            break;
+        }
+        let sep_x = x + (rc.x + rc.width) as f64 - h_off;
+        fill_rect(ctx, sep_x - 0.5, y, 1.0, header_height, theme.separator);
+    }
+
+    // Body rows.
+    let body_y = y + header_height;
+    let visible = layout
+        .visible_rows
+        .min(table.rows.len().saturating_sub(table.scroll_offset));
+
+    for row_idx in 0..visible {
+        let abs_idx = table.scroll_offset + row_idx;
+        let row = &table.rows[abs_idx];
+        let row_y = body_y + row_idx as f64 * line_height;
+        let is_selected = table.selected_idx == Some(abs_idx);
+        let is_hovered = hovered_idx == Some(abs_idx) && !is_selected;
+
+        if is_selected {
+            fill_rect(ctx, x, row_y, w, line_height, theme.selection_bg);
+        } else if is_hovered {
+            // Half-mix hover tint: blend tab_bar_bg into row bg.
+            fill_rect(ctx, x, row_y, w, line_height, theme.tab_bar_bg);
+        }
+
+        for (col_idx, rc) in layout.columns.iter().enumerate() {
+            let styled = match row.cells.get(col_idx) {
+                Some(c) if !c.spans.is_empty() => c,
+                _ => continue,
+            };
+            if rc.width <= 0.0 {
+                continue;
+            }
+            let col_w = rc.width as f64;
+            let col_x = x + rc.x as f64 - h_off;
+            let is_muted = matches!(row.decoration, Decoration::Muted);
+
+            let full_text: String = styled.spans.iter().map(|s| s.text.as_str()).collect();
+            let (text_w, text_h) = measure_text(font, &full_text);
+            let align = table
+                .columns
+                .get(col_idx)
+                .map(|c| c.align)
+                .unwrap_or(ColumnAlign::Left);
+            let text_x = match align {
+                ColumnAlign::Left => col_x,
+                ColumnAlign::Center => col_x + (col_w - text_w) / 2.0,
+                ColumnAlign::Right => col_x + col_w - text_w,
+            };
+            let fg = if is_muted {
+                theme.muted_fg
+            } else {
+                theme.foreground
+            };
+            draw_text(
+                ctx,
+                font,
+                &full_text,
+                text_x,
+                row_y + (line_height - text_h) / 2.0,
+                color_to_cg(fg),
+            );
+        }
+    }
+
+    // Vertical scrollbar — simple thumb on track.
+    if table.show_scrollbar
+        && table.rows.len() > layout.visible_rows
+        && layout.scrollbar_width > 0.0
+    {
+        let sb_x = x + w - layout.scrollbar_width as f64;
+        let track_y = body_y;
+        let track_h = (h - header_height - layout.h_scrollbar_height as f64).max(0.0);
+        fill_rect(
+            ctx,
+            sb_x,
+            track_y,
+            layout.scrollbar_width as f64,
+            track_h,
+            theme.tab_bar_bg,
+        );
+        // Thumb proportional to visible / total.
+        let total = table.rows.len() as f64;
+        let visible = layout.visible_rows.max(1) as f64;
+        let thumb_h = (track_h * (visible / total)).max(4.0);
+        let thumb_y = track_y
+            + (track_h - thumb_h) * (table.scroll_offset as f64 / (total - visible).max(1.0));
+        fill_rect(
+            ctx,
+            sb_x,
+            thumb_y,
+            layout.scrollbar_width as f64,
+            thumb_h,
+            theme.scrollbar_thumb,
+        );
+    }
+
+    // Horizontal scrollbar — same shape.
+    if layout.h_scrollbar_height > 0.0 && layout.content_width > 0.0 {
+        let hsb_y = y + h - layout.h_scrollbar_height as f64;
+        let track_w = (w - layout.scrollbar_width as f64).max(1.0);
+        fill_rect(
+            ctx,
+            x,
+            hsb_y,
+            track_w,
+            layout.h_scrollbar_height as f64,
+            theme.tab_bar_bg,
+        );
+        let visible = track_w as f32;
+        let total = layout.content_width;
+        let thumb_w = (track_w * (visible as f64 / total as f64)).max(4.0);
+        let thumb_x =
+            x + (track_w - thumb_w) * (table.h_scroll as f64 / (total - visible).max(1.0) as f64);
+        fill_rect(
+            ctx,
+            thumb_x,
+            hsb_y,
+            thumb_w,
+            layout.h_scrollbar_height as f64,
+            theme.scrollbar_thumb,
+        );
+    }
+
+    CGContextRestoreGState(ctx);
+    layout
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    CGContextFillRect(ctx, CGRect::new_xywh(x, y, w, h));
+}
+
+trait CGRectExt {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self;
+}
+impl CGRectExt for CGRect {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self {
+        use core_graphics::geometry::{CGPoint, CGSize};
+        CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h))
+    }
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextClipToRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::data_table::{Column, ColumnWidth, DataRow, DataTable, DataTableHit};
+    use crate::theme::Theme;
+    use crate::types::{StyledText, WidgetId};
+    use crate::Backend;
+
+    const W: u32 = 320;
+    const H: u32 = 200;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn sample_table() -> DataTable {
+        DataTable {
+            id: WidgetId::new("dt"),
+            columns: vec![
+                Column {
+                    title: "Name".into(),
+                    width: ColumnWidth::Flex(2.0),
+                    align: ColumnAlign::Left,
+                },
+                Column {
+                    title: "Value".into(),
+                    width: ColumnWidth::Flex(1.0),
+                    align: ColumnAlign::Right,
+                },
+            ],
+            rows: vec![
+                DataRow {
+                    cells: vec![StyledText::plain("alpha"), StyledText::plain("1")],
+                    decoration: Decoration::Normal,
+                },
+                DataRow {
+                    cells: vec![StyledText::plain("beta"), StyledText::plain("2")],
+                    decoration: Decoration::Normal,
+                },
+                DataRow {
+                    cells: vec![StyledText::plain("gamma"), StyledText::plain("3")],
+                    decoration: Decoration::Normal,
+                },
+            ],
+            selected_idx: Some(1),
+            scroll_offset: 0,
+            sort: Some((0, SortDirection::Ascending)),
+            has_focus: true,
+            show_scrollbar: false,
+            min_total_width: None,
+            h_scroll: 0.0,
+            column_overrides: vec![],
+        }
+    }
+
+    fn paint_via_backend(
+        table: &DataTable,
+        hovered: Option<usize>,
+    ) -> (BitmapSurface, DataTableLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_data_table(QRect::new(0.0, 0.0, W as f32, H as f32), table, hovered);
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    /// Probe a known glyph-free spot inside `col_idx`'s body area at
+    /// `body_row` (0-based) — column-internal padding region between
+    /// glyph runs and the column's right edge.
+    fn probe_cell_bg(
+        surface: &BitmapSurface,
+        layout: &DataTableLayout,
+        col_idx: usize,
+        body_row: usize,
+    ) -> (u8, u8, u8) {
+        let col = &layout.columns[col_idx];
+        // Right 30% of the column is typically glyph-free for plain
+        // short labels like "alpha" / "1".
+        let px = (col.x + col.width * 0.85) as u32;
+        let py = (layout.header_height + layout.row_height * (body_row as f32 + 0.5)) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        (r, g, b)
+    }
+
+    #[test]
+    fn header_strip_paints_tab_bar_bg() {
+        let table = sample_table();
+        let (surface, layout) = paint_via_backend(&table, None);
+        let theme = Theme::default();
+        // Probe header strip in the right-third of column 0 (after
+        // "Name ▲" glyphs, before the column-0/1 separator).
+        let col0 = &layout.columns[0];
+        let px = (col0.x + col0.width * 0.85) as u32;
+        let py = 1_u32; // top scanline — above glyph cap.
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+        );
+    }
+
+    #[test]
+    fn selected_row_paints_selection_bg() {
+        let table = sample_table();
+        let (surface, layout) = paint_via_backend(&table, None);
+        let theme = Theme::default();
+        // selected_idx = 1 → second body row. Probe glyph-free area of
+        // col 0 (after "beta").
+        let (r, g, b) = probe_cell_bg(&surface, &layout, 0, 1);
+        assert_eq!(
+            (r, g, b),
+            (
+                theme.selection_bg.r,
+                theme.selection_bg.g,
+                theme.selection_bg.b
+            ),
+        );
+    }
+
+    #[test]
+    fn hover_tint_painted_when_hovered_idx_set() {
+        let mut table = sample_table();
+        table.selected_idx = None;
+        let (surface, layout) = paint_via_backend(&table, Some(2));
+        let theme = Theme::default();
+        let (r, g, b) = probe_cell_bg(&surface, &layout, 0, 2);
+        assert_eq!(
+            (r, g, b),
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+        );
+    }
+
+    #[test]
+    fn hit_test_resolves_header_vs_row() {
+        let table = sample_table();
+        let (_surface, layout) = paint_via_backend(&table, None);
+        let total = table.rows.len();
+
+        // Header row center → Header { col: 0 }.
+        let hit = layout.hit_test(
+            layout.columns[0].x + layout.columns[0].width * 0.5,
+            layout.header_height * 0.5,
+            table.scroll_offset,
+            total,
+        );
+        assert!(matches!(hit, DataTableHit::Header { col: 0 }));
+
+        // Body row 1 (selected) → Row { idx: 1 }.
+        let hit = layout.hit_test(
+            10.0,
+            layout.header_height + layout.row_height * 1.5,
+            table.scroll_offset,
+            total,
+        );
+        assert!(matches!(hit, DataTableHit::Row { idx: 1 }));
+    }
+}

--- a/quadraui/src/macos/editor.rs
+++ b/quadraui/src/macos/editor.rs
@@ -1,0 +1,444 @@
+//! macOS rasteriser for [`crate::primitives::editor::Editor`].
+//!
+//! Minimum viable port of `crate::gtk::editor::draw_editor`: background,
+//! per-line text via Core Text, line-number gutter, and the primary
+//! cursor (Block / Bar / Underline). Returns a default
+//! [`EditorPaintResult`] — macOS, like GTK, paints its own caret rather
+//! than delegating to a terminal cursor.
+//!
+//! ## Scope omissions (follow-up)
+//!
+//! Deferred to subsequent tickets to keep #39 manageable; each ships
+//! when a kubeui-class consumer exercises it on macOS:
+//!
+//! - **Selection overlays** — `editor.selection`, `extra_selections`,
+//!   `yank_highlight`. Need the unified text-attribute path that also
+//!   carries bold/italic and selection-bg.
+//! - **Diagnostics + spell underlines** — wavy/dotted underlines via
+//!   `kCTUnderlineStyleAttributeName` (deferred with attrs).
+//! - **Indent guides, color columns, bracket-match alpha rects**.
+//! - **AI ghost text + multi-cursor secondary carets**.
+//! - **Diff backgrounds** (`DiffLine::Added`/`Removed`/`Padding`) and
+//!   **cursorline highlight** — straightforward pixel fills, will land
+//!   alongside the consumer that needs them.
+//! - **Gutter chrome** beyond line numbers — breakpoint glyph, git
+//!   column, diagnostic dot, lightbulb glyph.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::backend::EditorPaintResult;
+use crate::primitives::editor::{CursorShape, Editor};
+use crate::theme::Theme;
+use crate::types::Color;
+
+/// Paint `editor` onto `ctx`. Returns the default
+/// [`EditorPaintResult`] — macOS paints its own caret.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+pub unsafe fn draw_editor(
+    ctx: CGContextRef,
+    font: &CTFont,
+    editor: &Editor,
+    theme: &Theme,
+    char_width: f64,
+    line_height: f64,
+) -> EditorPaintResult {
+    let rect = &editor.rect;
+    if rect.width <= 0.0 || rect.height <= 0.0 {
+        return EditorPaintResult::default();
+    }
+
+    let x = rect.x as f64;
+    let y = rect.y as f64;
+    let w = rect.width as f64;
+    let h = rect.height as f64;
+
+    CGContextSaveGState(ctx);
+    CGContextClipToRect(ctx, CGRect::new_xywh(x, y, w, h));
+
+    let bg = if editor.show_active_bg {
+        theme.editor_active_background
+    } else {
+        theme.background
+    };
+    fill_rect(ctx, x, y, w, h, bg);
+
+    let gutter_width = editor.gutter_char_width as f64 * char_width;
+    let h_scroll_offset = editor.scroll_left as f64 * char_width;
+    let text_x_offset = x + gutter_width - h_scroll_offset;
+
+    // Cursorline highlight (active editor only) — painted before text.
+    if editor.is_active && editor.cursorline {
+        for (view_idx, line) in editor.lines.iter().enumerate() {
+            if line.is_current_line {
+                let line_y = y + view_idx as f64 * line_height;
+                fill_rect(ctx, x, line_y, w, line_height, theme.cursorline_bg);
+            }
+        }
+    }
+
+    // Lines + gutter.
+    for (view_idx, line) in editor.lines.iter().enumerate() {
+        let line_y = y + view_idx as f64 * line_height;
+        if line_y >= y + h {
+            break;
+        }
+
+        // Gutter — right-aligned line number text.
+        if gutter_width > 0.0 && !line.gutter_text.is_empty() {
+            let (gtw, _) = measure_text(font, &line.gutter_text);
+            let gx = x + gutter_width - gtw - 4.0;
+            draw_text(
+                ctx,
+                font,
+                &line.gutter_text,
+                gx.max(x + 2.0),
+                line_y + (line_height - measure_text(font, &line.gutter_text).1) / 2.0,
+                color_to_cg(theme.line_number_fg),
+            );
+        }
+
+        // Raw text painted as a single fg run; per-span colouring is
+        // applied on top below.
+        let raw_x = text_x_offset;
+        if !line.raw_text.is_empty() {
+            draw_text(
+                ctx,
+                font,
+                &line.raw_text,
+                raw_x,
+                line_y,
+                color_to_cg(theme.foreground),
+            );
+        }
+
+        // Per-span colouring — re-render coloured slices on top of the
+        // raw run. Crude but produces correct colour at character
+        // boundaries given the monospace baseline.
+        for span in &line.spans {
+            let start = span.start_byte.min(line.raw_text.len());
+            let end = span.end_byte.min(line.raw_text.len());
+            if start >= end {
+                continue;
+            }
+            let prefix = &line.raw_text[..start];
+            let slice = &line.raw_text[start..end];
+            let (px, _) = measure_text(font, prefix);
+            // Repaint the slice's bg first (if set) so the raw run
+            // beneath doesn't bleed through.
+            if let Some(sbg) = span.style.bg {
+                let (sw, _) = measure_text(font, slice);
+                fill_rect(ctx, raw_x + px, line_y, sw, line_height, sbg);
+            }
+            draw_text(
+                ctx,
+                font,
+                slice,
+                raw_x + px,
+                line_y,
+                color_to_cg(span.style.fg),
+            );
+        }
+    }
+
+    // Primary cursor.
+    if let Some(cursor) = editor.cursor {
+        if cursor.pos.view_line < editor.lines.len() {
+            let line = &editor.lines[cursor.pos.view_line];
+            let prefix_end = char_byte_offset(&line.raw_text, cursor.pos.col);
+            let prefix = &line.raw_text[..prefix_end];
+            let (prefix_w, _) = measure_text(font, prefix);
+            let cur_x = text_x_offset + prefix_w;
+            let cur_y = y + cursor.pos.view_line as f64 * line_height;
+            match cursor.shape {
+                CursorShape::Block => {
+                    fill_rect(ctx, cur_x, cur_y, char_width, line_height, theme.cursor);
+                    // Re-paint the glyph under the cursor in background
+                    // colour so it reads against the cursor fill.
+                    let ch = line.raw_text[prefix_end..]
+                        .chars()
+                        .next()
+                        .map(|c| c.to_string())
+                        .unwrap_or_default();
+                    if !ch.is_empty() {
+                        draw_text(ctx, font, &ch, cur_x, cur_y, color_to_cg(theme.background));
+                    }
+                }
+                CursorShape::Bar => {
+                    fill_rect(ctx, cur_x, cur_y, 2.0, line_height, theme.cursor);
+                }
+                CursorShape::Underline => {
+                    let underline_h = (line_height * 0.12).max(1.0);
+                    fill_rect(
+                        ctx,
+                        cur_x,
+                        cur_y + line_height - underline_h,
+                        char_width,
+                        underline_h,
+                        theme.cursor,
+                    );
+                }
+            }
+        }
+    }
+
+    CGContextRestoreGState(ctx);
+    EditorPaintResult::default()
+}
+
+/// Byte offset corresponding to the `col`-th character of `s`. Saturates
+/// at `s.len()` for out-of-range columns.
+fn char_byte_offset(s: &str, col: usize) -> usize {
+    s.char_indices().nth(col).map(|(b, _)| b).unwrap_or(s.len())
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    CGContextFillRect(ctx, CGRect::new_xywh(x, y, w, h));
+}
+
+trait CGRectExt {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self;
+}
+impl CGRectExt for CGRect {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self {
+        use core_graphics::geometry::{CGPoint, CGSize};
+        CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h))
+    }
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextClipToRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::{font_metrics, make_font};
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::editor::{
+        CursorPos, EditorCursor, EditorLine, Style, StyledSpan as ESpan,
+    };
+    use crate::theme::Theme;
+    use crate::Backend;
+    use std::collections::{HashMap, HashSet};
+
+    const W: u32 = 400;
+    const H: u32 = 160;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn one_line(text: &str) -> EditorLine {
+        EditorLine {
+            raw_text: text.into(),
+            gutter_text: "1".into(),
+            spans: vec![],
+            line_idx: 0,
+            is_current_line: true,
+            is_fold_header: false,
+            folded_line_count: 0,
+            git_diff: None,
+            diff_status: None,
+            diagnostics: vec![],
+            spell_errors: vec![],
+            is_breakpoint: false,
+            is_conditional_bp: false,
+            is_dap_current: false,
+            is_wrap_continuation: false,
+            segment_col_offset: 0,
+            annotation: None,
+            ghost_suffix: None,
+            is_ghost_continuation: false,
+            indent_guides: vec![],
+            colorcolumns: vec![],
+        }
+    }
+
+    fn editor_with_cursor(text: &str, shape: CursorShape, col: usize) -> Editor {
+        Editor {
+            id: "editor:0".into(),
+            rect: QRect::new(0.0, 0.0, W as f32, H as f32),
+            lines: vec![one_line(text)],
+            cursor: Some(EditorCursor {
+                pos: CursorPos { view_line: 0, col },
+                shape,
+            }),
+            extra_cursors: vec![],
+            selection: None,
+            extra_selections: vec![],
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: 0,
+            total_lines: 1,
+            max_col: text.chars().count(),
+            gutter_char_width: 3,
+            is_active: true,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: HashMap::new(),
+            code_action_lines: HashSet::new(),
+            bracket_match_positions: vec![],
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: false,
+            lightbulb_glyph: '!',
+        }
+    }
+
+    fn paint_via_backend(editor: &Editor) -> BitmapSurface {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            b.draw_editor(editor.rect, editor);
+        });
+        backend.end_frame();
+        surface
+    }
+
+    #[test]
+    fn block_cursor_paints_theme_cursor_color() {
+        let editor = editor_with_cursor("let x = 1;", CursorShape::Block, 0);
+        let surface = paint_via_backend(&editor);
+        let theme = Theme::default();
+        let metrics = font_metrics(&font());
+        // Cursor lands at column 0 in gutter-offset coords. Gutter is
+        // 3 char_widths, so cursor starts at 3*char_width on x.
+        let cx = (3.0 * metrics.char_width) as u32 + 1;
+        let cy = (metrics.line_height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(cx, cy);
+        assert_eq!(
+            (r, g, b),
+            (theme.cursor.r, theme.cursor.g, theme.cursor.b),
+            "block cursor pixel at ({}, {}) should be theme.cursor",
+            cx,
+            cy,
+        );
+    }
+
+    #[test]
+    fn cursorline_highlight_painted_when_active() {
+        let mut editor = editor_with_cursor("let x = 1;", CursorShape::Bar, 0);
+        editor.cursorline = true;
+        let surface = paint_via_backend(&editor);
+        let theme = Theme::default();
+        // Probe far to the right of any glyph or cursor.
+        let px = W - 4;
+        let py = 4_u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (
+                theme.cursorline_bg.r,
+                theme.cursorline_bg.g,
+                theme.cursorline_bg.b
+            ),
+        );
+    }
+
+    #[test]
+    fn span_bg_paints_over_raw_run() {
+        // A line whose first 3 bytes carry a coloured background — the
+        // probe inside that range should read the span bg, not the
+        // editor bg.
+        let mut line = one_line("alpha beta");
+        line.spans = vec![ESpan {
+            start_byte: 0,
+            end_byte: 3,
+            style: Style {
+                fg: Color::rgb(255, 255, 255),
+                bg: Some(Color::rgb(50, 100, 150)),
+                bold: false,
+                italic: false,
+                font_scale: 1.0,
+            },
+        }];
+        let mut editor = editor_with_cursor("alpha beta", CursorShape::Bar, 99);
+        editor.lines = vec![line];
+        let surface = paint_via_backend(&editor);
+        let metrics = font_metrics(&font());
+        // The span covers raw_text[0..3] ("alp"). Probe at the very
+        // top scanline (y=0) of the line — above any glyph ink and
+        // its anti-aliased boundary, fully inside the span bg.
+        let text_start = 3.0 * metrics.char_width;
+        let px = (text_start + metrics.char_width * 0.5) as u32;
+        let py = 0_u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        // Span bg painted over editor bg.
+        assert_eq!((r, g, b), (50, 100, 150));
+    }
+
+    #[test]
+    fn empty_editor_returns_default_paint_result() {
+        let editor = Editor {
+            id: "editor:empty".into(),
+            rect: QRect::new(0.0, 0.0, 0.0, 0.0),
+            lines: vec![],
+            cursor: None,
+            extra_cursors: vec![],
+            selection: None,
+            extra_selections: vec![],
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: 0,
+            total_lines: 0,
+            max_col: 0,
+            gutter_char_width: 0,
+            is_active: false,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: HashMap::new(),
+            code_action_lines: HashSet::new(),
+            bracket_match_positions: vec![],
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: false,
+            lightbulb_glyph: '!',
+        };
+        let surface = BitmapSurface::new(10, 10);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(10.0, 10.0, 1.0));
+        let result = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            *result.borrow_mut() = Some(b.draw_editor(editor.rect, &editor));
+        });
+        backend.end_frame();
+        assert_eq!(result.into_inner().unwrap(), EditorPaintResult::default(),);
+    }
+}

--- a/quadraui/src/macos/form.rs
+++ b/quadraui/src/macos/form.rs
@@ -1,0 +1,426 @@
+//! macOS rasteriser for [`crate::Form`].
+//!
+//! Mirrors [`crate::gtk::form::draw_form`] for the basic field kinds
+//! needed by current consumers: `Label`, `Toggle`, `TextInput`,
+//! `Button`, `ReadOnly`. Per-row height is `(line_height * 1.4).round()`
+//! to match GTK row pitch.
+//!
+//! ## Scope omissions (follow-up)
+//!
+//! - **Rich field kinds** — `Slider`, `ColorPicker`, `Dropdown`,
+//!   `SegmentedControl`, `ToggleGroup`, `ButtonRow`, `TextArea`,
+//!   `Password`, `Number`, `DateInput`, `FilePicker` render as
+//!   label-only rows for now. Layout still produces full hit regions
+//!   so click routing keeps working; pretty rendering lands when a
+//!   consumer needs it (parity check vs GTK before each add).
+//! - **Selection highlight** inside `TextInput` — deferred with the
+//!   unified text-attribute pass that also unlocks editor selection.
+//! - **Validation indicators** — `ValidationState` is honoured for
+//!   colour (error_fg / warning_fg on the field label) but the hint
+//!   strip below the row is not yet rendered.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::event::Rect as QRect;
+use crate::primitives::form::{FieldKind, Form, FormFieldMeasure, FormLayout, ValidationState};
+use crate::theme::Theme;
+use crate::types::Color;
+
+/// Compute the layout the macOS rasteriser would produce for `form`
+/// in `area` at `line_height`. Uniform `(line_height * 1.4).round()`
+/// rows.
+pub fn mac_form_layout(form: &Form, area: QRect, line_height: f64) -> FormLayout {
+    let row_h = (line_height * 1.4).round() as f32;
+    let mut layout = form.layout(area.width, area.height, |_| FormFieldMeasure::new(row_h));
+    let (dx, dy) = (area.x, area.y);
+    if dx != 0.0 || dy != 0.0 {
+        for vf in &mut layout.visible_fields {
+            vf.bounds.x += dx;
+            vf.bounds.y += dy;
+            for (_, ib) in &mut vf.item_bounds {
+                ib.x += dx;
+                ib.y += dy;
+            }
+        }
+        for (rect, _) in &mut layout.hit_regions {
+            rect.x += dx;
+            rect.y += dy;
+        }
+    }
+    layout
+}
+
+/// Draw a [`Form`] into `(x, y, w, h)` on `ctx`. Returns the same
+/// layout `mac_form_layout` would produce.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_form(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    form: &Form,
+    theme: &Theme,
+    line_height: f64,
+) -> FormLayout {
+    let area = QRect::new(x as f32, y as f32, w as f32, h as f32);
+    if w <= 0.0 || h <= 0.0 {
+        return mac_form_layout(form, area, line_height);
+    }
+
+    let layout = mac_form_layout(form, area, line_height);
+
+    CGContextSaveGState(ctx);
+    CGContextClipToRect(ctx, CGRect::new_xywh(x, y, w, h));
+    fill_rect(ctx, x, y, w, h, theme.tab_bar_bg);
+
+    for vis in &layout.visible_fields {
+        let field = &form.fields[vis.field_idx];
+        let row_x = vis.bounds.x as f64;
+        let row_y = vis.bounds.y as f64;
+        let row_w = vis.bounds.width as f64;
+        let row_h = vis.bounds.height as f64;
+
+        let is_focused = form.has_focus
+            && form
+                .focused_field
+                .as_ref()
+                .is_some_and(|id| id == &field.id);
+        let is_header = matches!(field.kind, FieldKind::Label);
+
+        let (default_fg, row_bg) = if is_focused {
+            (theme.foreground, theme.selected_bg)
+        } else if is_header {
+            (theme.header_fg, theme.header_bg)
+        } else {
+            (theme.foreground, theme.tab_bar_bg)
+        };
+
+        fill_rect(ctx, row_x, row_y, row_w, row_h, row_bg);
+
+        let validation_fg = field.validation.as_ref().map(|v| match v {
+            ValidationState::Error(_) => theme.error_fg,
+            ValidationState::Warning(_) => theme.warning_fg,
+        });
+        let field_fg = if field.disabled {
+            theme.muted_fg
+        } else {
+            validation_fg.unwrap_or(default_fg)
+        };
+
+        let label_text: String = field.label.spans.iter().map(|s| s.text.as_str()).collect();
+        let (label_w, label_h) = measure_text(font, &label_text);
+        let label_x = row_x + 6.0;
+        let text_y = (row_y + (row_h - label_h) / 2.0).round();
+        draw_text(
+            ctx,
+            font,
+            &label_text,
+            label_x,
+            text_y,
+            color_to_cg(field_fg),
+        );
+        let label_right = label_x + label_w;
+        let no_label = label_text.is_empty();
+
+        let input_right = row_x + row_w - 8.0;
+        match &field.kind {
+            FieldKind::Label => {}
+            FieldKind::Toggle { value } => {
+                let glyph = if *value { "[x]" } else { "[ ]" };
+                let fg_color = if *value && !field.disabled {
+                    theme.accent_fg
+                } else {
+                    field_fg
+                };
+                let (iw, _) = measure_text(font, glyph);
+                let ix = if no_label { label_x } else { input_right - iw };
+                if no_label || ix > label_right + 8.0 {
+                    draw_text(ctx, font, glyph, ix, text_y, color_to_cg(fg_color));
+                }
+            }
+            FieldKind::TextInput {
+                value,
+                placeholder,
+                cursor,
+                selection_anchor: _,
+            } => {
+                let shown = if value.is_empty() {
+                    placeholder.as_str()
+                } else {
+                    value.as_str()
+                };
+                let input_fg = if value.is_empty() {
+                    theme.muted_fg
+                } else {
+                    field_fg
+                };
+                let (shown_w, _) = measure_text(font, shown);
+
+                let (ix, bracket_right) = if no_label {
+                    (label_x, input_right - 4.0)
+                } else {
+                    let max_width = (row_w * 0.6).max(80.0);
+                    let dw = shown_w.min(max_width);
+                    let ix = input_right - dw - 14.0;
+                    (ix, ix + 8.0 + dw + 2.0)
+                };
+                if no_label || ix > label_right + 8.0 {
+                    draw_text(ctx, font, "[", ix, text_y, color_to_cg(theme.muted_fg));
+                    draw_text(ctx, font, shown, ix + 8.0, text_y, color_to_cg(input_fg));
+                    draw_text(
+                        ctx,
+                        font,
+                        "]",
+                        bracket_right,
+                        text_y,
+                        color_to_cg(theme.muted_fg),
+                    );
+
+                    // Caret — thin 1.5pt bar at the cursor's byte offset.
+                    if let Some(cur) = cursor {
+                        if is_focused {
+                            let prefix_byte = (*cur).min(shown.len());
+                            let prefix = &shown[..prefix_byte];
+                            let (prefix_w, _) = measure_text(font, prefix);
+                            let caret_x = ix + 8.0 + prefix_w;
+                            fill_rect(
+                                ctx,
+                                caret_x,
+                                row_y + 3.0,
+                                1.5,
+                                row_h - 6.0,
+                                theme.foreground,
+                            );
+                        }
+                    }
+                }
+            }
+            FieldKind::Button => {
+                // Label already painted above; nothing further to draw.
+            }
+            FieldKind::ReadOnly { value } => {
+                let value_text: String = value.spans.iter().map(|s| s.text.as_str()).collect();
+                let (vw, _) = measure_text(font, &value_text);
+                let vx = input_right - vw;
+                if vx > label_right + 8.0 {
+                    draw_text(
+                        ctx,
+                        font,
+                        &value_text,
+                        vx,
+                        text_y,
+                        color_to_cg(theme.muted_fg),
+                    );
+                }
+            }
+            // Rich field kinds — label-only fallback. Tracked in module
+            // header.
+            _ => {}
+        }
+    }
+
+    CGContextRestoreGState(ctx);
+    layout
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    CGContextFillRect(ctx, CGRect::new_xywh(x, y, w, h));
+}
+
+trait CGRectExt {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self;
+}
+impl CGRectExt for CGRect {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self {
+        use core_graphics::geometry::{CGPoint, CGSize};
+        CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h))
+    }
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextClipToRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::Viewport;
+    use crate::primitives::form::{FieldKind, FormField, FormHit};
+    use crate::theme::Theme;
+    use crate::types::{StyledText, WidgetId};
+    use crate::Backend;
+
+    const W: u32 = 320;
+    const H: u32 = 160;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn label(id: &str, text: &str) -> FormField {
+        FormField {
+            id: WidgetId::new(id),
+            label: StyledText::plain(text),
+            kind: FieldKind::Label,
+            hint: StyledText::default(),
+            disabled: false,
+            validation: None,
+        }
+    }
+
+    fn text_input(id: &str, label_text: &str, value: &str) -> FormField {
+        FormField {
+            id: WidgetId::new(id),
+            label: StyledText::plain(label_text),
+            kind: FieldKind::TextInput {
+                value: value.into(),
+                placeholder: String::new(),
+                cursor: Some(value.len()),
+                selection_anchor: None,
+            },
+            hint: StyledText::default(),
+            disabled: false,
+            validation: None,
+        }
+    }
+
+    fn toggle(id: &str, label_text: &str, value: bool) -> FormField {
+        FormField {
+            id: WidgetId::new(id),
+            label: StyledText::plain(label_text),
+            kind: FieldKind::Toggle { value },
+            hint: StyledText::default(),
+            disabled: false,
+            validation: None,
+        }
+    }
+
+    fn sample_form() -> Form {
+        Form {
+            id: WidgetId::new("settings"),
+            fields: vec![
+                label("hdr", "General"),
+                text_input("name", "Name", "alice"),
+                toggle("enabled", "Enabled", true),
+            ],
+            focused_field: Some(WidgetId::new("name")),
+            scroll_offset: 0,
+            has_focus: true,
+        }
+    }
+
+    fn paint_via_backend(form: &Form) -> (BitmapSurface, FormLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            b.draw_form(QRect::new(0.0, 0.0, W as f32, H as f32), form);
+            let l = super::mac_form_layout(
+                form,
+                QRect::new(0.0, 0.0, W as f32, H as f32),
+                b.line_height() as f64,
+            );
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn focused_field_paints_selected_bg() {
+        let form = sample_form();
+        let (surface, layout) = paint_via_backend(&form);
+        let theme = Theme::default();
+        let name = layout
+            .visible_fields
+            .iter()
+            .find(|v| v.id == WidgetId::new("name"))
+            .expect("name field visible");
+        // Probe near right edge to avoid the label glyph "Name".
+        let px = (name.bounds.x + name.bounds.width - 4.0) as u32;
+        let py = (name.bounds.y + name.bounds.height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        // Focused field row gets selected_bg.
+        assert_eq!(
+            (r, g, b),
+            (
+                theme.selected_bg.r,
+                theme.selected_bg.g,
+                theme.selected_bg.b
+            ),
+            "focused TextInput row should paint selected_bg",
+        );
+    }
+
+    #[test]
+    fn header_field_paints_header_bg() {
+        let form = sample_form();
+        let (surface, layout) = paint_via_backend(&form);
+        let theme = Theme::default();
+        let hdr = layout
+            .visible_fields
+            .iter()
+            .find(|v| v.id == WidgetId::new("hdr"))
+            .expect("header visible");
+        let px = (hdr.bounds.x + hdr.bounds.width - 4.0) as u32;
+        let py = (hdr.bounds.y + hdr.bounds.height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (theme.header_bg.r, theme.header_bg.g, theme.header_bg.b),
+        );
+    }
+
+    #[test]
+    fn hit_test_resolves_field_at_painted_centre() {
+        let form = sample_form();
+        let (_surface, layout) = paint_via_backend(&form);
+        for vis in &layout.visible_fields {
+            let cx = vis.bounds.x + vis.bounds.width * 0.5;
+            let cy = vis.bounds.y + vis.bounds.height * 0.5;
+            assert_eq!(
+                layout.hit_test(cx, cy),
+                FormHit::Field(vis.id.clone()),
+                "field {:?} hit-test",
+                vis.id,
+            );
+        }
+    }
+}

--- a/quadraui/src/macos/list.rs
+++ b/quadraui/src/macos/list.rs
@@ -1,0 +1,412 @@
+//! macOS rasteriser for [`crate::ListView`].
+//!
+//! Mirrors [`crate::gtk::list::draw_list`]: optional title strip at the
+//! top, then flat rows from `scroll_offset` until the viewport fills.
+//! Selection / header / decoration styling matches the GTK contract.
+//!
+//! ## Scope omissions (follow-up)
+//!
+//! - **`bordered` mode** — same status as GTK: no consumer sets it
+//!   today. The flat header+rows path is fully supported. Add the
+//!   rounded-rect frame + overlay title when a consumer needs it.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::primitives::list::{ListItemMeasure, ListView, ListViewLayout};
+use crate::theme::Theme;
+use crate::types::{Color, Decoration};
+
+/// Compute the layout the macOS rasteriser would produce for `list`
+/// at `(x, y, w, h)` and `line_height`. Hosts and tests call this to
+/// drive hit-testing without re-deriving row pitch. Title (if any)
+/// takes one `line_height` strip; items use the same.
+pub fn mac_list_layout(
+    list: &ListView,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    line_height: f64,
+) -> ListViewLayout {
+    let title_h = if list.title.is_some() {
+        line_height as f32
+    } else {
+        0.0
+    };
+    let mut layout = list.layout(w as f32, h as f32, title_h, |_| {
+        ListItemMeasure::new(line_height as f32)
+    });
+    // Translate hit regions + bounds from list-local (0,0) origin into
+    // surface coordinates so callers can hit_test screen-space clicks.
+    let (dx, dy) = (x as f32, y as f32);
+    if dx != 0.0 || dy != 0.0 {
+        if let Some(tb) = layout.title_bounds.as_mut() {
+            tb.x += dx;
+            tb.y += dy;
+        }
+        for vi in &mut layout.visible_items {
+            vi.bounds.x += dx;
+            vi.bounds.y += dy;
+        }
+        for (rect, _) in &mut layout.hit_regions {
+            rect.x += dx;
+            rect.y += dy;
+        }
+    }
+    layout
+}
+
+/// Draw a [`ListView`] into `(x, y, w, h)` on `ctx`. Returns the same
+/// layout `mac_list_layout` would produce — callers route clicks
+/// against this to consume one layout per frame.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call (typical: the frame-scope pointer on
+/// [`super::MacBackend`]). Calling with a freed or null pointer is UB.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_list(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    list: &ListView,
+    theme: &Theme,
+    line_height: f64,
+) -> ListViewLayout {
+    if w <= 0.0 || h <= 0.0 {
+        return mac_list_layout(list, x, y, w.max(0.0), h.max(0.0), line_height);
+    }
+
+    let layout = mac_list_layout(list, x, y, w, h, line_height);
+
+    CGContextSaveGState(ctx);
+    // Clip to the list rect so right-aligned detail / scroll-overflow
+    // rows don't paint past the viewport.
+    CGContextClipToRect(ctx, CGRect::new_xywh(x, y, w, h));
+
+    fill_rect(ctx, x, y, w, h, theme.background);
+
+    if let (Some(title_bounds), Some(title)) = (layout.title_bounds, list.title.as_ref()) {
+        let tx = title_bounds.x as f64;
+        let ty = title_bounds.y as f64;
+        let th = title_bounds.height as f64;
+        fill_rect(ctx, tx, ty, w, th, theme.header_bg);
+        let title_text: String = title.spans.iter().map(|s| s.text.as_str()).collect();
+        let (_, text_h) = measure_text(font, &title_text);
+        draw_text(
+            ctx,
+            font,
+            &title_text,
+            tx + 2.0,
+            ty + (th - text_h) / 2.0,
+            color_to_cg(theme.header_fg),
+        );
+    }
+
+    for vis in &layout.visible_items {
+        let item = &list.items[vis.item_idx];
+        let row_x = vis.bounds.x as f64;
+        let row_y = vis.bounds.y as f64;
+        let row_w = vis.bounds.width as f64;
+        let row_h = vis.bounds.height as f64;
+
+        let is_selected = vis.item_idx == list.selected_idx && list.has_focus;
+
+        let decoration_fg = match item.decoration {
+            Decoration::Error => theme.error_fg,
+            Decoration::Warning => theme.warning_fg,
+            Decoration::Muted => theme.muted_fg,
+            Decoration::Header => theme.header_fg,
+            _ => theme.surface_fg,
+        };
+        let row_bg = if is_selected {
+            theme.selected_bg
+        } else if matches!(item.decoration, Decoration::Header) {
+            theme.header_bg
+        } else {
+            theme.background
+        };
+
+        fill_rect(ctx, row_x, row_y, row_w, row_h, row_bg);
+
+        let mut cursor_x = row_x + 2.0;
+
+        let prefix = if is_selected { "▶ " } else { "  " };
+        let (pw, _) = measure_text(font, prefix);
+        let (_, text_h) = measure_text(font, prefix);
+        let text_y = row_y + (row_h - text_h) / 2.0;
+        draw_text(
+            ctx,
+            font,
+            prefix,
+            cursor_x,
+            text_y,
+            color_to_cg(decoration_fg),
+        );
+        cursor_x += pw;
+
+        let detail_info = item.detail.as_ref().map(|d| {
+            let detail_text: String = d.spans.iter().map(|s| s.text.as_str()).collect();
+            let (dw, _) = measure_text(font, &detail_text);
+            (detail_text, dw)
+        });
+        let detail_reserve = detail_info.as_ref().map(|(_, dw)| *dw + 8.0).unwrap_or(0.0);
+        let text_right_limit = row_x + row_w - detail_reserve - 4.0;
+
+        for span in &item.text.spans {
+            if cursor_x >= text_right_limit {
+                break;
+            }
+            let span_fg = span.fg.unwrap_or(decoration_fg);
+            if let Some(sbg) = span.bg {
+                let (sw, _) = measure_text(font, &span.text);
+                fill_rect(
+                    ctx,
+                    cursor_x,
+                    row_y,
+                    sw.min(text_right_limit - cursor_x),
+                    row_h,
+                    sbg,
+                );
+            }
+            let (sw, _) = measure_text(font, &span.text);
+            draw_text(
+                ctx,
+                font,
+                &span.text,
+                cursor_x,
+                text_y,
+                color_to_cg(span_fg),
+            );
+            cursor_x += sw;
+        }
+
+        if let Some((detail_text, dw)) = detail_info {
+            let dx = row_x + row_w - dw - 4.0;
+            if dx > cursor_x {
+                draw_text(
+                    ctx,
+                    font,
+                    &detail_text,
+                    dx,
+                    text_y,
+                    color_to_cg(theme.muted_fg),
+                );
+            }
+        }
+    }
+
+    CGContextRestoreGState(ctx);
+    layout
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    CGContextFillRect(ctx, CGRect::new_xywh(x, y, w, h));
+}
+
+trait CGRectExt {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self;
+}
+impl CGRectExt for CGRect {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self {
+        use core_graphics::geometry::{CGPoint, CGSize};
+        CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h))
+    }
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextClipToRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::list::{ListItem, ListViewHit};
+    use crate::types::{Color, StyledSpan, StyledText, WidgetId};
+    use crate::Backend;
+
+    const W: u32 = 240;
+    const H: u32 = 160;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn sample_item(label: &str, bg: Color) -> ListItem {
+        ListItem {
+            text: StyledText {
+                spans: vec![StyledSpan {
+                    text: label.into(),
+                    fg: Some(Color::rgb(255, 255, 255)),
+                    bg: Some(bg),
+                    bold: false,
+                    italic: false,
+                    underline: false,
+                }],
+            },
+            icon: None,
+            detail: None,
+            decoration: Decoration::Normal,
+        }
+    }
+
+    fn sample_list() -> ListView {
+        ListView {
+            id: WidgetId::new("lv"),
+            title: Some(StyledText::plain("Quick fix")),
+            items: vec![
+                sample_item("alpha", Color::rgb(10, 20, 30)),
+                sample_item("beta", Color::rgb(10, 20, 30)),
+                sample_item("gamma", Color::rgb(10, 20, 30)),
+                sample_item("delta", Color::rgb(10, 20, 30)),
+            ],
+            selected_idx: 1,
+            scroll_offset: 0,
+            has_focus: true,
+            bordered: false,
+        }
+    }
+
+    fn paint_via_backend(list: &ListView) -> (BitmapSurface, ListViewLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            b.draw_list(QRect::new(0.0, 0.0, W as f32, H as f32), list);
+            let l =
+                super::mac_list_layout(list, 0.0, 0.0, W as f64, H as f64, b.line_height() as f64);
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn title_strip_paints_header_bg() {
+        let list = sample_list();
+        let (surface, layout) = paint_via_backend(&list);
+        let theme = Theme::default();
+        let tb = layout.title_bounds.expect("title present");
+        // Probe at the right edge of the title strip (no glyph there).
+        let px = (tb.x + tb.width - 2.0) as u32;
+        let py = (tb.y + tb.height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (theme.header_bg.r, theme.header_bg.g, theme.header_bg.b),
+        );
+    }
+
+    #[test]
+    fn selected_row_paints_selected_bg() {
+        let list = sample_list();
+        let (surface, layout) = paint_via_backend(&list);
+        let theme = Theme::default();
+        // selected_idx = 1 → second visible row (after title).
+        let sel = layout
+            .visible_items
+            .iter()
+            .find(|v| v.item_idx == 1)
+            .expect("selected row visible");
+        // Probe near right edge to dodge the "▶ " prefix glyphs.
+        let px = (sel.bounds.x + sel.bounds.width - 2.0) as u32;
+        let py = (sel.bounds.y + sel.bounds.height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (
+                theme.selected_bg.r,
+                theme.selected_bg.g,
+                theme.selected_bg.b
+            ),
+        );
+    }
+
+    #[test]
+    fn unselected_row_paints_background() {
+        let list = sample_list();
+        let (surface, layout) = paint_via_backend(&list);
+        let theme = Theme::default();
+        let other = layout
+            .visible_items
+            .iter()
+            .find(|v| v.item_idx == 2)
+            .expect("non-selected row visible");
+        let px = (other.bounds.x + other.bounds.width - 2.0) as u32;
+        let py = (other.bounds.y + other.bounds.height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (theme.background.r, theme.background.g, theme.background.b),
+        );
+    }
+
+    #[test]
+    fn hit_test_resolves_painted_rows() {
+        let list = sample_list();
+        let (_surface, layout) = paint_via_backend(&list);
+        for vis in &layout.visible_items {
+            let cx = vis.bounds.x + vis.bounds.width * 0.5;
+            let cy = vis.bounds.y + vis.bounds.height * 0.5;
+            assert_eq!(
+                layout.hit_test(cx, cy),
+                ListViewHit::Item(vis.item_idx),
+                "row {} hit-test",
+                vis.item_idx,
+            );
+        }
+    }
+
+    #[test]
+    fn hit_test_below_last_row_is_empty() {
+        // Two short items in a tall viewport — clicks past the last
+        // row's bottom must return Empty, not the last row.
+        let list = ListView {
+            items: vec![
+                sample_item("alpha", Color::rgb(10, 20, 30)),
+                sample_item("beta", Color::rgb(10, 20, 30)),
+            ],
+            ..sample_list()
+        };
+        let (_surface, layout) = paint_via_backend(&list);
+        let last = layout.visible_items.last().expect("at least one row");
+        let cx = last.bounds.x + last.bounds.width * 0.5;
+        let below_y = last.bounds.y + last.bounds.height + 4.0;
+        assert_eq!(layout.hit_test(cx, below_y), ListViewHit::Empty);
+    }
+}

--- a/quadraui/src/macos/mod.rs
+++ b/quadraui/src/macos/mod.rs
@@ -22,22 +22,34 @@
 
 pub mod activity_bar;
 pub mod backend;
+pub mod chart;
 pub mod command_center;
+pub mod data_table;
+pub mod editor;
 pub mod events;
+pub mod form;
 #[cfg(test)]
 pub mod headless;
+pub mod list;
 pub mod menu_bar;
 mod run;
 pub mod services;
 pub mod status_bar;
 pub mod tab_bar;
 pub mod text;
+pub mod tree;
 
 pub use activity_bar::draw_activity_bar;
 pub use backend::MacBackend;
+pub use chart::{draw_chart, mac_chart_layout};
 pub use command_center::{draw_command_center, mac_command_center_layout};
+pub use data_table::{draw_data_table, mac_data_table_layout};
+pub use editor::draw_editor;
+pub use form::{draw_form, mac_form_layout};
+pub use list::{draw_list, mac_list_layout};
 pub use menu_bar::{draw_menu_bar, mac_menu_bar_layout};
 pub use run::run;
 pub use services::MacPlatformServices;
 pub use status_bar::draw_status_bar;
 pub use tab_bar::draw_tab_bar;
+pub use tree::{draw_tree, mac_tree_layout};

--- a/quadraui/src/macos/tree.rs
+++ b/quadraui/src/macos/tree.rs
@@ -1,0 +1,484 @@
+//! macOS rasteriser for [`crate::TreeView`].
+//!
+//! Mirrors [`crate::gtk::tree::draw_tree`]: header rows use
+//! `(line_height * 1.2)` pitch, leaves and branches use
+//! `(line_height * 1.4)`. Chevron / icon / text / badge layout within
+//! a row matches the GTK convention so a paired `macos_multi_tree`
+//! example reads identically to its GTK twin.
+//!
+//! ## Scope omissions (follow-up)
+//!
+//! - **Inline `TreeRowEditState` text input** — caret, selection
+//!   anchor, placeholder. Painted as a plain text fallback for now;
+//!   full inline-edit input lands with the unified text-attribute pass
+//!   alongside the editor selection highlight.
+
+use core_graphics::geometry::CGRect;
+use core_graphics::sys::CGContextRef;
+use core_text::font::CTFont;
+
+use super::text::{draw_text, measure_text};
+use crate::event::Rect as QRect;
+use crate::primitives::tree::{TreeRowMeasure, TreeView, TreeViewLayout};
+use crate::theme::Theme;
+use crate::types::{Color, Decoration};
+
+/// Compute the layout the macOS rasteriser would produce for `tree`
+/// in `area` at `line_height`. Hosts and tests call this to drive
+/// hit-testing without re-deriving row pitch. Header rows use
+/// `(line_height * 1.2).round()`, others use `(line_height * 1.4)`.
+pub fn mac_tree_layout(tree: &TreeView, area: QRect, line_height: f64) -> TreeViewLayout {
+    let header_height = (line_height * 1.2).round();
+    let item_height = (line_height * 1.4).round();
+    let mut layout = tree.layout(area.width, area.height, |i| {
+        let is_header = matches!(tree.rows[i].decoration, Decoration::Header);
+        TreeRowMeasure::new(if is_header {
+            header_height as f32
+        } else {
+            item_height as f32
+        })
+    });
+    let (dx, dy) = (area.x, area.y);
+    if dx != 0.0 || dy != 0.0 {
+        for vr in &mut layout.visible_rows {
+            vr.bounds.x += dx;
+            vr.bounds.y += dy;
+        }
+        for (rect, _) in &mut layout.hit_regions {
+            rect.x += dx;
+            rect.y += dy;
+        }
+    }
+    layout
+}
+
+/// Draw a [`TreeView`] into `(x, y, w, h)` on `ctx`. Returns the
+/// same layout `mac_tree_layout` would produce.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_tree(
+    ctx: CGContextRef,
+    font: &CTFont,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    tree: &TreeView,
+    theme: &Theme,
+    line_height: f64,
+) -> TreeViewLayout {
+    let area = QRect::new(x as f32, y as f32, w as f32, h as f32);
+    if w <= 0.0 || h <= 0.0 {
+        return mac_tree_layout(tree, area, line_height);
+    }
+
+    let layout = mac_tree_layout(tree, area, line_height);
+
+    CGContextSaveGState(ctx);
+    CGContextClipToRect(ctx, CGRect::new_xywh(x, y, w, h));
+
+    fill_rect(ctx, x, y, w, h, theme.tab_bar_bg);
+
+    let indent_px = (line_height * 0.9).round();
+    let header_height = (line_height * 1.2).round();
+    let item_height = (line_height * 1.4).round();
+
+    for vis_row in &layout.visible_rows {
+        let row = &tree.rows[vis_row.row_idx];
+        let row_x = vis_row.bounds.x as f64;
+        let row_y = vis_row.bounds.y as f64;
+        let row_w = vis_row.bounds.width as f64;
+        let row_h = vis_row.bounds.height as f64;
+
+        let is_header = matches!(row.decoration, Decoration::Header);
+        let full_h = if is_header {
+            header_height
+        } else {
+            item_height
+        };
+        // Skip rows the viewport clipped to a partial height — same
+        // smoothing as GTK.
+        if row_h < full_h - 0.5 {
+            continue;
+        }
+
+        let path_selected = tree.selected_path.as_ref().is_some_and(|p| p == &row.path);
+        let is_selected = tree.has_focus && path_selected;
+        let is_inactive_selected = !tree.has_focus && path_selected;
+
+        let (def_fg, row_bg) = if is_selected {
+            (theme.header_fg, theme.selected_bg)
+        } else if is_inactive_selected {
+            (theme.foreground, theme.inactive_selected_bg)
+        } else if is_header {
+            (theme.header_fg, theme.header_bg)
+        } else if matches!(row.decoration, Decoration::Muted) {
+            (theme.muted_fg, theme.tab_bar_bg)
+        } else {
+            (theme.foreground, theme.tab_bar_bg)
+        };
+
+        fill_rect(ctx, row_x, row_y, row_w, row_h, row_bg);
+
+        let mut cursor_x = row_x + 2.0 + (row.indent as f64) * indent_px;
+
+        if let Some(expanded) = row.is_expanded {
+            if tree.style.show_chevrons {
+                let chevron = if expanded {
+                    &tree.style.chevron_expanded
+                } else {
+                    &tree.style.chevron_collapsed
+                };
+                let (cw, ch) = measure_text(font, chevron);
+                draw_text(
+                    ctx,
+                    font,
+                    chevron,
+                    cursor_x,
+                    (row_y + (row_h - ch) / 2.0).round(),
+                    color_to_cg(def_fg),
+                );
+                cursor_x += cw + 4.0;
+            }
+        } else {
+            cursor_x += line_height * 0.8;
+        }
+
+        // Icon — uses the ASCII `fallback` (Nerd Font handling lives
+        // at a higher layer; this rasteriser doesn't take a per-frame
+        // toggle yet).
+        if let Some(ref icon) = row.icon {
+            let glyph = icon.fallback.as_str();
+            let (iw, ih) = measure_text(font, glyph);
+            draw_text(
+                ctx,
+                font,
+                glyph,
+                cursor_x,
+                (row_y + (row_h - ih) / 2.0).round(),
+                color_to_cg(def_fg),
+            );
+            cursor_x += iw + 6.0;
+        }
+
+        if let Some(ref edit) = row.edit {
+            // Inline-edit fallback: render the text + placeholder
+            // unstyled. Caret/selection painting deferred — see module
+            // header.
+            let render_text = if edit.text.is_empty() {
+                edit.placeholder.clone().unwrap_or_default()
+            } else {
+                edit.text.clone()
+            };
+            let (_, th) = measure_text(font, &render_text);
+            draw_text(
+                ctx,
+                font,
+                &render_text,
+                cursor_x,
+                (row_y + (row_h - th) / 2.0).round(),
+                color_to_cg(if edit.text.is_empty() {
+                    theme.muted_fg
+                } else {
+                    def_fg
+                }),
+            );
+            continue;
+        }
+
+        let badge_info = row.badge.as_ref().map(|b| {
+            let (bw, _) = measure_text(font, &b.text);
+            let bfg = b.fg.unwrap_or(theme.muted_fg);
+            let bbg = b.bg.unwrap_or(row_bg);
+            (b.text.clone(), bw, bfg, bbg)
+        });
+        let badge_reserve = badge_info
+            .as_ref()
+            .map(|(_, bw, ..)| *bw + 8.0)
+            .unwrap_or(0.0);
+        let text_right_limit = row_x + row_w - badge_reserve - 4.0;
+
+        for span in &row.text.spans {
+            if cursor_x >= text_right_limit {
+                break;
+            }
+            let span_fg = if let Some(c) = span.fg {
+                c
+            } else if matches!(row.decoration, Decoration::Muted) {
+                theme.muted_fg
+            } else {
+                def_fg
+            };
+            if let Some(sbg) = span.bg {
+                let (sw, _) = measure_text(font, &span.text);
+                fill_rect(
+                    ctx,
+                    cursor_x,
+                    row_y,
+                    sw.min(text_right_limit - cursor_x),
+                    row_h,
+                    sbg,
+                );
+            }
+            let (sw, sh) = measure_text(font, &span.text);
+            draw_text(
+                ctx,
+                font,
+                &span.text,
+                cursor_x,
+                (row_y + (row_h - sh) / 2.0).round(),
+                color_to_cg(span_fg),
+            );
+            cursor_x += sw;
+        }
+
+        if let Some((btext, bw, bfg, bbg)) = badge_info {
+            let bx = row_x + row_w - bw - 4.0;
+            if bx > cursor_x {
+                if bbg != row_bg {
+                    fill_rect(ctx, bx - 2.0, row_y, bw + 4.0, row_h, bbg);
+                }
+                let (_, bh) = measure_text(font, &btext);
+                draw_text(
+                    ctx,
+                    font,
+                    &btext,
+                    bx,
+                    row_y + (row_h - bh) / 2.0,
+                    color_to_cg(bfg),
+                );
+            }
+        }
+    }
+
+    CGContextRestoreGState(ctx);
+    layout
+}
+
+fn color_to_cg(c: Color) -> (f64, f64, f64, f64) {
+    (
+        c.r as f64 / 255.0,
+        c.g as f64 / 255.0,
+        c.b as f64 / 255.0,
+        c.a as f64 / 255.0,
+    )
+}
+
+unsafe fn fill_rect(ctx: CGContextRef, x: f64, y: f64, w: f64, h: f64, c: Color) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBFillColor(ctx, r, g, b, a);
+    CGContextFillRect(ctx, CGRect::new_xywh(x, y, w, h));
+}
+
+trait CGRectExt {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self;
+}
+impl CGRectExt for CGRect {
+    fn new_xywh(x: f64, y: f64, w: f64, h: f64) -> Self {
+        use core_graphics::geometry::{CGPoint, CGSize};
+        CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h))
+    }
+}
+
+extern "C" {
+    fn CGContextSaveGState(c: CGContextRef);
+    fn CGContextRestoreGState(c: CGContextRef);
+    fn CGContextClipToRect(c: CGContextRef, rect: CGRect);
+    fn CGContextSetRGBFillColor(
+        c: CGContextRef,
+        red: core_graphics::base::CGFloat,
+        green: core_graphics::base::CGFloat,
+        blue: core_graphics::base::CGFloat,
+        alpha: core_graphics::base::CGFloat,
+    );
+    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::Viewport;
+    use crate::primitives::tree::{TreeRow, TreeViewHit};
+    use crate::types::{Color, SelectionMode, StyledText, TreeStyle, WidgetId};
+    use crate::Backend;
+
+    const W: u32 = 240;
+    const H: u32 = 240;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn leaf(idx: u16, label: &str) -> TreeRow {
+        TreeRow {
+            path: vec![idx],
+            indent: 0,
+            icon: None,
+            text: StyledText::plain(label),
+            badge: None,
+            is_expanded: None,
+            decoration: Decoration::Normal,
+            edit: None,
+        }
+    }
+
+    fn header_row(idx: u16, label: &str) -> TreeRow {
+        TreeRow {
+            path: vec![idx],
+            indent: 0,
+            icon: None,
+            text: StyledText::plain(label),
+            badge: None,
+            is_expanded: None,
+            decoration: Decoration::Header,
+            edit: None,
+        }
+    }
+
+    fn make_tree(rows: Vec<TreeRow>) -> TreeView {
+        TreeView {
+            id: WidgetId::new("tree"),
+            rows,
+            selection_mode: SelectionMode::Single,
+            selected_path: None,
+            scroll_offset: 0,
+            style: TreeStyle::default(),
+            has_focus: true,
+        }
+    }
+
+    fn paint_via_backend(tree: &TreeView) -> (BitmapSurface, TreeViewLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        // Match GTK convention: use background as the tree bg so probes
+        // distinguish painted-by-tree from cleared-buffer pixels.
+        backend.set_current_theme(Theme {
+            tab_bar_bg: Color::rgb(255, 255, 255),
+            background: Color::rgb(255, 255, 255),
+            ..Theme::default()
+        });
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            b.draw_tree(QRect::new(0.0, 0.0, W as f32, H as f32), tree);
+            let l = super::mac_tree_layout(
+                tree,
+                QRect::new(0.0, 0.0, W as f32, H as f32),
+                b.line_height() as f64,
+            );
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn header_row_paints_header_bg() {
+        // Header row + plain leaf: probe inside the header row's
+        // bounds and assert header_bg.
+        let tree = make_tree(vec![header_row(0, "SECTION"), leaf(1, "alpha")]);
+        let (surface, layout) = paint_via_backend(&tree);
+        let hdr = &layout.visible_rows[0];
+        let theme = Theme {
+            tab_bar_bg: Color::rgb(255, 255, 255),
+            background: Color::rgb(255, 255, 255),
+            ..Theme::default()
+        };
+        // Probe near the right edge so chevron / text glyphs are out
+        // of the way.
+        let px = (hdr.bounds.x + hdr.bounds.width - 2.0) as u32;
+        let py = (hdr.bounds.y + hdr.bounds.height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (theme.header_bg.r, theme.header_bg.g, theme.header_bg.b),
+        );
+    }
+
+    #[test]
+    fn selected_row_paints_selected_bg() {
+        let mut tree = make_tree(vec![leaf(0, "alpha"), leaf(1, "beta"), leaf(2, "gamma")]);
+        tree.selected_path = Some(vec![1]);
+        let (surface, layout) = paint_via_backend(&tree);
+        let theme = Theme::default();
+        let sel = &layout.visible_rows[1];
+        let px = (sel.bounds.x + sel.bounds.width - 2.0) as u32;
+        let py = (sel.bounds.y + sel.bounds.height / 2.0) as u32;
+        let (r, g, b, _) = surface.pixel(px, py);
+        assert_eq!(
+            (r, g, b),
+            (
+                theme.selected_bg.r,
+                theme.selected_bg.g,
+                theme.selected_bg.b
+            ),
+        );
+    }
+
+    #[test]
+    fn hit_test_resolves_each_visible_row() {
+        let tree = make_tree(vec![
+            leaf(0, "alpha"),
+            leaf(1, "beta"),
+            leaf(2, "gamma"),
+            leaf(3, "delta"),
+        ]);
+        let (_surface, layout) = paint_via_backend(&tree);
+        for vr in &layout.visible_rows {
+            let cx = vr.bounds.x + vr.bounds.width * 0.5;
+            let cy = vr.bounds.y + vr.bounds.height * 0.5;
+            assert_eq!(
+                layout.hit_test(cx, cy),
+                TreeViewHit::Row(vr.row_idx),
+                "row {} mid-point hit-test",
+                vr.row_idx,
+            );
+        }
+    }
+
+    #[test]
+    fn scroll_offset_shifts_visible_window() {
+        let mut tree = make_tree((0..30).map(|i| leaf(i, &format!("item-{}", i))).collect());
+        tree.scroll_offset = 5;
+        let (_surface, layout) = paint_via_backend(&tree);
+        let first = layout.visible_rows.first().expect("rows visible");
+        assert_eq!(
+            first.row_idx, 5,
+            "first painted row should match scroll_offset",
+        );
+        // Hit-test at the top of the viewport must return row 5,
+        // not row 0 — catches scroll-vs-paint drift.
+        assert_eq!(
+            layout.hit_test(10.0, first.bounds.y + 2.0),
+            TreeViewHit::Row(5),
+        );
+    }
+
+    #[test]
+    fn mixed_header_and_leaves_use_different_row_pitch() {
+        // Sanity: header_height < item_height (1.2 vs 1.4 multiplier).
+        let tree = make_tree(vec![
+            header_row(0, "SECTION"),
+            leaf(1, "alpha"),
+            leaf(2, "beta"),
+        ]);
+        let (_surface, layout) = paint_via_backend(&tree);
+        let hdr_h = layout.visible_rows[0].bounds.height;
+        let item_h = layout.visible_rows[1].bounds.height;
+        assert!(
+            hdr_h < item_h,
+            "header pitch {} should be shorter than leaf pitch {}",
+            hdr_h,
+            item_h,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Six new rasterisers in \`quadraui::macos::{tree,list,form,editor,data_table,chart}\` with matching \`mac_*_layout\` helpers; \`MacBackend\` chrome \`mac_unimpl!\` stubs for these primitives replaced with the real implementations. Three new paired examples (\`macos_data_table\`, \`macos_chart\`, \`macos_form_groups\`) wire shared \`common::AppLogic\` through \`quadraui::macos::run\` — same logic as the TUI/GTK twins.

Closes #39.

## What landed per rasteriser

| Rasteriser | Notable details | Scope omissions |
|---|---|---|
| **tree** | Header rows at \`line_height * 1.2\`, leaves at \`line_height * 1.4\` (matches GTK). Chevron + icon + text + badge layout, scroll offset, selection / inactive selection / muted / header decoration. | Inline \`TreeRowEditState\` caret + selection painting (label fallback only). |
| **list** | Optional title strip, decoration → fg, detail span right-aligned. | \`bordered\` mode (no consumer today, same status as GTK). |
| **form** | Label / Toggle / TextInput / Button / ReadOnly. Focused row highlight, validation fg colour, text-input caret + brackets. | Slider / ColorPicker / Dropdown / SegmentedControl / ToggleGroup / ButtonRow render as label-only rows; hint strip below row not yet rendered. |
| **editor** | Background, per-line text via Core Text, line-number gutter, cursorline, per-span fg + bg, Block / Bar / Underline cursor. | Selections, diagnostics underlines, indent guides, bracket-match, AI ghost text, multi-cursors. |
| **data_table** | Header strip with sort glyphs (\`▲\` / \`▼\`), body rows with hover / select, column separators, vertical + horizontal scrollbars. | Bold header text (font traits), translucent selection alpha. |
| **chart** | Sparkline / Line / Bar via CG path API (\`CGContextMoveToPoint\` + \`AddLineToPoint\` + \`StrokePath\` bound in this PR). Legend swatches, axis tick labels, hover marker, crosshair. | — |

Two cross-cutting follow-ups (tracked separately) gate most of these omissions:
1. **Unified text-attribute pass** through \`macos::text\` (bold / italic / underline via \`CTAttributedString\` attributes). Currently \`draw_text\` only carries fg via the context fill colour.
2. **Backend selection-overlay path** shared by editor + text-input + tree-edit + data-table.

## Test plan

- [x] \`cargo test -p quadraui --features macos --lib macos::\` — 91 passing (+25 from #39), 4 ignored (PPM smoke dumps from #38)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --features macos --lib --tests\` — no warnings in #39 code (pre-existing warnings on develop in \`compose/sidebar_system.rs\` + \`tree_controller.rs\` + \`dispatch.rs\` left alone)
- [x] \`cargo build -p quadraui --features macos --examples\` — all four macos examples (\`macos_app\`, \`macos_demo\`, \`macos_data_table\`, \`macos_chart\`, \`macos_form_groups\`) build
- [ ] Visual confirmation: run each new example end-to-end on a macOS host (\`cargo run -p quadraui --example macos_data_table --features macos\`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)