### PR TITLE
feat(#298): MessageList styled-row model so ChatController transcript renders markdown

### DIFF
--- a/quadraui/examples/common/chat_demo.rs
+++ b/quadraui/examples/common/chat_demo.rs
@@ -108,6 +108,7 @@ impl AppLogic for ChatDemo {
                     role: ChatRole::User,
                     text: StyledText::colored(text.clone(), Color::rgb(220, 220, 220)),
                     timestamp_unix: None,
+                    line_scales: Vec::new(),
                 });
                 self.controller.clear_input();
                 // Queue a simulated reply (delivered after a few ticks).
@@ -148,6 +149,7 @@ impl AppLogic for ChatDemo {
                         role: ChatRole::Assistant,
                         text: StyledText::colored(reply, Color::rgb(180, 230, 180)),
                         timestamp_unix: None,
+                        line_scales: Vec::new(),
                     });
                 }
             }

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -62,13 +62,27 @@ pub enum ChatRole {
 /// A single turn in the chat transcript.
 ///
 /// `text` is a [`StyledText`] so rich markdown-derived colouring can be added
-/// in a future pass. V1 rasterisers simply concatenate span text.
+/// in a future pass. When `line_scales` is non-empty (turns created via
+/// [`ChatController::push_turn_markdown`]), the transcript renderer builds
+/// styled [`MessageRow`]s with per-span fg/bold/italic and per-line heading
+/// scale; otherwise it falls back to concatenating span text (the flat path).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatTurn {
     pub role: ChatRole,
     pub text: StyledText,
     /// Unix epoch seconds; `None` when not recorded.
     pub timestamp_unix: Option<f64>,
+    /// Per-line font-scale factors, parallel to the logical lines in `text`.
+    ///
+    /// Non-empty only for turns created by [`ChatController::push_turn_markdown`]
+    /// (where the markdown adapter supplies one scale per input line).  `1.0` for
+    /// body lines; `2.0` / `1.5` / `1.2` for H1 / H2 / H3 headings.
+    ///
+    /// When empty the transcript renderer uses the flat (legacy) path so that
+    /// turns created via [`ChatController::push_turn`] or
+    /// [`ChatController::set_transcript`] are visually unchanged.
+    #[serde(default)]
+    pub line_scales: Vec<f32>,
 }
 
 /// Events emitted by [`ChatController::handle`].
@@ -292,6 +306,7 @@ impl ChatController {
             role,
             text,
             timestamp_unix: None,
+            line_scales: Vec::new(),
         });
     }
 
