### PR TITLE
#269: tui runtime: allow mouse text selection / copy of rendered content (e.g. detail view)

### DIFF
--- a/quadraui/examples/common/panel_app.rs
+++ b/quadraui/examples/common/panel_app.rs
@@ -2,9 +2,11 @@
 //! ([`tui_panel`] / [`gtk_panel`]).
 //!
 //! [`PanelApp`] demonstrates a [`Panel`] with a title bar, close and
-//! maximize action buttons, and a content area showing a label.
+//! maximize action buttons, and a content area showing selectable text.
 //!
 //! Controls:
+//! - click-drag content area   select text (TUI: line-wise highlight)
+//! - Ctrl-C (with selection)   copy selection to clipboard (OSC52 + native)
 //! - click close button        quit
 //! - click maximize button     toggle collapsed
 //! - click title bar           log "title clicked"
@@ -13,8 +15,18 @@
 
 use quadraui::{
     AppLogic, Backend, Color, Key, NamedKey, Panel, PanelAction, PanelHit, Reaction, Rect,
-    StatusBar, StatusBarSegment, StyledSpan, StyledText, UiEvent, WidgetId,
+    StatusBar, StatusBarSegment, StyledSpan, StyledText, TextRegion, UiEvent, WidgetId,
 };
+
+const CONTENT_LINES: &[&str] = &[
+    "The quick brown fox jumps over the lazy dog.",
+    "Pack my box with five dozen liquor jugs.",
+    "How vexingly quick daft zebras jump!",
+    "The five boxing wizards jump quickly.",
+    "Sphinx of black quartz, judge my vow.",
+];
+
+const CONTENT_ID: &str = "panel-content";
 
 pub struct PanelApp {
     collapsed: bool,
@@ -25,7 +37,7 @@ impl PanelApp {
     pub fn new() -> Self {
         Self {
             collapsed: false,
-            last_message: "Click panel chrome or press keys".into(),
+            last_message: "Click-drag to select text, Ctrl-C to copy".into(),
         }
     }
 
@@ -74,24 +86,37 @@ impl PanelApp {
         }
     }
 
-    fn fill_content(&self, backend: &mut dyn Backend, bounds: Rect) {
+    /// Renders the selectable text block and returns the bounds covering all
+    /// rendered lines (used by `render` to register the `TextRegion`).
+    fn fill_content(&self, backend: &mut dyn Backend, bounds: Rect) -> Rect {
         if bounds.width < 1.0 || bounds.height < 1.0 {
-            return;
+            return bounds;
         }
         let lh = backend.line_height();
-        let label_rect = Rect::new(bounds.x, bounds.y, bounds.width, lh);
-        let bar = StatusBar {
-            id: WidgetId::new("content-label"),
-            left_segments: vec![StatusBarSegment {
-                text: " Panel content area ".into(),
-                fg: Color::rgb(200, 200, 200),
-                bg: Color::rgb(30, 30, 50),
-                bold: false,
-                action_id: None,
-            }],
-            right_segments: vec![],
-        };
-        let _ = backend.draw_status_bar(label_rect, &bar, None, None);
+        let bg = Color::rgb(20, 20, 35);
+        let fg = Color::rgb(210, 210, 210);
+        let mut rendered_height = 0.0_f32;
+        for (i, &line) in CONTENT_LINES.iter().enumerate() {
+            let row_y = bounds.y + i as f32 * lh;
+            if row_y + lh > bounds.y + bounds.height {
+                break;
+            }
+            let row_rect = Rect::new(bounds.x, row_y, bounds.width, lh);
+            let bar = StatusBar {
+                id: WidgetId::new(format!("{CONTENT_ID}-line-{i}")),
+                left_segments: vec![StatusBarSegment {
+                    text: format!(" {line} "),
+                    fg,
+                    bg,
+                    bold: false,
+                    action_id: None,
+                }],
+                right_segments: vec![],
+            };
+            let _ = backend.draw_status_bar(row_rect, &bar, None, None);
+            rendered_height = (i + 1) as f32 * lh;
+        }
+        Rect::new(bounds.x, bounds.y, bounds.width, rendered_height)
     }
 }
 
@@ -111,7 +136,11 @@ impl AppLogic for PanelApp {
         let panel = self.panel();
         let layout = backend.draw_panel(panel_rect, &panel);
 
-        self.fill_content(backend, layout.content_bounds);
+        let content_bounds = self.fill_content(backend, layout.content_bounds);
+        backend.register_text_region(TextRegion {
+            id: WidgetId::new(CONTENT_ID),
+            bounds: content_bounds,
+        });
 
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
         let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
@@ -139,7 +168,31 @@ impl AppLogic for PanelApp {
                 };
                 Reaction::Redraw
             }
+            UiEvent::ClipboardPaste(text) => {
+                let chars: Vec<char> = text.chars().take(40).collect();
+                let preview: String = chars.iter().collect();
+                let suffix = if text.chars().count() > 40 { "…" } else { "" };
+                self.last_message = format!("Copied: \"{preview}{suffix}\"");
+                Reaction::Redraw
+            }
+            UiEvent::TextSelectionChanged { anchor, focus, .. } => {
+                let lh = backend.line_height();
+                let anchor_row = (anchor.y / lh).floor() as usize;
+                let focus_row = (focus.y / lh).floor() as usize;
+                let (start, end) = if anchor_row <= focus_row {
+                    (anchor_row, focus_row)
+                } else {
+                    (focus_row, anchor_row)
+                };
+                self.last_message = if start == end {
+                    format!("Selecting row {} — Ctrl-C to copy", start + 1)
+                } else {
+                    format!("Selecting rows {}–{} — Ctrl-C to copy", start + 1, end + 1)
+                };
+                Reaction::Redraw
+            }
             UiEvent::MouseDown { position, .. } => {
+                self.last_message = "Click-drag to select text, Ctrl-C to copy".into();
                 let viewport = backend.viewport();
                 let lh = backend.line_height();
                 let panel_rect = Rect::new(0.0, 0.0, viewport.width, viewport.height - lh);
@@ -159,9 +212,6 @@ impl AppLogic for PanelApp {
                     }
                     PanelHit::TitleBar(_) => {
                         self.last_message = "Title bar clicked".into();
-                    }
-                    PanelHit::Content(_) => {
-                        self.last_message = "Content clicked".into();
                     }
                     _ => {}
                 }

--- a/quadraui/examples/common/panel_app.rs
+++ b/quadraui/examples/common/panel_app.rs
@@ -168,7 +168,7 @@ impl AppLogic for PanelApp {
                 };
                 Reaction::Redraw
             }
