### PR TITLE
feat(quadraui): macOS PlatformServices — clipboard, file dialogs, notifications, open_url (#36)

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -37,6 +37,7 @@ macos = [
     "dep:core-graphics",
     "dep:core-text",
     "dep:core-foundation",
+    "dep:arboard",
 ]
 
 [dependencies]
@@ -63,12 +64,17 @@ objc2-app-kit = { version = "0.2", optional = true, features = [
     "NSGraphics",
     "NSColor",
     "NSEvent",
+    "NSOpenPanel",
+    "NSPanel",
+    "NSSavePanel",
 ] }
 objc2-foundation = { version = "0.2", optional = true, features = [
+    "NSArray",
     "NSGeometry",
     "NSObject",
     "NSString",
     "NSThread",
+    "NSURL",
 ] }
 core-graphics = { version = "0.23", optional = true }
 core-text = { version = "20.1", optional = true }

--- a/quadraui/src/macos/services.rs
+++ b/quadraui/src/macos/services.rs
@@ -1,24 +1,35 @@
 //! macOS implementation of [`quadraui::PlatformServices`].
 //!
-//! All surfaces ship as **stubs** in #35 so the `Backend` trait wiring
-//! compiles end-to-end. **#36 replaces these with real implementations**:
-//!
-//! - Clipboard → `NSPasteboard` (general pasteboard, plain-text only
-//!   for the first cut).
-//! - File dialogs → `NSOpenPanel` / `NSSavePanel`.
-//! - Notifications → `UNUserNotificationCenter` (macOS 10.14+).
-//! - `open_url` → `NSWorkspace::openURL:`.
-//!
-//! `platform_name()` returns `"macos"` here today — the only piece
-//! of the trait that `quadraui::dispatch` already consults during
-//! `BackendNative` routing.
+//! - **Clipboard** → `arboard` (NSPasteboard under the hood; the sync
+//!   API matches the [`Clipboard`] trait exactly, and shares one
+//!   implementation with the TUI and GTK backends).
+//! - **File dialogs** → `NSOpenPanel` / `NSSavePanel`, sync
+//!   `runModal`. Apps must invoke these from event handlers running
+//!   on the main thread (the `MacBackend` run loop guarantees this).
+//! - **Notifications** → `osascript -e 'display notification ...'`.
+//!   `UNUserNotificationCenter` requires a bundled `.app` with
+//!   `CFBundleIdentifier` and user authorization, neither of which
+//!   suit an unbundled CLI host. The osascript route works for both
+//!   bundled and unbundled hosts.
+//! - **`open_url`** → `open <url>`. Equivalent to
+//!   `NSWorkspace.open(_:)` without needing AppKit initialisation.
 
+use std::cell::RefCell;
 use std::path::PathBuf;
+use std::process::Command;
+
+use objc2_app_kit::{NSOpenPanel, NSSavePanel};
+use objc2_foundation::{MainThreadMarker, NSArray, NSString, NSURL};
 
 use crate::backend::{Clipboard, FileDialogOptions, Notification};
 use crate::PlatformServices;
 
-/// macOS platform-services impl. Stubbed for #35; replaced in #36.
+/// `NSModalResponseOK` — the user clicked Open / Save.
+const NS_MODAL_RESPONSE_OK: isize = 1;
+
+/// macOS platform services backed by AppKit + `arboard` + shell-out
+/// helpers. Constructed by [`crate::macos::MacBackend::new`] and
+/// exposed through [`crate::Backend::services`].
 pub struct MacPlatformServices {
     clipboard: MacClipboard,
 }
@@ -26,7 +37,7 @@ pub struct MacPlatformServices {
 impl MacPlatformServices {
     pub fn new() -> Self {
         Self {
-            clipboard: MacClipboard,
+            clipboard: MacClipboard::new(),
         }
     }
 }
@@ -42,22 +53,51 @@ impl PlatformServices for MacPlatformServices {
         &self.clipboard
     }
 
-    fn show_file_open_dialog(&self, _opts: FileDialogOptions) -> Option<PathBuf> {
-        // #36 wires `NSOpenPanel::runModal`.
-        None
+    fn show_file_open_dialog(&self, opts: FileDialogOptions) -> Option<PathBuf> {
+        let mtm = MainThreadMarker::new()
+            .expect("show_file_open_dialog must be called from the main thread");
+        // SAFETY: AppKit panels are constructed and driven exclusively
+        // on the main thread; MainThreadMarker enforces that.
+        unsafe {
+            let panel = NSOpenPanel::openPanel(mtm);
+            panel.setCanChooseFiles(true);
+            panel.setCanChooseDirectories(false);
+            configure_panel(&panel, &opts);
+            if panel.runModal() != NS_MODAL_RESPONSE_OK {
+                return None;
+            }
+            url_to_path(panel.URL().as_deref())
+        }
     }
 
-    fn show_file_save_dialog(&self, _opts: FileDialogOptions) -> Option<PathBuf> {
-        // #36 wires `NSSavePanel::runModal`.
-        None
+    fn show_file_save_dialog(&self, opts: FileDialogOptions) -> Option<PathBuf> {
+        let mtm = MainThreadMarker::new()
+            .expect("show_file_save_dialog must be called from the main thread");
+        // SAFETY: same as `show_file_open_dialog` above.
+        unsafe {
+            let panel = NSSavePanel::savePanel(mtm);
+            configure_panel(&panel, &opts);
+            if let Some(ref name) = opts.initial_filename {
+                panel.setNameFieldStringValue(&NSString::from_str(name));
+            }
+            if panel.runModal() != NS_MODAL_RESPONSE_OK {
+                return None;
+            }
+            url_to_path(panel.URL().as_deref())
+        }
     }
 
-    fn send_notification(&self, _n: Notification) {
-        // #36 wires `UNUserNotificationCenter`.
+    fn send_notification(&self, n: Notification) {
+        let script = format!(
+            "display notification \"{body}\" with title \"{title}\"",
+            body = applescript_escape(&n.body),
+            title = applescript_escape(&n.title),
+        );
+        let _ = Command::new("osascript").arg("-e").arg(&script).spawn();
     }
 
-    fn open_url(&self, _url: &str) {
-        // #36 wires `NSWorkspace::openURL:`.
+    fn open_url(&self, url: &str) {
+        let _ = Command::new("open").arg(url).spawn();
     }
 
     fn platform_name(&self) -> &'static str {
@@ -65,13 +105,113 @@ impl PlatformServices for MacPlatformServices {
     }
 }
 
-/// Stub clipboard. #36 replaces with an `NSPasteboard` impl.
-pub struct MacClipboard;
+/// Apply common options (message, initial directory, file-type filters)
+/// to an `NSSavePanel` — also covers `NSOpenPanel`, which inherits all
+/// of these setters from `NSSavePanel`.
+///
+/// # Safety
+///
+/// Must be called from the main thread; `panel` must be a valid panel
+/// retrieved on this same thread via `openPanel:` / `savePanel:`.
+unsafe fn configure_panel(panel: &NSSavePanel, opts: &FileDialogOptions) {
+    if let Some(ref title) = opts.title {
+        panel.setMessage(Some(&NSString::from_str(title)));
+    }
+    if let Some(ref dir) = opts.initial_dir {
+        if let Some(dir_str) = dir.to_str() {
+            let url = NSURL::fileURLWithPath_isDirectory(&NSString::from_str(dir_str), true);
+            panel.setDirectoryURL(Some(&url));
+        }
+    }
+    let exts: Vec<_> = opts
+        .filters
+        .iter()
+        .flat_map(|(_, e)| e.iter())
+        .map(|ext| NSString::from_str(ext))
+        .collect();
+    if !exts.is_empty() {
+        // `NSArray::from_slice` requires `T: IsRetainable`, which
+        // NSString doesn't satisfy (it has an `NSMutableString`
+        // subclass). `from_vec` consumes owned retained handles and
+        // sidesteps that bound.
+        let arr = NSArray::from_vec(exts);
+        // `setAllowedFileTypes:` is deprecated in favour of
+        // `setAllowedContentTypes:` (UTType), but that requires the
+        // UniformTypeIdentifiers framework which objc2 doesn't yet
+        // wrap. The legacy API still works on macOS 11–15.
+        #[allow(deprecated)]
+        panel.setAllowedFileTypes(Some(&arr));
+    }
+}
+
+/// Convert an `NSURL` back to a Rust `PathBuf`. Returns `None` if the
+/// URL is missing or non-file-scheme.
+///
+/// # Safety
+///
+/// `url` must be a valid `NSURL` retrieved on the main thread.
+unsafe fn url_to_path(url: Option<&NSURL>) -> Option<PathBuf> {
+    let path = url?.path()?;
+    Some(PathBuf::from(path.to_string()))
+}
+
+/// Escape `"` and `\` so a string can be embedded inside an
+/// AppleScript double-quoted string literal.
+fn applescript_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// System clipboard via `arboard` (NSPasteboard under the hood on
+/// macOS). Held for the lifetime of `MacPlatformServices` so the
+/// pasteboard handle outlives any cached connection state.
+pub struct MacClipboard {
+    inner: RefCell<Option<arboard::Clipboard>>,
+}
+
+impl MacClipboard {
+    fn new() -> Self {
+        Self {
+            inner: RefCell::new(arboard::Clipboard::new().ok()),
+        }
+    }
+}
 
 impl Clipboard for MacClipboard {
     fn read_text(&self) -> Option<String> {
-        None
+        self.inner.borrow_mut().as_mut()?.get_text().ok()
     }
 
-    fn write_text(&self, _text: &str) {}
+    fn write_text(&self, text: &str) {
+        if let Some(cb) = self.inner.borrow_mut().as_mut() {
+            let _ = cb.set_text(text);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_name_is_macos() {
+        let svc = MacPlatformServices::new();
+        assert_eq!(svc.platform_name(), "macos");
+    }
+
+    #[test]
+    fn applescript_escape_handles_quotes_and_backslashes() {
+        // Empty + pass-through.
+        assert_eq!(applescript_escape(""), "");
+        assert_eq!(applescript_escape("plain text"), "plain text");
+        // Single-character escapes.
+        assert_eq!(applescript_escape("a\"b"), "a\\\"b");
+        assert_eq!(applescript_escape("c\\d"), "c\\\\d");
+        // Combined. Backslash MUST be escaped first so the subsequent
+        // quote-escape's added backslashes aren't re-escaped.
+        assert_eq!(applescript_escape("e\"f\\g"), "e\\\"f\\\\g");
+        // Order check: a backslash followed by a quote in input
+        // should produce `\\\"` (escaped slash + escaped quote),
+        // not `\\\\\"` (double-escaped slash + quote).
+        assert_eq!(applescript_escape("\\\""), "\\\\\\\"");
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the stub `MacPlatformServices` with real implementations, closing #36 and unblocking native macOS consumers (vimcode) that need clipboard + file dialogs.

- **Clipboard** → `arboard` (NSPasteboard under the hood; shares one impl with TUI/GTK backends).
- **`show_file_open_dialog`** → `NSOpenPanel::openPanel(mtm).runModal()`, honouring `title`, `initial_dir`, and file-type `filters`.
- **`show_file_save_dialog`** → `NSSavePanel::savePanel(mtm).runModal()`, plus `initial_filename`.
- **`send_notification`** → `osascript -e 'display notification …'`. `UNUserNotificationCenter` requires a bundled `.app` + user authorization, which doesn't suit unbundled CLI hosts; AppleScript works in both. AppleScript strings escaped via a regression-tested `applescript_escape` helper.
- **`open_url`** → `Command::new("open").arg(url)` — defers to NSWorkspace.

`Cargo.toml`: pulls `arboard` into the `macos` feature and enables the `NSOpenPanel` / `NSPanel` / `NSSavePanel` / `NSArray` / `NSURL` sub-features.

A shared `unsafe fn configure_panel(panel: &NSSavePanel, opts: &FileDialogOptions)` covers both panel kinds — `NSOpenPanel` inherits the setters from `NSSavePanel`. Uses `setAllowedFileTypes` (deprecated, still functional); the modern `setAllowedContentTypes` would require the `UniformTypeIdentifiers` framework which objc2 doesn't yet wrap. Flagged in a code comment.

## Test plan

- [x] `cargo build -p quadraui --features tui --features macos`
- [x] `cargo test  -p quadraui --features tui --features macos` — 851 pass (+2 new: `platform_name_is_macos`, `applescript_escape_handles_quotes_and_backslashes`)
- [x] `cargo clippy -p quadraui --features tui --features macos -- -D warnings` — same 18 pre-existing errors as `develop`, 0 regressions
- [x] `cargo fmt --check`
- [x] `cargo build -p quadraui --features macos --examples` — all macOS examples compile
- [ ] Manual smoke (deferred; no existing example exercises `PlatformServices`): a follow-up `macos_platform_services` example would key-bind clipboard read/write, open/save dialogs, notification, and open_url. Worth filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)