### PR TITLE
#265: PipelineView: focus border masks status colour — use a separate indicator

### DIFF
--- a/quadraui/src/gtk/pipeline_view.rs
+++ b/quadraui/src/gtk/pipeline_view.rs
@@ -35,6 +35,8 @@ const CORNER_RADIUS: f64 = 4.0;
 const H_PAD: f64 = 8.0;
 /// Border width for stage box outline.
 const BORDER_WIDTH: f64 = 1.0;
+/// Height reserved above stage boxes for the focus indicator (pixels).
+const GTK_FOCUS_INDICATOR_H: f64 = 8.0;
 
 /// Compute the GTK pixel-unit layout for a [`PipelineView`] without painting.
 pub fn gtk_pipeline_view_layout(
@@ -51,8 +53,13 @@ pub fn gtk_pipeline_view_layout(
     };
     view.layout(
         x as f32,
-        y as f32,
-        PipelineViewMeasure::new(w as f32, h as f32, GTK_ARROW_WIDTH_PX, action_h),
+        (y + GTK_FOCUS_INDICATOR_H) as f32,
+        PipelineViewMeasure::new(
+            w as f32,
+            (h - GTK_FOCUS_INDICATOR_H).max(0.0) as f32,
+            GTK_ARROW_WIDTH_PX,
+            action_h,
+        ),
     )
 }
 
