### PR TITLE
fix(quadraui): replace is_nerd_wide() with unicode-width crate (#206)

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [features]
 # Public TUI rasterisers in `quadraui::tui`. Pulls in ratatui.
-tui = ["dep:ratatui", "dep:arboard"]
+tui = ["dep:ratatui", "dep:arboard", "dep:unicode-width"]
 
 # Public GTK rasterisers in `quadraui::gtk`. Pulls in gtk4 + pangocairo.
 gtk = ["dep:gtk4", "dep:pangocairo", "dep:arboard"]
@@ -47,6 +47,7 @@ gtk4 = { version = "0.7", features = ["v4_10"], optional = true }
 pangocairo = { version = "0.18", optional = true }
 # Optional — pulled in by the `tui` feature.
 ratatui = { version = "0.29", optional = true }
+unicode-width = { version = "0.2", optional = true }
 # Optional — pulled in by `tui` and `gtk` for system clipboard access.
 arboard = { version = "3", optional = true }
 

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -133,12 +133,17 @@ fn set_cell_wide(buf: &mut Buffer, x: u16, y: u16, ch: char, fg: RatatuiColor, b
 }
 
 /// Terminal cell width of a character. Uses the `unicode-width` crate's
-/// UAX#11 tables, which match what most terminals do internally. Returns
-/// 1 for unassigned / PUA codepoints (including Nerd Font glyphs) since
-/// `UnicodeWidthChar::width()` returns `None` for those — most terminals
-/// render PUA glyphs as single-width unless overridden by a font config.
+/// UAX#11 tables, with a range-based fallback for the Nerd Font
+/// Supplement PUA range (`U+F0000`–`U+F9999`) which terminals render
+/// as double-width but `unicode-width` returns `None` for.
 fn cell_width(c: char) -> u16 {
-    unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) as u16
+    unicode_width::UnicodeWidthChar::width(c).unwrap_or(
+        if ('\u{F0000}'..='\u{F9999}').contains(&c) {
+            2
+        } else {
+            1
+        },
+    ) as u16
 }
 
 /// Convert a `quadraui::Color` to a ratatui palette colour, with `qc` as

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -132,6 +132,15 @@ fn set_cell_wide(buf: &mut Buffer, x: u16, y: u16, ch: char, fg: RatatuiColor, b
     }
 }
 
+/// Terminal cell width of a character. Uses the `unicode-width` crate's
+/// UAX#11 tables, which match what most terminals do internally. Returns
+/// 1 for unassigned / PUA codepoints (including Nerd Font glyphs) since
+/// `UnicodeWidthChar::width()` returns `None` for those — most terminals
+/// render PUA glyphs as single-width unless overridden by a font config.
+fn cell_width(c: char) -> u16 {
+    unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) as u16
+}
+
 /// Convert a `quadraui::Color` to a ratatui palette colour, with `qc` as
 /// the short name internal modules use (mirrors vimcode's tui rasteriser
 /// helper of the same name).

--- a/quadraui/src/tui/status_bar.rs
+++ b/quadraui/src/tui/status_bar.rs
@@ -11,7 +11,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::{Position, Rect};
 use ratatui::style::{Modifier, Style};
 
-use super::{ratatui_color, set_cell};
+use super::{cell_width, ratatui_color, set_cell, set_cell_wide};
 use crate::primitives::status_bar::{StatusBar, StatusBarLayout, StatusSegmentSide};
 use crate::theme::Theme;
 use crate::types::WidgetId;
@@ -97,13 +97,18 @@ pub fn draw_status_bar(
             if cx >= bar_end {
                 break;
             }
-            set_cell(buf, cx, y, ch, fg, bg);
+            let w = cell_width(ch);
+            if w == 2 && cx + 1 < bar_end {
+                set_cell_wide(buf, cx, y, ch, fg, bg);
+            } else {
+                set_cell(buf, cx, y, ch, fg, bg);
+            }
             if seg.bold {
                 if let Some(cell) = buf.cell_mut(Position::new(cx, y)) {
                     cell.set_style(Style::default().add_modifier(Modifier::BOLD));
                 }
             }
-            cx += 1;
+            cx += w;
         }
     }
     layout.clone()

--- a/quadraui/src/tui/tab_bar.rs
+++ b/quadraui/src/tui/tab_bar.rs
@@ -11,7 +11,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Modifier;
 
-use super::{ratatui_color, set_cell, set_cell_styled, set_cell_wide};
+use super::{cell_width, ratatui_color, set_cell, set_cell_styled, set_cell_wide};
 use crate::primitives::tab_bar::{TabBar, TabBarHits, TabBarLayout};
 use crate::theme::Theme;
 
@@ -25,20 +25,6 @@ pub const TAB_CLOSE_CHAR: char = '×';
 /// layout pass this as the `close_width` so the layout reserves the
 /// right amount of trailing space.
 pub const TAB_CLOSE_COLS: u16 = 2;
-
-/// Narrow hardcoded set of Private Use Area glyphs that render as 2
-/// cells in terminals and therefore need [`set_cell_wide`]. The wide-glyph
-/// predicate is empirical — extend this list as new wide Nerd Font
-/// icons appear in tab bars / status bars.
-fn is_nerd_wide(c: char) -> bool {
-    matches!(
-        c,
-        '\u{F0932}' // SPLIT_RIGHT
-        | '\u{F0143}' // DIFF_PREV
-        | '\u{F0140}' // DIFF_NEXT
-        | '\u{F0233}' // DIFF_FOLD
-    )
-}
 
 /// Draw a [`TabBar`] into `area` on `buf`. Returns the **tab-content
 /// width** in cells (`area.width - reserved_by_right_segments`) so
@@ -57,8 +43,8 @@ fn is_nerd_wide(c: char) -> bool {
 /// - **Preview tab:** `*_preview_*_fg` and [`Modifier::ITALIC`]; combines
 ///   with the underline accent when active.
 /// - **Right segments:** painted in `tab_inactive_fg` (or
-///   `tab_active_fg` when `seg.is_active`). Glyphs in the
-///   wide-Nerd-Font set use [`set_cell_wide`].
+///   `tab_active_fg` when `seg.is_active`). Double-width glyphs
+///   (per `unicode-width`) use [`set_cell_wide`].
 pub fn draw_tab_bar(
     buf: &mut Buffer,
     area: Rect,
@@ -101,10 +87,8 @@ pub fn draw_tab_bar(
             if cx >= seg_end {
                 break;
             }
-            if ch == ' ' {
-                set_cell(buf, cx, area.y, ' ', fg, bar_bg);
-                cx += 1;
-            } else if is_nerd_wide(ch) {
+            let w = cell_width(ch);
+            if w == 2 {
                 if cx + 1 < seg_end + 1 {
                     set_cell_wide(buf, cx, area.y, ch, fg, bar_bg);
                     cx += 2;


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 4-glyph `is_nerd_wide()` allowlist in `tui/tab_bar.rs` with a shared `cell_width()` helper backed by the `unicode-width` crate (UAX#11 tables).
- Adds `unicode-width = "0.2"` as an optional dependency gated on the `tui` feature (already a transitive dep via ratatui).
- Fixes `tui/status_bar.rs` which assumed all characters were single-width — double-width glyphs now use `set_cell_wide` and advance cursor by actual width.

## Test plan

- [x] 755 tests pass (both `--features tui` and `--features gtk`)
- [x] `cargo clippy` clean on both feature sets
- [x] `cargo fmt --check` clean
- [ ] Downstream: vimcode with `:set nerdfonts` — diff toolbar clicks should land on correct segments

Closes #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)