### PR TITLE
#291: Markdown adapter: lists, fenced code blocks, links, blockquotes, tables, images (follow-up to #262)

### DIFF
--- a/quadraui/examples/common/ai_transcript.rs
+++ b/quadraui/examples/common/ai_transcript.rs
@@ -7,10 +7,13 @@
 //! `inline_code`, bulleted / numbered lists, fenced code blocks, links, and
 //! blockquotes to a [`StyledText`] stored inside the [`ChatTurn`].
 //!
-//! The `ChatController` renders the structured plain text in the transcript
-//! (list bullets `•`, blockquote bars `│`, and code-block content are all
-//! visible as text cues).  Backends that support per-span colour (GTK) also
-//! show bold, italic, and link underlines.
+//! The `ChatController` renders the structured plain text in the transcript.
+//! Structural glyphs — list bullets `•`, blockquote bars `│`, and code-block
+//! content — survive as literal Unicode text cues in every backend.
+//! Per-span attributes (bold, italic, underline, foreground colour) are **not**
+//! preserved in the transcript renderer: `build_transcript_rows` extracts
+//! uniform plain text and applies a single `content_fg` per role.  Per-span
+//! colour rendering in the transcript is a planned future improvement.
 //!
 //! Controls:
 //! - `Ctrl+S` or `Alt+Enter` — submit (sends the next canned prompt).

--- a/quadraui/examples/common/ai_transcript.rs
+++ b/quadraui/examples/common/ai_transcript.rs
@@ -1,193 +1,149 @@
 //! Backend-agnostic `AppLogic` for the AI-chat-transcript demo
 //! ([`tui_ai_transcript`] / [`gtk_ai_transcript`]).
 //!
-//! This is the **headless-chat-server use case**: an upstream produces
-//! markdown text (an AI assistant's reply) and the UI must render it as
-//! styled, scrolling output. The demo wires the existing
-//! [`render_markdown_to_styled`] adapter straight into a [`TextDisplay`]
-//! — the append-only, auto-scrolling log primitive — instead of the
-//! modal [`RichTextPopup`] used by `tui_markdown`. `TextDisplay` is the
-//! better fit for a streaming transcript: lines arrive over time, the
-//! view pins to the newest line, and a scrollbar lets the user page back.
+//! Demonstrates [`ChatController::push_turn_markdown`]: the recommended API
+//! for assistant-role messages.  Each canned reply is passed as raw markdown
+//! to `push_turn_markdown`; the adapter converts headings, **bold**, *italic*,
+//! `inline_code`, bulleted / numbered lists, fenced code blocks, links, and
+//! blockquotes to a [`StyledText`] stored inside the [`ChatTurn`].
 //!
-//! The bridge is tiny and is the reusable pattern a real chat client
-//! would copy: [`markdown_to_display_lines`] maps each
-//! `RenderedMarkdown` line's spans onto a [`TextDisplayLine`]. No new
-//! primitive and no new `Backend` method — the same `AppLogic` drives
-//! every backend.
-//!
-//! To make the streaming visible (and to mimic a server that emits a
-//! reply token-by-token) the assistant's lines are queued and revealed
-//! one per `tick`, after a short "thinking" delay.
-//!
-//! The canned replies deliberately include markdown the adapter does
-//! **not** yet style — bulleted/numbered lists, fenced code blocks,
-//! links — so the demo doubles as a visual record of the gap tracked in
-//! the follow-up issue. Those lines render as plain (but readable) text.
+//! The `ChatController` renders the structured plain text in the transcript
+//! (list bullets `•`, blockquote bars `│`, and code-block content are all
+//! visible as text cues).  Backends that support per-span colour (GTK) also
+//! show bold, italic, and link underlines.
 //!
 //! Controls:
-//! - `Enter` / `s` — send the next canned prompt (cycles through a few).
-//! - `↑` / `↓` — scroll one line (pauses auto-scroll).
-//! - `PageUp` / `PageDown` — scroll a page (pauses auto-scroll).
-//! - `End` — jump to the newest line and re-enable auto-scroll.
-//! - `q` / `Esc` — quit.
-
-use std::collections::VecDeque;
+//! - `Ctrl+S` or `Alt+Enter` — submit (sends the next canned prompt).
+//! - `Enter` — insert a newline in the input box.
+//! - `PageUp` / `PageDown` / `↑` / `↓` — scroll the transcript.
+//! - `Esc` — quit.
 
 use quadraui::{
-    render_markdown_to_styled, AppLogic, Backend, Color, Decoration, Key, NamedKey, Reaction, Rect,
-    StyledSpan, StyledText, TextDisplay, TextDisplayLine, Theme, UiEvent, WidgetId,
+    AppLogic, Backend, ChatController, ChatControllerEvent, ChatRole, Reaction, Rect, StyledText,
+    Theme, UiEvent,
 };
 
-/// Map a markdown string to a list of [`TextDisplayLine`]s via the
-/// quadraui markdown adapter.
-///
-/// This is the headless-chat-server bridge: hand it the assistant's raw
-/// markdown reply, get back styled lines ready to `append_line` into a
-/// [`TextDisplay`]. `decoration` tags every produced line (e.g.
-/// [`Decoration::Muted`] for system notes); inline bold/italic/code from
-/// the markdown is preserved on the spans.
-///
-/// Per-line heading *scale* (`RenderedMarkdown::line_scales`) is dropped
-/// here: `TextDisplay` has no per-line font-size knob (neither does the
-/// TUI backend), so headings keep their bold weight but not larger type.
-fn markdown_to_display_lines(
-    md: &str,
-    theme: &Theme,
-    decoration: Decoration,
-) -> Vec<TextDisplayLine> {
-    render_markdown_to_styled(md, theme)
-        .lines
-        .into_iter()
-        .map(|StyledText { spans }| TextDisplayLine {
-            spans,
-            decoration,
-            timestamp: None,
-        })
-        .collect()
-}
-
 /// Canned (prompt, markdown-reply) pairs cycled through on each send.
