### PR TITLE
#233: Add Backend::set_theme to the trait surface

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -62,6 +62,18 @@ pub trait Backend {
     /// Flush the current frame to screen.
     fn end_frame(&mut self);
 
+    // ─── Theming ───────────────────────────────────────────────────────
+    /// Set the active [`crate::Theme`] on the backend.
+    ///
+    /// Apps that use a single theme call this once from `setup()`; apps
+    /// that vary the theme per-pane call it at the start of each pane's
+    /// render pass (e.g. to darken the background of a detail pane).
+    ///
+    /// Default: no-op. Backends that carry a `current_theme` field
+    /// (TUI, GTK, macOS) override this to store the value so subsequent
+    /// `draw_*` calls consume the updated palette.
+    fn set_theme(&mut self, _theme: crate::Theme) {}
+
     // ─── Events + keybindings ──────────────────────────────────────────
     /// Drain all queued native events. Returns a fully-translated
     /// `Vec<UiEvent>` ready for app dispatch. Never blocks.

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -487,6 +487,10 @@ impl Backend for GtkBackend {
         // explicit flush.
     }
 
+    fn set_theme(&mut self, theme: crate::Theme) {
+        self.set_current_theme(theme);
+    }
+
     fn poll_events(&mut self) -> Vec<UiEvent> {
         // Drain the queue without blocking. Stage 4 wires up the
         // signal-callback producers; until then this is always empty.

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -254,6 +254,10 @@ impl Backend for MacBackend {
         // flush.
     }
 
+    fn set_theme(&mut self, theme: Theme) {
+        self.set_current_theme(theme);
+    }
+
     fn poll_events(&mut self) -> Vec<UiEvent> {
         self.events.borrow_mut().drain(..).collect()
     }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -352,6 +352,10 @@ impl Backend for TuiBackend {
         // exists for parity with backends that need explicit flush.
     }
 
+    fn set_theme(&mut self, theme: crate::Theme) {
+        self.set_current_theme(theme);
+    }
+
     fn poll_events(&mut self) -> Vec<UiEvent> {
         // Drain every queued crossterm event; never blocks. Each
         // native event translates to zero, one, or more `UiEvent`s
@@ -1149,6 +1153,7 @@ mod tests {
         modal_stack: ModalStack,
         services: MockServices,
         viewport: Viewport,
+        theme: crate::Theme,
     }
 
     impl MockBackend {
@@ -1158,6 +1163,7 @@ mod tests {
                 modal_stack: ModalStack::new(),
                 services: MockServices::new(),
                 viewport: Viewport::new(80.0, 24.0, 1.0),
+                theme: crate::Theme::default(),
             }
         }
     }
@@ -1170,6 +1176,9 @@ mod tests {
             self.viewport = viewport;
         }
         fn end_frame(&mut self) {}
+        fn set_theme(&mut self, theme: crate::Theme) {
+            self.theme = theme;
+        }
         fn poll_events(&mut self) -> Vec<UiEvent> {
             Vec::new()
         }


### PR DESCRIPTION
Automated merge from the coordinator for assignment 32d7ff99b684 on issue #233.

Worker branch: `issue-233-add-backend-set-theme-to-the-trait-surfa` → `main`.