@@ -314,6 +329,9 @@ impl ChatController {
     /// markers, blockquote rules, etc.) as plain-text cues.
     pub fn push_turn_markdown(&mut self, role: ChatRole, markdown: &str, theme: &Theme) {
         let rendered = render_markdown_to_styled(markdown, theme);
+        // Preserve line-scale metadata so the transcript renderer can build
+        // styled rows with heading sizes.
+        let line_scales = rendered.line_scales.clone();
         let mut spans: Vec<StyledSpan> = Vec::new();
         for (i, line) in rendered.lines.into_iter().enumerate() {
             if i > 0 {
@@ -325,6 +343,7 @@ impl ChatController {
             role,
             text: StyledText { spans },
             timestamp_unix: None,
+            line_scales,
         });
     }
 
@@ -579,11 +598,40 @@ impl ChatController {
             // Role header row (no indent).
             rows.push(MessageRow::new(role_label, role_fg, 0.0));
 
-            // Content rows: wrap each raw line from the turn's plain text.
-            let plain: String = turn.text.spans.iter().map(|s| s.text.as_str()).collect();
-            for raw_line in plain.split('\n') {
-                for wrapped in wrap_text(raw_line, col_budget.saturating_sub(2)) {
-                    rows.push(MessageRow::new(wrapped, content_fg, 2.0));
+            let content_budget = col_budget.saturating_sub(2);
+
+            if !turn.line_scales.is_empty() {
+                // ── Styled path ──────────────────────────────────────────
+                // Turns created by `push_turn_markdown` carry per-line span
+                // lists (separated by plain `\n` spans) and matching scale
+                // factors.  Build styled MessageRows so rasterisers can apply
+                // per-span fg/bold/italic and heading font sizes.
+                let lines_spans = split_spans_by_newline(&turn.text.spans);
+                for (i, line_spans) in lines_spans.iter().enumerate() {
+                    let scale = turn.line_scales.get(i).copied().unwrap_or(1.0);
+                    let wrapped_groups = wrap_spans(line_spans, content_budget);
+                    for group in wrapped_groups {
+                        let text: String = group.iter().map(|s| s.text.as_str()).collect();
+                        rows.push(MessageRow {
+                            text,
+                            fg: content_fg,
+                            indent: 2.0,
+                            spans: group,
+                            scale,
+                        });
+                    }
+                }
+            } else {
+                // ── Flat path (unchanged) ────────────────────────────────
+                // Turns created by `push_turn` or `set_transcript` have
+                // empty `line_scales`.  Output is byte-for-byte identical
+                // to the pre-styled-row behaviour — existing callers
+                // (vimcode debug / AI sidebar) are visually unchanged.
+                let plain: String = turn.text.spans.iter().map(|s| s.text.as_str()).collect();
+                for raw_line in plain.split('\n') {
+                    for wrapped in wrap_text(raw_line, content_budget) {
+                        rows.push(MessageRow::new(wrapped, content_fg, 2.0));
+                    }
                 }
             }
 
@@ -1062,6 +1110,84 @@ fn wrap_text(text: &str, col_budget: usize) -> Vec<String> {
     lines
 }
 
+/// Split a flat span list (where `\n`-only spans act as line delimiters)
+/// into per-logical-line span lists.
+///
+/// This is the inverse of the encoding used by
+/// [`ChatController::push_turn_markdown`], which concatenates per-line
+/// span vecs with [`StyledSpan::plain`]`("\n")` separators.  The
+/// resulting `Vec<Vec<StyledSpan>>` has one entry per logical line
+/// (including an empty entry for blank lines).
+fn split_spans_by_newline(spans: &[StyledSpan]) -> Vec<Vec<StyledSpan>> {
+    let mut lines: Vec<Vec<StyledSpan>> = Vec::new();
+    let mut current: Vec<StyledSpan> = Vec::new();
+    for span in spans {
+        if span.text == "\n" {
+            lines.push(std::mem::take(&mut current));
+        } else {
+            current.push(span.clone());
+        }
+    }
+    lines.push(current);
+    lines
+}
+
+/// Wrap a flat span list at `col_budget` characters per rendered row.
+///
+/// Returns a `Vec` of per-row span lists.  Spans that cross a wrap
+/// boundary are split at the boundary — the span style (fg, bold, italic)
+/// is cloned onto both halves so styling is preserved.
+///
+/// Zero budget or empty input is handled gracefully (one group returned).
+fn wrap_spans(spans: &[StyledSpan], col_budget: usize) -> Vec<Vec<StyledSpan>> {
+    if spans.is_empty() {
+        return vec![vec![]];
+    }
+    let total_chars: usize = spans.iter().map(|s| s.text.chars().count()).sum();
+    if total_chars == 0 {
+        return vec![vec![]];
+    }
+    if col_budget == 0 || total_chars <= col_budget {
+        return vec![spans.to_vec()];
+    }
+
+    let mut result: Vec<Vec<StyledSpan>> = Vec::new();
+    let mut current_row: Vec<StyledSpan> = Vec::new();
+    let mut row_chars = 0usize;
+
+    for span in spans {
+        let chars: Vec<char> = span.text.chars().collect();
+        let mut span_start = 0usize;
+
+        while span_start < chars.len() {
+            // Flush a full row if no space remains.
+            if row_chars >= col_budget {
+                result.push(std::mem::take(&mut current_row));
+                row_chars = 0;
+            }
+            let available = col_budget - row_chars;
+            let can_take = (chars.len() - span_start).min(available);
+            if can_take > 0 {
+                let chunk: String = chars[span_start..span_start + can_take].iter().collect();
+                current_row.push(StyledSpan {
+                    text: chunk,
+                    ..span.clone()
+                });
+                row_chars += can_take;
+                span_start += can_take;
+            }
+        }
+    }
+
+    if !current_row.is_empty() {
+        result.push(current_row);
+    }
+    if result.is_empty() {
+        result.push(vec![]);
+    }
+    result
+}
+
 /// Convert a byte offset in `text` to `(line, char_col)`.
 fn cursor_byte_to_line_col(text: &str, cursor: usize) -> (usize, usize) {
     let cursor = cursor.min(text.len());
@@ -1509,6 +1635,7 @@ mod tests {
             role,
             text: StyledText::plain(text),
             timestamp_unix: None,
+            line_scales: Vec::new(),
         }
     }
 
@@ -1725,6 +1852,7 @@ mod tests {
             role: ChatRole::Assistant,
             text: StyledText::colored("hi there", Color::rgb(180, 230, 180)),
             timestamp_unix: Some(1_700_000_000.0),
+            line_scales: Vec::new(),
         };
         let json = serde_json::to_string(&turn).expect("serialize ChatTurn");
         let decoded: ChatTurn = serde_json::from_str(&json).expect("deserialize ChatTurn");
@@ -2008,6 +2136,236 @@ mod tests {
             .filter(|r| !r.text.is_empty() && r.indent > 0.0)
             .collect();
         assert_eq!(content.len(), 2);
+    }
+
+    // ── Styled transcript rows ────────────────────────────────────────
+
+    #[test]
+    fn push_turn_markdown_stores_line_scales() {
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        cc.push_turn_markdown(ChatRole::Assistant, "# Heading\nbody", &theme);
+        let turn = &cc.transcript[0];
+        // Markdown adapter produces 2 lines → 2 scales.
+        assert_eq!(
+            turn.line_scales.len(),
+            2,
+            "line_scales must have one entry per markdown line; got {:?}",
+            turn.line_scales
+        );
+        // H1 → scale 2.0.
+        assert!(
+            (turn.line_scales[0] - 2.0).abs() < f32::EPSILON,
+            "H1 line_scale must be 2.0; got {}",
+            turn.line_scales[0]
+        );
+        // Body → scale 1.0.
+        assert!(
+            (turn.line_scales[1] - 1.0).abs() < f32::EPSILON,
+            "body line_scale must be 1.0; got {}",
+            turn.line_scales[1]
+        );
+    }
+
+    #[test]
+    fn push_turn_has_empty_line_scales() {
+        // Turns created via push_turn must have empty line_scales so the
+        // flat render path is used — invariant for existing callers.
+        let mut cc = ChatController::new("c");
+        cc.push_turn(ChatRole::User, StyledText::plain("plain text"));
+        assert!(
+            cc.transcript[0].line_scales.is_empty(),
+            "push_turn must leave line_scales empty"
+        );
+    }
+
+    #[test]
+    fn build_transcript_rows_flat_path_unchanged() {
+        // Turns with empty line_scales must produce rows with empty spans
+        // — bit-for-bit identical to the pre-styled-row behaviour.
+        let mut cc = ChatController::new("c");
+        cc.set_transcript(vec![make_turn(ChatRole::User, "hello")]);
+        let rows = cc.build_transcript_rows(80);
+        // Content row at index 1 (after the "You" header).
+        let content_row = rows.iter().find(|r| r.text == "hello").unwrap();
+        assert!(
+            content_row.spans.is_empty(),
+            "flat-path rows must have empty spans; got {:?}",
+            content_row.spans
+        );
+        assert!(
+            (content_row.scale - 1.0).abs() < f32::EPSILON,
+            "flat-path rows must have scale 1.0"
+        );
+    }
+
+    #[test]
+    fn build_transcript_rows_styled_path_produces_spans() {
+        // Turns created by push_turn_markdown must produce rows with non-empty
+        // spans so rasterisers can apply per-span styling.
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        cc.push_turn_markdown(ChatRole::Assistant, "**bold** text", &theme);
+        let rows = cc.build_transcript_rows(80);
+        // Skip the "AI" role header row, find the content row.
+        let content_rows: Vec<_> = rows.iter().filter(|r| r.indent > 0.0).collect();
+        assert!(
+            !content_rows.is_empty(),
+            "expected at least one content row"
+        );
+        let first = &content_rows[0];
+        assert!(
+            !first.spans.is_empty(),
+            "markdown turns must produce rows with non-empty spans; got empty"
+        );
+        // The bold span must appear somewhere in the row spans.
+        let has_bold = first.spans.iter().any(|s| s.bold);
+        assert!(
+            has_bold,
+            "expected a bold span in the row; spans: {:?}",
+            first.spans
+        );
+    }
+
+    #[test]
+    fn build_transcript_rows_heading_carries_scale() {
+        // H1 markdown line → content rows must have scale 2.0.
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        cc.push_turn_markdown(ChatRole::Assistant, "# Title", &theme);
+        let rows = cc.build_transcript_rows(80);
+        let content_rows: Vec<_> = rows.iter().filter(|r| r.indent > 0.0).collect();
+        assert!(!content_rows.is_empty(), "expected content rows");
+        let heading_row = &content_rows[0];
+        assert!(
+            (heading_row.scale - 2.0).abs() < f32::EPSILON,
+            "H1 content row must have scale 2.0; got {}",
+            heading_row.scale
+        );
+    }
+
+    #[test]
+    fn build_transcript_rows_plain_role_header_has_no_spans() {
+        // Role headers ("You", "AI", "System") must always be flat rows —
+        // they are inserted by the controller, not from user content.
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        cc.push_turn_markdown(ChatRole::User, "**bold**", &theme);
+        let rows = cc.build_transcript_rows(80);
+        let header = rows.iter().find(|r| r.text == "You").unwrap();
+        assert!(
+            header.spans.is_empty(),
+            "role header must be a flat row; spans: {:?}",
+            header.spans
+        );
+    }
+
+    #[test]
+    fn build_transcript_rows_styled_wraps_across_budget() {
+        // A styled turn wider than the column budget must produce multiple rows.
+        let mut cc = ChatController::new("c");
+        let theme = crate::Theme::default();
+        // 10 plain chars; col_budget=7 → content_budget=5 → 2 rows.
+        cc.push_turn_markdown(ChatRole::Assistant, "1234567890", &theme);
+        let rows = cc.build_transcript_rows(7);
+        let content_rows: Vec<_> = rows.iter().filter(|r| r.indent > 0.0).collect();
+        assert_eq!(
+            content_rows.len(),
+            2,
+            "10-char styled line at budget=5 must wrap to 2 rows; got {}",
+            content_rows.len()
+        );
+    }
+
+    // ── split_spans_by_newline ────────────────────────────────────────
+
+    #[test]
+    fn split_spans_by_newline_single_line() {
+        let spans = vec![StyledSpan::plain("hello")];
+        let lines = split_spans_by_newline(&spans);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].len(), 1);
+        assert_eq!(lines[0][0].text, "hello");
+    }
+
+    #[test]
+    fn split_spans_by_newline_two_lines() {
+        let spans = vec![
+            StyledSpan::plain("line1"),
+            StyledSpan::plain("\n"),
+            StyledSpan::plain("line2"),
+        ];
+        let lines = split_spans_by_newline(&spans);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0][0].text, "line1");
+        assert_eq!(lines[1][0].text, "line2");
+    }
+
+    #[test]
+    fn split_spans_by_newline_empty_produces_one_empty_line() {
+        let lines = split_spans_by_newline(&[]);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].is_empty());
+    }
+
+    // ── wrap_spans ────────────────────────────────────────────────────
+
+    #[test]
+    fn wrap_spans_short_line_not_split() {
+        let spans = vec![StyledSpan::plain("hello")];
+        let groups = wrap_spans(&spans, 80);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].len(), 1);
+        assert_eq!(groups[0][0].text, "hello");
+    }
+
+    #[test]
+    fn wrap_spans_splits_single_span_at_budget() {
+        let spans = vec![StyledSpan::plain("abcde")];
+        let groups = wrap_spans(&spans, 3);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0][0].text, "abc");
+        assert_eq!(groups[1][0].text, "de");
+    }
+
+    #[test]
+    fn wrap_spans_preserves_style_on_split_chunks() {
+        let bold_span = StyledSpan {
+            text: "abcdef".to_string(),
+            fg: Some(Color::rgb(255, 0, 0)),
+            bg: None,
+            bold: true,
+            italic: false,
+            underline: false,
+        };
+        let groups = wrap_spans(&[bold_span], 4);
+        assert_eq!(groups.len(), 2);
+        assert!(groups[0][0].bold, "first chunk must retain bold");
+        assert!(groups[1][0].bold, "second chunk must retain bold");
+        assert_eq!(groups[0][0].fg, Some(Color::rgb(255, 0, 0)));
+        assert_eq!(groups[0][0].text, "abcd");
+        assert_eq!(groups[1][0].text, "ef");
+    }
+
+    #[test]
+    fn wrap_spans_multi_span_boundary() {
+        // Two 3-char spans at budget=4 → first row gets span-A (3) + one char
+        // of span-B; second row gets remaining 2 chars of span-B.
+        let a = StyledSpan::plain("abc");
+        let b = StyledSpan::plain("def");
+        let groups = wrap_spans(&[a, b], 4);
+        assert_eq!(groups.len(), 2);
+        let row0_text: String = groups[0].iter().map(|s| s.text.as_str()).collect();
+        let row1_text: String = groups[1].iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(row0_text, "abcd");
+        assert_eq!(row1_text, "ef");
+    }
+
+    #[test]
+    fn wrap_spans_empty_returns_one_empty_group() {
+        let groups = wrap_spans(&[], 80);
+        assert_eq!(groups.len(), 1);
+        assert!(groups[0].is_empty());
     }
 
     // ── Wrap helper ───────────────────────────────────────────────────