-/// The replies mix adapter-supported syntax (headings, **bold**,
-/// *italic*, `code`) with not-yet-styled syntax (lists, fenced blocks,
-/// links) so the demo shows both the feature and the gap.
+///
+/// The replies deliberately exercise every construct the adapter now supports:
+/// headings, bold/italic/code, bulleted lists, numbered lists, fenced code
+/// blocks, links, and blockquotes.  They also include `snake_case` identifiers
+/// to confirm the flanking guard keeps them upright.
 const EXCHANGES: &[(&str, &str)] = &[
     (
         "How do I convert markdown to styled text?",
         "\
 ## Markdown → StyledText
+
 Call `render_markdown_to_styled(input, &theme)`. It returns a
 `RenderedMarkdown` with three length-aligned vectors:
 
 - `lines` — one **StyledText** per source line
 - `line_text` — plain text, for hit-tests and search
-- `line_scales` — heading scale factors
+- `line_scales` — heading scale factors (H1=2.0, H2=1.5, H3=1.2)
 
-Then feed `lines` into a `TextDisplay` for a *scrolling* transcript.",
+Then pass the markdown string to `ChatController::push_turn_markdown` and the
+controller stores the styled result as a [`ChatTurn`].
+
+> **Tip**: `snake_case` identifiers like render_markdown_to_styled stay
+> upright — the adapter honours CommonMark flanking rules.",
     ),
     (
         "What markdown does it support today?",
         "\
-# Supported
-Inline **bold**, *italic*/_also_, and `inline_code` all render. Headings
-`#`/`##`/`###` scale up in GTK.
+# Supported constructs
 
-# Not yet (the gap)
-1. Bulleted and numbered lists
-2. Fenced code blocks:
+Inline **bold**, *italic*, and `inline_code` all render with correct spans.
+Headings `#` / `##` / `###` scale up in the GTK backend.
+
+## Lists
+
+1. Numbered items render with a styled marker
+2. Both dash and asterisk bullet syntax work
+
+- First bullet item
+- Second bullet item with **bold** text
+* Third item — asterisk syntax
+
+## Fenced code blocks
+
 ```rust
-fn main() { println!(\"hi\"); }
+pub fn push_turn_markdown(
+    &mut self,
+    role: ChatRole,
+    markdown: &str,
+    theme: &Theme,
+) {
+    // internally calls render_markdown_to_styled
+}
 ```
-3. Links like [quadraui](https://example.com), blockquotes, tables, images.
 
-These pass through as plain text for now.",
+## Links and blockquotes
+
+See [the quadraui docs](https://github.com/example/quadraui) for details.
+
+> This is a blockquote.  It renders with a `│` left-bar decoration.
+> You can put **bold** and `code` inside a blockquote too.",
     ),
     (
         "Anything else I should know?",
         "\
-### Notes
-Identifiers like foo_bar and baz_qux stay upright — the adapter honours
-CommonMark flanking, so `snake_case` is **never** mistaken for emphasis.
-Arithmetic like a * b * c is left alone too.",
+### A few rules to remember
+
+- `snake_case` identifiers stay upright — the flanking guard prevents
+  `foo_bar_baz` from being parsed as italic.
+- Arithmetic like a * b * c is left alone (whitespace-flanked `*`).
+- Nested lists are deferred — single level only for now.
+
+> The same `AppLogic` impl drives both TUI and GTK backends.  The markdown
+> adapter runs once; both backends consume `RenderedMarkdown` unchanged.",
     ),
 ];
 
-/// Demo app rendering an AI chat transcript into a [`TextDisplay`].
+/// Demo app that drives a [`ChatController`] with `push_turn_markdown`.
 pub struct AiTranscript {
-    td: TextDisplay,
-    /// Index of the next canned exchange to send.
+    controller: ChatController,
     next_exchange: usize,
-    /// Lines waiting to be revealed (simulating a streamed reply).
-    pending: VecDeque<TextDisplayLine>,
-    /// Ticks remaining before the queued reply starts streaming.
-    thinking_ticks: usize,
 }
 
 impl AiTranscript {
     pub fn new() -> Self {
-        let mut td = TextDisplay::new(WidgetId::new("ai:transcript"));
-        td.title = Some(StyledText::plain(
-            "AI transcript — Enter to send · ↑/↓/PgUp/PgDn scroll · End follow · q quit",
+        let mut controller = ChatController::new("ai-transcript");
+        controller.set_status(StyledText::plain(
+            "AI transcript  ·  Ctrl+S to send  ·  PgUp/PgDn scroll  ·  Esc quit",
         ));
-        td.show_scrollbar = true;
-        td.auto_scroll = true;
-        // Cap retention like a real long-running chat session.
-        td.set_max_lines(2000);
+        // TUI uses 1-cell-wide scrollbar; GTK uses ~8px.  Set to 1 so the
+        // demo looks right in TUI without further config.
+        controller.set_scrollbar_width(Some(1.0));
 
-        let mut app = Self {
-            td,
+        // Seed with a system greeting so the view is not empty on launch.
+        controller.push_turn(
+            ChatRole::System,
+            StyledText::plain(
+                "Connected. Press Ctrl+S or Alt+Enter to send the next canned prompt.",
+            ),
+        );
+
+        Self {
+            controller,
             next_exchange: 0,
-            pending: VecDeque::new(),
-            thinking_ticks: 0,
-        };
-        // Seed with a greeting so the view isn't empty on launch.
-        app.append_system("Connected to headless chat server. Ask away.");
-        app
-    }
-
-    /// Append a dim system note (its own styled line, no markdown).
-    fn append_system(&mut self, text: &str) {
-        self.td.append_line(TextDisplayLine {
-            spans: vec![StyledSpan::plain(text)],
-            decoration: Decoration::Muted,
-            timestamp: None,
-        });
-    }
-
-    /// Append the user's prompt as a single highlighted line.
-    fn append_user(&mut self, text: &str) {
-        self.td.append_line(TextDisplayLine {
-            spans: vec![StyledSpan {
-                text: format!("You › {text}"),
-                fg: Some(Color::rgb(120, 190, 255)),
-                bg: None,
-                bold: true,
-                italic: false,
-                underline: false,
-            }],
-            decoration: Decoration::Normal,
-            timestamp: None,
-        });
-    }
-
-    /// Send the next canned prompt: echo the user turn and queue the
-    /// markdown reply to stream in over the next ticks.
-    fn send_next(&mut self) {
-        // Don't start a new turn mid-stream.
-        if self.thinking_ticks > 0 || !self.pending.is_empty() {
-            return;
         }
+    }
+
+    /// Send the next canned prompt: echo the user turn, then use
+    /// `push_turn_markdown` to render and store the assistant reply.
+    fn send_next(&mut self) {
         let (prompt, reply_md) = EXCHANGES[self.next_exchange % EXCHANGES.len()];
         self.next_exchange += 1;
 
-        self.append_user(prompt);
-        // Re-enable follow so the streamed reply stays in view.
-        self.td.auto_scroll = true;
+        // User turn — plain text.
+        self.controller
+            .push_turn(ChatRole::User, StyledText::plain(prompt));
 
+        // Assistant turn — markdown rendered via the adapter.
         let theme = Theme::default();
-        let mut lines = markdown_to_display_lines(reply_md, &theme, Decoration::Normal);
-        self.pending.extend(lines.drain(..));
-        self.thinking_ticks = 3;
+        self.controller
+            .push_turn_markdown(ChatRole::Assistant, reply_md, &theme);
     }
 }
 
@@ -203,58 +159,20 @@ impl AppLogic for AiTranscript {
     fn render(&self, backend: &mut dyn Backend, _area: ()) {
         let vp = backend.viewport();
         let rect = Rect::new(0.0, 0.0, vp.width, vp.height);
-        backend.draw_text_display(rect, &self.td);
+        self.controller.render(backend, rect);
     }
 
-    fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
-        match event {
-            UiEvent::KeyPressed { key, .. } => match key {
-                Key::Char('q') | Key::Named(NamedKey::Escape) => Reaction::Exit,
-                Key::Named(NamedKey::Enter) | Key::Char('s') => {
-                    self.send_next();
-                    Reaction::Redraw
-                }
-                Key::Named(NamedKey::Up) => {
-                    self.td.auto_scroll = false;
-                    self.td.scroll_offset = self.td.scroll_offset.saturating_sub(1);
-                    Reaction::Redraw
-                }
-                Key::Named(NamedKey::Down) => {
-                    self.td.auto_scroll = false;
-                    self.td.scroll_offset = self.td.scroll_offset.saturating_add(1);
-                    Reaction::Redraw
-                }
-                Key::Named(NamedKey::PageUp) => {
-                    self.td.auto_scroll = false;
-                    self.td.scroll_offset = self.td.scroll_offset.saturating_sub(10);
-                    Reaction::Redraw
-                }
-                Key::Named(NamedKey::PageDown) => {
-                    self.td.auto_scroll = false;
-                    self.td.scroll_offset = self.td.scroll_offset.saturating_add(10);
-                    Reaction::Redraw
-                }
-                Key::Named(NamedKey::End) => {
-                    self.td.auto_scroll = true;
-                    Reaction::Redraw
-                }
-                _ => Reaction::Continue,
-            },
-            UiEvent::WindowResized { .. } => Reaction::Redraw,
+    fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+        let vp = backend.viewport();
+        let rect = Rect::new(0.0, 0.0, vp.width, vp.height);
+        match self.controller.handle(&event, backend, rect) {
+            ChatControllerEvent::Submit { .. } => {
+                self.send_next();
+                Reaction::Redraw
+            }
+            ChatControllerEvent::Cancelled => Reaction::Exit,
+            ChatControllerEvent::Consumed => Reaction::Redraw,
             _ => Reaction::Continue,
         }
-    }
-
-    fn tick(&mut self, _backend: &mut dyn Backend) -> Reaction {
-        if self.thinking_ticks > 0 {
-            self.thinking_ticks -= 1;
-            return Reaction::Redraw;
-        }
-        // Reveal one queued reply line per tick to simulate streaming.
-        if let Some(line) = self.pending.pop_front() {
-            self.td.append_line(line);
-            return Reaction::Redraw;
-        }
-        Reaction::Continue
     }
 }

--- a/quadraui/examples/common/markdown_demo.rs
+++ b/quadraui/examples/common/markdown_demo.rs
@@ -24,7 +24,15 @@ const DOC: &str = "\
 Body text with **bold**, *italic*, _also italic_, and `inline_code`.
 Identifiers like foo_bar and baz_qux stay upright (no intraword emphasis).
 Arithmetic like a * b * c is left alone too.
-Use `render_markdown_to_styled` to convert this into styled lines.";
+Use `render_markdown_to_styled` to convert this into styled lines.
+
+Fenced code blocks render with a language header and a `┃` rail:
+
+```rust
+fn main() {
+    println!(\"no raw backticks here\");
+}
+```";
 
 pub struct MarkdownDemo {
     scroll_top: usize,
@@ -68,7 +76,7 @@ impl AppLogic for MarkdownDemo {
             line_text: rendered.line_text,
             line_scales: rendered.line_scales,
             scroll_top: self.scroll_top,
-            max_visible_rows: 12,
+            max_visible_rows: 16,
             has_focus: true,
             selection: None,
             links: Vec::new(),

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -37,6 +37,9 @@
 //! transcript by 3 rows per tick. Backends normalise their native
 //! scroll direction before emitting [`crate::UiEvent::Scroll`].
 
+use crate::compose::markdown::render_markdown_to_styled;
+use crate::theme::Theme;
+use crate::types::StyledSpan;
 use crate::{
     Backend, ButtonMask, Color, Key, MessageList, MessageRow, Modifiers, MouseButton, NamedKey,
     Rect, Scrollbar, Spinner, StyledText, TextInput, TextInputHit, UiEvent, WidgetId,
@@ -271,6 +274,58 @@ impl ChatController {
     /// `None` (default) falls back to `backend.line_height()`.
     pub fn set_scrollbar_width(&mut self, width: Option<f32>) {
         self.scrollbar_width = width;
+    }
+
+    // ── Transcript push helpers ───────────────────────────────────────
+
+    /// Append a pre-styled turn to the controller's internal transcript.
+    ///
+    /// This is an alternative to [`set_transcript`] for apps that build the
+    /// transcript incrementally rather than replacing it each frame.  Do not
+    /// mix `push_turn` and `set_transcript` on the same controller — use one
+    /// model consistently.
+    ///
+    /// For markdown-formatted assistant messages, prefer
+    /// [`push_turn_markdown`].
+    pub fn push_turn(&mut self, role: ChatRole, text: StyledText) {
+        self.transcript.push(ChatTurn {
+            role,
+            text,
+            timestamp_unix: None,
+        });
+    }
+
+    /// Append a turn whose body is markdown text.
+    ///
+    /// This is the **recommended API for assistant-role messages**.  The
+    /// markdown adapter ([`render_markdown_to_styled`]) converts headings,
+    /// bold, italic, inline code, bulleted and numbered lists, blockquotes,
+    /// links, and fenced code blocks to a [`StyledText`] with colours and
+    /// decorations baked in.  The resulting [`ChatTurn`] is appended to the
+    /// controller's internal transcript.
+    ///
+    /// Use [`set_transcript`] instead if your app maintains its own
+    /// transcript vector and passes it each frame.  Do not mix `push_turn*`
+    /// and `set_transcript` on the same controller.
+    ///
+    /// Markdown lines are interleaved into a single [`StyledText`] with
+    /// `'\n'` separator spans so the transcript renderer can split them for
+    /// wrapping, preserving the structure produced by the adapter (list
+    /// markers, blockquote rules, etc.) as plain-text cues.
+    pub fn push_turn_markdown(&mut self, role: ChatRole, markdown: &str, theme: &Theme) {
+        let rendered = render_markdown_to_styled(markdown, theme);
+        let mut spans: Vec<StyledSpan> = Vec::new();
+        for (i, line) in rendered.lines.into_iter().enumerate() {
+            if i > 0 {
+                spans.push(StyledSpan::plain("\n"));
+            }
+            spans.extend(line.spans);
+        }
+        self.transcript.push(ChatTurn {
+            role,
+            text: StyledText { spans },
+            timestamp_unix: None,
+        });
     }
 
     /// Current transcript scroll offset (first visible wrapped row).

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -1884,6 +1884,94 @@ mod tests {
         assert_eq!(cc.transcript_scroll_top(), 5);
     }
 
+    // ── push_turn / push_turn_markdown ───────────────────────────────
+
+    #[test]
+    fn push_turn_appends_turn_to_transcript() {
+        let mut cc = ChatController::new("c");
+        cc.push_turn(ChatRole::User, StyledText::plain("hello"));
+        assert_eq!(cc.transcript.len(), 1);
+        assert_eq!(cc.transcript[0].role, ChatRole::User);
+        let text: String = cc.transcript[0]
+            .text
+            .spans
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect();
+        assert_eq!(text, "hello");
+    }
+
+    #[test]
+    fn push_turn_multiple_turns_accumulate() {
+        let mut cc = ChatController::new("c");
+        cc.push_turn(ChatRole::User, StyledText::plain("first"));
+        cc.push_turn(ChatRole::Assistant, StyledText::plain("second"));
+        assert_eq!(cc.transcript.len(), 2);
+        assert_eq!(cc.transcript[0].role, ChatRole::User);
+        assert_eq!(cc.transcript[1].role, ChatRole::Assistant);
+    }
+
+    #[test]
+    fn push_turn_markdown_joins_lines_with_newline() {
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        cc.push_turn_markdown(ChatRole::Assistant, "line one\nline two", &theme);
+        assert_eq!(cc.transcript.len(), 1);
+        assert_eq!(cc.transcript[0].role, ChatRole::Assistant);
+        // Span texts joined must contain both lines with a '\n' separator.
+        let text: String = cc.transcript[0]
+            .text
+            .spans
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect();
+        assert!(
+            text.contains("line one"),
+            "first line must be present; got: {text:?}"
+        );
+        assert!(
+            text.contains("line two"),
+            "second line must be present; got: {text:?}"
+        );
+        assert!(
+            text.contains('\n'),
+            "lines must be joined with a newline separator; got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn push_turn_markdown_structural_glyphs_survive_in_plain_text() {
+        // The ChatController renders transcript rows by concatenating span
+        // text — structural glyphs (bullets, blockquote bars) must survive
+        // so they appear as text cues in the rendered transcript.
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        cc.push_turn_markdown(ChatRole::Assistant, "- item one\n- item two", &theme);
+        let text: String = cc.transcript[0]
+            .text
+            .spans
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect();
+        assert!(
+            text.contains('\u{2022}'),
+            "bullet glyph must survive as a structural text cue; got: {text:?}"
+        );
+        assert!(
+            text.contains("item one"),
+            "first item content must be present; got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn push_turn_markdown_empty_string_produces_one_turn_no_panic() {
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        // Empty markdown must not panic and must append exactly one turn.
+        cc.push_turn_markdown(ChatRole::System, "", &theme);
+        assert_eq!(cc.transcript.len(), 1);
+    }
+
     // ── Transcript row building ───────────────────────────────────────
 
     #[test]

--- a/quadraui/src/compose/markdown.rs
+++ b/quadraui/src/compose/markdown.rs
@@ -1,4 +1,4 @@
-//! Markdown → [`StyledText`] adapter (first-cut implementation).
+//! Markdown → [`StyledText`] adapter.
 //!
 //! Converts a subset of CommonMark to [`StyledText`] lines that the TUI and
 //! GTK backends can render.  Supported features:
@@ -9,6 +9,11 @@
 //! | `**text**` / `__text__` | [`StyledSpan`] with `bold: true` |
 //! | `*text*` / `_text_` | [`StyledSpan`] with `italic: true` |
 //! | `` `text` `` | [`StyledSpan`] coloured with [`Theme::accent_fg`] |
+//! | `- item` / `* item` | indent + `•` marker span in [`Theme::accent_fg`] |
+//! | `1. item` | indent + `N.` marker span in [`Theme::accent_fg`] |
+//! | `` ```lang … ``` `` | dim-bg spans; `code_blocks` side-channel populated |
+//! | `[text](url)` | underlined [`Theme::link_fg`] span; `links` side-channel populated |
+//! | `> text` | `│ ` rule in [`Theme::link_fg`] + parsed inline content |
 //!
 //! Emphasis (`*`/`_`) honours a CommonMark-style **flanking** rule, so
 //! `snake_case` identifiers and whitespace-flanked operators are *not*
@@ -19,24 +24,27 @@
 //! `examples/gtk_markdown.rs` — it renders a document through
 //! [`render_markdown_to_styled`] into a `RichTextPopup`.
 //!
-//! # Intentional deferrals (first-cut scope)
+//! # Intentional deferrals
 //!
-//! The following are **consciously out of scope** for this first cut and will
-//! be addressed in a follow-up issue:
+//! The following are **consciously out of scope** and tracked in a follow-up
+//! issue:
 //!
-//! * **Bulleted / numbered lists** — currently pass through as literal `- ` /
-//!   `1. ` plain text with no indent or styling.  This was the second motivating
-//!   example in the original issue (coord-tui Review-findings panel).
+//! * **Nested lists** — single-level only.  A nested `- ` inside a list item
+//!   passes through as plain text.
+//! * **Tables** — largest effort, separate work.
+//! * **Images** — TUI has no raster path; lowest priority.
+//! * **Link text emphasis** — inline bold/italic inside `[text](url)` is not
+//!   parsed; the link text renders as a single unstyled-then-underlined span.
 //!
-//! * **`code_blocks: Vec<CodeBlockRange>` / `CodeBlockRange` struct** — omitted
-//!   from `RenderedMarkdown` intentionally.  The issue proposed this field so
-//!   tree-sitter-capable callers (vimcode) could opt into per-language syntax
-//!   highlighting.  Because `RenderedMarkdown` is library-constructed (consumers
-//!   only read its fields), adding `code_blocks` later is a non-breaking additive
-//!   change.  Fenced code blocks currently pass through as plain text.
+//! # Side-channels
 //!
-//! Everything else (links, blockquotes, tables, images) also passes through as
-//! plain text.
+//! [`RenderedMarkdown`] carries two additive side-channels that **do not
+//! affect the length-aligned vectors** (`lines` / `line_text` / `line_scales`):
+//!
+//! * `code_blocks: Vec<CodeBlockRange>` — fenced code block extents.
+//!   Tree-sitter-capable callers opt into per-language highlighting using this.
+//! * `links: Vec<(usize, Range<usize>, String)>` — `(line_idx, byte_range,
+//!   url)` triples.  `byte_range` indexes into `line_text[line_idx]`.
 //!
 //! # Example
 //!
@@ -49,15 +57,38 @@
 //! assert!(result.line_scales[0] > 1.0); // heading
 //! ```
 
+use std::ops::Range;
+
 use crate::theme::Theme;
 use crate::types::{StyledSpan, StyledText};
 
-// ── Public output type ─────────────────────────────────────────────────────
+// ── Public output types ────────────────────────────────────────────────────
+
+/// A fenced code block encountered during rendering.
+///
+/// `fence_open` is the index (into `RenderedMarkdown::lines`) of the opening
+/// `` ``` `` fence line.  Content lines span indices
+/// `fence_open + 1 .. fence_close` (exclusive).  If the input ended without a
+/// closing fence, `fence_close` is `None`.
+#[derive(Debug, Clone)]
+pub struct CodeBlockRange {
+    /// Line index of the opening `` ``` `` fence.
+    pub fence_open: usize,
+    /// Line index of the closing `` ``` `` fence, or `None` when unclosed.
+    pub fence_close: Option<usize>,
+    /// Language hint from the opening fence (e.g. `"rust"`, `"python"`).
+    pub lang: Option<String>,
+}
 
 /// Output of [`render_markdown_to_styled`].
 ///
-/// All three `Vec`s are **always the same length** — one entry per rendered
-/// line.  The invariant holds for all inputs including empty strings.
+/// All three primary `Vec`s are **always the same length** — one entry per
+/// rendered line.  The invariant holds for all inputs including empty strings
+/// and inputs that contain fenced code blocks.
+///
+/// `code_blocks` and `links` are **additive side-channels**: their lengths are
+/// independent of the primary vectors.  Consumers that only need styled text
+/// can ignore them.
 #[derive(Debug, Clone, Default)]
 pub struct RenderedMarkdown {
     /// One [`StyledText`] per line, with inline formatting applied.
@@ -68,40 +99,302 @@ pub struct RenderedMarkdown {
     /// Per-line font-scale factor.  `1.0` for body text; `2.0` / `1.5` /
     /// `1.2` for H1 / H2 / H3 respectively.
     pub line_scales: Vec<f32>,
+    /// Fenced code blocks.  Each entry describes the opening and closing fence
+    /// line indices plus the optional language tag.  Additive — does not affect
+    /// the primary vector lengths.
+    pub code_blocks: Vec<CodeBlockRange>,
+    /// Links found in the input.  Each entry is `(line_idx, byte_range, url)`.
+    /// `line_idx` indexes into the primary vectors.  `byte_range` is a byte
+    /// range into `line_text[line_idx]`.  Additive.
+    pub links: Vec<(usize, Range<usize>, String)>,
+}
+
+// ── Internal types ─────────────────────────────────────────────────────────
+
+/// A link extracted during inline parsing.  Byte ranges into `line_text` are
+/// resolved later by scanning the concatenated span text.
+struct RawLink {
+    text: String,
+    url: String,
 }
 
 // ── Public entry point ─────────────────────────────────────────────────────
 
 /// Convert a markdown `input` string to [`RenderedMarkdown`] using `theme`
-/// for inline-code foreground colour.
+/// for colours.
 ///
 /// Each `\n`-separated line in `input` produces exactly one entry in all
-/// three output vectors.  The function is deterministic and allocation-light
-/// (no regex, no external parser crate — pure Rust string scanning).
+/// three primary output vectors (`lines`, `line_text`, `line_scales`).  The
+/// function is deterministic and allocation-light (no regex, no external
+/// parser crate — pure Rust string scanning).
+///
+/// Fenced code blocks span multiple raw lines.  All fence and content lines
+/// are included in the primary vectors (one entry per raw line), but no
+/// inner emphasis is parsed for code block content.
 pub fn render_markdown_to_styled(input: &str, theme: &Theme) -> RenderedMarkdown {
     let mut result = RenderedMarkdown::default();
+    let mut in_code_block = false;
+    let mut open_fence_idx: Option<usize> = None;
+    let mut open_fence_lang: Option<String> = None;
 
     for raw_line in input.lines() {
-        let (plain, styled, scale) = render_line(raw_line, theme);
-        result.lines.push(styled);
-        result.line_text.push(plain);
-        result.line_scales.push(scale);
+        let line_idx = result.lines.len();
+
+        if in_code_block {
+            // Inside a fenced code block — check for closing fence first.
+            if detect_fence(raw_line).is_some() {
+                // Closing fence.
+                result.code_blocks.push(CodeBlockRange {
+                    fence_open: open_fence_idx.unwrap_or(line_idx),
+                    fence_close: Some(line_idx),
+                    lang: open_fence_lang.take(),
+                });
+                let (plain, styled) = render_fence_line(raw_line, theme);
+                result.lines.push(styled);
+                result.line_text.push(plain);
+                result.line_scales.push(1.0);
+                in_code_block = false;
+                open_fence_idx = None;
+            } else {
+                // Code block content — no emphasis parsing.
+                let (plain, styled) = render_code_content(raw_line, theme);
+                result.lines.push(styled);
+                result.line_text.push(plain);
+                result.line_scales.push(1.0);
+            }
+        } else if let Some(lang) = detect_fence(raw_line) {
+            // Opening fence.
+            let (plain, styled) = render_fence_line(raw_line, theme);
+            result.lines.push(styled);
+            result.line_text.push(plain);
+            result.line_scales.push(1.0);
+            in_code_block = true;
+            open_fence_idx = Some(line_idx);
+            open_fence_lang = lang;
+        } else {
+            // Regular line — headings, lists, blockquotes, body, inline markup.
+            let (plain, styled, scale, line_links) = render_regular_line(raw_line, theme);
+            for (start, end, url) in line_links {
+                result.links.push((line_idx, start..end, url));
+            }
+            result.lines.push(styled);
+            result.line_text.push(plain);
+            result.line_scales.push(scale);
+        }
+    }
+
+    // An unclosed code block: record it with no closing fence.
+    if in_code_block {
+        if let Some(fence_open) = open_fence_idx {
+            result.code_blocks.push(CodeBlockRange {
+                fence_open,
+                fence_close: None,
+                lang: open_fence_lang,
+            });
+        }
     }
 
     result
 }
 
-// ── Per-line rendering ─────────────────────────────────────────────────────
+// ── Fence detection ────────────────────────────────────────────────────────
 
-/// Process one raw markdown line, returning `(plain_text, StyledText, scale)`.
-fn render_line(line: &str, theme: &Theme) -> (String, StyledText, f32) {
+/// Detect a fenced code block delimiter (`` ``` `` with optional language tag).
+///
+/// Returns `Some(lang)` where `lang` is the language string (possibly `None`
+/// if the fence has no tag).  Returns `None` if this is not a fence line.
+fn detect_fence(line: &str) -> Option<Option<String>> {
+    let trimmed = line.trim_start();
+    if let Some(after_ticks) = trimmed.strip_prefix("```") {
+        let after = after_ticks.trim();
+        if after.is_empty() {
+            Some(None)
+        } else {
+            Some(Some(after.to_string()))
+        }
+    } else {
+        None
+    }
+}
+
+// ── Code block line rendering ──────────────────────────────────────────────
+
+/// Render a fence delimiter line (`` ```lang `` or `` ``` ``).
+///
+/// Styled with [`Theme::muted_fg`] on a [`Theme::surface_bg`] tint to
+/// visually distinguish it from body text.
+fn render_fence_line(line: &str, theme: &Theme) -> (String, StyledText) {
+    let plain = line.to_string();
+    let styled = StyledText {
+        spans: vec![StyledSpan {
+            text: plain.clone(),
+            fg: Some(theme.muted_fg),
+            bg: Some(theme.surface_bg),
+            bold: false,
+            italic: false,
+            underline: false,
+        }],
+    };
+    (plain, styled)
+}
+
+/// Render one content line inside a fenced code block.
+///
+/// No emphasis parsing is done.  Text colour is [`Theme::foreground`] on a
+/// [`Theme::surface_bg`] tint — matching the fence lines — so the whole block
+/// reads as a contiguous dimmed-bg region.
+fn render_code_content(line: &str, theme: &Theme) -> (String, StyledText) {
+    let plain = line.to_string();
+    let styled = StyledText {
+        spans: vec![StyledSpan {
+            text: plain.clone(),
+            fg: Some(theme.foreground),
+            bg: Some(theme.surface_bg),
+            bold: false,
+            italic: false,
+            underline: false,
+        }],
+    };
+    (plain, styled)
+}
+
+// ── Per-line rendering (regular lines) ────────────────────────────────────
+
+/// Process one regular (non-code-block) markdown line.
+///
+/// Returns `(plain_text, StyledText, scale, link_entries)`.
+/// `link_entries` are `(byte_start, byte_end, url)` triples into `plain_text`.
+fn render_regular_line(
+    line: &str,
+    theme: &Theme,
+) -> (String, StyledText, f32, Vec<(usize, usize, String)>) {
+    // ── Blockquote ────────────────────────────────────────────────────
+    if let Some(content) = parse_blockquote(line) {
+        let (inner_spans, raw_links) = parse_inline(content, false, false, theme);
+        let inner_plain: String = inner_spans.iter().map(|s| s.text.as_str()).collect();
+        // "│ " — U+2502 (3 UTF-8 bytes) + space = 4 bytes.
+        let prefix = "\u{2502} ";
+        let prefix_len = prefix.len(); // = 4
+        let plain = format!("{prefix}{inner_plain}");
+        let links = resolve_links(&raw_links, &inner_plain, prefix_len);
+        let bar_span = StyledSpan {
+            text: prefix.to_string(),
+            fg: Some(theme.link_fg),
+            bg: None,
+            bold: false,
+            italic: false,
+            underline: false,
+        };
+        let mut spans = vec![bar_span];
+        spans.extend(inner_spans);
+        return (plain, StyledText { spans }, 1.0, links);
+    }
+
+    // ── Bulleted list: "- item" / "* item" ───────────────────────────
+    if let Some(content) = parse_bullet_item(line) {
+        let (inner_spans, raw_links) = parse_inline(content, false, false, theme);
+        let inner_plain: String = inner_spans.iter().map(|s| s.text.as_str()).collect();
+        // "  • " — 2 spaces + U+2022 (3 bytes) + space = 6 bytes.
+        let prefix = "  \u{2022} ";
+        let prefix_len = prefix.len(); // = 6
+        let plain = format!("{prefix}{inner_plain}");
+        let links = resolve_links(&raw_links, &inner_plain, prefix_len);
+        let indent_span = StyledSpan::plain("  ");
+        let bullet_span = StyledSpan {
+            text: "\u{2022} ".to_string(),
+            fg: Some(theme.accent_fg),
+            bg: None,
+            bold: false,
+            italic: false,
+            underline: false,
+        };
+        let mut spans = vec![indent_span, bullet_span];
+        spans.extend(inner_spans);
+        return (plain, StyledText { spans }, 1.0, links);
+    }
+
+    // ── Numbered list: "1. item", "2. item", … ───────────────────────
+    if let Some((num, content)) = parse_ordered_item(line) {
+        let (inner_spans, raw_links) = parse_inline(content, false, false, theme);
+        let inner_plain: String = inner_spans.iter().map(|s| s.text.as_str()).collect();
+        let marker = format!("{num}. ");
+        // "  " (2 bytes) + marker
+        let prefix = format!("  {marker}");
+        let prefix_len = prefix.len();
+        let plain = format!("{prefix}{inner_plain}");
+        let links = resolve_links(&raw_links, &inner_plain, prefix_len);
+        let indent_span = StyledSpan::plain("  ");
+        let marker_span = StyledSpan {
+            text: marker,
+            fg: Some(theme.accent_fg),
+            bg: None,
+            bold: false,
+            italic: false,
+            underline: false,
+        };
+        let mut spans = vec![indent_span, marker_span];
+        spans.extend(inner_spans);
+        return (plain, StyledText { spans }, 1.0, links);
+    }
+
+    // ── Heading / body ────────────────────────────────────────────────
     let (heading_level, content) = parse_heading_prefix(line);
     let scale = heading_scale(heading_level);
-    // Headings pass `bold = true` as the base style so every span in the
-    // heading is bold (inline **bold** inside a heading stays bold too).
-    let spans = parse_inline(content, heading_level > 0, false, theme);
+    let (spans, raw_links) = parse_inline(content, heading_level > 0, false, theme);
     let plain: String = spans.iter().map(|s| s.text.as_str()).collect();
-    (plain, StyledText { spans }, scale)
+    let links = resolve_links(&raw_links, &plain, 0);
+    (plain, StyledText { spans }, scale, links)
+}
+
+// ── Block-level prefix detectors ───────────────────────────────────────────
+
+/// Detect a blockquote prefix (`> ` or bare `>`).
+///
+/// Returns the content after the prefix, or `None` if not a blockquote.
+fn parse_blockquote(line: &str) -> Option<&str> {
+    if let Some(rest) = line.strip_prefix("> ") {
+        Some(rest)
+    } else if line.starts_with('>') && !line.starts_with(">>>") {
+        // Bare ">" or ">text" (no space) — strip only the leading ">".
+        Some(&line[1..])
+    } else {
+        None
+    }
+}
+
+/// Detect a bullet list item (`- ` or `* ` prefix).
+///
+/// Returns the item content (after the prefix), or `None`.
+fn parse_bullet_item(line: &str) -> Option<&str> {
+    if let Some(rest) = line.strip_prefix("- ") {
+        Some(rest)
+    } else if let Some(rest) = line.strip_prefix("* ") {
+        Some(rest)
+    } else {
+        None
+    }
+}
+
+/// Detect an ordered list item (`N. ` prefix where N is one or more digits).
+///
+/// Returns `(number, item_content)`, or `None`.
+fn parse_ordered_item(line: &str) -> Option<(u32, &str)> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 {
+        return None;
+    }
+    if i >= bytes.len() || bytes[i] != b'.' {
+        return None;
+    }
+    if i + 1 >= bytes.len() || bytes[i + 1] != b' ' {
+        return None;
+    }
+    let num: u32 = line[..i].parse().ok()?;
+    Some((num, &line[i + 2..]))
 }
 
 /// Detect a heading prefix (`# `, `## `, `### `).
@@ -129,16 +422,47 @@ fn heading_scale(level: u8) -> f32 {
     }
 }
 
+// ── Link side-channel helper ───────────────────────────────────────────────
+
+/// Resolve [`RawLink`]s to `(byte_start, byte_end, url)` triples into a line's
+/// plain text.
+///
+/// `inner_plain` is the plain text of the inline content (without any block
+/// prefix).  `prefix_len` is the byte length of the block prefix prepended
+/// before `inner_plain` in the final `plain` string (e.g. `"  • "` = 6 bytes).
+///
+/// Links are resolved left-to-right: each link text is searched for in
+/// `inner_plain` starting from after the previous match, so duplicate link
+/// texts resolve to distinct, non-overlapping positions.
+fn resolve_links(
+    raw_links: &[RawLink],
+    inner_plain: &str,
+    prefix_len: usize,
+) -> Vec<(usize, usize, String)> {
+    let mut result = Vec::new();
+    let mut search_from = 0usize;
+    for link in raw_links {
+        if let Some(pos) = inner_plain[search_from..].find(&link.text) {
+            let abs_start = prefix_len + search_from + pos;
+            let abs_end = abs_start + link.text.len();
+            result.push((abs_start, abs_end, link.url.clone()));
+            search_from += pos + link.text.len();
+        }
+    }
+    result
+}
+
 // ── Inline span parser ─────────────────────────────────────────────────────
 
 /// Parse inline markdown in `text` with the given base `bold`/`italic` flags,
-/// returning a flat list of [`StyledSpan`]s.
+/// returning a flat list of [`StyledSpan`]s and any [`RawLink`]s found.
 ///
 /// Delimiters are matched left-to-right with the following priority:
 ///
 /// 1. `` ` ``…`` ` `` — inline code (no further parsing inside)
-/// 2. `**` / `__` — bold (content is recursively parsed)
-/// 3. `*` / `_` — italic (content is recursively parsed)
+/// 2. `[text](url)` — link (no emphasis parsing inside the link text)
+/// 3. `**` / `__` — bold (content is recursively parsed)
+/// 4. `*` / `_` — italic (content is recursively parsed)
 ///
 /// Emphasis (`*`/`_`) delimiters obey a CommonMark-style **flanking** rule so
 /// that intraword and dangling delimiters are *not* mistaken for emphasis:
@@ -153,12 +477,14 @@ fn heading_scale(level: u8) -> f32 {
 /// as literal plain text.  See [`can_open`] / [`can_close`].
 ///
 /// Unmatched or non-flanking delimiters are treated as literal plain text.
-///
-/// The function is not recursive-descent in the pathological sense: real
-/// markdown is shallow (at most a few levels of nesting) and the recursion
-/// only fires on matched delimiter pairs.
-fn parse_inline(text: &str, bold: bool, italic: bool, theme: &Theme) -> Vec<StyledSpan> {
+fn parse_inline(
+    text: &str,
+    bold: bool,
+    italic: bool,
+    theme: &Theme,
+) -> (Vec<StyledSpan>, Vec<RawLink>) {
     let mut spans: Vec<StyledSpan> = Vec::new();
+    let mut links: Vec<RawLink> = Vec::new();
     let bytes = text.as_bytes();
     let len = bytes.len();
     let mut pos = 0usize;
@@ -198,6 +524,33 @@ fn parse_inline(text: &str, bold: bool, italic: bool, theme: &Theme) -> Vec<Styl
             continue;
         }
 
+        // ── Link: [text](url) ────────────────────────────────────────────
+        if b == b'[' {
+            if let Some((link_text, url, after)) = parse_link(text, pos) {
+                if plain_start < pos {
+                    spans.push(make_span(&text[plain_start..pos], bold, italic, None));
+                }
+                spans.push(StyledSpan {
+                    text: link_text.to_string(),
+                    fg: Some(theme.link_fg),
+                    bg: None,
+                    bold: false,
+                    italic: false,
+                    underline: true,
+                });
+                links.push(RawLink {
+                    text: link_text.to_string(),
+                    url: url.to_string(),
+                });
+                pos = after;
+                plain_start = pos;
+                continue;
+            }
+            // No valid link syntax — treat `[` as plain text.
+            pos += 1;
+            continue;
+        }
+
         // ── Bold: **...** / __...__ ──────────────────────────────────────
         if (b == b'*' || b == b'_') && pos + 1 < len && bytes[pos + 1] == b {
             let run_end = pos + 2;
@@ -207,7 +560,9 @@ fn parse_inline(text: &str, bold: bool, italic: bool, theme: &Theme) -> Vec<Styl
                         spans.push(make_span(&text[plain_start..pos], bold, italic, None));
                     }
                     let inner = &text[run_end..close];
-                    spans.extend(parse_inline(inner, true, italic, theme));
+                    let (inner_spans, inner_links) = parse_inline(inner, true, italic, theme);
+                    spans.extend(inner_spans);
+                    links.extend(inner_links);
                     pos = close + 2;
                     plain_start = pos;
                     continue;
@@ -229,7 +584,9 @@ fn parse_inline(text: &str, bold: bool, italic: bool, theme: &Theme) -> Vec<Styl
                         spans.push(make_span(&text[plain_start..pos], bold, italic, None));
                     }
                     let inner = &text[run_end..close];
-                    spans.extend(parse_inline(inner, bold, true, theme));
+                    let (inner_spans, inner_links) = parse_inline(inner, bold, true, theme);
+                    spans.extend(inner_spans);
+                    links.extend(inner_links);
                     pos = close + 1;
                     plain_start = pos;
                     continue;
@@ -248,7 +605,62 @@ fn parse_inline(text: &str, bold: bool, italic: bool, theme: &Theme) -> Vec<Styl
         spans.push(make_span(&text[plain_start..], bold, italic, None));
     }
 
-    spans
+    (spans, links)
+}
+
+// ── Link syntax parser ─────────────────────────────────────────────────────
+
+/// Attempt to parse a Markdown link starting at `start` (which must be `[`).
+///
+/// Returns `(link_text, url, byte_after)` on success, or `None` if the
+/// text at `start` does not form a valid `[text](url)` pattern.
+///
+/// Known limitation: URLs containing `)` are truncated at the first `)`.
+/// This is a deliberate first-cut simplification.
+fn parse_link(text: &str, start: usize) -> Option<(&str, &str, usize)> {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+
+    // Scan forward to find the matching `]`, tracking bracket nesting.
+    let mut i = start + 1;
+    let mut depth = 1i32;
+    while i < len {
+        match bytes[i] {
+            b'[' => depth += 1,
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            b'\\' if i + 1 < len => {
+                // Skip escaped character.
+                i += 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth != 0 || i >= len {
+        return None;
+    }
+
+    let close_bracket = i; // index of `]`
+    let link_text = &text[start + 1..close_bracket];
+
+    // Require `(` immediately after `]`.
+    let after_bracket = close_bracket + 1;
+    if after_bracket >= len || bytes[after_bracket] != b'(' {
+        return None;
+    }
+
+    let url_start = after_bracket + 1;
+    // Find the closing `)`.  Simple scan — does not handle nested parens.
+    let url_end = text[url_start..].find(')')?;
+    let url = &text[url_start..url_start + url_end];
+    let after = url_start + url_end + 1;
+
+    Some((link_text, url, after))
 }
 
 // ── Flanking rules (CommonMark-subset) ─────────────────────────────────────
@@ -387,6 +799,14 @@ mod tests {
             "line one\nline two\nline three",
             "**bold** and *italic* and `code`",
             "# H1\n## H2\n### H3\nbody",
+            // New constructs must also maintain the invariant.
+            "- bullet item",
+            "1. numbered item",
+            "> blockquote",
+            "```rust\nfn main() {}\n```",
+            "see [link](http://example.com) here",
+            // Unclosed code block.
+            "```\nunclosed",
         ];
         let theme = Theme::default();
         for input in inputs {
@@ -545,40 +965,31 @@ mod tests {
         assert_eq!(r.lines.len(), 1);
         let spans = &r.lines[0].spans;
 
-        // There must be a bold span containing "bold".
         assert!(
             spans.iter().any(|s| s.bold && s.text.contains("bold")),
             "missing bold span; spans: {spans:?}"
         );
-        // There must be an italic span containing "italic".
         assert!(
             spans.iter().any(|s| s.italic && s.text.contains("italic")),
             "missing italic span; spans: {spans:?}"
         );
-        // There must be a code-colored span containing "code".
         assert!(
             spans
                 .iter()
                 .any(|s| s.fg == Some(theme.accent_fg) && s.text.contains("code")),
             "missing code span; spans: {spans:?}"
         );
-        // Plain text between the styled regions must be present too.
         assert!(
             spans.iter().any(|s| s.text.contains(" and ")),
             "expected plain ' and ' separator; spans: {spans:?}"
         );
-        // The reconstructed plain text must match the styled text stripped of syntax.
         assert_eq!(r.line_text[0], "bold and italic and code");
     }
 
     #[test]
     fn bold_italic_combined_in_heading() {
-        // Inside a heading, the base style is bold=true.  An extra * makes it
-        // italic too — the span should carry both flags.
         let theme = Theme::default();
         let r = render_markdown_to_styled("# *emphasized heading*", &theme);
-        // The span for "emphasized heading" should be both bold (from heading)
-        // and italic (from *...*).
         assert!(
             r.lines[0].spans.iter().any(|s| s.bold && s.italic),
             "expected bold+italic span inside heading; spans: {:?}",
@@ -613,7 +1024,6 @@ mod tests {
         let theme = Theme::default();
         let r = render_markdown_to_styled("Hello, world!", &theme);
         assert_eq!(r.line_text[0], "Hello, world!");
-        // No special styling expected on a plain line.
         assert_eq!(r.lines[0].spans.len(), 1);
         assert!(!r.lines[0].spans[0].bold);
         assert!(!r.lines[0].spans[0].italic);
@@ -625,10 +1035,8 @@ mod tests {
     #[test]
     fn unmatched_delimiter_treated_as_plain_text() {
         let theme = Theme::default();
-        // A lone * with no closing * should pass through as plain text.
         let r = render_markdown_to_styled("price is $5*2", &theme);
         assert_eq!(r.line_text[0], "price is $5*2");
-        // No italic spans expected.
         assert!(r.lines[0].spans.iter().all(|s| !s.italic));
     }
 
@@ -636,8 +1044,6 @@ mod tests {
 
     #[test]
     fn intraword_underscores_do_not_italicise() {
-        // snake_case identifiers must NOT trigger emphasis — the two `_`s here
-        // would otherwise greedily italicise "bar and baz" across two words.
         let theme = Theme::default();
         let r = render_markdown_to_styled("the foo_bar and baz_qux funcs", &theme);
         assert!(
@@ -650,8 +1056,6 @@ mod tests {
 
     #[test]
     fn whitespace_flanked_asterisks_do_not_italicise() {
-        // `a * b * c` — the asterisks are surrounded by spaces, so they are
-        // neither left- nor right-flanking and cannot open/close emphasis.
         let theme = Theme::default();
         let r = render_markdown_to_styled("a * b * c", &theme);
         assert!(
@@ -664,8 +1068,6 @@ mod tests {
 
     #[test]
     fn single_snake_case_underscore_is_literal() {
-        // A single underscore inside one identifier has no partner and is
-        // intraword — it must stay literal.
         let theme = Theme::default();
         let r = render_markdown_to_styled("render_markdown_to_styled does work", &theme);
         assert!(r.lines[0].spans.iter().all(|s| !s.italic));
@@ -674,7 +1076,6 @@ mod tests {
 
     #[test]
     fn intraword_double_underscore_does_not_bold() {
-        // `foo__bar__baz` — intraword `__` should not produce bold.
         let theme = Theme::default();
         let r = render_markdown_to_styled("foo__bar__baz", &theme);
         assert!(
@@ -687,8 +1088,6 @@ mod tests {
 
     #[test]
     fn well_formed_emphasis_still_works_after_flanking_guard() {
-        // Regression guard: the flanking rules must not break legitimate
-        // emphasis at word boundaries.
         let theme = Theme::default();
         let r = render_markdown_to_styled("use *italic* and _also_ and **bold**", &theme);
         let spans = &r.lines[0].spans;
@@ -699,7 +1098,6 @@ mod tests {
 
     #[test]
     fn inline_code_in_heading_stays_bold() {
-        // A code span inside a heading should inherit the heading's bold.
         let theme = Theme::default();
         let r = render_markdown_to_styled("# the `fn` keyword", &theme);
         let code_span = r.lines[0]
@@ -714,14 +1112,12 @@ mod tests {
     #[test]
     fn heading_with_no_content_is_still_a_heading() {
         let theme = Theme::default();
-        // "# " followed by nothing — should still produce scale 2.0.
         let r = render_markdown_to_styled("# ", &theme);
         assert!((r.line_scales[0] - 2.0).abs() < f32::EPSILON);
     }
 
     #[test]
     fn hash_without_space_is_not_a_heading() {
-        // "#title" without a space after # is not CommonMark heading syntax.
         let theme = Theme::default();
         let r = render_markdown_to_styled("#title", &theme);
         assert!(
@@ -729,5 +1125,302 @@ mod tests {
             "should be body, not heading"
         );
         assert_eq!(r.line_text[0], "#title");
+    }
+
+    // ── Bulleted lists ─────────────────────────────────────────────────
+
+    #[test]
+    fn dash_bullet_emits_bullet_glyph_and_accent() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("- hello", &theme);
+        assert_eq!(r.lines.len(), 1);
+        // plain text includes the "• " marker.
+        assert!(
+            r.line_text[0].contains('\u{2022}'),
+            "plain text must contain bullet glyph; got: {:?}",
+            r.line_text[0]
+        );
+        assert!(
+            r.line_text[0].contains("hello"),
+            "plain text must include the item content"
+        );
+        // The bullet span is coloured with accent_fg.
+        assert!(
+            r.lines[0]
+                .spans
+                .iter()
+                .any(|s| s.fg == Some(theme.accent_fg) && s.text.contains('\u{2022}')),
+            "expected an accent-coloured bullet span; spans: {:?}",
+            r.lines[0].spans
+        );
+    }
+
+    #[test]
+    fn asterisk_bullet_emits_bullet_glyph() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("* world", &theme);
+        assert!(r.line_text[0].contains('\u{2022}'));
+        assert!(r.line_text[0].contains("world"));
+    }
+
+    #[test]
+    fn bullet_item_inline_markup_is_parsed() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("- **bold** item", &theme);
+        assert!(
+            r.lines[0].spans.iter().any(|s| s.bold && s.text == "bold"),
+            "inline bold inside bullet must be parsed; spans: {:?}",
+            r.lines[0].spans
+        );
+        assert_eq!(r.line_text[0], "  \u{2022} bold item");
+    }
+
+    #[test]
+    fn bullet_scale_is_1_0() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("- item", &theme);
+        assert!((r.line_scales[0] - 1.0).abs() < f32::EPSILON);
+    }
+
+    // ── Numbered lists ─────────────────────────────────────────────────
+
+    #[test]
+    fn numbered_list_emits_number_and_accent() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("1. first", &theme);
+        assert_eq!(r.lines.len(), 1);
+        assert!(
+            r.line_text[0].contains("1."),
+            "plain text must contain the marker"
+        );
+        assert!(r.line_text[0].contains("first"));
+        assert!(
+            r.lines[0]
+                .spans
+                .iter()
+                .any(|s| s.fg == Some(theme.accent_fg) && s.text.contains("1.")),
+            "expected accent-coloured marker span; spans: {:?}",
+            r.lines[0].spans
+        );
+    }
+
+    #[test]
+    fn numbered_list_multi_digit() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("10. tenth", &theme);
+        assert!(r.line_text[0].contains("10."));
+        assert!(r.line_text[0].contains("tenth"));
+    }
+
+    #[test]
+    fn numbered_list_inline_markup_is_parsed() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("2. *italic* content", &theme);
+        assert!(
+            r.lines[0]
+                .spans
+                .iter()
+                .any(|s| s.italic && s.text == "italic"),
+            "inline italic inside numbered item must be parsed; spans: {:?}",
+            r.lines[0].spans
+        );
+    }
+
+    #[test]
+    fn numbered_scale_is_1_0() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("3. item", &theme);
+        assert!((r.line_scales[0] - 1.0).abs() < f32::EPSILON);
+    }
+
+    // ── Fenced code blocks ─────────────────────────────────────────────
+
+    #[test]
+    fn code_block_three_lines_produce_three_entries() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```rust\nfn main() {}\n```", &theme);
+        assert_eq!(r.lines.len(), 3, "fence-open, content, fence-close");
+        // All three lines must have scale 1.0.
+        for scale in &r.line_scales {
+            assert!((scale - 1.0).abs() < f32::EPSILON);
+        }
+    }
+
+    #[test]
+    fn code_block_fence_line_uses_muted_fg() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```\ncode\n```", &theme);
+        // First and last lines are fence lines — muted_fg.
+        let fence_open = &r.lines[0].spans[0];
+        assert_eq!(
+            fence_open.fg,
+            Some(theme.muted_fg),
+            "fence line must use muted_fg"
+        );
+    }
+
+    #[test]
+    fn code_block_content_line_uses_foreground() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```\ncontent\n```", &theme);
+        let content = &r.lines[1].spans[0];
+        assert_eq!(
+            content.fg,
+            Some(theme.foreground),
+            "code content must use foreground fg"
+        );
+    }
+
+    #[test]
+    fn code_block_content_not_emphasis_parsed() {
+        let theme = Theme::default();
+        // **bold** inside a code block must NOT produce a bold span.
+        let r = render_markdown_to_styled("```\n**not bold**\n```", &theme);
+        assert!(
+            r.lines[1].spans.iter().all(|s| !s.bold),
+            "content inside code block must not be emphasis-parsed"
+        );
+        assert_eq!(r.line_text[1], "**not bold**");
+    }
+
+    #[test]
+    fn code_block_range_side_channel_populated() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```rust\nfn f() {}\n```", &theme);
+        assert_eq!(r.code_blocks.len(), 1);
+        let cb = &r.code_blocks[0];
+        assert_eq!(cb.fence_open, 0);
+        assert_eq!(cb.fence_close, Some(2));
+        assert_eq!(cb.lang.as_deref(), Some("rust"));
+    }
+
+    #[test]
+    fn code_block_no_lang_tag() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```\ncode\n```", &theme);
+        assert_eq!(r.code_blocks.len(), 1);
+        assert!(r.code_blocks[0].lang.is_none());
+    }
+
+    #[test]
+    fn unclosed_code_block_recorded_with_no_close() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```\nline1\nline2", &theme);
+        assert_eq!(r.lines.len(), 3);
+        assert_eq!(r.code_blocks.len(), 1);
+        assert_eq!(r.code_blocks[0].fence_open, 0);
+        assert!(r.code_blocks[0].fence_close.is_none());
+    }
+
+    // ── Links ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn link_emits_underlined_link_fg_span() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("[click here](http://example.com)", &theme);
+        assert_eq!(r.lines.len(), 1);
+        let link_span = r.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "click here")
+            .expect("expected a span with the link text");
+        assert!(link_span.underline, "link span must be underlined");
+        assert_eq!(
+            link_span.fg,
+            Some(theme.link_fg),
+            "link span must use link_fg"
+        );
+    }
+
+    #[test]
+    fn link_plain_text_is_link_text_not_url() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("[label](http://example.com)", &theme);
+        assert_eq!(r.line_text[0], "label");
+    }
+
+    #[test]
+    fn link_side_channel_populated() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("[label](http://example.com)", &theme);
+        assert_eq!(r.links.len(), 1);
+        let (line_idx, ref range, ref url) = r.links[0];
+        assert_eq!(line_idx, 0);
+        assert_eq!(&r.line_text[0][range.clone()], "label");
+        assert_eq!(url, "http://example.com");
+    }
+
+    #[test]
+    fn link_inside_body_text_mixed() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("see [docs](http://docs.example.com) for more", &theme);
+        assert_eq!(r.line_text[0], "see docs for more");
+        assert_eq!(r.links.len(), 1);
+        let (_, ref range, _) = r.links[0];
+        assert_eq!(&r.line_text[0][range.clone()], "docs");
+    }
+
+    #[test]
+    fn link_side_channel_byte_range_matches_plain_text() {
+        // Multiple links on one line — ranges must point to the correct text.
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("[alpha](http://a.com) and [beta](http://b.com)", &theme);
+        assert_eq!(r.links.len(), 2);
+        let (_, ref r0, ref u0) = r.links[0];
+        let (_, ref r1, ref u1) = r.links[1];
+        assert_eq!(&r.line_text[0][r0.clone()], "alpha");
+        assert_eq!(u0, "http://a.com");
+        assert_eq!(&r.line_text[0][r1.clone()], "beta");
+        assert_eq!(u1, "http://b.com");
+    }
+
+    // ── Blockquotes ────────────────────────────────────────────────────
+
+    #[test]
+    fn blockquote_emits_bar_glyph_and_link_fg() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("> quoted text", &theme);
+        assert_eq!(r.lines.len(), 1);
+        // The bar span uses link_fg.
+        assert!(
+            r.lines[0]
+                .spans
+                .iter()
+                .any(|s| s.fg == Some(theme.link_fg) && s.text.contains('\u{2502}')),
+            "expected a link_fg bar span; spans: {:?}",
+            r.lines[0].spans
+        );
+        // plain text includes the bar prefix.
+        assert!(r.line_text[0].contains('\u{2502}'));
+        assert!(r.line_text[0].contains("quoted text"));
+    }
+
+    #[test]
+    fn blockquote_inline_markup_is_parsed() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("> **bold** inside quote", &theme);
+        assert!(
+            r.lines[0].spans.iter().any(|s| s.bold && s.text == "bold"),
+            "inline bold inside blockquote must be parsed; spans: {:?}",
+            r.lines[0].spans
+        );
+    }
+
+    #[test]
+    fn blockquote_scale_is_1_0() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("> quote", &theme);
+        assert!((r.line_scales[0] - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn blockquote_link_inside_quote_tracked() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("> see [here](http://example.com)", &theme);
+        assert_eq!(r.links.len(), 1);
+        let (line_idx, ref range, ref url) = r.links[0];
+        assert_eq!(line_idx, 0);
+        assert_eq!(&r.line_text[0][range.clone()], "here");
+        assert_eq!(url, "http://example.com");
     }
 }

--- a/quadraui/src/compose/markdown.rs
+++ b/quadraui/src/compose/markdown.rs
@@ -11,7 +11,7 @@
 //! | `` `text` `` | [`StyledSpan`] coloured with [`Theme::accent_fg`] |
 //! | `- item` / `* item` | indent + `•` marker span in [`Theme::accent_fg`] |
 //! | `1. item` | indent + `N.` marker span in [`Theme::accent_fg`] |
-//! | `` ```lang … ``` `` | dim-bg spans; `code_blocks` side-channel populated |
+//! | `` ```lang … ``` `` | `lang` dim header + per-line `┃` code rail; the `` ``` `` fences are **not** shown; `code_blocks` side-channel populated |
 //! | `[text](url)` | underlined [`Theme::link_fg`] span; `links` side-channel populated |
 //! | `> text` | `│ ` rule in [`Theme::link_fg`] + parsed inline content |
 //!
@@ -143,13 +143,15 @@ pub fn render_markdown_to_styled(input: &str, theme: &Theme) -> RenderedMarkdown
         if in_code_block {
             // Inside a fenced code block — check for closing fence first.
             if detect_fence(raw_line).is_some() {
-                // Closing fence.
+                // Closing fence — rendered as a blank row (the ``` delimiter
+                // is never shown; the code rail above already delimits the
+                // block).
                 result.code_blocks.push(CodeBlockRange {
                     fence_open: open_fence_idx.unwrap_or(line_idx),
                     fence_close: Some(line_idx),
                     lang: open_fence_lang.take(),
                 });
-                let (plain, styled) = render_fence_line(raw_line, theme);
+                let (plain, styled) = render_fence_close();
                 result.lines.push(styled);
                 result.line_text.push(plain);
                 result.line_scales.push(1.0);
@@ -163,8 +165,9 @@ pub fn render_markdown_to_styled(input: &str, theme: &Theme) -> RenderedMarkdown
                 result.line_scales.push(1.0);
             }
         } else if let Some(lang) = detect_fence(raw_line) {
-            // Opening fence.
-            let (plain, styled) = render_fence_line(raw_line, theme);
+            // Opening fence — rendered as a dim language header (or a blank
+            // row when untagged).  The ``` delimiter is never shown.
+            let (plain, styled) = render_fence_open(lang.as_deref(), theme);
             result.lines.push(styled);
             result.line_text.push(plain);
             result.line_scales.push(1.0);
@@ -219,43 +222,82 @@ fn detect_fence(line: &str) -> Option<Option<String>> {
 
 // ── Code block line rendering ──────────────────────────────────────────────
 
-/// Render a fence delimiter line (`` ```lang `` or `` ``` ``).
+/// Left "code rail" prefix prepended to every code-block content line:
+/// 2-space indent + `┃` (U+2503, HEAVY VERTICAL) + space.  Deliberately a
+/// *heavy* bar so it reads as distinct from the blockquote rule (`│`,
+/// U+2502, light) even in plain-text transcripts that discard span colour.
+const CODE_RAIL: &str = "  \u{2503} ";
+
+/// Render the opening fence as a dim language header (e.g. `  rust`), or a
+/// blank row when the fence carries no language tag.
 ///
-/// Styled with [`Theme::muted_fg`] on a [`Theme::surface_bg`] tint to
-/// visually distinguish it from body text.
-fn render_fence_line(line: &str, theme: &Theme) -> (String, StyledText) {
-    let plain = line.to_string();
-    let styled = StyledText {
-        spans: vec![StyledSpan {
-            text: plain.clone(),
+/// The `` ``` `` delimiter itself is **never** emitted — code blocks read as
+/// a block via this header plus the per-line rail from [`render_code_content`],
+/// which survives even in plain-text contexts (the chat transcript discards
+/// span colour and background, so a textual cue is the only thing that shows).
+fn render_fence_open(lang: Option<&str>, theme: &Theme) -> (String, StyledText) {
+    match lang {
+        Some(lang) if !lang.is_empty() => {
+            let plain = format!("  {lang}");
+            let styled = StyledText {
+                spans: vec![
+                    StyledSpan::plain("  "),
+                    StyledSpan {
+                        text: lang.to_string(),
+                        fg: Some(theme.muted_fg),
+                        bg: None,
+                        bold: false,
+                        italic: true,
+                        underline: false,
+                    },
+                ],
+            };
+            (plain, styled)
+        }
+        _ => blank_line(),
+    }
+}
+
+/// Render the closing fence as a blank row — the `` ``` `` delimiter is never
+/// shown; the rail above already delimits the block.
+fn render_fence_close() -> (String, StyledText) {
+    blank_line()
+}
+
+/// An empty rendered line (no spans, empty plain text).
+fn blank_line() -> (String, StyledText) {
+    (String::new(), StyledText { spans: Vec::new() })
+}
+
+/// Render one content line inside a fenced code block, prefixed with the
+/// [`CODE_RAIL`] gutter.
+///
+/// No emphasis parsing is done.  The rail uses [`Theme::muted_fg`]; the code
+/// text uses [`Theme::foreground`].  Both carry a [`Theme::surface_bg`] tint
+/// so styling-aware backends paint a contiguous dimmed block; plain-text
+/// consumers fall back to the rail glyph as the block cue.
+fn render_code_content(line: &str, theme: &Theme) -> (String, StyledText) {
+    let plain = format!("{CODE_RAIL}{line}");
+    let spans = vec![
+        StyledSpan::plain("  "),
+        StyledSpan {
+            text: "\u{2503} ".to_string(),
             fg: Some(theme.muted_fg),
             bg: Some(theme.surface_bg),
             bold: false,
             italic: false,
             underline: false,
-        }],
-    };
-    (plain, styled)
-}
-
-/// Render one content line inside a fenced code block.
-///
-/// No emphasis parsing is done.  Text colour is [`Theme::foreground`] on a
-/// [`Theme::surface_bg`] tint — matching the fence lines — so the whole block
-/// reads as a contiguous dimmed-bg region.
-fn render_code_content(line: &str, theme: &Theme) -> (String, StyledText) {
-    let plain = line.to_string();
-    let styled = StyledText {
-        spans: vec![StyledSpan {
-            text: plain.clone(),
+        },
+        StyledSpan {
+            text: line.to_string(),
             fg: Some(theme.foreground),
             bg: Some(theme.surface_bg),
             bold: false,
             italic: false,
             underline: false,
-        }],
-    };
-    (plain, styled)
+        },
+    ];
+    (plain, StyledText { spans })
 }
 
 // ── Per-line rendering (regular lines) ────────────────────────────────────
@@ -1247,15 +1289,65 @@ mod tests {
     }
 
     #[test]
-    fn code_block_fence_line_uses_muted_fg() {
+    fn code_block_open_fence_shows_language_header() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```rust\ncode\n```", &theme);
+        // The opening fence renders the language as a dim header — NOT the
+        // raw ``` delimiter.
+        assert_eq!(r.line_text[0], "  rust");
+        assert!(
+            r.lines[0]
+                .spans
+                .iter()
+                .any(|s| s.fg == Some(theme.muted_fg) && s.text == "rust"),
+            "opening fence must show the language in muted_fg; spans: {:?}",
+            r.lines[0].spans
+        );
+    }
+
+    #[test]
+    fn code_block_open_fence_without_lang_is_blank() {
         let theme = Theme::default();
         let r = render_markdown_to_styled("```\ncode\n```", &theme);
-        // First and last lines are fence lines — muted_fg.
-        let fence_open = &r.lines[0].spans[0];
-        assert_eq!(
-            fence_open.fg,
-            Some(theme.muted_fg),
-            "fence line must use muted_fg"
+        // An untagged fence has no header text — just a blank cap row.
+        assert_eq!(r.line_text[0], "");
+        assert!(r.lines[0].spans.is_empty());
+    }
+
+    #[test]
+    fn code_block_close_fence_is_blank() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```rust\ncode\n```", &theme);
+        // The closing fence is a blank row — the ``` delimiter is never shown.
+        assert_eq!(r.line_text[2], "");
+        assert!(r.lines[2].spans.is_empty());
+    }
+
+    #[test]
+    fn code_block_never_emits_raw_backtick_fences() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```rust\nlet x = 1;\n```", &theme);
+        // No rendered line may contain the literal ``` fence delimiter.
+        assert!(
+            r.line_text.iter().all(|l| !l.contains("```")),
+            "raw ``` fences must not leak into rendered text; got: {:?}",
+            r.line_text
+        );
+    }
+
+    #[test]
+    fn code_block_content_has_code_rail() {
+        let theme = Theme::default();
+        let r = render_markdown_to_styled("```\nlet x = 1;\n```", &theme);
+        // Content lines are prefixed with the heavy-bar code rail.
+        assert_eq!(r.line_text[1], "  \u{2503} let x = 1;");
+        assert!(
+            r.lines[1]
+                .spans
+                .iter()
+                .any(|s| s.fg == Some(theme.muted_fg) && s.text.contains('\u{2503}')),
+            "expected a muted_fg rail span; spans: {:?}",
+            r.lines[1].spans
         );
     }
 
@@ -1263,7 +1355,11 @@ mod tests {
     fn code_block_content_line_uses_foreground() {
         let theme = Theme::default();
         let r = render_markdown_to_styled("```\ncontent\n```", &theme);
-        let content = &r.lines[1].spans[0];
+        let content = r.lines[1]
+            .spans
+            .iter()
+            .find(|s| s.text == "content")
+            .expect("expected a span carrying the code content");
         assert_eq!(
             content.fg,
             Some(theme.foreground),
@@ -1280,7 +1376,8 @@ mod tests {
             r.lines[1].spans.iter().all(|s| !s.bold),
             "content inside code block must not be emphasis-parsed"
         );
-        assert_eq!(r.line_text[1], "**not bold**");
+        // The rail prefix is added but the code text is otherwise verbatim.
+        assert_eq!(r.line_text[1], "  \u{2503} **not bold**");
     }
 
     #[test]

--- a/quadraui/src/compose/markdown.rs
+++ b/quadraui/src/compose/markdown.rs
@@ -111,11 +111,20 @@ pub struct RenderedMarkdown {
 
 // ── Internal types ─────────────────────────────────────────────────────────
 
-/// A link extracted during inline parsing.  Byte ranges into `line_text` are
-/// resolved later by scanning the concatenated span text.
+/// A link extracted during inline parsing.
+///
+/// `plain_offset` is the byte offset of the link text in the assembled
+/// `inner_plain` string (the concatenation of all span texts returned by
+/// `parse_inline`).  It is recorded *inside* `parse_inline` as spans are
+/// built — not reconstructed by searching afterward — so duplicate link
+/// texts that also appear as plain text before the link always resolve to
+/// the correct position.
 struct RawLink {
     text: String,
     url: String,
+    /// Byte offset of `text` within the `inner_plain` produced by the same
+    /// `parse_inline` call that created this link.
+    plain_offset: usize,
 }
 
 // ── Public entry point ─────────────────────────────────────────────────────
@@ -318,7 +327,7 @@ fn render_regular_line(
         let prefix = "\u{2502} ";
         let prefix_len = prefix.len(); // = 4
         let plain = format!("{prefix}{inner_plain}");
-        let links = resolve_links(&raw_links, &inner_plain, prefix_len);
+        let links = resolve_links(&raw_links, prefix_len);
         let bar_span = StyledSpan {
             text: prefix.to_string(),
             fg: Some(theme.link_fg),
@@ -340,7 +349,7 @@ fn render_regular_line(
         let prefix = "  \u{2022} ";
         let prefix_len = prefix.len(); // = 6
         let plain = format!("{prefix}{inner_plain}");
-        let links = resolve_links(&raw_links, &inner_plain, prefix_len);
+        let links = resolve_links(&raw_links, prefix_len);
         let indent_span = StyledSpan::plain("  ");
         let bullet_span = StyledSpan {
             text: "\u{2022} ".to_string(),
@@ -364,7 +373,7 @@ fn render_regular_line(
         let prefix = format!("  {marker}");
         let prefix_len = prefix.len();
         let plain = format!("{prefix}{inner_plain}");
-        let links = resolve_links(&raw_links, &inner_plain, prefix_len);
+        let links = resolve_links(&raw_links, prefix_len);
         let indent_span = StyledSpan::plain("  ");
         let marker_span = StyledSpan {
             text: marker,
@@ -384,7 +393,7 @@ fn render_regular_line(
     let scale = heading_scale(heading_level);
     let (spans, raw_links) = parse_inline(content, heading_level > 0, false, theme);
     let plain: String = spans.iter().map(|s| s.text.as_str()).collect();
-    let links = resolve_links(&raw_links, &plain, 0);
+    let links = resolve_links(&raw_links, 0);
     (plain, StyledText { spans }, scale, links)
 }
 
@@ -393,11 +402,20 @@ fn render_regular_line(
 /// Detect a blockquote prefix (`> ` or bare `>`).
 ///
 /// Returns the content after the prefix, or `None` if not a blockquote.
+///
+/// Only single-level blockquotes are matched: `"> text"` (canonical CommonMark)
+/// or `">text"` (no space, accepted as a pragmatic extension for AI output).
+/// Bare `">"` (empty blockquote line) is also matched.
+/// Lines that begin with `">>"` or more are **not** matched — nested
+/// blockquotes are intentionally deferred (see module-level deferrals) and
+/// pass through as plain text rather than being silently mis-rendered.
 fn parse_blockquote(line: &str) -> Option<&str> {
     if let Some(rest) = line.strip_prefix("> ") {
         Some(rest)
-    } else if line.starts_with('>') && !line.starts_with(">>>") {
-        // Bare ">" or ">text" (no space) — strip only the leading ">".
+    } else if line.starts_with('>') && !line.starts_with(">>") {
+        // Bare ">" or ">text" (no space after the chevron).
+        // We exclude ">>" and deeper to avoid silently mis-rendering nested
+        // blockquotes as "│ >text" — they should just be plain text.
         Some(&line[1..])
     } else {
         None
@@ -466,32 +484,26 @@ fn heading_scale(level: u8) -> f32 {
 
 // ── Link side-channel helper ───────────────────────────────────────────────
 
-/// Resolve [`RawLink`]s to `(byte_start, byte_end, url)` triples into a line's
-/// plain text.
+/// Resolve [`RawLink`]s to `(byte_start, byte_end, url)` triples into a
+/// line's plain text.
 ///
-/// `inner_plain` is the plain text of the inline content (without any block
-/// prefix).  `prefix_len` is the byte length of the block prefix prepended
-/// before `inner_plain` in the final `plain` string (e.g. `"  • "` = 6 bytes).
+/// `prefix_len` is the byte length of any block-level prefix prepended
+/// before `inner_plain` in the final `plain` string (e.g. `"  • "` = 6
+/// bytes for a bullet item, `0` for body text).
 ///
-/// Links are resolved left-to-right: each link text is searched for in
-/// `inner_plain` starting from after the previous match, so duplicate link
-/// texts resolve to distinct, non-overlapping positions.
-fn resolve_links(
-    raw_links: &[RawLink],
-    inner_plain: &str,
-    prefix_len: usize,
-) -> Vec<(usize, usize, String)> {
-    let mut result = Vec::new();
-    let mut search_from = 0usize;
-    for link in raw_links {
-        if let Some(pos) = inner_plain[search_from..].find(&link.text) {
-            let abs_start = prefix_len + search_from + pos;
-            let abs_end = abs_start + link.text.len();
-            result.push((abs_start, abs_end, link.url.clone()));
-            search_from += pos + link.text.len();
-        }
-    }
-    result
+/// Each link's position comes from the `plain_offset` recorded by
+/// [`parse_inline`] as spans were built — not reconstructed by text
+/// search — so links whose visible text coincidentally appears as prose
+/// earlier on the same line are still resolved to the correct position.
+fn resolve_links(raw_links: &[RawLink], prefix_len: usize) -> Vec<(usize, usize, String)> {
+    raw_links
+        .iter()
+        .map(|link| {
+            let start = prefix_len + link.plain_offset;
+            let end = start + link.text.len();
+            (start, end, link.url.clone())
+        })
+        .collect()
 }
 
 // ── Inline span parser ─────────────────────────────────────────────────────
@@ -531,6 +543,11 @@ fn parse_inline(
     let len = bytes.len();
     let mut pos = 0usize;
     let mut plain_start = 0usize;
+    // `plain_offset` tracks the cumulative byte count of all span text
+    // produced so far.  When a link span is emitted we record its start
+    // offset here so `RawLink::plain_offset` points directly to the right
+    // position — no after-the-fact text search required.
+    let mut plain_offset = 0usize;
 
     while pos < len {
         let b = bytes[pos];
@@ -541,7 +558,9 @@ fn parse_inline(
             if let Some(close_rel) = text[after..].find('`') {
                 // Flush plain text before this code span.
                 if plain_start < pos {
-                    spans.push(make_span(&text[plain_start..pos], bold, italic, None));
+                    let chunk = &text[plain_start..pos];
+                    plain_offset += chunk.len();
+                    spans.push(make_span(chunk, bold, italic, None));
                 }
                 let code_text = &text[after..after + close_rel];
                 // `accent_fg` is the closest Theme field to "code_fg".
@@ -557,6 +576,7 @@ fn parse_inline(
                     italic: false,
                     underline: false,
                 });
+                plain_offset += code_text.len();
                 pos = after + close_rel + 1;
                 plain_start = pos;
                 continue;
@@ -570,8 +590,12 @@ fn parse_inline(
         if b == b'[' {
             if let Some((link_text, url, after)) = parse_link(text, pos) {
                 if plain_start < pos {
-                    spans.push(make_span(&text[plain_start..pos], bold, italic, None));
+                    let chunk = &text[plain_start..pos];
+                    plain_offset += chunk.len();
+                    spans.push(make_span(chunk, bold, italic, None));
                 }
+                // Record the link's start offset *before* advancing plain_offset.
+                let link_start_in_plain = plain_offset;
                 spans.push(StyledSpan {
                     text: link_text.to_string(),
                     fg: Some(theme.link_fg),
@@ -580,9 +604,11 @@ fn parse_inline(
                     italic: false,
                     underline: true,
                 });
+                plain_offset += link_text.len();
                 links.push(RawLink {
                     text: link_text.to_string(),
                     url: url.to_string(),
+                    plain_offset: link_start_in_plain,
                 });
                 pos = after;
                 plain_start = pos;
@@ -599,10 +625,19 @@ fn parse_inline(
             if can_open(text, pos, run_end, b) {
                 if let Some(close) = find_emphasis_close(text, run_end, b, 2) {
                     if plain_start < pos {
-                        spans.push(make_span(&text[plain_start..pos], bold, italic, None));
+                        let chunk = &text[plain_start..pos];
+                        plain_offset += chunk.len();
+                        spans.push(make_span(chunk, bold, italic, None));
                     }
                     let inner = &text[run_end..close];
-                    let (inner_spans, inner_links) = parse_inline(inner, true, italic, theme);
+                    let offset_before_inner = plain_offset;
+                    let (inner_spans, mut inner_links) = parse_inline(inner, true, italic, theme);
+                    // Adjust inner link offsets: they are relative to `inner`'s
+                    // plain text, so add our current plain_offset before them.
+                    for lnk in &mut inner_links {
+                        lnk.plain_offset += offset_before_inner;
+                    }
+                    plain_offset += inner_spans.iter().map(|s| s.text.len()).sum::<usize>();
                     spans.extend(inner_spans);
                     links.extend(inner_links);
                     pos = close + 2;
@@ -623,10 +658,17 @@ fn parse_inline(
             if can_open(text, pos, run_end, b) {
                 if let Some(close) = find_emphasis_close(text, run_end, b, 1) {
                     if plain_start < pos {
-                        spans.push(make_span(&text[plain_start..pos], bold, italic, None));
+                        let chunk = &text[plain_start..pos];
+                        plain_offset += chunk.len();
+                        spans.push(make_span(chunk, bold, italic, None));
                     }
                     let inner = &text[run_end..close];
-                    let (inner_spans, inner_links) = parse_inline(inner, bold, true, theme);
+                    let offset_before_inner = plain_offset;
+                    let (inner_spans, mut inner_links) = parse_inline(inner, bold, true, theme);
+                    for lnk in &mut inner_links {
+                        lnk.plain_offset += offset_before_inner;
+                    }
+                    plain_offset += inner_spans.iter().map(|s| s.text.len()).sum::<usize>();
                     spans.extend(inner_spans);
                     links.extend(inner_links);
                     pos = close + 1;
@@ -1469,6 +1511,54 @@ mod tests {
         assert_eq!(u0, "http://a.com");
         assert_eq!(&r.line_text[0][r1.clone()], "beta");
         assert_eq!(u1, "http://b.com");
+    }
+
+    // ── Link byte-range correctness (duplicate text before the link) ───
+
+    /// Regression test for the `resolve_links` bug: when the link text also
+    /// appears as ordinary prose *before* the actual link on the same line,
+    /// the recorded byte range must point to the link occurrence — not the
+    /// first (plain-text) occurrence.
+    #[test]
+    fn link_range_correct_when_text_appears_before_link() {
+        let theme = Theme::default();
+        // "see foo and [foo](http://example.com)" — "foo" appears twice in the
+        // plain text, but only the second occurrence is the link.
+        let r = render_markdown_to_styled("see foo and [foo](http://example.com)", &theme);
+        assert_eq!(r.links.len(), 1);
+        let (_, ref range, ref url) = r.links[0];
+        // plain text is "see foo and foo" (15 bytes).
+        // The link "foo" must be at 12..15, NOT at 4..7.
+        assert_eq!(
+            &r.line_text[0][range.clone()],
+            "foo",
+            "byte range must point to the link occurrence, not the plain-text occurrence; \
+             line_text={:?}, range={range:?}",
+            r.line_text[0]
+        );
+        let start = range.start;
+        assert_eq!(
+            start, 12,
+            "link must start at byte 12 (after 'see foo and '), got {start}"
+        );
+        assert_eq!(url, "http://example.com");
+    }
+
+    #[test]
+    fn link_range_correct_inside_bold_when_text_appears_before() {
+        let theme = Theme::default();
+        // "alpha **[alpha](url)**" — "alpha" appears as plain prose then as link.
+        let r = render_markdown_to_styled("alpha **[alpha](url)**", &theme);
+        assert_eq!(r.links.len(), 1);
+        let (_, ref range, _) = r.links[0];
+        assert_eq!(
+            &r.line_text[0][range.clone()],
+            "alpha",
+            "byte range must target the bold-link occurrence; line_text={:?}, range={range:?}",
+            r.line_text[0]
+        );
+        // plain text is "alpha alpha" (11 bytes); link must be at 6..11.
+        assert_eq!(range.start, 6, "link must start after leading 'alpha '");
     }
 
     // ── Blockquotes ────────────────────────────────────────────────────

--- a/quadraui/src/compose/mod.rs
+++ b/quadraui/src/compose/mod.rs
@@ -37,6 +37,7 @@ pub use focus_group::FocusGroup;
 pub use focus_ring::FocusRing;
 pub use folder_picker::{FolderPickerController, FolderPickerEvent, PALETTE_CHROME_ROWS};
 pub use form_controller::{FormController, FormControllerEvent};
+pub use markdown::{CodeBlockRange, RenderedMarkdown};
 pub use menu_system::{MenuDef, MenuEvent, MenuSystem};
 pub use sidebar_system::{
     NavigationMode, SectionKind, SidebarEvent, SidebarSectionDef, SidebarSystem,

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -269,7 +269,7 @@ pub use frame::{FrameHitMap, FrameZone, ScreenLayout, Surface};
 pub use shell::{ShellApp, ShellConfig, ShellContext};
 
 // Phase B.4 re-exports.
-pub use compose::markdown::{render_markdown_to_styled, RenderedMarkdown};
+pub use compose::markdown::{render_markdown_to_styled, CodeBlockRange, RenderedMarkdown};
 pub use compose::{
     AppShell, AppShellEvent, AppShellLayout, ChatController, ChatControllerEvent, ChatRole,
     ChatTurn, FocusGroup, FocusRing, FolderPickerController, FolderPickerEvent, FormController,


### PR DESCRIPTION
Closes #291

Automated merge from the coordinator for assignment 66fcb619f8c9 on issue #291.

Worker branch: `issue-291-markdown-adapter-lists-fenced-code-block` → `develop`.