### PR TITLE
fix(quadraui): GTK context menu uses rounded-rect border (#209)

### DIFF
--- a/quadraui/src/gtk/context_menu.rs
+++ b/quadraui/src/gtk/context_menu.rs
@@ -1,7 +1,7 @@
 //! GTK rasteriser for [`crate::ContextMenu`].
 //!
 //! Cairo + Pango equivalent of `quadraui::tui::draw_context_menu`.
-//! Draws a rectangle (background fill + 1 px stroke border), then
+//! Draws a rounded rectangle (3px corner radius, bg fill + 1 px stroke), then
 //! per-item rows (selection bg for the focused item, separator as a
 //! thin horizontal line, optional right-aligned shortcut text).
 //!
@@ -13,7 +13,7 @@ use gtk4::cairo::Context;
 use gtk4::pango;
 use pangocairo::functions as pcfn;
 
-use super::cairo_rgb;
+use super::{cairo_rgb, rounded_rect_path};
 use crate::accelerator::{render_accelerator, Platform};
 use crate::primitives::context_menu::{ContextMenu, ContextMenuItem, ContextMenuLayout};
 use crate::theme::Theme;
@@ -63,8 +63,9 @@ pub fn draw_context_menu(
     let sel = cairo_rgb(theme.selected_bg);
     let dim = cairo_rgb(theme.muted_fg);
 
+    let radius = 3.0;
+    rounded_rect_path(cr, bx, by, bw, bh, radius);
     cr.set_source_rgb(bg.0, bg.1, bg.2);
-    cr.rectangle(bx, by, bw, bh);
     cr.fill().ok();
 
     let mut rects: Vec<(f64, f64, f64, f64, WidgetId)> = Vec::new();
@@ -146,9 +147,9 @@ pub fn draw_context_menu(
     }
 
     // Pass 3: border on top so selection bg never obscures edges.
+    rounded_rect_path(cr, bx + 0.5, by + 0.5, bw - 1.0, bh - 1.0, radius);
     cr.set_source_rgb(border.0, border.1, border.2);
     cr.set_line_width(1.0);
-    cr.rectangle(bx + 0.5, by + 0.5, bw - 1.0, bh - 1.0);
     cr.stroke().ok();
 
     rects

--- a/quadraui/src/gtk/list.rs
+++ b/quadraui/src/gtk/list.rs
@@ -13,7 +13,7 @@ use gtk4::cairo::Context;
 use gtk4::pango;
 use pangocairo::functions as pcfn;
 
-use super::cairo_rgb;
+use super::{cairo_rgb, rounded_rect_path};
 use crate::primitives::list::{ListItemMeasure, ListView};
 use crate::theme::Theme;
 use crate::types::Decoration;
@@ -243,14 +243,4 @@ pub fn draw_list(
     }
 
     layout.set_attributes(None);
-}
-
-fn rounded_rect_path(cr: &Context, x: f64, y: f64, w: f64, h: f64, r: f64) {
-    use std::f64::consts::{FRAC_PI_2, PI};
-    cr.new_path();
-    cr.arc(x + w - r, y + r, r, -FRAC_PI_2, 0.0);
-    cr.arc(x + w - r, y + h - r, r, 0.0, FRAC_PI_2);
-    cr.arc(x + r, y + h - r, r, FRAC_PI_2, PI);
-    cr.arc(x + r, y + r, r, PI, 3.0 * FRAC_PI_2);
-    cr.close_path();
 }

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -112,6 +112,19 @@ pub fn set_source(cr: &Context, c: Color) {
     cr.set_source_rgb(r, g, b);
 }
 
+/// Build a closed rounded-rectangle Cairo path with corner radius `r`.
+/// Used by rasterisers that need bordered/clipped rounded rects
+/// (context menu, list view, command center).
+pub(crate) fn rounded_rect_path(cr: &Context, x: f64, y: f64, w: f64, h: f64, r: f64) {
+    use std::f64::consts::{FRAC_PI_2, PI};
+    cr.new_path();
+    cr.arc(x + w - r, y + r, r, -FRAC_PI_2, 0.0);
+    cr.arc(x + w - r, y + h - r, r, 0.0, FRAC_PI_2);
+    cr.arc(x + r, y + h - r, r, FRAC_PI_2, PI);
+    cr.arc(x + r, y + r, r, PI, 3.0 * FRAC_PI_2);
+    cr.close_path();
+}
+
 /// Re-export so apps can name the Pango layout type without depending
 /// on `gtk4::pango` directly.
 pub use pango::Layout as PangoLayout;


### PR DESCRIPTION
## Summary

- Replaces the square `cr.rectangle` stroke in `draw_context_menu` with a 3px rounded-rect path, matching ListView's bordered mode (#207).
- Extracts `rounded_rect_path` to a shared `pub(crate)` helper in `gtk/mod.rs` — deduplicates the private copy from `list.rs`.
- Both bg fill and border stroke now use the rounded path, so corner pixels outside the arcs aren't filled.

## Test plan

- [x] `cargo build --features gtk` — builds
- [x] `cargo test --features gtk` — 755 tests pass
- [x] `cargo clippy --features gtk` — clean
- [x] `cargo fmt --check` — clean
- [ ] Visual: right-click in a GTK example/vimcode — context menu should have rounded corners

Closes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)