--- a/quadraui/src/gtk/message_list.rs
+++ b/quadraui/src/gtk/message_list.rs
@@ -7,6 +7,23 @@
 //! message list paints) — this rasteriser only paints text, since
 //! repeated per-row bg fills would overdraw any header / separator the
 //! caller has already drawn outside the message area.
+//!
+//! # Styled rows
+//!
+//! When a row's `spans` vector is **non-empty**, the rasteriser builds a
+//! Pango [`AttrList`] and attaches:
+//!
+//! * `AttrColor::new_foreground` per span that has an explicit `fg`.
+//! * `AttrInt::new_weight(Bold)` for bold spans.
+//! * `AttrInt::new_style(Italic)` for italic spans.
+//! * `AttrInt::new_underline(Single)` for underlined spans.
+//! * `AttrFloat::new_scale(row.scale)` over the full row text when
+//!   `row.scale` differs from `1.0` (heading rows).
+//!
+//! This mirrors the rich path in [`crate::gtk::rich_text_popup`] (lines
+//! ~118–249).  When `spans` is **empty** the rasteriser falls back to the
+//! flat `row.text` + `row.fg` path — output is identical to the
+//! pre-styled-row behaviour.
 
 use gtk4::cairo::Context;
 use gtk4::pango;
@@ -22,6 +39,11 @@ use crate::primitives::message_list::MessageList;
 /// baseline would fall at or past `max_y` are skipped (the caller's
 /// input row sits below `max_y`). `line_height` is the per-row pixel
 /// height.
