### PR TITLE
shell: add ShellApp::tick() and forward from ShellAdapter

### DIFF
--- a/quadraui/src/gtk/shell_runner.rs
+++ b/quadraui/src/gtk/shell_runner.rs
@@ -72,6 +72,10 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         };
         self.app.handle(event, backend, &ctx)
     }
+
+    fn tick(&mut self, backend: &mut dyn Backend) -> Reaction {
+        self.app.tick(backend)
+    }
 }
 
 /// Run a [`ShellApp`] with AppShell chrome on the GTK backend.

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -195,4 +195,12 @@ pub trait ShellApp {
     /// Notified when a panel switch occurs (activity bar click or
     /// programmatic). Optional.
     fn on_shell_event(&mut self, _event: &AppShellEvent) {}
+
+    /// Periodic callback invoked by the runner on every frame (≈60Hz on
+    /// the TUI backend, GTK timeout on GTK). Use for timer-driven work —
+    /// polling background tasks, expiring caches, draining channels —
+    /// that must happen without a user input event. Default is no-op.
+    fn tick(&mut self, _backend: &mut dyn Backend) -> Reaction {
+        Reaction::Continue
+    }
 }

--- a/quadraui/src/tui/shell_runner.rs
+++ b/quadraui/src/tui/shell_runner.rs
@@ -72,6 +72,10 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         };
         self.app.handle(event, backend, &ctx)
     }
+
+    fn tick(&mut self, backend: &mut dyn Backend) -> Reaction {
+        self.app.tick(backend)
+    }
 }
 
 /// Run a [`ShellApp`] with AppShell chrome on the TUI backend.


### PR DESCRIPTION
Closes the coord-tui side of the Watch-overlay freeze (claude-coordinator#202).

## Why

\`ShellAdapter\` adapts \`ShellApp\` to \`AppLogic\` for the runner, but it inherited the default no-op \`AppLogic::tick()\`. The runner calls \`tick()\` after every event batch (including timeout-triggered empty batches at ~60Hz), but the call never reached the inner ShellApp.

Result: ShellApp consumers had no way to do periodic work — cache expiry, log polling, background-task draining — without a user input event. coord-tui's Watch overlay notoriously froze without keypresses for exactly this reason.

## Changes

- Add \`fn tick(&mut self, _backend: &mut dyn Backend) -> Reaction\` to the \`ShellApp\` trait (default \`Reaction::Continue\`).
- Have both \`ShellAdapter\` impls (TUI and GTK) forward to \`self.app.tick(backend)\`.

## Test plan

- [x] \`cargo build --workspace\` — clean
- [x] \`cargo test --workspace\` — clean
- Default no-op means zero impact on existing consumers; opt-in for new periodic work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)