@@ -93,16 +100,31 @@ pub fn draw_pipeline_view(
         rounded_rect_path(cr, bx, by, bw, bh, CORNER_RADIUS);
         cr.fill().ok();
 
-        // ── Box border ───────────────────────────────────────────────────
-        let border_color = if is_focused {
-            theme.accent_bg
-        } else {
-            theme.muted_fg
+        // ── Box border (per-status colour; focus uses an above-box indicator) ──
+        let border_color = match stage.status {
+            StageStatus::Active => theme.accent_bg,
+            StageStatus::Done => theme.git_added,
+            StageStatus::Failed => theme.error_fg,
+            StageStatus::Stale | StageStatus::Pending | StageStatus::Skipped => theme.muted_fg,
         };
         set_source(cr, border_color);
         cr.set_line_width(BORDER_WIDTH);
         rounded_rect_path(cr, bx, by, bw, bh, CORNER_RADIUS);
         cr.stroke().ok();
+
+        // ── Focus indicator (small ▼ triangle above the box) ─────────────
+        if is_focused {
+            let ind_x = bx + bw / 2.0;
+            let tri_tip_y = by - 1.0;
+            let tri_base_y = by - GTK_FOCUS_INDICATOR_H + 1.0;
+            let tri_half_w = 5.0;
+            set_source(cr, theme.muted_fg);
+            cr.move_to(ind_x, tri_tip_y);
+            cr.line_to(ind_x - tri_half_w, tri_base_y);
+            cr.line_to(ind_x + tri_half_w, tri_base_y);
+            cr.close_path();
+            cr.fill().ok();
+        }
 
         // ── Status icon (top third of box) ───────────────────────────────
         let icon_text = status_icon_text(stage);

--- a/quadraui/src/gtk/pipeline_view.rs
+++ b/quadraui/src/gtk/pipeline_view.rs
@@ -51,6 +51,11 @@ pub fn gtk_pipeline_view_layout(
     } else {
         0.0
     };
+    // Note: the returned layout (incl. `bounds`) is offset down by
+    // `GTK_FOCUS_INDICATOR_H`, so `bounds.y` starts below the reserved caret
+    // strip. The focus caret is painted in the gap between the passed-in `y`
+    // and `bounds.y`; a host that clips drawing to `layout.bounds` would clip
+    // the caret — clip to the original `(y, h)` instead.
     view.layout(
         x as f32,
         (y + GTK_FOCUS_INDICATOR_H) as f32,
@@ -230,5 +235,192 @@ fn status_icon_color(
         StageStatus::Pending => theme.muted_fg,
         StageStatus::Skipped => theme.muted_fg,
         StageStatus::Stale => theme.muted_fg,
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+//
+// Headless painted-indicator tests (mirror the TUI tests in
+// `tui/pipeline_view.rs`). They verify two state-derived geometry facts that
+// this primitive's focus decoupling depends on:
+//
+//   1. A focused stage paints the `▼` caret in the reserved strip above the
+//      box (and an unfocused stage leaves that strip blank).
+//   2. The box border renders in the per-status colour (`git_added` for Done)
+//      rather than the focus accent (`accent_bg`).
+//
+// Uses a Cairo `ImageSurface` (no display required) and reads back pixels
+// directly, following the established pattern in `gtk/tab_bar.rs`. Gated on the
+// `gtk` feature so it only runs under `cargo test --features gtk`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::pipeline_view::{PipelineStage, PipelineViewLayout};
+    use crate::types::WidgetId;
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    // Surface large enough to contain the box plus the reserved caret strip.
+    const W: i32 = 240;
+    const H: i32 = 80;
+    const X: f64 = 20.0;
+    const Y: f64 = 20.0;
+    const BOX_W: f64 = 200.0;
+    const BOX_H: f64 = 50.0;
+
+    /// Read an RGB triple from an ARgb32 surface at pixel (x, y).
+    ///
+    /// Cairo's `ARgb32` stores each pixel as four bytes in native
+    /// (little-endian) byte order: [B, G, R, A]. `stride` is in bytes and may
+    /// include padding. All pixels painted here are opaque, so premultiplied
+    /// and straight alpha coincide.
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    /// Squared Euclidean distance between two RGB triples.
+    fn dist2(a: (u8, u8, u8), b: (u8, u8, u8)) -> i64 {
+        let dr = a.0 as i64 - b.0 as i64;
+        let dg = a.1 as i64 - b.1 as i64;
+        let db = a.2 as i64 - b.2 as i64;
+        dr * dr + dg * dg + db * db
+    }
+
+    /// Find the most-chromatic pixel (max channel spread) in an inclusive
+    /// rectangular region. Used to locate the coloured border line, which is a
+    /// 1px antialiased stroke blended with its surroundings.
+    fn most_chromatic(
+        data: &[u8],
+        stride: usize,
+        x0: i32,
+        y0: i32,
+        x1: i32,
+        y1: i32,
+    ) -> (u8, u8, u8) {
+        let mut best = (0u8, 0u8, 0u8);
+        let mut best_chroma = -1i32;
+        for y in y0..=y1 {
+            for x in x0..=x1 {
+                let (r, g, b) = pixel(data, stride, x, y);
+                let chroma = r.max(g).max(b) as i32 - r.min(g).min(b) as i32;
+                if chroma > best_chroma {
+                    best_chroma = chroma;
+                    best = (r, g, b);
+                }
+            }
+        }
+        best
+    }
+
+    fn make_view() -> PipelineView {
+        PipelineView {
+            id: WidgetId::new("pipe"),
+            stages: vec![PipelineStage {
+                label: "Build".into(),
+                status: StageStatus::Done,
+                action: None,
+            }],
+            focused_stage: None,
+        }
+    }
+
+    /// Paint a single Done stage into a fresh white surface with the given
+    /// focus state. Returns the surface and the resolved layout so tests can
+    /// derive box geometry rather than hardcoding it.
+    fn paint(focused: Option<usize>) -> (ImageSurface, PipelineViewLayout) {
+        let surface = ImageSurface::create(Format::ARgb32, W, H).expect("create ImageSurface");
+        let layout;
+        {
+            let cr = Context::new(&surface).expect("Context::new");
+            // White background so any untouched pixel is clearly white.
+            cr.set_source_rgb(1.0, 1.0, 1.0);
+            cr.paint().ok();
+
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            let mut view = make_view();
+            view.focused_stage = focused;
+            layout = draw_pipeline_view(
+                &cr,
+                &pango_layout,
+                X,
+                Y,
+                BOX_W,
+                BOX_H,
+                &view,
+                &Theme::default(),
+            );
+        }
+        (surface, layout)
+    }
+
+    /// Centroid of the `▼` caret painted above the box: tip at `by - 1`, base
+    /// at `by - 7`, so the centroid sits at `by - 5` on the box centre column.
+    fn caret_centroid(layout: &PipelineViewLayout) -> (i32, i32) {
+        let bb = layout.stages[0].box_bounds;
+        let cx = (bb.x + bb.width / 2.0).round() as i32;
+        let cy = (bb.y as f64 - 5.0).round() as i32;
+        (cx, cy)
+    }
+
+    /// Focused Done stage: the caret is painted above the box AND the box
+    /// border keeps its per-status (`git_added`) colour rather than the focus
+    /// accent. This is the exact issue scenario — focus + Done together.
+    #[test]
+    fn focused_done_stage_shows_indicator_and_retains_border() {
+        let (mut surface, layout) = paint(Some(0));
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        let theme = Theme::default();
+        let git_added = (theme.git_added.r, theme.git_added.g, theme.git_added.b);
+        let accent = (theme.accent_bg.r, theme.accent_bg.g, theme.accent_bg.b);
+        let muted = (theme.muted_fg.r, theme.muted_fg.g, theme.muted_fg.b);
+
+        // (a) The caret region above the box is painted (not background white)
+        //     and is the muted indicator colour.
+        let (cx, cy) = caret_centroid(&layout);
+        let caret_px = pixel(&data, stride, cx, cy);
+        assert_ne!(
+            caret_px,
+            (255, 255, 255),
+            "focus caret should paint the reserved strip above the box, got white"
+        );
+        assert!(
+            dist2(caret_px, muted) < 1500,
+            "caret pixel {caret_px:?} should be ~muted_fg {muted:?}"
+        );
+
+        // (b) The box border renders in the Done colour, not the focus accent.
+        //     Scan the straight left-border segment and find the coloured
+        //     stroke pixel (a blended 1px line).
+        let bb = layout.stages[0].box_bounds;
+        let bx = bb.x.round() as i32;
+        let by = bb.y.round() as i32;
+        let bh = bb.height.round() as i32;
+        let border = most_chromatic(&data, stride, bx - 2, by + bh / 4, bx + 2, by + bh * 3 / 4);
+        assert!(
+            dist2(border, git_added) < dist2(border, accent),
+            "border {border:?} should be closer to git_added {git_added:?} \
+             than to accent_bg {accent:?}"
+        );
+    }
+
+    /// When no stage is focused the reserved strip above the box stays blank.
+    #[test]
+    fn no_indicator_when_not_focused() {
+        let (mut surface, layout) = paint(None);
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        let (cx, cy) = caret_centroid(&layout);
+        let px = pixel(&data, stride, cx, cy);
+        assert_eq!(
+            px,
+            (255, 255, 255),
+            "no focus → reserved strip above the box must stay background white, got {px:?}"
+        );
     }
 }

--- a/quadraui/src/macos/pipeline_view.rs
+++ b/quadraui/src/macos/pipeline_view.rs
@@ -37,6 +37,11 @@ pub fn mac_pipeline_view_layout(
     } else {
         0.0
     };
+    // Note: the returned layout (incl. `bounds`) is offset down by
+    // `MAC_FOCUS_INDICATOR_H`, so `bounds.y` starts below the reserved caret
+    // strip. The focus caret is painted in the gap between the passed-in `y`
+    // and `bounds.y`; a host that clips drawing to `layout.bounds` would clip
+    // the caret — clip to the original `(y, h)` instead.
     view.layout(
         x as f32,
         (y + MAC_FOCUS_INDICATOR_H) as f32,

--- a/quadraui/src/macos/pipeline_view.rs
+++ b/quadraui/src/macos/pipeline_view.rs
@@ -21,6 +21,8 @@ const MAC_ARROW_WIDTH_PX: f32 = 32.0;
 const MAC_ACTION_HEIGHT_PX: f32 = 22.0;
 /// Border width for stage box outline.
 const BORDER_WIDTH: f64 = 1.0;
+/// Height reserved above stage boxes for the focus indicator (pixels).
+const MAC_FOCUS_INDICATOR_H: f64 = 8.0;
 
 /// Compute the macOS pixel-unit layout for a [`PipelineView`].
 pub fn mac_pipeline_view_layout(
@@ -37,8 +39,13 @@ pub fn mac_pipeline_view_layout(
     };
     view.layout(
         x as f32,
-        y as f32,
-        PipelineViewMeasure::new(w as f32, h as f32, MAC_ARROW_WIDTH_PX, action_h),
+        (y + MAC_FOCUS_INDICATOR_H) as f32,
+        PipelineViewMeasure::new(
+            w as f32,
+            (h - MAC_FOCUS_INDICATOR_H).max(0.0) as f32,
+            MAC_ARROW_WIDTH_PX,
+            action_h,
+        ),
     )
 }
 
@@ -81,13 +88,28 @@ pub unsafe fn draw_pipeline_view(
         // ── Box fill ─────────────────────────────────────────────────────
         fill_rect(ctx, bx, by, bw, bh, theme.surface_bg);
 
-        // ── Box border ───────────────────────────────────────────────────
-        let border_color = if is_focused {
-            theme.accent_bg
-        } else {
-            theme.muted_fg
+        // ── Box border (per-status colour; focus uses an above-box indicator) ──
+        let border_color = match stage.status {
+            StageStatus::Active => theme.accent_bg,
+            StageStatus::Done => theme.git_added,
+            StageStatus::Failed => theme.error_fg,
+            StageStatus::Stale | StageStatus::Pending | StageStatus::Skipped => theme.muted_fg,
         };
         stroke_rect(ctx, bx, by, bw, bh, border_color, BORDER_WIDTH);
+
+        // ── Focus indicator (small ▼ triangle above the box) ─────────────
+        if is_focused {
+            let ind_x = bx + bw / 2.0;
+            let tri_tip_y = by - 1.0;
+            let tri_base_y = by - MAC_FOCUS_INDICATOR_H + 1.0;
+            let tri_half_w = 5.0_f64;
+            set_fill_color(ctx, theme.muted_fg);
+            CGContextMoveToPoint(ctx, ind_x, tri_tip_y);
+            CGContextAddLineToPoint(ctx, ind_x - tri_half_w, tri_base_y);
+            CGContextAddLineToPoint(ctx, ind_x + tri_half_w, tri_base_y);
+            CGContextClosePath(ctx);
+            CGContextFillPath(ctx);
+        }
 
         // ── Status icon ───────────────────────────────────────────────────
         let icon_text = status_icon_text(stage);

--- a/quadraui/src/tui/pipeline_view.rs
+++ b/quadraui/src/tui/pipeline_view.rs
@@ -42,6 +42,11 @@ pub fn tui_pipeline_view_layout(view: &PipelineView, area: Rect) -> PipelineView
     } else {
         0.0
     };
+    // Note: the returned layout (incl. `bounds`) is offset down by
+    // `TUI_FOCUS_INDICATOR_H`, so `bounds.y` starts below the reserved caret
+    // row. The focus caret is drawn in that reserved row (above `bounds.y`);
+    // a host that clips drawing to `layout.bounds` would clip it — clip to the
+    // original `area` instead.
     view.layout(
         area.x as f32,
         (area.y + TUI_FOCUS_INDICATOR_H) as f32,

--- a/quadraui/src/tui/pipeline_view.rs
+++ b/quadraui/src/tui/pipeline_view.rs
@@ -15,7 +15,8 @@
 //! | Pending  | ·    | dim (`theme.muted_fg`)         |
 //! | Skipped  | ─    | grey (`theme.muted_fg`)        |
 //!
-//! The focused stage (keyboard navigation) receives a highlighted border.
+//! The focused stage (keyboard navigation) shows a `▼` caret in the row
+//! reserved above the box; the box border retains its per-status colour.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -31,6 +32,8 @@ use crate::theme::Theme;
 const TUI_ARROW_WIDTH: f32 = 4.0;
 /// Height reserved for the action button row (cells). `0` = no actions.
 const TUI_ACTION_HEIGHT: f32 = 1.0;
+/// Height reserved above stage boxes for the focus indicator (cells).
+const TUI_FOCUS_INDICATOR_H: u16 = 1;
 
 /// Compute the TUI cell-unit layout for a [`PipelineView`] without painting.
 pub fn tui_pipeline_view_layout(view: &PipelineView, area: Rect) -> PipelineViewLayout {
@@ -41,10 +44,10 @@ pub fn tui_pipeline_view_layout(view: &PipelineView, area: Rect) -> PipelineView
     };
     view.layout(
         area.x as f32,
-        area.y as f32,
+        (area.y + TUI_FOCUS_INDICATOR_H) as f32,
         PipelineViewMeasure::new(
             area.width as f32,
-            area.height as f32,
+            area.height.saturating_sub(TUI_FOCUS_INDICATOR_H) as f32,
             TUI_ARROW_WIDTH,
             action_h,
         ),
@@ -69,26 +72,19 @@ pub fn draw_pipeline_view(
     let fg = ratatui_color(theme.foreground);
     let muted = ratatui_color(theme.muted_fg);
     let accent = ratatui_color(theme.accent_bg);
-    let border_normal = muted;
-    let border_focus = accent;
 
     for sb in &layout.stages {
         let stage = &view.stages[sb.index];
         let is_focused = view.focused_stage == Some(sb.index);
-        // Per-status border so the active / done / failed stage is
-        // distinguishable at a glance. Focus override beats status colour.
-        let status_border = match stage.status {
+        // Per-status border colour. Focus no longer overrides it — a ▼
+        // indicator drawn in the reserved row above the box signals focus.
+        let border_col = match stage.status {
             StageStatus::Active => ratatui_color(theme.accent_bg),
             StageStatus::Done => ratatui_color(theme.git_added),
             StageStatus::Failed => ratatui_color(theme.error_fg),
             // Stale gets a dim border so it visually retreats — the prior
             // verdict is shown but de-emphasised to signal "no longer trusted."
-            StageStatus::Stale | StageStatus::Pending | StageStatus::Skipped => border_normal,
-        };
-        let border_col = if is_focused {
-            border_focus
-        } else {
-            status_border
+            StageStatus::Stale | StageStatus::Pending | StageStatus::Skipped => muted,
         };
 
         let bx = sb.box_bounds.x.round() as u16;
@@ -207,6 +203,11 @@ pub fn draw_pipeline_view(
                 set_cell(buf, ax + aw - 1, mid_y, '▶', muted, bg);
             }
         }
+
+        // ── Focus indicator (drawn in the reserved row above the box) ────
+        if is_focused && by > 0 {
+            set_cell(buf, bx + bw / 2, by - 1, '▼', muted, bg);
+        }
     }
 
     layout
@@ -263,8 +264,8 @@ mod tests {
         let mut buf = Buffer::empty(area);
         let view = make_view();
         draw_pipeline_view(&mut buf, area, &view, &Theme::default());
-        // Top-left corner of first stage box.
-        assert_eq!(cell_char(&buf, 0, 0), '┌');
+        // Row 0 is reserved for the focus indicator; box starts at row 1.
+        assert_eq!(cell_char(&buf, 0, 1), '┌');
     }
 
     #[test]
@@ -303,5 +304,47 @@ mod tests {
         let _layout = draw_pipeline_view(&mut buf, area, &view, &Theme::default());
         // Buffer should remain empty.
         assert_eq!(cell_char(&buf, 0, 0), ' ');
+    }
+
+    /// Focused Done stage: ▼ appears in row 0 and the box border is still drawn.
+    #[test]
+    fn focused_done_stage_shows_indicator_and_retains_border() {
+        let area = Rect::new(0, 0, 30, 6);
+        let mut buf = Buffer::empty(area);
+        let mut view = make_view();
+        view.focused_stage = Some(0); // stage 0 is Done
+        let layout = draw_pipeline_view(&mut buf, area, &view, &Theme::default());
+
+        let bb = layout.stages[0].box_bounds;
+        let bx = bb.x.round() as u16;
+        let by = bb.y.round() as u16;
+        let bw = bb.width.round() as u16;
+
+        // Box must be pushed down by the indicator row.
+        assert_eq!(by, 1, "box top must be at indicator row + 1");
+
+        // The ▼ caret appears in the reserved row above the box.
+        let ind_col = bx + bw / 2;
+        assert_eq!(cell_char(&buf, ind_col, 0), '▼');
+
+        // The box border is still drawn (status colour, not overridden).
+        assert_eq!(cell_char(&buf, bx, by), '┌');
+    }
+
+    /// When no stage is focused the indicator row stays blank.
+    #[test]
+    fn no_indicator_when_not_focused() {
+        let area = Rect::new(0, 0, 30, 6);
+        let mut buf = Buffer::empty(area);
+        let view = make_view(); // focused_stage = None
+        let layout = draw_pipeline_view(&mut buf, area, &view, &Theme::default());
+
+        let bb = layout.stages[0].box_bounds;
+        let bx = bb.x.round() as u16;
+        let bw = bb.width.round() as u16;
+        let ind_col = bx + bw / 2;
+
+        // Indicator row should be blank since nothing is focused.
+        assert_eq!(cell_char(&buf, ind_col, 0), ' ');
     }
 }


### PR DESCRIPTION
Closes #265

Automated PR opened by coordinator for review of issue #265.