+///
+/// When a row's `spans` is non-empty, per-span Pango attributes are
+/// applied (fg, bold, italic, underline) and the row's `scale` is
+/// applied via `AttrFloat::new_scale`.  When `spans` is empty the flat
+/// `text` + `fg` path is used unchanged.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_message_list(
     cr: &Context,
@@ -36,17 +58,78 @@ pub fn draw_message_list(
     if w <= 0.0 || line_height <= 0.0 {
         return;
     }
+    // Helper: widen a u8 channel to a 16-bit Pango colour component.
+    let to_u16 = |c: u8| -> u16 { ((c as u16) << 8) | c as u16 };
+
     layout.set_attributes(None);
     for (i, row) in list.rows.iter().skip(list.scroll_top).enumerate() {
         let ry = y + i as f64 * line_height;
         if ry + line_height > max_y {
             break;
         }
-        let (r, g, b) = cairo_rgb(row.fg);
-        cr.set_source_rgb(r, g, b);
-        layout.set_text(&row.text);
-        let (_, lh) = layout.pixel_size();
-        cr.move_to(x + row.indent as f64, ry + (line_height - lh as f64) / 2.0);
-        pcfn::show_layout(cr, layout);
+
+        if !row.spans.is_empty() {
+            // ── Styled path ─────────────────────────────────────────────
+            let attrs = pango::AttrList::new();
+
+            // Per-row scale for heading rows (H1=2.0, H2=1.5, H3=1.2).
+            if (row.scale - 1.0).abs() > 0.01 {
+                let mut a = pango::AttrFloat::new_scale(row.scale as f64);
+                a.set_start_index(0);
+                a.set_end_index(row.text.len() as u32);
+                attrs.insert(a);
+            }
+
+            // Per-span fg / bold / italic / underline.
+            let mut byte_pos = 0usize;
+            for span in &row.spans {
+                let start = byte_pos as u32;
+                let end = (byte_pos + span.text.len()) as u32;
+
+                if let Some(c) = span.fg {
+                    let mut a =
+                        pango::AttrColor::new_foreground(to_u16(c.r), to_u16(c.g), to_u16(c.b));
+                    a.set_start_index(start);
+                    a.set_end_index(end);
+                    attrs.insert(a);
+                }
+                if span.bold {
+                    let mut a = pango::AttrInt::new_weight(pango::Weight::Bold);
+                    a.set_start_index(start);
+                    a.set_end_index(end);
+                    attrs.insert(a);
+                }
+                if span.italic {
+                    let mut a = pango::AttrInt::new_style(pango::Style::Italic);
+                    a.set_start_index(start);
+                    a.set_end_index(end);
+                    attrs.insert(a);
+                }
+                if span.underline {
+                    let mut a = pango::AttrInt::new_underline(pango::Underline::Single);
+                    a.set_start_index(start);
+                    a.set_end_index(end);
+                    attrs.insert(a);
+                }
+                byte_pos += span.text.len();
+            }
+
+            let (r, g, b) = cairo_rgb(row.fg);
+            cr.set_source_rgb(r, g, b);
+            layout.set_text(&row.text);
+            layout.set_attributes(Some(&attrs));
+            let (_, lh) = layout.pixel_size();
+            cr.move_to(x + row.indent as f64, ry + (line_height - lh as f64) / 2.0);
+            pcfn::show_layout(cr, layout);
+            layout.set_attributes(None);
+        } else {
+            // ── Flat path (unchanged from before spans were added) ───────
+            let (r, g, b) = cairo_rgb(row.fg);
+            cr.set_source_rgb(r, g, b);
+            layout.set_text(&row.text);
+            let (_, lh) = layout.pixel_size();
+            cr.move_to(x + row.indent as f64, ry + (line_height - lh as f64) / 2.0);
+            pcfn::show_layout(cr, layout);
+        }
     }
 }

