### PR TITLE
feat: add AppLogic::tick() for timer-driven updates

### DIFF
--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -276,6 +276,17 @@ fn activate<A: AppLogic + 'static>(
             };
             apply_reaction(reaction, &drain_da, &drain_window);
         }
+
+        // Periodic tick — called after every queue drain, including
+        // idle ticks where no events arrived. Lets apps drive timer
+        // logic without synthetic event injection.
+        let tick_reaction = {
+            let mut backend_mut = backend.borrow_mut();
+            let mut app_mut = app.borrow_mut();
+            app_mut.tick(&mut *backend_mut)
+        };
+        apply_reaction(tick_reaction, &drain_da, &drain_window);
+
         glib::ControlFlow::Continue
     });
 

--- a/quadraui/src/runner.rs
+++ b/quadraui/src/runner.rs
@@ -109,4 +109,16 @@ pub trait AppLogic {
     /// [`UiEvent`] returned from `backend.wait_events`. Returns a
     /// [`Reaction`] telling the runner what to do next.
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction;
+
+    /// Periodic tick. Called by the runner after each event batch
+    /// (including batches where no events arrived — i.e. on every
+    /// `wait_events` timeout). Apps implement this for timer logic,
+    /// auto-refresh, background-task polling, etc., without needing
+    /// synthetic event injection.
+    ///
+    /// Default impl is a no-op so apps that don't need periodic
+    /// callbacks don't have to write boilerplate.
+    fn tick(&mut self, _backend: &mut dyn Backend) -> Reaction {
+        Reaction::Continue
+    }
 }

--- a/quadraui/src/tui/run.rs
+++ b/quadraui/src/tui/run.rs
@@ -142,6 +142,15 @@ fn run_inner<A: AppLogic>(
                 Reaction::Exit => return Ok(()),
             }
         }
+
+        // Periodic tick — called after every event batch (including
+        // timeout-triggered empty batches). Lets apps drive timer
+        // logic without synthetic event injection.
+        match app.tick(backend) {
+            Reaction::Continue => {}
+            Reaction::Redraw => needs_redraw = true,
+            Reaction::Exit => return Ok(()),
+        }
     }
 }
 


### PR DESCRIPTION
Closes #236.

## Summary
- Adds `tick(&mut self, backend: &mut dyn Backend) -> Reaction` to `AppLogic` trait with default no-op returning `Reaction::Continue`
- TUI runner calls `tick()` after each `wait_events()` batch, regardless of whether events arrived
- GTK runner calls `tick()` after each idle drain cycle
- Apps can now implement periodic timers without synthetic event injection

## Test plan
- [ ] `cargo build` succeeds
- [ ] `cargo test` passes
- [ ] Apps not implementing `tick()` behave identically (default no-op)
- [ ] coord-tui can replace its custom event loop workaround with `quadraui::tui::run()` + `tick()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)