### PR TITLE
fix(quadraui): tab_bar_layout computes correct_scroll_offset (#213)

### DIFF
--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -807,13 +807,18 @@ impl Backend for GtkBackend {
             0.0
         };
 
+        let tab_name_widths: Vec<f32> = bar
+            .tabs
+            .iter()
+            .map(|t| self.pango_str_width(&pango_layout, &t.label, char_w))
+            .collect();
+
         let layout = bar.layout(
             rect.width,
             rect.height,
             0.0, // no scroll arrows — matches the draw path
             |i| {
-                let name_w = self.pango_str_width(&pango_layout, &bar.tabs[i].label, char_w);
-                let total = tab_pad + name_w + close_extra + tab_pad + tab_outer_gap;
+                let total = tab_pad + tab_name_widths[i] + close_extra + tab_pad + tab_outer_gap;
                 let close_w = if bar.show_tab_close {
                     tab_inner_gap + close_glyph_w + tab_pad + tab_outer_gap
                 } else {
@@ -827,7 +832,32 @@ impl Backend for GtkBackend {
                 crate::SegmentMeasure::new(text_w)
             },
         );
-        tab_bar_layout_to_hits(&layout, bar)
+
+        let mut hits = tab_bar_layout_to_hits(&layout, bar);
+
+        let active_idx = bar.tabs.iter().position(|t| t.is_active);
+        let reserved_px: f32 = bar
+            .right_segments
+            .iter()
+            .map(|seg| self.pango_str_width(&pango_layout, &seg.text, char_w))
+            .sum();
+        let effective_tab_area = (rect.width - reserved_px).max(0.0);
+
+        hits.correct_scroll_offset = if let Some(active) = active_idx {
+            TabBar::fit_active_scroll_offset(
+                active,
+                bar.tabs.len(),
+                effective_tab_area as usize,
+                |i| {
+                    (tab_pad + tab_name_widths[i] + close_extra + tab_pad + tab_outer_gap).ceil()
+                        as usize
+                },
+            )
+        } else {
+            bar.scroll_offset
+        };
+
+        hits
     }
 
     fn activity_bar_layout(&self, rect: QRect, bar: &ActivityBar) -> Vec<crate::ActivityBarRowHit> {

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -606,7 +606,26 @@ impl Backend for TuiBackend {
             |i| crate::TabMeasure::new(tab_widths[i] as f32, close_cols as f32),
             |i| crate::SegmentMeasure::new(bar.right_segments[i].width_cells as f32),
         );
-        tab_bar_layout_to_hits(&layout, bar)
+
+        let mut hits = tab_bar_layout_to_hits(&layout, bar);
+
+        let active_idx = bar.tabs.iter().position(|t| t.is_active);
+        let reserved: usize = bar
+            .right_segments
+            .iter()
+            .map(|s| s.width_cells as usize)
+            .sum();
+        let effective_tab_area = (rect.width as usize).saturating_sub(reserved);
+
+        hits.correct_scroll_offset = if let Some(active) = active_idx {
+            TabBar::fit_active_scroll_offset(active, bar.tabs.len(), effective_tab_area, |i| {
+                tab_widths[i]
+            })
+        } else {
+            bar.scroll_offset
+        };
+
+        hits
     }
 
     fn activity_bar_layout(&self, rect: QRect, bar: &ActivityBar) -> Vec<crate::ActivityBarRowHit> {


### PR DESCRIPTION
## Summary

- `tab_bar_layout()` on `GtkBackend` and `TuiBackend` now computes `correct_scroll_offset` via `TabBar::fit_active_scroll_offset`, matching the rasteriser's post-layout step
- Previously `correct_scroll_offset` was just `resolved_scroll_offset` (== `bar.scroll_offset` when `scroll_arrow_width = 0.0`), so the active tab was never scrolled into view
- Unblocks vimcode#461 (tab-bar migration chunk B)

Closes #213

## Test plan

- [x] `cargo build --features tui --features gtk`
- [x] `cargo test --features tui` — 743 pass
- [x] `cargo test --features gtk` — 743 pass
- [x] `cargo clippy --features tui -- -D warnings`
- [x] `cargo clippy --features gtk -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)