--- a/quadraui/src/primitives/message_list.rs
+++ b/quadraui/src/primitives/message_list.rs
@@ -11,14 +11,32 @@
 //! Wrapping happens at the call site (vimcode's adapter splits message
 //! content into wrap-width chunks before pushing rows) — the primitive
 //! is data-only.
+//!
+//! # Styled rows
+//!
+//! Rows produced by the chat-controller's markdown path carry a non-empty
+//! `spans` vector and a `scale` factor.  Backends that support rich text
+//! (GTK via Pango attributes, TUI via ratatui modifiers) use those fields;
+//! backends that don't fall back to `text` + `fg`.  The invariant is:
+//!
+//! * `spans.is_empty()` → render exactly as before (unchanged output on
+//!   every backend).
+//! * `spans` non-empty → render each span in its own fg / bold / italic;
+//!   apply `scale` (GTK `AttrFloat::new_scale`, TUI ignores it).
 
-use crate::types::{Color, WidgetId};
+use crate::types::{Color, StyledSpan, StyledText, WidgetId};
 use serde::{Deserialize, Serialize};
 
 /// A single row in a [`MessageList`].
 ///
 /// `indent` is in surface units — TUI cells or GTK pixels — so the
 /// caller picks the unit appropriate for its rasteriser.
+///
+/// When `spans` is **empty** the row is rendered with the flat `text` +
+/// `fg` path — output is byte-for-byte identical to pre-styled-row
+/// behaviour, preserving existing callers.  When `spans` is non-empty
+/// the rasteriser applies per-span fg/bold/italic and the per-row `scale`
+/// multiplier.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MessageRow {
     pub text: String,