-            UiEvent::ClipboardPaste(text) => {
+            UiEvent::TextCopied(text) => {
                 let chars: Vec<char> = text.chars().take(40).collect();
                 let preview: String = chars.iter().collect();
                 let suffix = if text.chars().count() > 40 { "…" } else { "" };

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -76,6 +76,27 @@ pub trait Backend {
     /// `draw_*` calls consume the updated palette.
     fn set_theme(&mut self, _theme: crate::Theme) {}
 
+    // ─── Text selection ────────────────────────────────────────────────
+    /// Register a selectable text region for the current frame.
+    ///
+    /// Call once per selectable content area during render (in paint
+    /// order: back regions first, front regions last). The backend
+    /// records the region so that click dispatch via
+    /// [`crate::dispatch::dispatch_click`] can begin a
+    /// [`crate::DragTarget::TextSelection`] drag when the user clicks
+    /// inside the bounds.
+    ///
+    /// The TUI backend additionally applies per-frame selection
+    /// highlights (inverted cells over the selected range) and extracts
+    /// text on Ctrl-C. GTK/macOS backends can use it for native
+    /// selection support. The registration is cleared at the start of
+    /// each frame (`begin_frame`), so apps must call this every frame
+    /// for regions that should be selectable.
+    ///
+    /// Default: no-op. Backends that implement selection highlight
+    /// override this to accumulate regions for the current frame.
+    fn register_text_region(&mut self, _region: crate::dispatch::TextRegion) {}
+
     // ─── Events + keybindings ──────────────────────────────────────────
     /// Drain all queued native events. Returns a fully-translated
     /// `Vec<UiEvent>` ready for app dispatch. Never blocks.

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -10,8 +10,8 @@
 //!
 //! # Keyboard behaviour
 //!
-//! - `Ctrl+Enter` or `Alt+Enter` — submit the current input.
-//!   `Alt+Enter` works on all terminals; `Ctrl+Enter` requires the Kitty
+//! - `Ctrl+S`, `Alt+Enter`, or `Ctrl+Enter` — submit the current input.
+//!   `Ctrl+S` and `Alt+Enter` work on all terminals; `Ctrl+Enter` requires Kitty
 //!   keyboard protocol (supported by kitty, Alacritty ≥0.12, WezTerm, foot).
 //! - `Enter` — insert a newline in the input.
 //! - `Esc` — emit [`ChatControllerEvent::Cancelled`]; the app decides
@@ -68,7 +68,7 @@ pub struct ChatTurn {
 /// Events emitted by [`ChatController::handle`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChatControllerEvent {
-    /// User submitted a message (`Ctrl+Enter` or `Alt+Enter`). Contains the full input text
+    /// User submitted a message (`Ctrl+S`, `Alt+Enter`, or `Ctrl+Enter`). Contains the full input text
     /// (with embedded `\n` for multi-line messages). Apps should:
     /// 1. Append the text as a `User` turn to their own transcript.
     /// 2. Call [`ChatController::clear_input`].
@@ -548,7 +548,7 @@ impl ChatController {
             cursor_line,
             cursor_col,
             placeholder: Some(
-                "Type a message\u{2026} (Ctrl+Enter or Alt+Enter to send, Enter for newline, Esc to cancel)"
+                "Type a message\u{2026} (Ctrl+S or Alt+Enter to send, Enter for newline, Esc to cancel)"
                     .into(),
             ),
             scroll_offset: self.input_scroll_offset,
@@ -567,8 +567,22 @@ impl ChatController {
         layout: &ChatLayout,
     ) -> ChatControllerEvent {
         match key {
-            // ── Submit: Ctrl+Enter or Alt+Enter ───────────────────────
-            // Alt+Enter works on all terminals; Ctrl+Enter needs Kitty protocol.
+            // ── Submit: Ctrl+S, Alt+Enter, or Ctrl+Enter ─────────────────
+            // Ctrl+S works on all terminals.
+            // Alt+Enter works on all terminals (ESC+Enter escape sequence).
+            // Ctrl+Enter needs Kitty protocol — unreliable as the primary affordance.
+            Key::Char('s') if modifiers.ctrl => {
+                if self.input_buf.is_empty() {
+                    return ChatControllerEvent::Ignored;
+                }
+                let text = self.input_buf.clone();
+                if !text.trim().is_empty() && self.history.last() != Some(&text) {
+                    self.history.push(text.clone());
+                }
+                self.history_pos = None;
+                self.saved_input = None;
+                ChatControllerEvent::Submit { text }
+            }
             Key::Named(NamedKey::Enter) if modifiers.ctrl || modifiers.alt => {
                 if self.input_buf.is_empty() {
                     return ChatControllerEvent::Ignored;

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -11,8 +11,11 @@
 //! # Keyboard behaviour
 //!
 //! - `Ctrl+S`, `Alt+Enter`, or `Ctrl+Enter` — submit the current input.
-//!   `Ctrl+S` and `Alt+Enter` work on all terminals; `Ctrl+Enter` requires Kitty
+//!   `Ctrl+S` and `Alt+Enter` work on most terminals; `Ctrl+Enter` requires Kitty
 //!   keyboard protocol (supported by kitty, Alacritty ≥0.12, WezTerm, foot).
+//!   **Note**: `Ctrl+S` is the XON/XOFF flow-control suspend key in some
+//!   terminal configurations (`stty -ixon` disables it). If `Ctrl+S` appears
+//!   to freeze the terminal, run `stty -ixon` or use `Alt+Enter` instead.
 //! - `Enter` — insert a newline in the input.
 //! - `Esc` — emit [`ChatControllerEvent::Cancelled`]; the app decides
 //!   whether to close the overlay.
@@ -1528,6 +1531,44 @@ mod tests {
         let rect = make_rect();
         let event = UiEvent::KeyPressed {
             key: Key::Named(NamedKey::Enter),
+            modifiers: Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+            repeat: false,
+        };
+        let ev = cc.handle(&event, &MockBackend, rect);
+        assert_eq!(ev, ChatControllerEvent::Ignored);
+    }
+
+    #[test]
+    fn ctrl_s_submits_and_emits_event() {
+        let mut cc = ChatController::new("c");
+        cc.input_insert_str("hello");
+        let rect = make_rect();
+        let event = UiEvent::KeyPressed {
+            key: Key::Char('s'),
+            modifiers: Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+            repeat: false,
+        };
+        let ev = cc.handle(&event, &MockBackend, rect);
+        assert_eq!(
+            ev,
+            ChatControllerEvent::Submit {
+                text: "hello".into()
+            }
+        );
+    }
+
+    #[test]
+    fn ctrl_s_on_empty_input_ignored() {
+        let mut cc = ChatController::new("c");
+        let rect = make_rect();
+        let event = UiEvent::KeyPressed {
+            key: Key::Char('s'),
             modifiers: Modifiers {
                 ctrl: true,
                 ..Default::default()

--- a/quadraui/src/dispatch.rs
+++ b/quadraui/src/dispatch.rs
@@ -112,6 +112,18 @@ pub enum DragTarget {
         /// [`DragTarget::ScrollbarY::inverted`].
         inverted: bool,
     },
+    /// A text-selection drag. `region` is the id of the
+    /// [`TextRegion`] where the drag started; `anchor` is the screen
+    /// position at click-down. The anchor is fixed for the lifetime of
+    /// the drag; [`dispatch_mouse_drag`] reads it to emit
+    /// [`UiEvent::TextSelectionChanged`] with the current cursor as
+    /// the `focus`.
+    TextSelection {
+        /// Which text region is being selected.
+        region: WidgetId,
+        /// Screen position where the drag started.
+        anchor: Point,
+    },
 }
 
 /// One drag in progress, or none. Backends hold one instance; call
@@ -301,6 +313,13 @@ pub fn dispatch_mouse_drag(
                 new_offset,
             });
         }
+        Some(DragTarget::TextSelection { region, anchor }) => {
+            events.push(UiEvent::TextSelectionChanged {
+                region: region.clone(),
+                anchor: *anchor,
+                focus: position,
+            });
+        }
         _ => {}
     }
 
@@ -325,6 +344,102 @@ pub fn dispatch_mouse_up(
         button,
         position,
     }]
+}
+
+// ─── Text region ─────────────────────────────────────────────────────────────
+
+/// A selectable text region registered during paint. Apps push one
+/// entry per selectable text area each frame;
+/// [`dispatch_click`] hit-tests the list to begin a
+/// [`DragTarget::TextSelection`] drag when the user clicks inside.
+///
+/// Push in paint order (back-to-front). The dispatcher walks
+/// last-to-first so the topmost-painted region wins on overlap.
+/// Text regions take priority over [`ScrollSurface`] *bodies* (not
+/// scrollbars) — a text region registered inside a scroll surface body
+/// will capture clicks first.
+///
+/// # Relationship with `ScrollSurface`
+///
+/// A text region is typically co-located with a scroll surface: the
+/// scroll surface owns the scrollbar; the text region owns the content
+/// body. Register them both, and the precedence chain
+/// (scrollbar thumb/track → text region → surface body → none) falls
+/// out automatically.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextRegion {
+    pub id: WidgetId,
+    pub bounds: crate::event::Rect,
+}
+
+/// Compute the screen-cell ranges covered by a line-wise text selection.
+///
+/// Given `anchor` and `focus` in screen coordinates (TUI: cells;
+/// GTK/macOS: pixels) and the `bounds` of the [`TextRegion`], returns
+/// a `Vec` of `(row, col_start, col_end)` tuples (half-open:
+/// `col_start..col_end`) in document order (top-to-bottom).
+///
+/// **Line-wise stream semantics** (same as most terminal selections):
+///
+/// | Position | Range |
+/// |---|---|
+/// | First row | `anchor_col .. region_end_col` |
+/// | Middle rows | `region_start_col .. region_end_col` |
+/// | Last row | `region_start_col .. focus_col + 1` |
+/// | Single row | `min_col .. max_col + 1` |
+///
+/// Coordinates are clamped to `bounds`. Returns an empty `Vec` when
+/// `anchor == focus` (selection collapsed to a point — plain click).
+pub fn text_selection_line_range(
+    anchor: Point,
+    focus: Point,
+    bounds: crate::event::Rect,
+) -> Vec<(u16, u16, u16)> {
+    // Empty when anchor == focus (no movement → collapsed click).
+    let ax = anchor.x.round() as i32;
+    let ay = anchor.y.round() as i32;
+    let fx = focus.x.round() as i32;
+    let fy = focus.y.round() as i32;
+    if ax == fx && ay == fy {
+        return Vec::new();
+    }
+
+    // Put in document order (top-to-bottom, left-to-right).
+    let (start, end) = if ay < fy || (ay == fy && ax <= fx) {
+        (anchor, focus)
+    } else {
+        (focus, anchor)
+    };
+
+    let region_x = bounds.x.round() as u16;
+    let region_end_x = (bounds.x + bounds.width).round() as u16;
+    let region_y = bounds.y.round() as u16;
+    let region_end_y = (bounds.y + bounds.height).round() as u16;
+
+    // Clamp start/end rows and cols to region.
+    let start_row = (start.y.round() as u16).clamp(region_y, region_end_y.saturating_sub(1));
+    let end_row = (end.y.round() as u16).clamp(region_y, region_end_y.saturating_sub(1));
+    let start_col = (start.x.round() as u16).clamp(region_x, region_end_x);
+    // End col is inclusive → add 1 for the half-open range, then clamp.
+    let end_col = ((end.x.round() as u16).saturating_add(1)).clamp(region_x, region_end_x);
+
+    if start_row == end_row {
+        if start_col >= end_col {
+            return Vec::new();
+        }
+        return vec![(start_row, start_col, end_col)];
+    }
+
+    let mut ranges = Vec::with_capacity((end_row - start_row + 1) as usize);
+    // First row: from start_col to region end.
+    ranges.push((start_row, start_col, region_end_x));
+    // Middle rows: full region width.
+    for row in (start_row + 1)..end_row {
+        ranges.push((row, region_x, region_end_x));
+    }
+    // Last row: from region start to end_col.
+    ranges.push((end_row, region_x, end_col));
+    ranges
 }
 
 // ─── Scroll dispatch ──────────────────────────────────────────────────────
@@ -447,8 +562,8 @@ pub struct SurfaceScrollbar {
 
 /// Translate a raw mouse-down event, consulting the modal stack first,
 /// then the registered scroll surfaces (including their scrollbar
-/// regions). Supersedes [`dispatch_mouse_down`] for consumers that
-/// register scroll surfaces.
+/// regions) and text regions. Supersedes [`dispatch_mouse_down`] for
+/// consumers that register scroll surfaces and/or text regions.
 ///
 /// # Returns
 ///
@@ -464,12 +579,17 @@ pub struct SurfaceScrollbar {
 /// 4. **Click on a scroll surface's scrollbar track** (above or below
 ///    thumb) → emits `ScrollOffsetChanged { widget, new_offset }`
 ///    with the offset paged up or down by `visible_items`.
-/// 5. **Click on a scroll surface body** (not scrollbar) →
-///    `MouseDown { widget: Some(surface_id) }`.
-/// 6. **No surface matched** → `MouseDown { widget: None }`.
+/// 5. **Click inside a registered [`TextRegion`]** → starts a
+///    [`DragTarget::TextSelection`] drag, emits
+///    `MouseDown { widget: Some(region_id) }`. Text regions take
+///    priority over scroll surface bodies (not scrollbars).
+/// 6. **Click on a scroll surface body** (not scrollbar, not text
+///    region) → `MouseDown { widget: Some(surface_id) }`.
+/// 7. **No surface or region matched** → `MouseDown { widget: None }`.
 pub fn dispatch_click(
     stack: &ModalStack,
     scroll_surfaces: &[ScrollSurface],
+    text_regions: &[TextRegion],
     drag: &mut DragState,
     position: Point,
     button: MouseButton,
@@ -582,7 +702,24 @@ pub fn dispatch_click(
             }
         }
 
-        // Body click (not on scrollbar).
+        // Case 5: Check text regions before falling through to body click.
+        // Walk last-to-first so the topmost-painted region wins on overlap.
+        for tr in text_regions.iter().rev() {
+            if tr.bounds.contains(position) {
+                drag.begin(DragTarget::TextSelection {
+                    region: tr.id.clone(),
+                    anchor: position,
+                });
+                return vec![UiEvent::MouseDown {
+                    widget: Some(tr.id.clone()),
+                    button,
+                    position,
+                    modifiers,
+                }];
+            }
+        }
+
+        // Case 6: body click (not on scrollbar, not on text region).
         return vec![UiEvent::MouseDown {
             widget: Some(surface.id.clone()),
             button,
@@ -591,7 +728,24 @@ pub fn dispatch_click(
         }];
     }
 
-    // Case 6: no surface matched.
+    // No scroll surface hit. Still check standalone text regions
+    // (not nested inside any scroll surface).
+    for tr in text_regions.iter().rev() {
+        if tr.bounds.contains(position) {
+            drag.begin(DragTarget::TextSelection {
+                region: tr.id.clone(),
+                anchor: position,
+            });
+            return vec![UiEvent::MouseDown {
+                widget: Some(tr.id.clone()),
+                button,
+                position,
+                modifiers,
+            }];
+        }
+    }
+
+    // Case 7: no surface or region matched.
     vec![UiEvent::MouseDown {
         widget: None,
         button,
@@ -755,6 +909,7 @@ mod tests {
         match drag.target().unwrap() {
             DragTarget::ScrollbarY { widget, .. } => assert_eq!(widget, &id("picker")),
             DragTarget::ScrollbarX { .. } => panic!("expected ScrollbarY"),
+            DragTarget::TextSelection { .. } => panic!("expected ScrollbarY"),
         }
         drag.end();
         assert!(!drag.is_active());
@@ -1225,6 +1380,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(39.5, 22.0),
             MouseButton::Left,
@@ -1259,6 +1415,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(39.5, 5.0),
             MouseButton::Left,
@@ -1285,6 +1442,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(39.5, 29.0),
             MouseButton::Left,
@@ -1310,6 +1468,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(10.0, 10.0),
             MouseButton::Left,
@@ -1333,6 +1492,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &[],
+            &[],
             &mut drag,
             pt(50.0, 50.0),
             MouseButton::Left,
@@ -1354,6 +1514,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(39.5, 22.0),
             MouseButton::Left,
@@ -1450,6 +1611,7 @@ mod tests {
         dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(39.5, 22.0),
             MouseButton::Left,
@@ -1458,7 +1620,9 @@ mod tests {
         assert!(drag.is_active());
         match drag.target().unwrap() {
             DragTarget::ScrollbarY { inverted, .. } => assert!(*inverted),
-            other => panic!("expected ScrollbarY, got {:?}", other),
+            DragTarget::ScrollbarX { .. } | DragTarget::TextSelection { .. } => {
+                panic!("expected ScrollbarY")
+            }
         }
     }
 
@@ -1473,6 +1637,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(39.5, 5.0),
             MouseButton::Left,
@@ -1489,6 +1654,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(39.5, 29.0),
             MouseButton::Left,
@@ -1531,6 +1697,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(60.0, 297.0),
             MouseButton::Left,
@@ -1558,7 +1725,9 @@ mod tests {
                 assert_eq!(*max_scroll, 1800);
                 assert!(*grab_offset > 9.0 && *grab_offset < 11.0); // 60.0 - 50.0 = 10.0
             }
-            other => panic!("expected ScrollbarX, got {:?}", other),
+            DragTarget::ScrollbarY { .. } | DragTarget::TextSelection { .. } => {
+                panic!("expected ScrollbarX")
+            }
         }
     }
 
@@ -1571,6 +1740,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(10.0, 297.0),
             MouseButton::Left,
@@ -1595,6 +1765,7 @@ mod tests {
         let events = dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(200.0, 297.0),
             MouseButton::Left,
@@ -1619,6 +1790,7 @@ mod tests {
         dispatch_click(
             &stack,
             &surfaces,
+            &[],
             &mut drag,
             pt(60.0, 297.0),
             MouseButton::Left,
@@ -1634,6 +1806,219 @@ mod tests {
                 assert_eq!(*new_offset, 1800); // max_scroll
             }
             other => panic!("expected ScrollOffsetChanged, got {:?}", other),
+        }
+    }
+
+    // ── TextRegion / text-selection tests ─────────────────────────────
+
+    #[test]
+    fn click_text_region_starts_text_selection_drag() {
+        let stack = ModalStack::new();
+        let mut drag = DragState::new();
+        let text_regions = vec![TextRegion {
+            id: id("log:body"),
+            bounds: rect(0.0, 0.0, 40.0, 30.0),
+        }];
+        let events = dispatch_click(
+            &stack,
+            &[],
+            &text_regions,
+            &mut drag,
+            pt(10.0, 5.0),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            UiEvent::MouseDown {
+                widget: Some(w), ..
+            } if w.as_str() == "log:body"
+        ));
+        assert!(drag.is_active());
+        match drag.target().unwrap() {
+            DragTarget::TextSelection { region, anchor } => {
+                assert_eq!(region.as_str(), "log:body");
+                assert_eq!(*anchor, pt(10.0, 5.0));
+            }
+            other => panic!("expected TextSelection, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn scrollbar_wins_over_text_region() {
+        let stack = ModalStack::new();
+        let surfaces = vec![surface_with_scrollbar()];
+        let text_regions = vec![TextRegion {
+            id: id("log:body"),
+            // Covers the whole surface including the scrollbar column.
+            bounds: rect(0.0, 0.0, 40.0, 30.0),
+        }];
+        let mut drag = DragState::new();
+        // Click on scrollbar thumb (x=39.5, y=22) — scrollbar must win.
+        dispatch_click(
+            &stack,
+            &surfaces,
+            &text_regions,
+            &mut drag,
+            pt(39.5, 22.0),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        assert!(matches!(
+            drag.target().unwrap(),
+            DragTarget::ScrollbarY { .. }
+        ));
+    }
+
+    #[test]
+    fn text_region_wins_over_surface_body() {
+        let stack = ModalStack::new();
+        let surfaces = vec![ScrollSurface {
+            id: id("log"),
+            bounds: rect(0.0, 0.0, 40.0, 30.0),
+            scrollbar: None,
+        }];
+        let text_regions = vec![TextRegion {
+            id: id("log:body"),
+            bounds: rect(0.0, 0.0, 40.0, 30.0),
+        }];
+        let mut drag = DragState::new();
+        let events = dispatch_click(
+            &stack,
+            &surfaces,
+            &text_regions,
+            &mut drag,
+            pt(10.0, 5.0),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        assert!(matches!(
+            &events[0],
+            UiEvent::MouseDown { widget: Some(w), .. } if w.as_str() == "log:body"
+        ));
+        assert!(matches!(
+            drag.target().unwrap(),
+            DragTarget::TextSelection { .. }
+        ));
+    }
+
+    #[test]
+    fn modal_wins_over_text_region() {
+        let mut stack = ModalStack::new();
+        stack.push(id("dialog"), rect(0.0, 0.0, 100.0, 100.0));
+        let text_regions = vec![TextRegion {
+            id: id("body"),
+            bounds: rect(0.0, 0.0, 100.0, 100.0),
+        }];
+        let mut drag = DragState::new();
+        let events = dispatch_click(
+            &stack,
+            &[],
+            &text_regions,
+            &mut drag,
+            pt(50.0, 50.0),
+            MouseButton::Left,
+            Modifiers::default(),
+        );
+        // Modal wins — no TextSelection drag started.
+        assert!(!drag.is_active());
+        assert!(matches!(
+            &events[0],
+            UiEvent::MouseDown { widget: Some(w), .. } if w.as_str() == "dialog"
+        ));
+    }
+
+    #[test]
+    fn dispatch_mouse_drag_text_selection_emits_changed() {
+        let mut drag = DragState::new();
+        drag.begin(DragTarget::TextSelection {
+            region: id("log:body"),
+            anchor: pt(5.0, 2.0),
+        });
+        let events = dispatch_mouse_drag(&drag, pt(10.0, 5.0), buttons_mask_left());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], UiEvent::MouseMoved { .. }));
+        match &events[1] {
+            UiEvent::TextSelectionChanged {
+                region,
+                anchor,
+                focus,
+            } => {
+                assert_eq!(region.as_str(), "log:body");
+                assert_eq!(*anchor, pt(5.0, 2.0));
+                assert_eq!(*focus, pt(10.0, 5.0));
+            }
+            other => panic!("expected TextSelectionChanged, got {:?}", other),
+        }
+    }
+
+    // ── text_selection_line_range tests ──────────────────────────────────
+
+    #[test]
+    fn line_range_empty_when_anchor_equals_focus() {
+        let bounds = rect(0.0, 0.0, 40.0, 10.0);
+        let ranges = text_selection_line_range(pt(5.0, 3.0), pt(5.0, 3.0), bounds);
+        assert!(ranges.is_empty(), "collapsed selection must be empty");
+    }
+
+    #[test]
+    fn line_range_single_row() {
+        // Same row, anchor before focus.
+        let bounds = rect(0.0, 0.0, 40.0, 10.0);
+        let ranges = text_selection_line_range(pt(5.0, 3.0), pt(10.0, 3.0), bounds);
+        // Half-open: 5..11 (focus_col 10 is inclusive → +1 = 11).
+        assert_eq!(ranges, vec![(3, 5, 11)]);
+    }
+
+    #[test]
+    fn line_range_single_row_reversed() {
+        // Same row, focus before anchor — must swap to document order.
+        let bounds = rect(0.0, 0.0, 40.0, 10.0);
+        let ranges = text_selection_line_range(pt(10.0, 3.0), pt(5.0, 3.0), bounds);
+        assert_eq!(ranges, vec![(3, 5, 11)]);
+    }
+
+    #[test]
+    fn line_range_multi_row() {
+        let bounds = rect(0.0, 0.0, 40.0, 10.0);
+        // anchor at (2,1), focus at (5,3).
+        let ranges = text_selection_line_range(pt(2.0, 1.0), pt(5.0, 3.0), bounds);
+        // Row 1: 2..40 (start_col to region_end)
+        // Row 2: 0..40 (full width)
+        // Row 3: 0..6  (region_start to focus_col+1)
+        assert_eq!(ranges, vec![(1, 2, 40), (2, 0, 40), (3, 0, 6)]);
+    }
+
+    #[test]
+    fn line_range_multi_row_reversed() {
+        let bounds = rect(0.0, 0.0, 40.0, 10.0);
+        // Swap anchor and focus — must produce same result in document order.
+        let ranges = text_selection_line_range(pt(5.0, 3.0), pt(2.0, 1.0), bounds);
+        assert_eq!(ranges, vec![(1, 2, 40), (2, 0, 40), (3, 0, 6)]);
+    }
+
+    #[test]
+    fn line_range_clamped_to_bounds() {
+        // Region starts at x=5, y=2; anchor/focus way outside — must clamp.
+        let bounds = rect(5.0, 2.0, 20.0, 5.0);
+        let ranges = text_selection_line_range(pt(0.0, 0.0), pt(100.0, 100.0), bounds);
+        // start row clamped to 2, end row clamped to 6 (2+5-1),
+        // start_col clamped to 5, end_col clamped to 25.
+        assert_eq!(
+            ranges[0],
+            (2, 5, 25),
+            "first row: anchor clamped to region x"
+        );
+        assert_eq!(
+            *ranges.last().unwrap(),
+            (6, 5, 25),
+            "last row: focus clamped to region end"
+        );
+        // All middle rows are full region width.
+        for &(_, c_start, c_end) in &ranges[1..ranges.len() - 1] {
+            assert_eq!(c_start, 5);
+            assert_eq!(c_end, 25);
         }
     }
 }

--- a/quadraui/src/event.rs
+++ b/quadraui/src/event.rs
@@ -305,6 +305,32 @@ pub enum UiEvent {
         new_offset: usize,
     },
 
+    // ── Text selection ────────────────────────────────────────────────
+    /// A mouse text-selection drag extended or finalised its range.
+    /// Emitted by [`crate::dispatch::dispatch_mouse_drag`] while a
+    /// [`crate::DragTarget::TextSelection`] is active.
+    ///
+    /// `anchor` is the screen position where the drag started (set
+    /// once at click-down; does not change during the drag). `focus`
+    /// is the current cursor position. Both are in the backend's
+    /// native units (TUI: cells; GTK/macOS: pixels).
+    ///
+    /// The range `anchor → focus` defines what is currently selected —
+    /// call [`crate::dispatch::text_selection_line_range`] to convert
+    /// the pair to a list of `(row, col_start, col_end)` spans.
+    /// The TUI backend applies selection highlights automatically
+    /// inside the draw loop; other backends may consume this event to
+    /// drive native selection highlight.
+    ///
+    /// If the user releases without moving (plain click), this event
+    /// is never emitted; the app receives a plain `MouseDown + MouseUp`
+    /// pair instead.
+    TextSelectionChanged {
+        region: WidgetId,
+        anchor: Point,
+        focus: Point,
+    },
+
     // ── Native menu activation ────────────────────────────────────────
     /// A menu item was activated via a native menu installer
     /// ([`Backend::install_menu_bar`][crate::Backend::install_menu_bar]).

--- a/quadraui/src/event.rs
+++ b/quadraui/src/event.rs
@@ -27,6 +27,7 @@
 //! | Window (`WindowResized`, `WindowClose`, `WindowFocused`, `DpiChanged`) | Application-global |
 //! | `FilesDropped` | Hit-test at drop position |
 //! | `ClipboardPaste` | Focus |
+//! | `TextCopied` | Broadcast (no target) |
 //!
 //! The consequence apps rely on: **scroll wheel events dispatch to the
 //! widget under the cursor, regardless of which widget has keyboard focus.**
@@ -290,6 +291,21 @@ pub enum UiEvent {
         position: Point,
     },
     ClipboardPaste(String),
+
+    // ── Clipboard copy notification ────────────────────────────────
+    /// Text was copied to the clipboard by the TUI runner's built-in
+    /// text-selection mechanism (click-drag → Ctrl-C). The payload is
+    /// the text that was copied.
+    ///
+    /// This event is **distinct from [`Self::ClipboardPaste`]**. Paste
+    /// means "insert text into the focused input"; `TextCopied` is a
+    /// one-way notification that lets apps display a confirmation badge
+    /// ("Copied!") without any risk of accidentally inserting text into
+    /// an input widget that happens to handle `ClipboardPaste`.
+    ///
+    /// Routing: broadcast (no widget target — it is not input-focus
+    /// routed). Apps that don't need copy confirmation can ignore it.
+    TextCopied(String),
 
     // ── Cross-primitive scroll event ──────────────────────────────────
     /// A scrollbar drag or click resolved to a new offset. Generic

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -279,7 +279,7 @@ pub use compose::{
 };
 pub use dispatch::{
     dispatch_click, dispatch_mouse_down, dispatch_mouse_drag, dispatch_mouse_up, dispatch_scroll,
-    DragState, DragTarget, ScrollSurface, SurfaceScrollbar,
+    text_selection_line_range, DragState, DragTarget, ScrollSurface, SurfaceScrollbar, TextRegion,
 };
 pub use modal_stack::{ModalEntry, ModalStack};
 pub use runner::{AppLogic, Reaction};

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -117,6 +117,13 @@ pub struct TuiBackend {
     /// cleared by [`Self::clear_text_selection`] or on a new
     /// `MouseDown`.
     active_selection: Option<TuiTextSelection>,
+    /// Text extracted from the last rendered buffer for the active
+    /// selection. Populated by `apply_selection_highlight` (which has
+    /// access to the live buffer inside `terminal.draw`). After the
+    /// draw closure returns ratatui swaps its double-buffer, so
+    /// `terminal.current_buffer_mut()` would return an empty buffer —
+    /// caching here is the only reliable way to get the text.
+    cached_selection_text: String,
 }
 
 impl TuiBackend {
@@ -140,6 +147,7 @@ impl TuiBackend {
             double_click: super::events::DoubleClickDetector::new(),
             text_regions: Vec::new(),
             active_selection: None,
+            cached_selection_text: String::new(),
         }
     }
 
@@ -255,14 +263,22 @@ impl TuiBackend {
         }
     }
 
+    /// Clear only the displayed selection highlight without touching drag
+    /// state. Used by the run loop on `MouseDown` so that the drag just
+    /// initiated by `dispatch_click` is not immediately cancelled.
+    pub(crate) fn clear_selection_display(&mut self) {
+        self.active_selection = None;
+    }
+
     /// Invert (highlight) the cells in the ratatui buffer that fall
-    /// within the active text selection range. Swaps foreground and
-    /// background colour for each selected cell.
+    /// within the active text selection range, and cache the extracted
+    /// text in `self.cached_selection_text`.
     ///
     /// Must be called inside `terminal.draw(|frame| …)` after
-    /// `app.render` so that the selection is overlaid on top of the
-    /// app's content.
-    pub(crate) fn apply_selection_highlight(&self, buf: &mut ratatui::buffer::Buffer) {
+    /// `app.render`. The cache is necessary because ratatui swaps its
+    /// double-buffer after `draw` returns, so `terminal.current_buffer_mut()`
+    /// would return an empty buffer by the time Ctrl-C fires.
+    pub(crate) fn apply_selection_highlight(&mut self, buf: &mut ratatui::buffer::Buffer) {
         let sel = match &self.active_selection {
             Some(s) => s,
             None => return,
@@ -279,6 +295,25 @@ impl TuiBackend {
         );
         let ranges = crate::dispatch::text_selection_line_range(sel.anchor, sel.focus, bounds);
         let area = buf.area;
+
+        // Cache text before inverting so we read the original cell content.
+        let mut lines: Vec<String> = Vec::with_capacity(ranges.len());
+        for &(row, col_start, col_end) in &ranges {
+            if row >= area.y + area.height {
+                continue;
+            }
+            let mut line = String::new();
+            for col in col_start..col_end {
+                if col < area.x + area.width {
+                    line.push_str(buf[(col, row)].symbol());
+                }
+            }
+            let trimmed = line.trim_end_matches(|c: char| c.is_whitespace() || c == '\0');
+            lines.push(trimmed.to_string());
+        }
+        self.cached_selection_text = lines.join("\n");
+
+        // Now invert cells for the highlight.
         for (row, col_start, col_end) in ranges {
             for col in col_start..col_end {
                 if col < area.x + area.width && row < area.y + area.height {
@@ -292,11 +327,21 @@ impl TuiBackend {
         }
     }
 
+    /// Return the selection text cached by the last `apply_selection_highlight` call.
+    pub(crate) fn take_cached_selection_text(&self) -> String {
+        self.cached_selection_text.clone()
+    }
+
     /// Read the selected cells back from `buf`, trim trailing whitespace
     /// per line, and return the joined text (lines separated by `\n`).
     ///
     /// Falls back to an empty `String` when there is no active selection
     /// or the region id can no longer be found in the registered regions.
+    ///
+    /// Only used in tests — production code uses the text cached by
+    /// `apply_selection_highlight` (the live buffer is unavailable after
+    /// `terminal.draw` swaps ratatui's double-buffer).
+    #[cfg(test)]
     pub(crate) fn extract_selection_text(&self, buf: &ratatui::buffer::Buffer) -> String {
         let sel = match &self.active_selection {
             Some(s) => s,
@@ -344,6 +389,58 @@ impl TuiBackend {
     /// backend doesn't know which widget has focus or what mode the app
     /// is in. Apps that want those scopes match against `KeyPressed`
     /// themselves once they have that context.
+    /// Run raw translated events through the dispatch layer so that
+    /// `MouseDown` on a text region begins a `TextSelection` drag and
+    /// `MouseMoved` (with button held) emits `TextSelectionChanged`.
+    ///
+    /// Scroll-surface arbitration is not wired here yet — scroll surfaces
+    /// are not registered per-frame by `TuiBackend`. That is a TODO for
+    /// the scrollbar dispatch epic; passing an empty slice means text
+    /// regions work correctly today and scrollbar drags are unaffected
+    /// (they continue to be handled by app-side hit-tests as before).
+    fn apply_dispatch(&mut self, raw: Vec<UiEvent>) -> Vec<UiEvent> {
+        let mut out = Vec::with_capacity(raw.len());
+        for event in raw {
+            match event {
+                UiEvent::MouseDown {
+                    button,
+                    position,
+                    modifiers,
+                    ..
+                } => {
+                    out.extend(crate::dispatch::dispatch_click(
+                        &self.modal_stack,
+                        &[],
+                        &self.text_regions.clone(),
+                        &mut self.drag_state,
+                        position,
+                        button,
+                        modifiers,
+                    ));
+                }
+                UiEvent::MouseMoved { position, buttons } => {
+                    out.extend(crate::dispatch::dispatch_mouse_drag(
+                        &self.drag_state,
+                        position,
+                        buttons,
+                    ));
+                }
+                UiEvent::MouseUp {
+                    button, position, ..
+                } => {
+                    out.extend(crate::dispatch::dispatch_mouse_up(
+                        &self.modal_stack,
+                        &mut self.drag_state,
+                        position,
+                        button,
+                    ));
+                }
+                other => out.push(other),
+            }
+        }
+        out
+    }
+
     fn apply_accelerators(&self, events: &mut [UiEvent]) {
         if self.parsed_accelerators.is_empty() {
             return;
@@ -503,15 +600,16 @@ impl Backend for TuiBackend {
         // Drain every queued crossterm event; never blocks. Each
         // native event translates to zero, one, or more `UiEvent`s
         // via [`super::events::crossterm_to_uievents`], then runs
-        // through [`Self::apply_accelerators`] so registered bindings
-        // surface as `UiEvent::Accelerator` instead of `KeyPressed`.
-        let mut out = Vec::new();
+        // through the dispatch layer (text-region hit-test, drag state)
+        // and [`Self::apply_accelerators`].
+        let mut raw = Vec::new();
         while ratatui::crossterm::event::poll(Duration::ZERO).unwrap_or(false) {
             match ratatui::crossterm::event::read() {
-                Ok(ev) => out.extend(super::events::crossterm_to_uievents(ev)),
+                Ok(ev) => raw.extend(super::events::crossterm_to_uievents(ev)),
                 Err(_) => break,
             }
         }
+        let mut out = self.apply_dispatch(raw);
         self.apply_accelerators(&mut out);
         self.double_click.process(&mut out);
         out
@@ -519,16 +617,13 @@ impl Backend for TuiBackend {
 
     fn wait_events(&mut self, timeout: Duration) -> Vec<UiEvent> {
         // Block up to `timeout` for the next native event, translate it,
-        // match against registered accelerators, and return. Empty `Vec`
-        // on timeout.
-        //
-        // The "one event per call" shape preserves the existing event
-        // loop's `match` semantics: each iteration handles exactly one
-        // event before checking timing-sensitive state (yank highlight
-        // expiry, notification spinner cadence, etc.).
+        // run through the dispatch layer (text-region hit-test, drag
+        // state), match against registered accelerators, and return.
+        // Empty `Vec` on timeout.
         if let Ok(true) = ratatui::crossterm::event::poll(timeout) {
             if let Ok(ev) = ratatui::crossterm::event::read() {
-                let mut out = super::events::crossterm_to_uievents(ev);
+                let raw = super::events::crossterm_to_uievents(ev);
+                let mut out = self.apply_dispatch(raw);
                 self.apply_accelerators(&mut out);
                 self.double_click.process(&mut out);
                 return out;

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -45,11 +45,12 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::backend::{activity_bar_hits, tab_bar_layout_to_hits};
+use crate::dispatch::TextRegion;
 use crate::{
     parse_key_binding, Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Backend,
-    CommandLine, DragState, Form, KeyBinding, ListView, MenuBar, ModalStack, Palette,
-    ParsedBinding, PlatformServices, Rect as QRect, Split, StatusBar, TabBar,
-    Terminal as TerminalPrim, TextDisplay, TreeView, UiEvent, Viewport,
+    CommandLine, DragState, DragTarget, Form, KeyBinding, ListView, MenuBar, ModalStack, Palette,
+    ParsedBinding, PlatformServices, Point, Rect as QRect, Split, StatusBar, TabBar,
+    Terminal as TerminalPrim, TextDisplay, TreeView, UiEvent, Viewport, WidgetId,
 };
 use ratatui::layout::Rect;
 use ratatui::Frame;
@@ -60,6 +61,16 @@ use super::services::TuiPlatformServices;
 /// before priority drop kicks in. Mirrors `crate::gtk::status_bar`'s
 /// `MIN_GAP_PX = 16.0`. Irrelevant for bars without right segments.
 const MIN_GAP_CELLS: f32 = 2.0;
+
+/// Finalised text selection held between frames. Persists after the
+/// mouse button is released until Ctrl-C copies the text or a new
+/// mouse-down clears it.
+#[derive(Debug, Clone)]
+pub(crate) struct TuiTextSelection {
+    pub region: WidgetId,
+    pub anchor: Point,
+    pub focus: Point,
+}
 
 /// TUI backend implementing [`crate::Backend`].
 ///
@@ -97,6 +108,15 @@ pub struct TuiBackend {
     /// settings via [`Self::set_nerd_fonts`]; defaults to `true`.
     nerd_fonts_enabled: bool,
     double_click: super::events::DoubleClickDetector,
+    /// Selectable text regions registered during the current frame via
+    /// [`crate::Backend::register_text_region`]. Cleared at the start
+    /// of each frame by [`Self::begin_frame`].
+    text_regions: Vec<TextRegion>,
+    /// Finalised selection (may persist after mouse-up). `None` when
+    /// no selection is active. Set by [`Self::set_active_text_selection`],
+    /// cleared by [`Self::clear_text_selection`] or on a new
+    /// `MouseDown`.
+    active_selection: Option<TuiTextSelection>,
 }
 
 impl TuiBackend {
@@ -118,6 +138,8 @@ impl TuiBackend {
             current_theme: crate::Theme::default(),
             nerd_fonts_enabled: true,
             double_click: super::events::DoubleClickDetector::new(),
+            text_regions: Vec::new(),
+            active_selection: None,
         }
     }
 
@@ -197,6 +219,120 @@ impl TuiBackend {
     pub fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack) {
         (&mut self.drag_state, &mut self.modal_stack)
     }
+
+    // ── Text selection ─────────────────────────────────────────────────────
+
+    /// Return the current active text selection, if any.
+    pub(crate) fn active_text_selection(&self) -> Option<&TuiTextSelection> {
+        self.active_selection.as_ref()
+    }
+
+    /// Update (or start) the active text selection. Called by the runner
+    /// when a [`UiEvent::TextSelectionChanged`] event arrives.
+    pub(crate) fn set_active_text_selection(
+        &mut self,
+        region: WidgetId,
+        anchor: Point,
+        focus: Point,
+    ) {
+        self.active_selection = Some(TuiTextSelection {
+            region,
+            anchor,
+            focus,
+        });
+    }
+
+    /// Clear the active text selection and, if a `TextSelection` drag is
+    /// in progress, end it. Called by the runner on `MouseDown` or after
+    /// Ctrl-C copies the selection.
+    pub(crate) fn clear_text_selection(&mut self) {
+        self.active_selection = None;
+        if matches!(
+            self.drag_state.target(),
+            Some(DragTarget::TextSelection { .. })
+        ) {
+            self.drag_state.end();
+        }
+    }
+
+    /// Invert (highlight) the cells in the ratatui buffer that fall
+    /// within the active text selection range. Swaps foreground and
+    /// background colour for each selected cell.
+    ///
+    /// Must be called inside `terminal.draw(|frame| …)` after
+    /// `app.render` so that the selection is overlaid on top of the
+    /// app's content.
+    pub(crate) fn apply_selection_highlight(&self, buf: &mut ratatui::buffer::Buffer) {
+        let sel = match &self.active_selection {
+            Some(s) => s,
+            None => return,
+        };
+        let region = match self.text_regions.iter().find(|r| r.id == sel.region) {
+            Some(r) => r,
+            None => return,
+        };
+        let bounds = crate::event::Rect::new(
+            region.bounds.x,
+            region.bounds.y,
+            region.bounds.width,
+            region.bounds.height,
+        );
+        let ranges = crate::dispatch::text_selection_line_range(sel.anchor, sel.focus, bounds);
+        let area = buf.area;
+        for (row, col_start, col_end) in ranges {
+            for col in col_start..col_end {
+                if col < area.x + area.width && row < area.y + area.height {
+                    let cell = &mut buf[(col, row)];
+                    let fg = cell.fg;
+                    let bg = cell.bg;
+                    cell.fg = bg;
+                    cell.bg = fg;
+                }
+            }
+        }
+    }
+
+    /// Read the selected cells back from `buf`, trim trailing whitespace
+    /// per line, and return the joined text (lines separated by `\n`).
+    ///
+    /// Falls back to an empty `String` when there is no active selection
+    /// or the region id can no longer be found in the registered regions.
+    pub(crate) fn extract_selection_text(&self, buf: &ratatui::buffer::Buffer) -> String {
+        let sel = match &self.active_selection {
+            Some(s) => s,
+            None => return String::new(),
+        };
+        let region = match self.text_regions.iter().find(|r| r.id == sel.region) {
+            Some(r) => r,
+            None => return String::new(),
+        };
+        let bounds = crate::event::Rect::new(
+            region.bounds.x,
+            region.bounds.y,
+            region.bounds.width,
+            region.bounds.height,
+        );
+        let ranges = crate::dispatch::text_selection_line_range(sel.anchor, sel.focus, bounds);
+        let area = buf.area;
+        let mut lines: Vec<String> = Vec::with_capacity(ranges.len());
+        for (row, col_start, col_end) in ranges {
+            if row >= area.y + area.height {
+                continue;
+            }
+            let mut line = String::new();
+            for col in col_start..col_end {
+                if col < area.x + area.width {
+                    line.push_str(buf[(col, row)].symbol());
+                }
+            }
+            // Trim trailing whitespace and NUL padding per line.
+            let trimmed = line.trim_end_matches(|c: char| c.is_whitespace() || c == '\0');
+            lines.push(trimmed.to_string());
+        }
+        lines.join("\n")
+    }
+
+    // ── Accelerators ───────────────────────────────────────────────────────
 
     /// Walk `events` and rewrite any `UiEvent::KeyPressed` whose key +
     /// modifiers match a registered `Global`-scope accelerator into
@@ -344,6 +480,13 @@ impl Backend for TuiBackend {
 
     fn begin_frame(&mut self, viewport: Viewport) {
         self.viewport = viewport;
+        // Clear per-frame text regions so stale registrations from the
+        // previous frame don't linger.
+        self.text_regions.clear();
+    }
+
+    fn register_text_region(&mut self, region: TextRegion) {
+        self.text_regions.push(region);
     }
 
     fn end_frame(&mut self) {
@@ -2038,5 +2181,111 @@ mod tests {
         backend.apply_accelerators(&mut events);
 
         assert!(matches!(events[0], UiEvent::KeyPressed { .. }));
+    }
+
+    // ── Text selection / highlight round-trip tests ──────────────────────────
+
+    /// Build a minimal ratatui buffer filled with known text, set up a
+    /// text selection, and verify that:
+    ///   1. `apply_selection_highlight` inverts the selected cells.
+    ///   2. `extract_selection_text` returns the trimmed, newline-joined text.
+    #[test]
+    fn selection_highlight_and_extract_round_trip() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect as RRect;
+        use ratatui::style::Color as RC;
+
+        // 10 wide × 3 tall buffer filled with known characters.
+        let area = RRect::new(0, 0, 10, 3);
+        let mut buf = Buffer::empty(area);
+
+        // Row 0: "hello     " (trailing spaces)
+        // Row 1: "world     "
+        // Row 2: "!         "
+        for (col, ch) in "hello     ".chars().enumerate() {
+            buf[(col as u16, 0)]
+                .set_char(ch)
+                .set_fg(RC::White)
+                .set_bg(RC::Black);
+        }
+        for (col, ch) in "world     ".chars().enumerate() {
+            buf[(col as u16, 1)]
+                .set_char(ch)
+                .set_fg(RC::White)
+                .set_bg(RC::Black);
+        }
+        for (col, ch) in "!         ".chars().enumerate() {
+            buf[(col as u16, 2)]
+                .set_char(ch)
+                .set_fg(RC::White)
+                .set_bg(RC::Black);
+        }
+
+        // Register text region and set selection: anchor at (0,0), focus at (0,2).
+        // That covers rows 0–2, starting from col 0.
+        let mut backend = TuiBackend::new();
+        backend.text_regions.push(crate::dispatch::TextRegion {
+            id: WidgetId::new("log:body"),
+            bounds: crate::event::Rect::new(0.0, 0.0, 10.0, 3.0),
+        });
+        backend.set_active_text_selection(
+            WidgetId::new("log:body"),
+            Point::new(0.0, 0.0),
+            Point::new(0.0, 2.0),
+        );
+
+        // 1. Extract text before highlight (cells still normal).
+        let text = backend.extract_selection_text(&buf);
+        // anchor(0,0) → focus(0,2):
+        //   row 0: col 0..10 → "hello     " trimmed → "hello"
+        //   row 1: col 0..10 → "world     " trimmed → "world"
+        //   row 2: col 0..1  → "!" trimmed → "!"
+        assert_eq!(text, "hello\nworld\n!");
+
+        // 2. Apply highlight — selected cells should swap fg/bg.
+        backend.apply_selection_highlight(&mut buf);
+        // Spot-check: (0,0) should be inverted (fg=Black, bg=White).
+        assert_eq!(buf[(0u16, 0u16)].fg, RC::Black);
+        assert_eq!(buf[(0u16, 0u16)].bg, RC::White);
+        // A cell outside the last row's range (col 1 of row 2 is outside
+        // 0..1, so col=1 should be un-inverted).
+        assert_eq!(buf[(1u16, 2u16)].fg, RC::White);
+        assert_eq!(buf[(1u16, 2u16)].bg, RC::Black);
+    }
+
+    #[test]
+    fn selection_clears_on_clear_text_selection() {
+        let mut backend = TuiBackend::new();
+        backend.set_active_text_selection(
+            WidgetId::new("r"),
+            Point::new(0.0, 0.0),
+            Point::new(5.0, 0.0),
+        );
+        assert!(backend.active_text_selection().is_some());
+        backend.clear_text_selection();
+        assert!(backend.active_text_selection().is_none());
+        // Drag state should also be cleared if it was a TextSelection.
+        backend.drag_state.begin(DragTarget::TextSelection {
+            region: WidgetId::new("r"),
+            anchor: Point::new(0.0, 0.0),
+        });
+        backend.clear_text_selection();
+        assert!(!backend.drag_state.is_active());
+    }
+
+    #[test]
+    fn text_regions_cleared_on_begin_frame() {
+        let mut backend = TuiBackend::new();
+        backend.register_text_region(crate::dispatch::TextRegion {
+            id: WidgetId::new("r"),
+            bounds: crate::event::Rect::new(0.0, 0.0, 40.0, 20.0),
+        });
+        assert_eq!(backend.text_regions.len(), 1);
+        backend.begin_frame(Viewport::default());
+        assert_eq!(
+            backend.text_regions.len(),
+            0,
+            "text_regions must be cleared on begin_frame"
+        );
     }
 }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -327,8 +327,11 @@ impl TuiBackend {
         }
     }
 
-    /// Return the selection text cached by the last `apply_selection_highlight` call.
-    pub(crate) fn take_cached_selection_text(&self) -> String {
+    /// Return a clone of the selection text cached by the last
+    /// `apply_selection_highlight` call. Named `cached_selection_text`
+    /// rather than `take_*` because the value is cloned, not consumed —
+    /// the cache persists until the selection is cleared.
+    pub(crate) fn cached_selection_text(&self) -> String {
         self.cached_selection_text.clone()
     }
 
@@ -393,11 +396,16 @@ impl TuiBackend {
     /// `MouseDown` on a text region begins a `TextSelection` drag and
     /// `MouseMoved` (with button held) emits `TextSelectionChanged`.
     ///
+    /// # TODO: scrollbar dispatch
+    ///
     /// Scroll-surface arbitration is not wired here yet — scroll surfaces
-    /// are not registered per-frame by `TuiBackend`. That is a TODO for
-    /// the scrollbar dispatch epic; passing an empty slice means text
-    /// regions work correctly today and scrollbar drags are unaffected
-    /// (they continue to be handled by app-side hit-tests as before).
+    /// are not registered per-frame by `TuiBackend`. Passing an empty slice
+    /// to `dispatch_click` means text regions work correctly today and
+    /// scrollbar drags are unaffected (they continue to be handled by
+    /// app-side hit-tests as before). The consequence is that the
+    /// "scrollbar wins over an overlapping text region" acceptance
+    /// criterion is not enforced in TUI. Tracked as a follow-up issue
+    /// (scrollbar dispatch epic).
     fn apply_dispatch(&mut self, raw: Vec<UiEvent>) -> Vec<UiEvent> {
         let mut out = Vec::with_capacity(raw.len());
         for event in raw {

--- a/quadraui/src/tui/run.rs
+++ b/quadraui/src/tui/run.rs
@@ -30,6 +30,7 @@ use ratatui::Terminal;
 use crate::backend::Backend;
 use crate::runner::{AppLogic, Reaction};
 use crate::tui::backend::TuiBackend;
+use crate::{Key, Modifiers, UiEvent};
 
 /// Default poll timeout — 16 ms ≈ 60 fps. The runner sleeps inside
 /// `wait_events(timeout)` waiting for input; on timeout the loop
@@ -128,6 +129,10 @@ fn run_inner<A: AppLogic>(
                     // the AreaId for whichever surface is repainting.
                     app.render(b, A::AreaId::default());
                 });
+                // After app.render: overlay selection highlight on the
+                // rendered buffer. Done outside enter_frame_scope so the
+                // closure lifetime doesn't conflict with the frame borrow.
+                backend.apply_selection_highlight(frame.buffer_mut());
             })?;
             backend.end_frame();
             needs_redraw = false;
@@ -136,6 +141,46 @@ fn run_inner<A: AppLogic>(
         // Drain events. `wait_events` blocks for up to POLL_TIMEOUT.
         let events = backend.wait_events(POLL_TIMEOUT);
         for event in events {
+            // ── Text-selection event pre-processing ────────────────────
+            // These are handled before the app sees the event so the
+            // runner can update backend state and intercept Ctrl-C.
+            match &event {
+                // Update active selection while dragging.
+                UiEvent::TextSelectionChanged {
+                    region,
+                    anchor,
+                    focus,
+                } => {
+                    backend.set_active_text_selection(region.clone(), *anchor, *focus);
+                    needs_redraw = true;
+                }
+                // Clear active selection on any mouse-down (new click).
+                UiEvent::MouseDown { .. } => {
+                    backend.clear_text_selection();
+                }
+                // Ctrl-C with an active selection → copy to clipboard
+                // and suppress the event (don't pass to app).
+                UiEvent::KeyPressed {
+                    key: Key::Char('c'),
+                    modifiers:
+                        Modifiers {
+                            ctrl: true,
+                            shift: false,
+                            alt: false,
+                            cmd: false,
+                        },
+                    ..
+                } if backend.active_text_selection().is_some() => {
+                    let text = backend.extract_selection_text(terminal.current_buffer_mut());
+                    backend.services().clipboard().write_text(&text);
+                    backend.clear_text_selection();
+                    needs_redraw = true;
+                    // Do NOT pass this Ctrl-C to the app.
+                    continue;
+                }
+                _ => {}
+            }
+            // ── Normal app dispatch ─────────────────────────────────────
             match app.handle(event, backend) {
                 Reaction::Continue => {}
                 Reaction::Redraw => needs_redraw = true,

--- a/quadraui/src/tui/run.rs
+++ b/quadraui/src/tui/run.rs
@@ -177,13 +177,17 @@ fn run_inner<A: AppLogic>(
                     && !modifiers.cmd
                     && backend.active_text_selection().is_some() =>
                 {
-                    let text = backend.take_cached_selection_text();
+                    let text = backend.cached_selection_text();
                     backend.services().clipboard().write_text(&text);
                     backend.clear_text_selection();
-                    // Deliver a ClipboardPaste event to the app so it can
-                    // show copy confirmation in its UI. Do NOT pass the
-                    // original Ctrl-C — that would trigger quit/etc.
-                    if app.handle(UiEvent::ClipboardPaste(text), backend) == Reaction::Exit {
+                    // Notify the app via TextCopied so it can show a
+                    // copy-confirmation badge. We use a dedicated event
+                    // rather than ClipboardPaste because ClipboardPaste
+                    // is routed to the focused text input ("insert this
+                    // text"), which is the opposite of what we want here.
+                    // Do NOT forward the original Ctrl-C — that would
+                    // trigger quit/copy-all/etc in app handlers.
+                    if app.handle(UiEvent::TextCopied(text), backend) == Reaction::Exit {
                         return Ok(());
                     }
                     needs_redraw = true;

--- a/quadraui/src/tui/run.rs
+++ b/quadraui/src/tui/run.rs
@@ -30,7 +30,7 @@ use ratatui::Terminal;
 use crate::backend::Backend;
 use crate::runner::{AppLogic, Reaction};
 use crate::tui::backend::TuiBackend;
-use crate::{Key, Modifiers, UiEvent};
+use crate::{Key, UiEvent};
 
 /// Default poll timeout — 16 ms ≈ 60 fps. The runner sleeps inside
 /// `wait_events(timeout)` waiting for input; on timeout the loop
@@ -154,28 +154,39 @@ fn run_inner<A: AppLogic>(
                     backend.set_active_text_selection(region.clone(), *anchor, *focus);
                     needs_redraw = true;
                 }
-                // Clear active selection on any mouse-down (new click).
+                // Clear the displayed selection highlight on any mouse-down.
+                // Use `clear_selection_display` rather than
+                // `clear_text_selection` so we don't cancel the
+                // `TextSelection` drag that `apply_dispatch` just started
+                // in `wait_events` for this very event.
                 UiEvent::MouseDown { .. } => {
-                    backend.clear_text_selection();
+                    backend.clear_selection_display();
                 }
-                // Ctrl-C with an active selection → copy to clipboard
-                // and suppress the event (don't pass to app).
+                // Ctrl-C (any case, any additional modifiers) with an
+                // active selection → copy to clipboard and notify the app
+                // via ClipboardPaste so it can show confirmation feedback.
+                // Accepts 'C' as well as 'c' (CapsLock), and does not
+                // require shift/alt/cmd to be false (some terminals tag
+                // Ctrl-C with unexpected modifier bits).
                 UiEvent::KeyPressed {
-                    key: Key::Char('c'),
-                    modifiers:
-                        Modifiers {
-                            ctrl: true,
-                            shift: false,
-                            alt: false,
-                            cmd: false,
-                        },
+                    key: Key::Char('c') | Key::Char('C'),
+                    modifiers,
                     ..
-                } if backend.active_text_selection().is_some() => {
-                    let text = backend.extract_selection_text(terminal.current_buffer_mut());
+                } if modifiers.ctrl
+                    && !modifiers.alt
+                    && !modifiers.cmd
+                    && backend.active_text_selection().is_some() =>
+                {
+                    let text = backend.take_cached_selection_text();
                     backend.services().clipboard().write_text(&text);
                     backend.clear_text_selection();
+                    // Deliver a ClipboardPaste event to the app so it can
+                    // show copy confirmation in its UI. Do NOT pass the
+                    // original Ctrl-C — that would trigger quit/etc.
+                    if app.handle(UiEvent::ClipboardPaste(text), backend) == Reaction::Exit {
+                        return Ok(());
+                    }
                     needs_redraw = true;
-                    // Do NOT pass this Ctrl-C to the app.
                     continue;
                 }
                 _ => {}

--- a/quadraui/src/tui/run.rs
+++ b/quadraui/src/tui/run.rs
@@ -164,7 +164,7 @@ fn run_inner<A: AppLogic>(
                 }
                 // Ctrl-C (any case, any additional modifiers) with an
                 // active selection → copy to clipboard and notify the app
-                // via ClipboardPaste so it can show confirmation feedback.
+                // via TextCopied so it can show confirmation feedback.
                 // Accepts 'C' as well as 'c' (CapsLock), and does not
                 // require shift/alt/cmd to be false (some terminals tag
                 // Ctrl-C with unexpected modifier bits).

--- a/quadraui/src/tui/services.rs
+++ b/quadraui/src/tui/services.rs
@@ -90,6 +90,12 @@ fn tmux_passthrough_wrap(seq: &str) -> String {
 /// - **screen**: not widely supported; falls back silently.
 /// - **SSH**: works when the remote terminal supports OSC 52 passthrough
 ///   (most do).
+///
+/// **Payload size limits**: Many terminals cap the OSC 52 base64 payload
+/// at roughly 74–100 KB of encoded data (≈ 55–75 KB of raw text) and
+/// silently drop or truncate sequences that exceed it. Very large
+/// selections may not reach the clipboard; no feedback is given when
+/// this occurs.
 pub(crate) fn emit_osc52_with(text: &str, in_tmux: bool, writer: &mut dyn std::io::Write) {
     let seq = osc52_sequence(text);
     let _ = writer.write_all(seq.as_bytes());

--- a/quadraui/src/tui/services.rs
+++ b/quadraui/src/tui/services.rs
@@ -1,18 +1,83 @@
 //! Default `PlatformServices` impl for the TUI backend.
 //!
-//! Clipboard access uses `arboard` for real system clipboard
-//! integration on all platforms. Other services (file picker,
-//! notifications, URL open) remain no-op stubs — apps that need them
-//! supply their own `PlatformServices` or call platform APIs directly.
+//! Clipboard access uses **both** `arboard` (local desktop clipboard)
+//! and OSC 52 (terminal clipboard via escape sequence). Writing via
+//! OSC 52 works over SSH and inside tmux (when `set -g set-clipboard
+//! on` is set), covering environments where arboard cannot reach the
+//! host clipboard.
+//!
+//! Other services (file picker, notifications, URL open) remain no-op
+//! stubs — apps that need them supply their own `PlatformServices` or
+//! call platform APIs directly.
 
 use std::cell::RefCell;
 use std::path::PathBuf;
 
 use crate::backend::{Clipboard, FileDialogOptions, Notification, PlatformServices};
 
-/// System clipboard via `arboard`. The handle is kept alive for the
-/// process lifetime so Linux clipboard serving threads persist (dropping
-/// the handle immediately would clear clipboard contents on X11/Wayland).
+// ── OSC 52 support ────────────────────────────────────────────────────────────
+
+/// Base64-encode `data` using the standard alphabet (no line wrapping).
+fn base64_encode(data: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    let mut i = 0;
+    while i < data.len() {
+        let b0 = data[i] as u32;
+        let b1 = if i + 1 < data.len() {
+            data[i + 1] as u32
+        } else {
+            0
+        };
+        let b2 = if i + 2 < data.len() {
+            data[i + 2] as u32
+        } else {
+            0
+        };
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(CHARS[((n >> 18) & 0x3f) as usize] as char);
+        out.push(CHARS[((n >> 12) & 0x3f) as usize] as char);
+        if i + 1 < data.len() {
+            out.push(CHARS[((n >> 6) & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        if i + 2 < data.len() {
+            out.push(CHARS[(n & 0x3f) as usize] as char);
+        } else {
+            out.push('=');
+        }
+        i += 3;
+    }
+    out
+}
+
+/// Emit an OSC 52 clipboard-write sequence for `text` to `writer`.
+///
+/// The sequence is: `ESC ] 52 ; c ; <base64(text)> BEL`.
+///
+/// Terminal requirements:
+/// - Most modern terminals (kitty, WezTerm, iTerm2, alacritty, xterm)
+///   support OSC 52 by default.
+/// - **tmux**: `set -g set-clipboard on` is required for tmux to
+///   forward the sequence to the outer terminal.
+/// - **screen**: not widely supported; falls back silently.
+/// - **SSH**: works when the remote terminal supports OSC 52 passthrough
+///   (most do).
+pub(crate) fn emit_osc52_to(text: &str, writer: &mut dyn std::io::Write) {
+    let encoded = base64_encode(text.as_bytes());
+    // `\x1b]52;c;…\x07` — ESC ] = OSC introducer; BEL = ST alternative.
+    let _ = write!(writer, "\x1b]52;c;{}\x07", encoded);
+    let _ = writer.flush();
+}
+
+// ── TuiClipboard ──────────────────────────────────────────────────────────────
+
+/// System clipboard that writes via **both** arboard and OSC 52.
+///
+/// The arboard handle is kept alive for the process lifetime so Linux
+/// clipboard serving threads persist (dropping the handle immediately
+/// would clear clipboard contents on X11/Wayland).
 pub struct TuiClipboard {
     inner: RefCell<Option<arboard::Clipboard>>,
 }
@@ -31,9 +96,62 @@ impl Clipboard for TuiClipboard {
     }
 
     fn write_text(&self, text: &str) {
+        // 1. arboard — local desktop clipboard (works when not over SSH).
         if let Some(cb) = self.inner.borrow_mut().as_mut() {
             let _ = cb.set_text(text);
         }
+        // 2. OSC 52 — terminal clipboard escape (works over SSH / tmux).
+        emit_osc52_to(text, &mut std::io::stdout());
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_empty() {
+        assert_eq!(base64_encode(b""), "");
+    }
+
+    #[test]
+    fn base64_three_bytes_no_padding() {
+        // "Man" → "TWFu"
+        assert_eq!(base64_encode(b"Man"), "TWFu");
+    }
+
+    #[test]
+    fn base64_two_bytes_one_pad() {
+        // "Ma" → "TWE="
+        assert_eq!(base64_encode(b"Ma"), "TWE=");
+    }
+
+    #[test]
+    fn base64_one_byte_two_pads() {
+        // "M" → "TQ=="
+        assert_eq!(base64_encode(b"M"), "TQ==");
+    }
+
+    #[test]
+    fn base64_hello() {
+        assert_eq!(base64_encode(b"hello"), "aGVsbG8=");
+    }
+
+    #[test]
+    fn osc52_sequence_correct() {
+        let mut out = Vec::new();
+        emit_osc52_to("hello", &mut out);
+        // ESC ] 52 ; c ; aGVsbG8= BEL
+        assert_eq!(String::from_utf8(out).unwrap(), "\x1b]52;c;aGVsbG8=\x07");
+    }
+
+    #[test]
+    fn osc52_empty_text() {
+        let mut out = Vec::new();
+        emit_osc52_to("", &mut out);
+        assert_eq!(String::from_utf8(out).unwrap(), "\x1b]52;c;\x07");
     }
 }
 

--- a/quadraui/src/tui/services.rs
+++ b/quadraui/src/tui/services.rs
@@ -2,9 +2,19 @@
 //!
 //! Clipboard access uses **both** `arboard` (local desktop clipboard)
 //! and OSC 52 (terminal clipboard via escape sequence). Writing via
-//! OSC 52 works over SSH and inside tmux (when `set -g set-clipboard
-//! on` is set), covering environments where arboard cannot reach the
-//! host clipboard.
+//! OSC 52 works over SSH and inside tmux, covering environments where
+//! arboard cannot reach the host clipboard.
+//!
+//! ### tmux
+//!
+//! Inside tmux a bare OSC 52 sequence only reaches the outer terminal
+//! when `set -g set-clipboard on` is configured (with `external`/`off`
+//! tmux drops or swallows the application's sequence). To cover the
+//! other common config, when `$TMUX` is set we *also* emit a copy
+//! wrapped in tmux's DCS passthrough (`ESC P tmux ; … ESC \`), which
+//! tmux forwards verbatim to the outer terminal when `allow-passthrough
+//! on` is set. Emitting both is harmless: each config consumes the form
+//! it understands and ignores the other.
 //!
 //! Other services (file picker, notifications, URL open) remain no-op
 //! stubs — apps that need them supply their own `PlatformServices` or
@@ -52,23 +62,49 @@ fn base64_encode(data: &[u8]) -> String {
     out
 }
 
-/// Emit an OSC 52 clipboard-write sequence for `text` to `writer`.
-///
-/// The sequence is: `ESC ] 52 ; c ; <base64(text)> BEL`.
+/// Build the raw OSC 52 clipboard-write sequence for `text`:
+/// `ESC ] 52 ; c ; <base64(text)> BEL` (ESC ] = OSC introducer; BEL
+/// terminates).
+fn osc52_sequence(text: &str) -> String {
+    format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()))
+}
+
+/// Wrap a terminal escape sequence in tmux's DCS passthrough so tmux
+/// forwards it verbatim to the outer terminal: `ESC P tmux ; <seq> ESC \`,
+/// with every inner `ESC` doubled (tmux's escaping rule). Requires
+/// `allow-passthrough on` in the tmux config.
+fn tmux_passthrough_wrap(seq: &str) -> String {
+    let escaped = seq.replace('\x1b', "\x1b\x1b");
+    format!("\x1bPtmux;{}\x1b\\", escaped)
+}
+
+/// Emit an OSC 52 clipboard-write sequence for `text` to `writer`,
+/// additionally emitting a tmux DCS-passthrough copy when `in_tmux`.
 ///
 /// Terminal requirements:
 /// - Most modern terminals (kitty, WezTerm, iTerm2, alacritty, xterm)
 ///   support OSC 52 by default.
-/// - **tmux**: `set -g set-clipboard on` is required for tmux to
-///   forward the sequence to the outer terminal.
+/// - **tmux**: the bare sequence needs `set -g set-clipboard on`; the
+///   passthrough copy (emitted when `in_tmux`) needs `allow-passthrough
+///   on`. Emitting both covers either config.
 /// - **screen**: not widely supported; falls back silently.
 /// - **SSH**: works when the remote terminal supports OSC 52 passthrough
 ///   (most do).
-pub(crate) fn emit_osc52_to(text: &str, writer: &mut dyn std::io::Write) {
-    let encoded = base64_encode(text.as_bytes());
-    // `\x1b]52;c;…\x07` — ESC ] = OSC introducer; BEL = ST alternative.
-    let _ = write!(writer, "\x1b]52;c;{}\x07", encoded);
+pub(crate) fn emit_osc52_with(text: &str, in_tmux: bool, writer: &mut dyn std::io::Write) {
+    let seq = osc52_sequence(text);
+    let _ = writer.write_all(seq.as_bytes());
+    if in_tmux {
+        let _ = writer.write_all(tmux_passthrough_wrap(&seq).as_bytes());
+    }
     let _ = writer.flush();
+}
+
+/// Emit OSC 52 for `text`, auto-detecting tmux from `$TMUX`. Thin
+/// wrapper over [`emit_osc52_with`] used by production code; tests call
+/// `emit_osc52_with` with an explicit `in_tmux` to stay independent of
+/// the ambient environment.
+pub(crate) fn emit_osc52_to(text: &str, writer: &mut dyn std::io::Write) {
+    emit_osc52_with(text, std::env::var_os("TMUX").is_some(), writer);
 }
 
 // ── TuiClipboard ──────────────────────────────────────────────────────────────
@@ -142,7 +178,7 @@ mod tests {
     #[test]
     fn osc52_sequence_correct() {
         let mut out = Vec::new();
-        emit_osc52_to("hello", &mut out);
+        emit_osc52_with("hello", false, &mut out);
         // ESC ] 52 ; c ; aGVsbG8= BEL
         assert_eq!(String::from_utf8(out).unwrap(), "\x1b]52;c;aGVsbG8=\x07");
     }
@@ -150,8 +186,27 @@ mod tests {
     #[test]
     fn osc52_empty_text() {
         let mut out = Vec::new();
-        emit_osc52_to("", &mut out);
+        emit_osc52_with("", false, &mut out);
         assert_eq!(String::from_utf8(out).unwrap(), "\x1b]52;c;\x07");
+    }
+
+    #[test]
+    fn osc52_tmux_emits_raw_then_passthrough() {
+        let mut out = Vec::new();
+        emit_osc52_with("hello", true, &mut out);
+        // Raw sequence first, then the DCS-passthrough copy with the
+        // inner ESC doubled and an `ESC \` terminator.
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "\x1b]52;c;aGVsbG8=\x07\x1bPtmux;\x1b\x1b]52;c;aGVsbG8=\x07\x1b\\"
+        );
+    }
+
+    #[test]
+    fn tmux_passthrough_doubles_every_esc() {
+        // A two-ESC payload must come back with four ESCs, wrapped.
+        let wrapped = tmux_passthrough_wrap("\x1bA\x1bB");
+        assert_eq!(wrapped, "\x1bPtmux;\x1b\x1bA\x1b\x1bB\x1b\\");
     }
 }
 


### PR DESCRIPTION
Closes #269

Automated PR opened by coordinator for review of issue #269.