### PR TITLE
pipeline_view: add StageStatus::Stale variant

### DIFF
--- a/quadraui/src/gtk/pipeline_view.rs
+++ b/quadraui/src/gtk/pipeline_view.rs
@@ -193,6 +193,7 @@ fn status_icon_text(stage: &crate::primitives::pipeline_view::PipelineStage) -> 
         StageStatus::Failed => "✗",
         StageStatus::Pending => "·",
         StageStatus::Skipped => "─",
+        StageStatus::Stale => "↻",
     }
 }
 
@@ -206,5 +207,6 @@ fn status_icon_color(
         StageStatus::Failed => theme.error_fg,
         StageStatus::Pending => theme.muted_fg,
         StageStatus::Skipped => theme.muted_fg,
+        StageStatus::Stale => theme.muted_fg,
     }
 }

--- a/quadraui/src/macos/pipeline_view.rs
+++ b/quadraui/src/macos/pipeline_view.rs
@@ -171,6 +171,7 @@ fn status_icon_text(stage: &crate::primitives::pipeline_view::PipelineStage) -> 
         StageStatus::Failed => "✗",
         StageStatus::Pending => "·",
         StageStatus::Skipped => "─",
+        StageStatus::Stale => "↻",
     }
 }
 
@@ -184,6 +185,7 @@ fn status_icon_color(
         StageStatus::Failed => theme.error_fg,
         StageStatus::Pending => theme.muted_fg,
         StageStatus::Skipped => theme.muted_fg,
+        StageStatus::Stale => theme.muted_fg,
     }
 }
 

--- a/quadraui/src/primitives/pipeline_view.rs
+++ b/quadraui/src/primitives/pipeline_view.rs
@@ -46,6 +46,11 @@ pub enum StageStatus {
     Failed,
     /// Intentionally bypassed — rendered with strikethrough / grey dash (─).
     Skipped,
+    /// Previously completed (or failed), but an upstream stage has since been
+    /// re-dispatched — the result is against an older revision and should not
+    /// be trusted. Distinct from Pending ("never run") and Done ("trustworthy").
+    /// Rendered dim with an `↻` icon to suggest re-running.
+    Stale,
 }
 
 /// A single stage in a [`PipelineView`].

--- a/quadraui/src/tui/pipeline_view.rs
+++ b/quadraui/src/tui/pipeline_view.rs
@@ -81,7 +81,9 @@ pub fn draw_pipeline_view(
             StageStatus::Active => ratatui_color(theme.accent_bg),
             StageStatus::Done => ratatui_color(theme.git_added),
             StageStatus::Failed => ratatui_color(theme.error_fg),
-            StageStatus::Pending | StageStatus::Skipped => border_normal,
+            // Stale gets a dim border so it visually retreats — the prior
+            // verdict is shown but de-emphasised to signal "no longer trusted."
+            StageStatus::Stale | StageStatus::Pending | StageStatus::Skipped => border_normal,
         };
         let border_col = if is_focused { border_focus } else { status_border };
 
@@ -216,6 +218,9 @@ fn status_icon(
         StageStatus::Failed => ('✗', ratatui_color(theme.error_fg)),
         StageStatus::Pending => ('·', ratatui_color(theme.muted_fg)),
         StageStatus::Skipped => ('─', ratatui_color(theme.muted_fg)),
+        // ↻ suggests re-running. Stale renders dim like Pending so its
+        // prior verdict doesn't compete with a fresh Done downstream.
+        StageStatus::Stale => ('↻', ratatui_color(theme.muted_fg)),
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a fifth \`StageStatus\` variant — \`Stale\` — for stages where a previously-completed result has been invalidated by an upstream re-dispatch.

Renderers (TUI / GTK / macOS) display Stale with the \`↻\` glyph in \`muted_fg\` so the prior verdict visually retreats without disappearing. Existing match arms updated to stay exhaustive.

Host application use case: claude-coordinator's pipeline (companion PR follows) — when a Review against an older Work output is shown as Done, the user can't tell whether the verdict still applies after Work was re-run. Stale gives the host a way to express "previously run, no longer trustworthy" without lying (Done) or forgetting (Pending).

## Test plan
- [x] \`cargo build\` — clean across all backends
- [x] \`cargo test\` — 586 pass (no regressions)
- [ ] Live verification — visual check pending host-app companion PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)