### PR TITLE
fix(quadraui): layout methods measure with frame-scope pango layout (#215)

### DIFF
--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -781,7 +781,8 @@ impl Backend for GtkBackend {
     fn status_bar_layout(&self, rect: QRect, bar: &StatusBar) -> crate::StatusBarLayout {
         let char_w = self.current_char_width as f32;
         let lh = self.current_line_height as f32;
-        let pango_layout = self.pango_ctx.as_ref().map(pango::Layout::new);
+        let frame_layout = self.current_frame_refs().map(|(_, l)| l.clone());
+        let pango_layout = frame_layout.or_else(|| self.pango_ctx.as_ref().map(pango::Layout::new));
         bar.layout(rect.width, lh, crate::gtk::MIN_GAP_PX, |seg| {
             let text_w = self.pango_str_width(&pango_layout, &seg.text, char_w);
             crate::StatusSegmentMeasure::new(text_w)
@@ -790,7 +791,8 @@ impl Backend for GtkBackend {
 
     fn tab_bar_layout(&self, rect: QRect, bar: &TabBar) -> crate::TabBarHits {
         let char_w = self.current_char_width as f32;
-        let pango_layout = self.pango_ctx.as_ref().map(pango::Layout::new);
+        let frame_layout = self.current_frame_refs().map(|(_, l)| l.clone());
+        let pango_layout = frame_layout.or_else(|| self.pango_ctx.as_ref().map(pango::Layout::new));
 
         let tab_pad: f32 = if bar.compact { 2.0 } else { 14.0 };
         let tab_inner_gap: f32 = if bar.compact { 4.0 } else { 10.0 };


### PR DESCRIPTION
## Summary

- `status_bar_layout` and `tab_bar_layout` on `GtkBackend` now prefer the frame-scope pango layout (via `current_frame_refs()`) over `self.pango_ctx`
- Ensures layout methods measure with the same font the rasteriser paints with, eliminating hit-test drift when the caller's active font differs from the startup font
- `activity_bar_layout` is unchanged — it uses pure geometry, no pango measurement
- Falls back to `self.pango_ctx` when called outside a frame scope (backwards compatible)

Closes #215

## Test plan

- [x] `cargo build --features tui --features gtk`
- [x] `cargo test --features tui` — 743 pass
- [x] `cargo test --features gtk` — 743 pass
- [x] `cargo clippy --features tui -- -D warnings`
- [x] `cargo clippy --features gtk -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)