### PR TITLE
feat(quadraui): AppShell chrome slots + single-DA decision (#217)

### DIFF
--- a/quadraui/examples/common/appshell_demo.rs
+++ b/quadraui/examples/common/appshell_demo.rs
@@ -139,6 +139,10 @@ impl ShellApp for AppShellDemo {
             AppShellEvent::SidebarResized { new_width } => {
                 format!("Resized: {new_width:.0}px")
             }
+            AppShellEvent::BottomPanelResized { new_height } => {
+                format!("Bottom panel: {new_height:.0}px")
+            }
+            AppShellEvent::BottomPanelHidden => "Bottom panel hidden".into(),
             AppShellEvent::BottomItemClicked { id } => {
                 format!("Bottom: {}", id.as_str())
             }

--- a/quadraui/examples/common/full_chrome_demo.rs
+++ b/quadraui/examples/common/full_chrome_demo.rs
@@ -1,0 +1,230 @@
+//! Full-chrome AppShell demo — proves all four chrome slots
+//! (title bar, bottom panel, command line, status bar) plus the
+//! existing activity bar / sidebar / main layout.
+
+use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
+use quadraui::{
+    Backend, Color, Key, NamedKey, Reaction, Rect, ShellApp as ShellAppTrait, ShellConfig,
+    ShellContext, StatusBar, StatusBarSegment, UiEvent, WidgetId,
+};
+
+pub struct FullChromeDemo {
+    last_event: String,
+}
+
+impl FullChromeDemo {
+    pub fn new() -> Self {
+        Self {
+            last_event: "click icons | drag dividers | q=quit".into(),
+        }
+    }
+
+    pub fn config() -> ShellConfig {
+        ShellConfig::new(
+            "Full Chrome Demo",
+            vec![
+                PanelDefinition {
+                    id: WidgetId::new("panel:explorer"),
+                    icon: "E".into(),
+                    tooltip: "Explorer".into(),
+                    title: "EXPLORER".into(),
+                },
+                PanelDefinition {
+                    id: WidgetId::new("panel:search"),
+                    icon: "S".into(),
+                    tooltip: "Search".into(),
+                    title: "SEARCH".into(),
+                },
+                PanelDefinition {
+                    id: WidgetId::new("panel:git"),
+                    icon: "G".into(),
+                    tooltip: "Source Control".into(),
+                    title: "SOURCE CONTROL".into(),
+                },
+                PanelDefinition {
+                    id: WidgetId::new("panel:debug"),
+                    icon: "D".into(),
+                    tooltip: "Debug".into(),
+                    title: "RUN AND DEBUG".into(),
+                },
+            ],
+        )
+        .with_bottom_items(vec![PanelDefinition {
+            id: WidgetId::new("panel:settings"),
+            icon: "*".into(),
+            tooltip: "Settings".into(),
+            title: "Settings".into(),
+        }])
+        .with_title_bar(1.5)
+        .with_bottom_panel(8.0)
+        .with_bottom_panel_limits(3.0, 25.0)
+        .with_command_line()
+        .with_status_bar()
+    }
+
+    fn draw_label(
+        backend: &mut dyn Backend,
+        bounds: Rect,
+        text: &str,
+        fg: Color,
+        bg: Color,
+        bold: bool,
+    ) {
+        let lh = backend.line_height();
+        let bar = StatusBar {
+            id: WidgetId::new("chrome-label"),
+            left_segments: vec![StatusBarSegment {
+                text: format!(" {text} "),
+                fg,
+                bg,
+                bold,
+                action_id: None,
+            }],
+            right_segments: vec![],
+        };
+        let rect = Rect::new(bounds.x, bounds.y, bounds.width, lh.min(bounds.height));
+        backend.draw_status_bar(rect, &bar, None, None);
+    }
+}
+
+impl Default for FullChromeDemo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ShellAppTrait for FullChromeDemo {
+    fn render_content(&self, backend: &mut dyn Backend, layout: &AppShellLayout) {
+        let title_fg = Color::rgb(220, 220, 220);
+        let title_bg = Color::rgb(50, 50, 55);
+        let content_fg = Color::rgb(140, 140, 140);
+        let content_bg = Color::rgb(30, 30, 30);
+        let status_fg = Color::rgb(200, 200, 220);
+        let status_bg = Color::rgb(0, 120, 210);
+
+        if let Some(tb) = layout.title_bar_bounds {
+            Self::draw_label(
+                backend,
+                tb,
+                "TITLE BAR  |  File  Edit  View  Help",
+                title_fg,
+                title_bg,
+                true,
+            );
+        }
+
+        if let Some(content) = layout.sidebar_content_bounds {
+            Self::draw_label(
+                backend,
+                content,
+                "(sidebar content)",
+                content_fg,
+                content_bg,
+                false,
+            );
+        }
+
+        Self::draw_label(
+            backend,
+            layout.main_content_bounds,
+            &self.last_event,
+            Color::rgb(200, 200, 200),
+            content_bg,
+            false,
+        );
+
+        if let Some(bp) = layout.bottom_panel_bounds {
+            Self::draw_label(
+                backend,
+                bp,
+                "TERMINAL  |  bottom panel (drag top edge to resize)",
+                content_fg,
+                Color::rgb(25, 25, 28),
+                false,
+            );
+        }
+
+        if let Some(cl) = layout.command_line_bounds {
+            Self::draw_label(
+                backend,
+                cl,
+                ":command-line-slot",
+                Color::rgb(180, 180, 180),
+                Color::rgb(35, 35, 40),
+                false,
+            );
+        }
+
+        if let Some(sb) = layout.status_bar_bounds {
+            Self::draw_label(
+                backend,
+                sb,
+                "main  |  UTF-8  |  Ln 1, Col 1",
+                status_fg,
+                status_bg,
+                false,
+            );
+        }
+    }
+
+    fn handle(
+        &mut self,
+        event: UiEvent,
+        _backend: &mut dyn Backend,
+        ctx: &ShellContext,
+    ) -> Reaction {
+        match &event {
+            UiEvent::KeyPressed { key, .. } => match key {
+                Key::Char('q') | Key::Named(NamedKey::Escape) => Reaction::Exit,
+                _ => Reaction::Continue,
+            },
+            UiEvent::MouseDown { position, .. } => {
+                if ctx.in_title_bar(position.x, position.y) {
+                    self.last_event = "Title bar click".into();
+                    Reaction::Redraw
+                } else if ctx.in_sidebar(position.x, position.y) {
+                    self.last_event = format!(
+                        "Sidebar click (panel: {})",
+                        ctx.active_panel_id.map(|id| id.as_str()).unwrap_or("none")
+                    );
+                    Reaction::Redraw
+                } else if ctx.in_main(position.x, position.y) {
+                    self.last_event = "Main area click".into();
+                    Reaction::Redraw
+                } else if ctx.in_bottom_panel(position.x, position.y) {
+                    self.last_event = "Bottom panel click".into();
+                    Reaction::Redraw
+                } else if ctx.in_command_line(position.x, position.y) {
+                    self.last_event = "Command line click".into();
+                    Reaction::Redraw
+                } else if ctx.in_status_bar(position.x, position.y) {
+                    self.last_event = "Status bar click".into();
+                    Reaction::Redraw
+                } else {
+                    Reaction::Continue
+                }
+            }
+            _ => Reaction::Continue,
+        }
+    }
+
+    fn on_shell_event(&mut self, event: &AppShellEvent) {
+        self.last_event = match event {
+            AppShellEvent::PanelChanged { panel_id } => {
+                format!("Panel: {}", panel_id.as_str())
+            }
+            AppShellEvent::SidebarHidden => "Sidebar hidden".into(),
+            AppShellEvent::SidebarResized { new_width } => {
+                format!("Sidebar resized: {new_width:.0}px")
+            }
+            AppShellEvent::BottomPanelResized { new_height } => {
+                format!("Bottom panel resized: {new_height:.0}px")
+            }
+            AppShellEvent::BottomPanelHidden => "Bottom panel hidden".into(),
+            AppShellEvent::BottomItemClicked { id } => {
+                format!("Bottom item: {}", id.as_str())
+            }
+            _ => return,
+        };
+    }
+}

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -32,6 +32,7 @@ pub mod demo;
 pub mod form_groups;
 pub mod form_scroll;
 pub mod frame_demo;
+pub mod full_chrome_demo;
 pub mod hscroll_editor;
 pub mod indicators_app;
 pub mod menu_bar_app;

--- a/quadraui/examples/common/shell_app.rs
+++ b/quadraui/examples/common/shell_app.rs
@@ -201,6 +201,14 @@ impl AppLogic for ShellApp {
                 self.last_message = format!("Sidebar width: {:.0}", new_width);
                 return Reaction::Redraw;
             }
+            AppShellEvent::BottomPanelResized { new_height } => {
+                self.last_message = format!("Bottom panel: {new_height:.0}px");
+                return Reaction::Redraw;
+            }
+            AppShellEvent::BottomPanelHidden => {
+                self.last_message = "Bottom panel hidden".into();
+                return Reaction::Redraw;
+            }
             AppShellEvent::BottomItemClicked { id } => {
                 self.last_message = format!("Settings clicked ({})", id.as_str());
                 return Reaction::Redraw;

--- a/quadraui/examples/gtk_full_chrome_demo.rs
+++ b/quadraui/examples/gtk_full_chrome_demo.rs
@@ -1,0 +1,9 @@
+//! GTK runner for the full-chrome AppShell demo (#217 Stage 2).
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() {
+    let app = common::full_chrome_demo::FullChromeDemo::new();
+    let config = common::full_chrome_demo::FullChromeDemo::config();
+    quadraui::gtk::shell_runner::run_with_shell(app, config);
+}

--- a/quadraui/examples/tui_full_chrome_demo.rs
+++ b/quadraui/examples/tui_full_chrome_demo.rs
@@ -1,0 +1,9 @@
+//! TUI runner for the full-chrome AppShell demo (#217 Stage 2).
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() {
+    let app = common::full_chrome_demo::FullChromeDemo::new();
+    let config = common::full_chrome_demo::FullChromeDemo::config();
+    quadraui::tui::shell_runner::run_with_shell(app, config);
+}

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -44,6 +44,8 @@ pub enum AppShellEvent {
     PanelChanged { panel_id: WidgetId },
     SidebarHidden,
     SidebarResized { new_width: f32 },
+    BottomPanelResized { new_height: f32 },
+    BottomPanelHidden,
     BottomItemClicked { id: WidgetId },
     Consumed,
     Ignored,
@@ -52,18 +54,22 @@ pub enum AppShellEvent {
 /// Layout bounds returned by [`AppShell::render`] and [`AppShell::layout`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppShellLayout {
+    pub title_bar_bounds: Option<Rect>,
     pub activity_bar_bounds: Rect,
     pub sidebar_header_bounds: Option<Rect>,
     pub sidebar_content_bounds: Option<Rect>,
     pub divider_bounds: Option<Rect>,
     pub main_content_bounds: Rect,
+    pub bottom_panel_bounds: Option<Rect>,
+    pub command_line_bounds: Option<Rect>,
+    pub status_bar_bounds: Option<Rect>,
 }
 
 // ── AppShell ─────────────────────────────────────────────────────────
 
-/// All width fields are stored as **multiples of `line_height`** so
-/// they are portable across TUI (cells) and GUI (pixels) backends.
-/// `compute_layout()` resolves them: `width_native = field * lh`.
+/// All width/height fields are stored as **multiples of `line_height`**
+/// so they are portable across TUI (cells) and GUI (pixels) backends.
+/// `compute_layout()` resolves them: `dimension_native = field * lh`.
 pub struct AppShell {
     panels: Vec<PanelDefinition>,
     bottom_items: Vec<PanelDefinition>,
@@ -78,6 +84,17 @@ pub struct AppShell {
     position: ShellPosition,
     drag_offset: Option<f32>,
     hovered_activity_idx: Option<usize>,
+    // ── Chrome slot config ───────────────────────────────────────
+    has_title_bar: bool,
+    title_bar_height_lh: f32,
+    has_bottom_panel: bool,
+    bottom_panel_height_lh: f32,
+    min_bottom_panel_height_lh: f32,
+    max_bottom_panel_height_lh: f32,
+    bottom_panel_visible: bool,
+    has_command_line: bool,
+    has_status_bar: bool,
+    bottom_panel_drag_offset: Option<f32>,
     /// Cached hit regions from the last `render()` call. `handle()`
     /// dispatches clicks against these so paint and click agree on
     /// row positions — the structural fix for the GTK ACTIVITY_ROW_PX
@@ -103,6 +120,16 @@ impl AppShell {
             position: ShellPosition::Left,
             drag_offset: None,
             hovered_activity_idx: None,
+            has_title_bar: false,
+            title_bar_height_lh: 1.5,
+            has_bottom_panel: false,
+            bottom_panel_height_lh: 10.0,
+            min_bottom_panel_height_lh: 3.0,
+            max_bottom_panel_height_lh: 30.0,
+            bottom_panel_visible: true,
+            has_command_line: false,
+            has_status_bar: false,
+            bottom_panel_drag_offset: None,
             cached_activity_hits: RefCell::new(Vec::new()),
             cached_activity_bar_bounds: RefCell::new(None),
         }
@@ -130,6 +157,34 @@ impl AppShell {
 
     pub fn with_position(mut self, position: ShellPosition) -> Self {
         self.position = position;
+        self
+    }
+
+    pub fn with_title_bar(mut self, height_lh: f32) -> Self {
+        self.has_title_bar = true;
+        self.title_bar_height_lh = height_lh;
+        self
+    }
+
+    pub fn with_bottom_panel(mut self, height_lh: f32) -> Self {
+        self.has_bottom_panel = true;
+        self.bottom_panel_height_lh = height_lh;
+        self
+    }
+
+    pub fn with_bottom_panel_limits(mut self, min: f32, max: f32) -> Self {
+        self.min_bottom_panel_height_lh = min;
+        self.max_bottom_panel_height_lh = max;
+        self
+    }
+
+    pub fn with_command_line(mut self) -> Self {
+        self.has_command_line = true;
+        self
+    }
+
+    pub fn with_status_bar(mut self) -> Self {
+        self.has_status_bar = true;
         self
     }
 
@@ -181,6 +236,33 @@ impl AppShell {
 
     pub fn set_sidebar_width(&mut self, width: f32) {
         self.sidebar_width = width.clamp(self.min_sidebar_width, self.max_sidebar_width);
+    }
+
+    pub fn bottom_panel_visible(&self) -> bool {
+        self.has_bottom_panel && self.bottom_panel_visible
+    }
+
+    pub fn bottom_panel_height(&self) -> f32 {
+        self.bottom_panel_height_lh
+    }
+
+    pub fn show_bottom_panel(&mut self) {
+        self.bottom_panel_visible = true;
+    }
+
+    pub fn hide_bottom_panel(&mut self) {
+        self.bottom_panel_visible = false;
+    }
+
+    pub fn toggle_bottom_panel(&mut self) {
+        self.bottom_panel_visible = !self.bottom_panel_visible;
+    }
+
+    pub fn set_bottom_panel_height(&mut self, height: f32) {
+        self.bottom_panel_height_lh = height.clamp(
+            self.min_bottom_panel_height_lh,
+            self.max_bottom_panel_height_lh,
+        );
     }
 
     // ── Dynamic panel registration ──────────────────────────────────
@@ -378,6 +460,14 @@ impl AppShell {
                     }
                 }
 
+                if let Some(bp) = layout.bottom_panel_bounds {
+                    let grip = Rect::new(bp.x, bp.y - 3.0, bp.width, 6.0);
+                    if contains(grip, p) {
+                        self.bottom_panel_drag_offset = Some(p.y - bp.y);
+                        return AppShellEvent::Consumed;
+                    }
+                }
+
                 if contains(layout.activity_bar_bounds, p) {
                     if let Some(hit) = self.cached_activity_hit(p) {
                         return self.handle_activity_click(&hit);
@@ -415,6 +505,21 @@ impl AppShell {
                         new_width: clamped * lh,
                     };
                 }
+                if let Some(offset) = self.bottom_panel_drag_offset {
+                    let bottom_edge = area.y + area.height;
+                    let new_native = bottom_edge - (position.y - offset);
+                    let status_lh = if self.has_status_bar { 1.0 } else { 0.0 };
+                    let cmd_lh = if self.has_command_line { 1.0 } else { 0.0 };
+                    let new_lh = new_native / lh - status_lh - cmd_lh;
+                    let clamped = new_lh.clamp(
+                        self.min_bottom_panel_height_lh,
+                        self.max_bottom_panel_height_lh,
+                    );
+                    self.bottom_panel_height_lh = clamped;
+                    return AppShellEvent::BottomPanelResized {
+                        new_height: clamped * lh,
+                    };
+                }
                 self.update_hover(position, &layout, lh);
                 AppShellEvent::Ignored
             }
@@ -431,6 +536,9 @@ impl AppShell {
                 if self.drag_offset.take().is_some() {
                     return AppShellEvent::Consumed;
                 }
+                if self.bottom_panel_drag_offset.take().is_some() {
+                    return AppShellEvent::Consumed;
+                }
                 AppShellEvent::Ignored
             }
 
@@ -442,34 +550,82 @@ impl AppShell {
 
     fn compute_layout(&self, area: Rect, line_height: f32) -> AppShellLayout {
         let lh = line_height.max(1.0);
+
+        // ── Vertical carve: title bar (top), then status/cmd/bottom (bottom) ──
+
+        let mut band_y = area.y;
+        let mut band_h = area.height;
+
+        let title_bar_bounds = if self.has_title_bar {
+            let h = (self.title_bar_height_lh * lh).round();
+            let r = Rect::new(area.x, band_y, area.width, h);
+            band_y += h;
+            band_h -= h;
+            Some(r)
+        } else {
+            None
+        };
+
+        let status_bar_bounds = if self.has_status_bar {
+            let h = lh.round();
+            band_h -= h;
+            Some(Rect::new(area.x, band_y + band_h, area.width, h))
+        } else {
+            None
+        };
+
+        let command_line_bounds = if self.has_command_line {
+            let h = lh.round();
+            band_h -= h;
+            Some(Rect::new(area.x, band_y + band_h, area.width, h))
+        } else {
+            None
+        };
+
+        let bottom_panel_bounds = if self.has_bottom_panel && self.bottom_panel_visible {
+            let h = (self.bottom_panel_height_lh.clamp(
+                self.min_bottom_panel_height_lh,
+                self.max_bottom_panel_height_lh,
+            ) * lh)
+                .round();
+            let h = h.min(band_h * 0.6);
+            band_h -= h;
+            Some(Rect::new(area.x, band_y + band_h, area.width, h))
+        } else {
+            None
+        };
+
+        let band_h = band_h.max(0.0);
+
+        // ── Horizontal carve: activity bar + sidebar + divider + main ──
+
         let ab_w = (self.activity_bar_width * lh).round();
         let divider_w = (lh * 0.25).max(1.0).round().min(4.0);
 
         if !self.sidebar_visible || self.panels.is_empty() {
             let (ab_bounds, main_bounds) = match self.position {
                 ShellPosition::Left => (
-                    Rect::new(area.x, area.y, ab_w, area.height),
-                    Rect::new(
-                        area.x + ab_w,
-                        area.y,
-                        (area.width - ab_w).max(0.0),
-                        area.height,
-                    ),
+                    Rect::new(area.x, band_y, ab_w, band_h),
+                    Rect::new(area.x + ab_w, band_y, (area.width - ab_w).max(0.0), band_h),
                 ),
                 ShellPosition::Right => {
                     let ab_x = area.x + area.width - ab_w;
                     (
-                        Rect::new(ab_x.max(area.x), area.y, ab_w, area.height),
-                        Rect::new(area.x, area.y, (area.width - ab_w).max(0.0), area.height),
+                        Rect::new(ab_x.max(area.x), band_y, ab_w, band_h),
+                        Rect::new(area.x, band_y, (area.width - ab_w).max(0.0), band_h),
                     )
                 }
             };
             return AppShellLayout {
+                title_bar_bounds,
                 activity_bar_bounds: ab_bounds,
                 sidebar_header_bounds: None,
                 sidebar_content_bounds: None,
                 divider_bounds: None,
                 main_content_bounds: main_bounds,
+                bottom_panel_bounds,
+                command_line_bounds,
+                status_bar_bounds,
             };
         }
 
@@ -484,47 +640,55 @@ impl AppShell {
 
         match self.position {
             ShellPosition::Left => {
-                let ab_bounds = Rect::new(area.x, area.y, ab_w, area.height);
+                let ab_bounds = Rect::new(area.x, band_y, ab_w, band_h);
                 let sidebar_x = area.x + ab_w;
-                let header_bounds = Rect::new(sidebar_x, area.y, sidebar_w, header_h);
-                let content_y = area.y + header_h;
-                let content_h = (area.height - header_h).max(0.0);
+                let header_bounds = Rect::new(sidebar_x, band_y, sidebar_w, header_h);
+                let content_y = band_y + header_h;
+                let content_h = (band_h - header_h).max(0.0);
                 let content_bounds = Rect::new(sidebar_x, content_y, sidebar_w, content_h);
                 let div_x = sidebar_x + sidebar_w;
-                let div_bounds = Rect::new(div_x, area.y, divider_w, area.height);
+                let div_bounds = Rect::new(div_x, band_y, divider_w, band_h);
                 let main_x = div_x + divider_w;
                 let main_w = (area.x + area.width - main_x).max(0.0);
-                let main_bounds = Rect::new(main_x, area.y, main_w, area.height);
+                let main_bounds = Rect::new(main_x, band_y, main_w, band_h);
 
                 AppShellLayout {
+                    title_bar_bounds,
                     activity_bar_bounds: ab_bounds,
                     sidebar_header_bounds: Some(header_bounds),
                     sidebar_content_bounds: Some(content_bounds),
                     divider_bounds: Some(div_bounds),
                     main_content_bounds: main_bounds,
+                    bottom_panel_bounds,
+                    command_line_bounds,
+                    status_bar_bounds,
                 }
             }
             ShellPosition::Right => {
                 let ab_x = area.x + area.width - ab_w;
-                let ab_bounds = Rect::new(ab_x.max(area.x), area.y, ab_w, area.height);
+                let ab_bounds = Rect::new(ab_x.max(area.x), band_y, ab_w, band_h);
                 let sidebar_x = ab_x - sidebar_w;
-                let header_bounds = Rect::new(sidebar_x.max(area.x), area.y, sidebar_w, header_h);
-                let content_y = area.y + header_h;
-                let content_h = (area.height - header_h).max(0.0);
+                let header_bounds = Rect::new(sidebar_x.max(area.x), band_y, sidebar_w, header_h);
+                let content_y = band_y + header_h;
+                let content_h = (band_h - header_h).max(0.0);
                 let content_bounds =
                     Rect::new(sidebar_x.max(area.x), content_y, sidebar_w, content_h);
                 let div_x = sidebar_x - divider_w;
-                let div_bounds = Rect::new(div_x.max(area.x), area.y, divider_w, area.height);
+                let div_bounds = Rect::new(div_x.max(area.x), band_y, divider_w, band_h);
                 let main_x = area.x;
                 let main_w = (div_x - area.x).max(0.0);
-                let main_bounds = Rect::new(main_x, area.y, main_w, area.height);
+                let main_bounds = Rect::new(main_x, band_y, main_w, band_h);
 
                 AppShellLayout {
+                    title_bar_bounds,
                     activity_bar_bounds: ab_bounds,
                     sidebar_header_bounds: Some(header_bounds),
                     sidebar_content_bounds: Some(content_bounds),
                     divider_bounds: Some(div_bounds),
                     main_content_bounds: main_bounds,
+                    bottom_panel_bounds,
+                    command_line_bounds,
+                    status_bar_bounds,
                 }
             }
         }
@@ -1082,6 +1246,153 @@ mod tests {
             area(),
         );
         assert_eq!(ev, AppShellEvent::Ignored);
+    }
+
+    // ── Chrome slot layout ─────────────────────────────────────────
+
+    fn full_chrome_shell() -> AppShell {
+        AppShell::new(sample_panels(), 30.0)
+            .with_bottom_items(sample_bottom())
+            .with_title_bar(1.5)
+            .with_bottom_panel(8.0)
+            .with_bottom_panel_limits(3.0, 25.0)
+            .with_command_line()
+            .with_status_bar()
+    }
+
+    #[test]
+    fn chrome_slots_none_when_not_configured() {
+        let s = shell();
+        let l = s.layout(area(), 1.0);
+        assert!(l.title_bar_bounds.is_none());
+        assert!(l.bottom_panel_bounds.is_none());
+        assert!(l.command_line_bounds.is_none());
+        assert!(l.status_bar_bounds.is_none());
+    }
+
+    #[test]
+    fn chrome_slots_present_when_configured() {
+        let s = full_chrome_shell();
+        let l = s.layout(area(), 1.0);
+        assert!(l.title_bar_bounds.is_some());
+        assert!(l.bottom_panel_bounds.is_some());
+        assert!(l.command_line_bounds.is_some());
+        assert!(l.status_bar_bounds.is_some());
+    }
+
+    #[test]
+    fn title_bar_at_top_edge() {
+        let s = full_chrome_shell();
+        let l = s.layout(area(), 1.0);
+        let tb = l.title_bar_bounds.unwrap();
+        assert_eq!(tb.y, 0.0);
+        assert_eq!(tb.x, 0.0);
+        assert_eq!(tb.width, area().width);
+    }
+
+    #[test]
+    fn status_bar_at_bottom_edge() {
+        let s = full_chrome_shell();
+        let l = s.layout(area(), 1.0);
+        let sb = l.status_bar_bounds.unwrap();
+        let sb_bottom = sb.y + sb.height;
+        assert!((sb_bottom - area().height).abs() < 0.01);
+        assert_eq!(sb.width, area().width);
+    }
+
+    #[test]
+    fn command_line_above_status_bar() {
+        let s = full_chrome_shell();
+        let l = s.layout(area(), 1.0);
+        let cl = l.command_line_bounds.unwrap();
+        let sb = l.status_bar_bounds.unwrap();
+        assert!((cl.y + cl.height - sb.y).abs() < 0.01);
+    }
+
+    #[test]
+    fn bottom_panel_above_command_line() {
+        let s = full_chrome_shell();
+        let l = s.layout(area(), 1.0);
+        let bp = l.bottom_panel_bounds.unwrap();
+        let cl = l.command_line_bounds.unwrap();
+        assert!((bp.y + bp.height - cl.y).abs() < 0.01);
+    }
+
+    #[test]
+    fn middle_band_between_title_and_bottom() {
+        let s = full_chrome_shell();
+        let l = s.layout(area(), 1.0);
+        let tb = l.title_bar_bounds.unwrap();
+        let bp = l.bottom_panel_bounds.unwrap();
+        let ab_top = l.activity_bar_bounds.y;
+        let ab_bottom = l.activity_bar_bounds.y + l.activity_bar_bounds.height;
+        assert!((ab_top - (tb.y + tb.height)).abs() < 0.01);
+        assert!((ab_bottom - bp.y).abs() < 0.01);
+    }
+
+    #[test]
+    fn chrome_vertical_no_overlap_no_gap() {
+        let s = full_chrome_shell();
+        let l = s.layout(area(), 1.0);
+        let tb = l.title_bar_bounds.unwrap();
+        let bp = l.bottom_panel_bounds.unwrap();
+        let cl = l.command_line_bounds.unwrap();
+        let sb = l.status_bar_bounds.unwrap();
+        let middle_h = l.activity_bar_bounds.height;
+        let total = tb.height + middle_h + bp.height + cl.height + sb.height;
+        assert!(
+            (total - area().height).abs() < 1.0,
+            "total={total}, expected={}",
+            area().height
+        );
+    }
+
+    #[test]
+    fn bottom_panel_hidden_no_bounds() {
+        let mut s = full_chrome_shell();
+        s.hide_bottom_panel();
+        let l = s.layout(area(), 1.0);
+        assert!(l.bottom_panel_bounds.is_none());
+        assert!(l.command_line_bounds.is_some());
+        assert!(l.status_bar_bounds.is_some());
+    }
+
+    #[test]
+    fn bottom_panel_toggle() {
+        let mut s = full_chrome_shell();
+        assert!(s.bottom_panel_visible());
+        s.toggle_bottom_panel();
+        assert!(!s.bottom_panel_visible());
+        s.toggle_bottom_panel();
+        assert!(s.bottom_panel_visible());
+    }
+
+    #[test]
+    fn set_bottom_panel_height_clamps() {
+        let mut s = full_chrome_shell();
+        s.set_bottom_panel_height(1.0);
+        assert_eq!(s.bottom_panel_height(), 3.0);
+        s.set_bottom_panel_height(999.0);
+        assert_eq!(s.bottom_panel_height(), 25.0);
+    }
+
+    #[test]
+    fn bottom_panel_resize_drag() {
+        let mut s = full_chrome_shell();
+        s.bottom_panel_drag_offset = Some(0.0);
+        let ev = s.handle(
+            &UiEvent::MouseMoved {
+                position: Point::new(40.0, 18.0),
+                buttons: ButtonMask {
+                    left: true,
+                    middle: false,
+                    right: false,
+                },
+            },
+            &MockBackend,
+            area(),
+        );
+        assert!(matches!(ev, AppShellEvent::BottomPanelResized { .. }));
     }
 
     // ── Mock backend for handle() tests ─────────────────────────────

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -765,9 +765,9 @@ impl Backend for GtkBackend {
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_activity_bar called outside enter_frame_scope");
-        // The rasteriser paints from (0, 0) to (width, height); rect.x/y ignored.
-        let _ = rect;
-        crate::gtk::draw_activity_bar(
+        cr.save().ok();
+        cr.translate(rect.x as f64, rect.y as f64);
+        let hits = crate::gtk::draw_activity_bar(
             cr,
             layout,
             rect.width as f64,
@@ -775,7 +775,9 @@ impl Backend for GtkBackend {
             bar,
             &self.current_theme,
             hovered_idx,
-        )
+        );
+        cr.restore().ok();
+        hits
     }
 
     fn status_bar_layout(&self, rect: QRect, bar: &StatusBar) -> crate::StatusBarLayout {

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -15,19 +15,19 @@
 //!   subsequent frame.
 //! - [`crate::Reaction`] dispatch (Continue / Redraw / Exit).
 //!
-//! ## Single vs multi-area
+//! ## Single-DA model (decided: #217 Stage 1)
 //!
-//! The first runner ships with a **single-area** model: one
-//! `DrawingArea`, one `set_draw_func` callback, one
-//! `app.render(backend, AreaId::default())` invocation per redraw.
+//! The runner uses a **single-DrawingArea** model: one DA, one
+//! `set_draw_func`, one `app.render(backend, AreaId::default())` per
+//! redraw. Zone routing (sidebar, main, status bar, etc.) is handled
+//! entirely by `AppShell::compute_layout` + `FrameHitMap` hit-testing
+//! — not by multiple GTK DAs.
 //!
-//! Apps with multiple independently-painted surfaces (vimcode's
-//! per-DrawingArea model with ~20 distinct DAs) need a richer shape.
-//! The associated-type [`crate::AppLogic::AreaId`] is the trait-level
-//! plumbing for that future work — once a multi-area runner ships,
-//! it will pass the AreaId for whichever DA is repainting and the
-//! single trait method body branches on `area`. Stage B (this file)
-//! proves the trait shape end-to-end on the simple case.
+//! This was a deliberate decision (#217). All vimcode paint paths
+//! already go through quadraui primitives (vimcode#446), so per-zone
+//! DAs add GTK widget-tree complexity without benefit. The
+//! `AppLogic::AreaId` associated type remains in the trait as a
+//! compatibility seam but is always `()` in practice.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/quadraui/src/gtk/shell_runner.rs
+++ b/quadraui/src/gtk/shell_runner.rs
@@ -48,6 +48,14 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
                 self.app.on_shell_event(&shell_ev);
                 return Reaction::Redraw;
             }
+            AppShellEvent::BottomPanelResized { .. } => {
+                self.app.on_shell_event(&shell_ev);
+                return Reaction::Redraw;
+            }
+            AppShellEvent::BottomPanelHidden => {
+                self.app.on_shell_event(&shell_ev);
+                return Reaction::Redraw;
+            }
             AppShellEvent::BottomItemClicked { .. } => {
                 self.app.on_shell_event(&shell_ev);
                 return Reaction::Redraw;
@@ -68,11 +76,29 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
 
 /// Run a [`ShellApp`] with AppShell chrome on the GTK backend.
 pub fn run_with_shell<A: ShellApp + 'static>(app: A, config: ShellConfig) {
-    let shell = AppShell::new(config.panels, config.default_sidebar_width)
+    let mut shell = AppShell::new(config.panels, config.default_sidebar_width)
         .with_bottom_items(config.bottom_items)
         .with_min_width(config.min_sidebar_width)
         .with_max_width(config.max_sidebar_width)
         .with_position(config.position);
+
+    if config.has_title_bar {
+        shell = shell.with_title_bar(config.title_bar_height_lh);
+    }
+    if config.has_bottom_panel {
+        shell = shell
+            .with_bottom_panel(config.bottom_panel_height_lh)
+            .with_bottom_panel_limits(
+                config.min_bottom_panel_height_lh,
+                config.max_bottom_panel_height_lh,
+            );
+    }
+    if config.has_command_line {
+        shell = shell.with_command_line();
+    }
+    if config.has_status_bar {
+        shell = shell.with_status_bar();
+    }
 
     let active_panel_id = shell.active_panel_id().cloned();
 

--- a/quadraui/src/runner.rs
+++ b/quadraui/src/runner.rs
@@ -27,16 +27,14 @@
 //! access also gives apps `services()` (clipboard, dialogs) and
 //! `modal_stack_mut()` for free in the event handler.
 //!
-//! # Multi-area shape (#270 Stage B)
+//! # AreaId associated type
 //!
-//! The trait carries an [`AppLogic::AreaId`] associated type so apps
-//! with multiple independently-painted surfaces (typical of GTK with
-//! multiple `DrawingArea` widgets) route paints to the right surface
-//! via [`AppLogic::render(_, area)`].
-//!
-//! Single-area apps (the typical TUI shape — one frame per redraw)
-//! can use `type AreaId = ();` and ignore the parameter. The TUI
-//! runner always passes `Default::default()`.
+//! The trait carries an [`AppLogic::AreaId`] associated type. In
+//! practice all runners (GTK single-DA, TUI) use `type AreaId = ()`
+//! and pass `Default::default()`. The single-DA model was locked in
+//! by #217: zone routing is handled by `AppShell::compute_layout` +
+//! `FrameHitMap` hit-testing, not by multiple GTK DrawingAreas. The
+//! associated type is retained as a compatibility seam.
 
 use crate::backend::Backend;
 use crate::event::UiEvent;
@@ -64,24 +62,10 @@ pub enum Reaction {
 /// and tear-down. The app owns its state (`&mut self`), per-frame
 /// rendering, and event dispatch.
 pub trait AppLogic {
-    /// App-defined identifier for distinct render targets. Single-area
-    /// apps (typical TUI shape) use `type AreaId = ();` and the unit
-    /// type's `Default` impl satisfies the bound. GTK apps with
-    /// multiple `DrawingArea` widgets define a custom enum:
-    ///
-    /// ```ignore
-    /// #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash)]
-    /// enum MyArea {
-    ///     #[default]
-    ///     Editor,
-    ///     Sidebar,
-    ///     StatusBar,
-    /// }
-    /// ```
-    ///
-    /// The TUI runner always passes `Default::default()` to
-    /// [`Self::render`]. Multi-area runners pass the area whose
-    /// surface is being repainted.
+    /// Identifier for distinct render targets. All current runners
+    /// use `type AreaId = ()` — zone routing is handled by
+    /// `AppShell::compute_layout` + `FrameHitMap`, not multiple DAs
+    /// (#217). Retained as a compatibility seam.
     type AreaId: Copy + Eq + std::fmt::Debug + Default;
 
     /// One-time setup hook. Called by the runner after backend

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -20,6 +20,14 @@ pub struct ShellConfig {
     pub min_sidebar_width: f32,
     pub max_sidebar_width: f32,
     pub position: ShellPosition,
+    pub has_title_bar: bool,
+    pub title_bar_height_lh: f32,
+    pub has_bottom_panel: bool,
+    pub bottom_panel_height_lh: f32,
+    pub min_bottom_panel_height_lh: f32,
+    pub max_bottom_panel_height_lh: f32,
+    pub has_command_line: bool,
+    pub has_status_bar: bool,
 }
 
 impl ShellConfig {
@@ -32,6 +40,14 @@ impl ShellConfig {
             min_sidebar_width: 8.0,
             max_sidebar_width: 50.0,
             position: ShellPosition::Left,
+            has_title_bar: false,
+            title_bar_height_lh: 1.5,
+            has_bottom_panel: false,
+            bottom_panel_height_lh: 10.0,
+            min_bottom_panel_height_lh: 3.0,
+            max_bottom_panel_height_lh: 30.0,
+            has_command_line: false,
+            has_status_bar: false,
         }
     }
 
@@ -42,6 +58,34 @@ impl ShellConfig {
 
     pub fn with_position(mut self, position: ShellPosition) -> Self {
         self.position = position;
+        self
+    }
+
+    pub fn with_title_bar(mut self, height_lh: f32) -> Self {
+        self.has_title_bar = true;
+        self.title_bar_height_lh = height_lh;
+        self
+    }
+
+    pub fn with_bottom_panel(mut self, height_lh: f32) -> Self {
+        self.has_bottom_panel = true;
+        self.bottom_panel_height_lh = height_lh;
+        self
+    }
+
+    pub fn with_bottom_panel_limits(mut self, min: f32, max: f32) -> Self {
+        self.min_bottom_panel_height_lh = min;
+        self.max_bottom_panel_height_lh = max;
+        self
+    }
+
+    pub fn with_command_line(mut self) -> Self {
+        self.has_command_line = true;
+        self
+    }
+
+    pub fn with_status_bar(mut self) -> Self {
+        self.has_status_bar = true;
         self
     }
 }
@@ -60,20 +104,32 @@ pub struct ShellContext<'a> {
 impl<'a> ShellContext<'a> {
     /// Check if a mouse position lands inside the sidebar content area.
     pub fn in_sidebar(&self, x: f32, y: f32) -> bool {
-        if let Some(bounds) = self.layout.sidebar_content_bounds {
-            x >= bounds.x
-                && x < bounds.x + bounds.width
-                && y >= bounds.y
-                && y < bounds.y + bounds.height
-        } else {
-            false
-        }
+        rect_contains_opt(self.layout.sidebar_content_bounds, x, y)
     }
 
     /// Check if a mouse position lands inside the main content area.
     pub fn in_main(&self, x: f32, y: f32) -> bool {
-        let b = self.layout.main_content_bounds;
-        x >= b.x && x < b.x + b.width && y >= b.y && y < b.y + b.height
+        rect_contains(self.layout.main_content_bounds, x, y)
+    }
+
+    /// Check if a mouse position lands inside the bottom panel.
+    pub fn in_bottom_panel(&self, x: f32, y: f32) -> bool {
+        rect_contains_opt(self.layout.bottom_panel_bounds, x, y)
+    }
+
+    /// Check if a mouse position lands inside the title bar.
+    pub fn in_title_bar(&self, x: f32, y: f32) -> bool {
+        rect_contains_opt(self.layout.title_bar_bounds, x, y)
+    }
+
+    /// Check if a mouse position lands inside the status bar.
+    pub fn in_status_bar(&self, x: f32, y: f32) -> bool {
+        rect_contains_opt(self.layout.status_bar_bounds, x, y)
+    }
+
+    /// Check if a mouse position lands inside the command line.
+    pub fn in_command_line(&self, x: f32, y: f32) -> bool {
+        rect_contains_opt(self.layout.command_line_bounds, x, y)
     }
 
     /// Sidebar content bounds (convenience for coordinate translation).
@@ -85,6 +141,34 @@ impl<'a> ShellContext<'a> {
     pub fn main_bounds(&self) -> Rect {
         self.layout.main_content_bounds
     }
+
+    /// Bottom panel bounds.
+    pub fn bottom_panel_bounds(&self) -> Option<Rect> {
+        self.layout.bottom_panel_bounds
+    }
+
+    /// Title bar bounds.
+    pub fn title_bar_bounds(&self) -> Option<Rect> {
+        self.layout.title_bar_bounds
+    }
+
+    /// Status bar bounds.
+    pub fn status_bar_bounds(&self) -> Option<Rect> {
+        self.layout.status_bar_bounds
+    }
+
+    /// Command line bounds.
+    pub fn command_line_bounds(&self) -> Option<Rect> {
+        self.layout.command_line_bounds
+    }
+}
+
+fn rect_contains(r: Rect, x: f32, y: f32) -> bool {
+    x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height
+}
+
+fn rect_contains_opt(r: Option<Rect>, x: f32, y: f32) -> bool {
+    r.is_some_and(|r| rect_contains(r, x, y))
 }
 
 /// Application trait for apps that use the AppShell chrome.

--- a/quadraui/src/tui/shell_runner.rs
+++ b/quadraui/src/tui/shell_runner.rs
@@ -48,6 +48,14 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
                 self.app.on_shell_event(&shell_ev);
                 return Reaction::Redraw;
             }
+            AppShellEvent::BottomPanelResized { .. } => {
+                self.app.on_shell_event(&shell_ev);
+                return Reaction::Redraw;
+            }
+            AppShellEvent::BottomPanelHidden => {
+                self.app.on_shell_event(&shell_ev);
+                return Reaction::Redraw;
+            }
             AppShellEvent::BottomItemClicked { .. } => {
                 self.app.on_shell_event(&shell_ev);
                 return Reaction::Redraw;
@@ -68,11 +76,29 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
 
 /// Run a [`ShellApp`] with AppShell chrome on the TUI backend.
 pub fn run_with_shell<A: ShellApp + 'static>(app: A, config: ShellConfig) {
-    let shell = AppShell::new(config.panels, config.default_sidebar_width)
+    let mut shell = AppShell::new(config.panels, config.default_sidebar_width)
         .with_bottom_items(config.bottom_items)
         .with_min_width(config.min_sidebar_width)
         .with_max_width(config.max_sidebar_width)
         .with_position(config.position);
+
+    if config.has_title_bar {
+        shell = shell.with_title_bar(config.title_bar_height_lh);
+    }
+    if config.has_bottom_panel {
+        shell = shell
+            .with_bottom_panel(config.bottom_panel_height_lh)
+            .with_bottom_panel_limits(
+                config.min_bottom_panel_height_lh,
+                config.max_bottom_panel_height_lh,
+            );
+    }
+    if config.has_command_line {
+        shell = shell.with_command_line();
+    }
+    if config.has_status_bar {
+        shell = shell.with_status_bar();
+    }
 
     let active_panel_id = shell.active_panel_id().cloned();
 


### PR DESCRIPTION
## Summary

- **Stage 1 — single-DA decision**: locks in single-DrawingArea model for the GTK runner. Zone routing handled by `AppShell::compute_layout` + `FrameHitMap`, not multiple GTK DAs. Updated `runner.rs` and `gtk/run.rs` docs to reflect the decided architecture (#217 Gap 1).
- **Stage 2 — chrome slots**: extends `AppShellLayout` with four new `Option<Rect>` slots: `title_bar_bounds`, `bottom_panel_bounds`, `command_line_bounds`, `status_bar_bounds`. `ShellConfig` and `AppShell` gain matching builder methods. Bottom panel supports resize drag with min/max clamping. Both GTK and TUI shell runners apply the new config.
- Ships `gtk_full_chrome_demo` + `tui_full_chrome_demo` examples proving all four slots with click detection and bottom panel resize.

## Test plan

- [x] 755 tests pass (was 743 — 12 new chrome slot tests)
- [x] `cargo clippy --features tui` and `--features gtk` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo build --features gtk --example gtk_full_chrome_demo` — builds
- [ ] Smoke test: `cargo run --features gtk --example gtk_full_chrome_demo` — verify title bar, activity bar, sidebar, main, bottom panel, command line, status bar all visible; bottom panel resize drag works; click detection reports correct zone

Closes #217 (Stage 1 + Stage 2). Stages 3 (multi-panel sidebar ergonomics) and 4 (file dialog / PlatformServices) tracked as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)