@@ -26,15 +44,160 @@ pub struct MessageRow {
     /// Left-indent offset in surface units (cells / pixels).
     #[serde(default)]
     pub indent: f32,
+    /// Per-span rich styling.  Empty for flat rows (the `new` path).
+    /// Non-empty for styled rows produced by the markdown transcript path.
+    #[serde(default)]
+    pub spans: Vec<StyledSpan>,
+    /// Font-scale multiplier (`1.0` = body, `2.0`/`1.5`/`1.2` for H1/H2/H3).
+    /// GTK applies this via `pango::AttrFloat::new_scale`; TUI ignores it
+    /// (terminal cells have no variable character size).
+    #[serde(default = "MessageRow::default_scale")]
+    pub scale: f32,
 }
 
 impl MessageRow {
+    /// Construct a flat row. `spans` is empty and `scale` is `1.0`.
+    /// Output on every backend is **identical** to the pre-styled-row
+    /// behaviour — this is the safe "no change" path for existing callers.
     pub fn new(text: impl Into<String>, fg: Color, indent: f32) -> Self {
         Self {
             text: text.into(),
             fg,
             indent,
+            spans: Vec::new(),
+            scale: 1.0,
         }
+    }
+
+    /// Construct a styled row from a [`StyledText`].
+    ///
+    /// `text` is set to the concatenation of all span texts (the plain-text
+    /// fallback used by backends that don't read `spans`).  `fg` is the
+    /// fallback foreground applied to spans whose `fg` is `None`.
+    pub fn styled(styled: StyledText, fg: Color, indent: f32, scale: f32) -> Self {
+        let text: String = styled.spans.iter().map(|s| s.text.as_str()).collect();
+        Self {
+            text,
+            fg,
+            indent,
+            spans: styled.spans,
+            scale,
+        }
+    }
+
+    fn default_scale() -> f32 {
+        1.0
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_has_empty_spans_and_unit_scale() {
+        let row = MessageRow::new("hello", Color::rgb(200, 200, 200), 2.0);
+        assert!(
+            row.spans.is_empty(),
+            "MessageRow::new must produce empty spans"
+        );
+        assert!(
+            (row.scale - 1.0).abs() < f32::EPSILON,
+            "MessageRow::new must set scale to 1.0"
+        );
+        assert_eq!(row.text, "hello");
+        assert_eq!(row.indent, 2.0);
+    }
+
+    #[test]
+    fn styled_carries_spans_and_scale() {
+        let spans = vec![
+            StyledSpan {
+                text: "bold".to_string(),
+                fg: Some(Color::rgb(255, 255, 0)),
+                bg: None,
+                bold: true,
+                italic: false,
+                underline: false,
+            },
+            StyledSpan::plain(" text"),
+        ];
+        let styled = StyledText {
+            spans: spans.clone(),
+        };
+        let row = MessageRow::styled(styled, Color::rgb(200, 200, 200), 2.0, 1.5);
+
+        assert_eq!(row.spans, spans);
+        assert!((row.scale - 1.5).abs() < f32::EPSILON);
+        assert_eq!(row.text, "bold text");
+        assert_eq!(row.indent, 2.0);
+    }
+
+    #[test]
+    fn styled_with_empty_styled_text_produces_empty_spans_and_empty_text() {
+        let row = MessageRow::styled(StyledText::default(), Color::rgb(100, 100, 100), 0.0, 1.0);
+        assert!(row.spans.is_empty());
+        assert_eq!(row.text, "");
+    }
+
+    #[test]
+    fn new_and_equivalent_styled_plain_rows_have_same_text() {
+        // A styled row built from a plain StyledText must have the same
+        // text field as the corresponding flat row — ensuring callers that
+        // read `row.text` on the plain path see the same value.
+        let plain = StyledText::plain("same content");
+        let flat = MessageRow::new("same content", Color::rgb(200, 200, 200), 2.0);
+        let rich = MessageRow::styled(plain, Color::rgb(200, 200, 200), 2.0, 1.0);
+        assert_eq!(flat.text, rich.text);
+        assert_eq!(flat.fg, rich.fg);
+        assert_eq!(flat.indent, rich.indent);
+        assert_eq!(flat.scale, rich.scale);
+        // The styled constructor always populates spans (even if just plain).
+        assert_eq!(rich.spans.len(), 1);
+        assert!(flat.spans.is_empty());
+    }
+
+    #[test]
+    fn serde_round_trip_flat_row() {
+        let row = MessageRow::new("flat", Color::rgb(1, 2, 3), 0.0);
+        let json = serde_json::to_string(&row).unwrap();
+        let decoded: MessageRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(row, decoded);
+    }
+
+    #[test]
+    fn serde_round_trip_styled_row() {
+        let styled = StyledText {
+            spans: vec![StyledSpan {
+                text: "hi".to_string(),
+                fg: Some(Color::rgb(255, 0, 0)),
+                bg: None,
+                bold: true,
+                italic: false,
+                underline: false,
+            }],
+        };
+        let row = MessageRow::styled(styled, Color::rgb(200, 200, 200), 2.0, 1.5);
+        let json = serde_json::to_string(&row).unwrap();
+        let decoded: MessageRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(row, decoded);
+    }
+
+    #[test]
+    fn serde_legacy_json_without_spans_defaults_to_empty() {
+        // Deserialise a JSON object that has no "spans" or "scale" fields —
+        // this is the pre-styled-row wire format.  Both fields must default
+        // gracefully so old serialised data remains loadable.
+        let legacy = r#"{"text":"legacy","fg":{"r":100,"g":100,"b":100,"a":255},"indent":0.0}"#;
+        let row: MessageRow = serde_json::from_str(legacy).unwrap();
+        assert!(row.spans.is_empty(), "spans must default to empty");
+        assert!(
+            (row.scale - 1.0).abs() < f32::EPSILON,
+            "scale must default to 1.0"
+        );
+        assert_eq!(row.text, "legacy");
     }
 }
 

--- a/quadraui/src/tui/message_list.rs
+++ b/quadraui/src/tui/message_list.rs
@@ -3,11 +3,24 @@
 //! Walks `rows[scroll_top..]` row by row, painting each row at
 //! `panel_bg` with the row's `fg` colour. Indents are in cell units —
 //! the caller pre-builds the indent via [`crate::MessageRow::indent`].
+//!
+//! # Styled rows
+//!
+//! When a row's `spans` vector is **non-empty**, each span is rendered
+//! in its own `fg` colour, with ratatui `Modifier::BOLD` / `ITALIC` /
+//! `UNDERLINED` applied as appropriate.  Spans whose `fg` is `None`
+//! fall back to `row.fg`.  The `scale` field is ignored by TUI (terminal
+//! cells have no variable character size).
+//!
+//! When `spans` is **empty**, the rasteriser uses the flat `row.text` +
+//! `row.fg` path — output is byte-for-byte identical to the pre-styled-row
+//! behaviour.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::Modifier;
 
-use super::{ratatui_color, set_cell};
+use super::{ratatui_color, set_cell, set_cell_styled};
 use crate::primitives::message_list::MessageList;
 use crate::types::Color;
 
@@ -16,6 +29,10 @@ use crate::types::Color;
 /// Stops once `area.height` rows have been painted (any unpainted rows
 /// are left untouched — the caller fills the remainder if it wants a
 /// uniform panel bg).
+///
+/// When a row carries a non-empty `spans` vector the rasteriser applies
+/// per-span fg/bold/italic via ratatui cell modifiers.  When `spans` is
+/// empty the flat `text` + `fg` path is used unchanged.
 pub fn draw_message_list(buf: &mut Buffer, area: Rect, list: &MessageList, panel_bg: Color) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -28,16 +45,46 @@ pub fn draw_message_list(buf: &mut Buffer, area: Rect, list: &MessageList, panel
         }
         let y = area.y + i as u16;
         let fg = ratatui_color(row.fg);
+        // Fill the row background first.
         for x in area.x..area.x + area.width {
             set_cell(buf, x, y, ' ', fg, bg);
         }
         let start_col = row.indent.round() as u16;
-        for (j, ch) in row.text.chars().enumerate() {
-            let cx = area.x + start_col + j as u16;
-            if cx >= area.x + area.width {
-                break;
+
+        if !row.spans.is_empty() {
+            // ── Styled path ─────────────────────────────────────────────
+            // Iterate spans in order, computing fg + modifier per span.
+            let mut col = start_col;
+            'span_loop: for span in &row.spans {
+                let span_fg = span.fg.map(ratatui_color).unwrap_or(fg);
+                let mut modifier = Modifier::empty();
+                if span.bold {
+                    modifier |= Modifier::BOLD;
+                }
+                if span.italic {
+                    modifier |= Modifier::ITALIC;
+                }
+                if span.underline {
+                    modifier |= Modifier::UNDERLINED;
+                }
+                for ch in span.text.chars() {
+                    let cx = area.x + col;
+                    if cx >= area.x + area.width {
+                        break 'span_loop;
+                    }
+                    set_cell_styled(buf, cx, y, ch, span_fg, bg, modifier, None);
+                    col += 1;
+                }
             }
-            set_cell(buf, cx, y, ch, fg, bg);
+        } else {
+            // ── Flat path (unchanged from before spans were added) ───────
+            for (j, ch) in row.text.chars().enumerate() {
+                let cx = area.x + start_col + j as u16;
+                if cx >= area.x + area.width {
+                    break;
+                }
+                set_cell(buf, cx, y, ch, fg, bg);
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #298.

Gives `MessageList` a styled-row model so the `ChatController` transcript renders markdown (bold/italic/colour + heading scale) on **both** TUI and GTK, instead of flattening to one colour.

## Changes
- `MessageRow` gains `spans: Vec<StyledSpan>` (#[serde(default)]) and `scale: f32` (defaults to 1.0); keeps `new()`, adds `styled()`.
- `ChatTurn` gains `line_scales: Vec<f32>`; `push_turn_markdown` carries `rendered.line_scales` through.
- `build_transcript_rows` builds styled rows (split-by-newline + `wrap_spans`, per-line scale) when present, else a **byte-for-byte identical** flat path.
- GTK + TUI rasterisers render spans/scale (Pango attrs / per-span fg) when present.

## Backward compat
`MessageRow::new` and empty-`spans` rows render identically to before; serde legacy wire format (no `spans`/`scale`) decodes via defaults — covered by tests incl. `serde_legacy_json_without_spans_defaults_to_empty`.

## Verification
- Worker (precision): `cargo build --features tui --features gtk` clean, 1168 tests pass.
- Coordinator (elitebook): independently rebuilt — `--features tui --features gtk` EXIT 0, `cargo test --features tui` green.

## ⚠ Downstream note
`ChatTurn` gains a required field, so direct constructors in consumers (coord-tui builds `ChatTurn` literals) need `line_scales` added. Tracked as a coord-tui adoption follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)