### PR TITLE
#279: Lift terminal engine (portable-pty + vt100 + scrollback + tabs) out of vimcode into a reusable primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,8 +531,19 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1261,6 +1284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1516,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1521,6 +1568,20 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1871,6 +1932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1954,27 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
 ]
 
 [[package]]
@@ -1972,11 +2060,13 @@ dependencies = [
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "pangocairo",
+ "portable-pty",
  "ratatui",
  "serde",
  "serde_json",
  "tempfile",
  "unicode-width 0.2.0",
+ "vt100",
 ]
 
 [[package]]
@@ -2331,6 +2421,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2483,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2515,6 +2663,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2817,6 +2974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,6 +2990,39 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+dependencies = [
+ "itoa",
+ "log",
+ "unicode-width 0.1.14",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "want"
@@ -3125,6 +3321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -478,6 +478,11 @@ path = "examples/tui_terminal.rs"
 required-features = ["tui", "terminal"]
 
 [[example]]
+name = "gtk_terminal"
+path = "examples/gtk_terminal.rs"
+required-features = ["gtk", "terminal"]
+
+[[example]]
 name = "gtk_toolbar"
 path = "examples/gtk_toolbar.rs"
 required-features = ["gtk"]

--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -10,6 +10,10 @@ publish = false
 [lib]
 
 [features]
+# PTY + vt100 + scrollback engine. No rasteriser — pairs with any backend.
+# Enables `quadraui::terminal_engine`. Pulls in portable-pty and vt100.
+terminal = ["dep:portable-pty", "dep:vt100"]
+
 # Public TUI rasterisers in `quadraui::tui`. Pulls in ratatui.
 tui = ["dep:ratatui", "dep:arboard", "dep:unicode-width"]
 
@@ -50,6 +54,9 @@ ratatui = { version = "0.29", optional = true }
 unicode-width = { version = "0.2", optional = true }
 # Optional — pulled in by `tui` and `gtk` for system clipboard access.
 arboard = { version = "3", optional = true }
+# Optional — pulled in by the `terminal` feature.
+portable-pty = { version = "0.8", optional = true }
+vt100 = { version = "0.15", optional = true }
 
 # macOS-only optional deps. Gated on `target_os = "macos"` so the `macos`
 # feature is a no-op on other platforms — keeps cross-platform CI green.
@@ -464,6 +471,11 @@ required-features = ["gtk"]
 name = "tui_toolbar"
 path = "examples/tui_toolbar.rs"
 required-features = ["tui"]
+
+[[example]]
+name = "tui_terminal"
+path = "examples/tui_terminal.rs"
+required-features = ["tui", "terminal"]
 
 [[example]]
 name = "gtk_toolbar"

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -28,6 +28,11 @@
 // unused-import warnings are expected and not actionable here.
 #![allow(dead_code, unused_imports)]
 
+#[cfg(feature = "terminal")]
+pub mod terminal_app;
+#[cfg(feature = "terminal")]
+pub use terminal_app::TerminalApp;
+
 pub mod ai_transcript;
 pub mod appshell_demo;
 pub mod bottom_panel_demo;

--- a/quadraui/examples/common/terminal_app.rs
+++ b/quadraui/examples/common/terminal_app.rs
@@ -99,7 +99,7 @@ impl TerminalApp {
         let footer_rect = Rect::new(0.0, y, vp.width, FOOTER_ROWS as f32);
 
         let (text, fg, bg) = if let Some(ref sess) = self.session {
-            if sess.exited {
+            if sess.is_exited() {
                 let code = sess.exit_code().unwrap_or(0);
                 (
                     format!(" [process exited {code}] — press Ctrl+Q to close"),
@@ -189,8 +189,8 @@ impl AppLogic for TerminalApp {
         let rect = Rect::new(0.0, 0.0, vp.width, term_h);
 
         if let Some(ref sess) = self.session {
-            let total = sess.history_len() + sess.rows as usize;
-            let sb = if total > sess.rows as usize {
+            let total = sess.history_len() + sess.rows() as usize;
+            let sb = if total > sess.rows() as usize {
                 Some(sess.scrollbar_state(None))
             } else {
                 None
@@ -269,8 +269,8 @@ impl AppLogic for TerminalApp {
 
                 if in_scrollbar {
                     if let Some(ref sess) = self.session {
-                        let total = sess.history_len() + sess.rows as usize;
-                        let visible = sess.rows as usize;
+                        let total = sess.history_len() + sess.rows() as usize;
+                        let visible = sess.rows() as usize;
                         if total > visible {
                             // Start drag only when the scrollbar is visible.
                             self.scrollbar_drag = Some(ScrollbarDrag {
@@ -310,7 +310,7 @@ impl AppLogic for TerminalApp {
             // ── Bracketed paste ───────────────────────────────────────────────
             UiEvent::ClipboardPaste(text) => {
                 if let Some(ref mut sess) = self.session {
-                    if !sess.exited {
+                    if !sess.is_exited() {
                         // Wrap in bracketed-paste markers so the shell handles it
                         // correctly (avoids interpreting pasted newlines as commands).
                         let mut bytes = b"\x1b[200~".to_vec();
@@ -330,7 +330,7 @@ impl AppLogic for TerminalApp {
                 ..
             } if modifiers.shift => {
                 if let Some(ref mut sess) = self.session {
-                    let page = sess.rows as usize;
+                    let page = sess.rows() as usize;
                     sess.scroll_up(page);
                 }
                 return Reaction::Redraw;
@@ -343,7 +343,7 @@ impl AppLogic for TerminalApp {
                 ..
             } if modifiers.shift => {
                 if let Some(ref mut sess) = self.session {
-                    let page = sess.rows as usize;
+                    let page = sess.rows() as usize;
                     sess.scroll_down(page);
                 }
                 return Reaction::Redraw;
@@ -365,8 +365,8 @@ impl AppLogic for TerminalApp {
             // ── Key input ─────────────────────────────────────────────────────
             UiEvent::KeyPressed { key, modifiers, .. } => {
                 if let Some(ref mut sess) = self.session {
-                    // FIX 1: dead PTY — swallow all key input.
-                    if sess.exited {
+                    // Dead PTY — swallow all key input.
+                    if sess.is_exited() {
                         return Reaction::Continue;
                     }
                     // Any key press returns to live view.
@@ -381,8 +381,8 @@ impl AppLogic for TerminalApp {
             // ── Printable characters typed ────────────────────────────────────
             UiEvent::CharTyped(ch) => {
                 if let Some(ref mut sess) = self.session {
-                    // FIX 1: dead PTY — swallow all character input.
-                    if sess.exited {
+                    // Dead PTY — swallow all character input.
+                    if sess.is_exited() {
                         return Reaction::Continue;
                     }
                     sess.scroll_reset();
@@ -527,12 +527,38 @@ fn xterm_cursor_seq(letter: &[u8], mod_param: Option<u8>) -> Vec<u8> {
 
 /// Function-key byte sequences (xterm encoding).
 fn f_key_bytes(n: u8, mod_param: Option<u8>) -> Option<Vec<u8>> {
-    // F1-F4 use SS3 sequences; F5-F12 use CSI sequences.
+    // F1-F4 use SS3 sequences when unmodified (\x1bOP…\x1bOS).
+    // When a modifier is present they fall back to CSI: \x1b[1;<mod>P…S.
+    // F5-F12 always use tilde-terminated CSI sequences.
     let bytes = match n {
-        1 => xterm_cursor_seq(b"P", mod_param), // \x1bOP or \x1b[1;mP
-        2 => xterm_cursor_seq(b"Q", mod_param),
-        3 => xterm_cursor_seq(b"R", mod_param),
-        4 => xterm_cursor_seq(b"S", mod_param),
+        1 => {
+            if mod_param.is_none() {
+                b"\x1bOP".to_vec()
+            } else {
+                xterm_cursor_seq(b"P", mod_param)
+            }
+        }
+        2 => {
+            if mod_param.is_none() {
+                b"\x1bOQ".to_vec()
+            } else {
+                xterm_cursor_seq(b"Q", mod_param)
+            }
+        }
+        3 => {
+            if mod_param.is_none() {
+                b"\x1bOR".to_vec()
+            } else {
+                xterm_cursor_seq(b"R", mod_param)
+            }
+        }
+        4 => {
+            if mod_param.is_none() {
+                b"\x1bOS".to_vec()
+            } else {
+                xterm_cursor_seq(b"S", mod_param)
+            }
+        }
         5 => xterm_seq(b"15", mod_param),
         6 => xterm_seq(b"17", mod_param),
         7 => xterm_seq(b"18", mod_param),
@@ -608,8 +634,41 @@ mod tests {
 
     #[test]
     fn f1_plain() {
+        // F1 unmodified must emit the SS3 sequence \x1bOP, NOT the CSI \x1b[P.
         let bytes = key_to_pty_bytes(Key::Named(NamedKey::F(1)), Modifiers::default()).unwrap();
-        assert_eq!(bytes, b"\x1b[P");
+        assert_eq!(bytes, b"\x1bOP");
+    }
+
+    #[test]
+    fn f2_plain() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::F(2)), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\x1bOQ");
+    }
+
+    #[test]
+    fn f3_plain() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::F(3)), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\x1bOR");
+    }
+
+    #[test]
+    fn f4_plain() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::F(4)), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\x1bOS");
+    }
+
+    #[test]
+    fn f1_ctrl_uses_csi() {
+        // Ctrl+F1 → \x1b[1;5P (CSI modifier form, not SS3).
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::F(1)),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(bytes, b"\x1b[1;5P");
     }
 
     #[test]

--- a/quadraui/examples/common/terminal_app.rs
+++ b/quadraui/examples/common/terminal_app.rs
@@ -495,15 +495,18 @@ fn modifier_param(mods: Modifiers) -> Option<u8> {
     }
 }
 
-/// Build `\x1b[<code>~` or `\x1b[1;<mod><code>~` for tilde-terminated sequences.
+/// Build `\x1b[<code>~` or `\x1b[<code>;<mod>~` for tilde-terminated sequences.
+///
+/// Per xterm conventions, the modifier parameter follows the code (separated by `;`)
+/// for tilde-terminated sequences (Home, End, Insert, Delete, PageUp, PageDown, F5–F12).
+/// Cursor-letter sequences use the `1;<mod>` prefix instead — see [`xterm_cursor_seq`].
 fn xterm_seq(code: &[u8], mod_param: Option<u8>) -> Vec<u8> {
     let mut v = b"\x1b[".to_vec();
+    v.extend_from_slice(code);
     if let Some(m) = mod_param {
-        v.push(b'1');
         v.push(b';');
         v.push(b'0' + m);
     }
-    v.extend_from_slice(code);
     v.push(b'~');
     v
 }
@@ -681,6 +684,91 @@ mod tests {
     fn page_up_plain() {
         let bytes = key_to_pty_bytes(Key::Named(NamedKey::PageUp), Modifiers::default()).unwrap();
         assert_eq!(bytes, b"\x1b[5~");
+    }
+
+    #[test]
+    fn delete_ctrl() {
+        // Tilde-terminated keys with a modifier must use the form `\x1b[<code>;<mod>~`,
+        // NOT `\x1b[1;<mod><code>~` (which is the cursor-letter form).
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::Delete),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(bytes, b"\x1b[3;5~");
+    }
+
+    #[test]
+    fn page_up_ctrl() {
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::PageUp),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(bytes, b"\x1b[5;5~");
+    }
+
+    #[test]
+    fn home_shift() {
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::Home),
+            Modifiers {
+                shift: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // shift mod_param = 2 → "\x1b[1;2~"  (Home code = "1")
+        assert_eq!(bytes, b"\x1b[1;2~");
+    }
+
+    #[test]
+    fn end_alt() {
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::End),
+            Modifiers {
+                alt: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // alt mod_param = 3 → "\x1b[4;3~"  (End code = "4")
+        assert_eq!(bytes, b"\x1b[4;3~");
+    }
+
+    #[test]
+    fn f5_ctrl() {
+        // F5+ are tilde-terminated; Ctrl+F5 → \x1b[15;5~ (not \x1b[1;515~).
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::F(5)),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(bytes, b"\x1b[15;5~");
+    }
+
+    #[test]
+    fn page_down_shift_ctrl() {
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::PageDown),
+            Modifiers {
+                shift: true,
+                ctrl: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // shift+ctrl mod_param = 6 → "\x1b[6;6~"  (PageDown code = "6")
+        assert_eq!(bytes, b"\x1b[6;6~");
     }
 
     #[test]

--- a/quadraui/examples/common/terminal_app.rs
+++ b/quadraui/examples/common/terminal_app.rs
@@ -9,17 +9,45 @@
 //! - All printable characters are forwarded to the PTY.
 //! - Arrow keys, Tab, Backspace, Enter, Delete, Home, End, PgUp/PgDn
 //!   are translated to the appropriate VT100 escape sequences.
+//! - **Shift+PageUp / Shift+PageDown** scroll the history view (not sent to PTY).
+//! - **Shift+Home** jumps to the oldest available history line.
 //! - Ctrl+C / Ctrl+D / Ctrl+Z forward as terminal control bytes.
 //! - Scroll wheel scrolls the history (3 rows per notch).
+//! - Dragging the scrollbar thumb scrolls the history.
 //! - Window resize triggers a PTY resize.
 //! - Ctrl+Q quits.
 //! - Bracketed paste is forwarded verbatim.
+//! - When the shell exits a status line shows the exit code; Ctrl+Q closes.
 
 use quadraui::terminal_engine::{default_shell, TerminalSession};
 use quadraui::{
-    AppLogic, Backend, Key, Modifiers, NamedKey, Reaction, Rect, ScrollDelta, UiEvent, Viewport,
-    WidgetId,
+    AppLogic, Backend, ButtonMask, Color, Key, Modifiers, MouseButton, NamedKey, Reaction, Rect,
+    ScrollDelta, StatusBar, StatusBarSegment, UiEvent, Viewport, WidgetId,
 };
+
+// ── Layout ───────────────────────────────────────────────────────────────────
+
+/// Rows reserved at the bottom of the viewport for the hint / status footer.
+const FOOTER_ROWS: u16 = 1;
+
+// ── Drag-tracking state ───────────────────────────────────────────────────────
+
+/// Tracks an in-progress scrollbar-thumb drag.
+///
+/// All values are captured at `MouseDown` time so that `MouseMoved` has
+/// stable geometry to compute from even if the viewport changes mid-drag.
+struct ScrollbarDrag {
+    /// Y coordinate of the top of the scrollbar track (TUI: always 0.0).
+    track_y: f32,
+    /// Height of the scrollbar track in rows.
+    track_h: f32,
+    /// Total line count from the scrollbar state snapshot.
+    total: usize,
+    /// Visible line count from the scrollbar state snapshot.
+    visible: usize,
+}
+
+// ── TerminalApp ───────────────────────────────────────────────────────────────
 
 /// Single-session terminal example app.
 pub struct TerminalApp {
@@ -27,6 +55,8 @@ pub struct TerminalApp {
     last_viewport: Viewport,
     /// Status line message (shown only when session is absent).
     error_msg: String,
+    /// In-progress scrollbar thumb drag, if any.
+    scrollbar_drag: Option<ScrollbarDrag>,
 }
 
 impl TerminalApp {
@@ -35,15 +65,106 @@ impl TerminalApp {
             session: None,
             last_viewport: Viewport::default(),
             error_msg: String::new(),
+            scrollbar_drag: None,
         }
     }
 
-    /// Return the PTY dimensions (cols, rows) from a viewport.
+    /// Return the PTY dimensions (cols, rows) from a viewport,
+    /// reserving `FOOTER_ROWS` at the bottom for the hint bar.
     fn viewport_to_pty(vp: Viewport) -> (u16, u16) {
         // TUI backend: viewport units are cells (f32 but always integral).
         let cols = vp.width.max(10.0) as u16;
-        let rows = vp.height.max(3.0) as u16;
+        let rows = (vp.height - FOOTER_ROWS as f32).max(3.0) as u16;
         (cols, rows)
+    }
+
+    /// Height of the terminal grid area (viewport height minus footer).
+    fn term_height(vp: Viewport) -> f32 {
+        (vp.height - FOOTER_ROWS as f32).max(0.0)
+    }
+
+    /// X column of the scrollbar (rightmost column of the viewport).
+    fn scrollbar_col(vp: Viewport) -> f32 {
+        (vp.width - 1.0).max(0.0)
+    }
+
+    // ── Footer rendering ──────────────────────────────────────────────────────
+
+    /// Render the one-row hint / status footer at the very bottom of the viewport.
+    ///
+    /// - Normal operation: shows keyboard shortcuts.
+    /// - Process exited: shows the exit code and prompts the user to quit.
+    fn render_footer(&self, backend: &mut dyn Backend, vp: Viewport) {
+        let y = vp.height - FOOTER_ROWS as f32;
+        let footer_rect = Rect::new(0.0, y, vp.width, FOOTER_ROWS as f32);
+
+        let (text, fg, bg) = if let Some(ref sess) = self.session {
+            if sess.exited {
+                let code = sess.exit_code().unwrap_or(0);
+                (
+                    format!(" [process exited {code}] — press Ctrl+Q to close"),
+                    Color::rgb(255, 200, 100),
+                    Color::rgb(60, 30, 0),
+                )
+            } else {
+                (
+                    " Ctrl+Q quit  ·  wheel / Shift+PgUp scroll  ·  type to run".to_string(),
+                    Color::rgb(160, 160, 160),
+                    Color::rgb(40, 40, 40),
+                )
+            }
+        } else {
+            (
+                " Ctrl+Q quit".to_string(),
+                Color::rgb(160, 160, 160),
+                Color::rgb(40, 40, 40),
+            )
+        };
+
+        let bar = StatusBar {
+            id: WidgetId::new("term-footer"),
+            left_segments: vec![StatusBarSegment {
+                text,
+                fg,
+                bg,
+                bold: false,
+                action_id: None,
+            }],
+            right_segments: vec![],
+        };
+        backend.draw_status_bar(footer_rect, &bar, None, None);
+    }
+
+    // ── Scrollbar drag helper ─────────────────────────────────────────────────
+
+    /// Compute and apply a new `scroll_offset` from a drag Y position.
+    ///
+    /// Uses the geometry captured in `self.scrollbar_drag` at `MouseDown`
+    /// time. The scrollbar is **inverted**: dragging the thumb to the top
+    /// of the track shows the oldest history, dragging to the bottom shows
+    /// the live view.
+    fn apply_scrollbar_drag(&mut self, y: f32) {
+        // Copy values out of `scrollbar_drag` before mutably borrowing `session`.
+        let (track_y, track_h, max_scroll) = match &self.scrollbar_drag {
+            Some(d) => (d.track_y, d.track_h, d.total.saturating_sub(d.visible)),
+            None => return,
+        };
+        if track_h <= 0.0 {
+            return;
+        }
+        // fraction 0 = top of track, 1 = bottom of track
+        let fraction = ((y - track_y) / track_h).clamp(0.0, 1.0);
+        // Inverted: top → max history, bottom → live (offset 0)
+        let offset = ((1.0 - fraction) * max_scroll as f32).round() as usize;
+        if let Some(ref mut sess) = self.session {
+            sess.set_scroll_offset(offset);
+        }
+    }
+}
+
+impl Default for TerminalApp {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -64,7 +185,8 @@ impl AppLogic for TerminalApp {
 
     fn render(&self, backend: &mut dyn Backend, _area: ()) {
         let vp = backend.viewport();
-        let rect = Rect::new(0.0, 0.0, vp.width, vp.height);
+        let term_h = Self::term_height(vp);
+        let rect = Rect::new(0.0, 0.0, vp.width, term_h);
 
         if let Some(ref sess) = self.session {
             let total = sess.history_len() + sess.rows as usize;
@@ -77,7 +199,6 @@ impl AppLogic for TerminalApp {
             backend.draw_terminal(rect, &snapshot);
         } else {
             // No session — show an error in the status bar.
-            use quadraui::{Color, StatusBar, StatusBarSegment};
             let msg = if self.error_msg.is_empty() {
                 "Spawning terminal…".to_string()
             } else {
@@ -97,6 +218,8 @@ impl AppLogic for TerminalApp {
             let bar_rect = Rect::new(0.0, rect.height - 1.0, rect.width, 1.0);
             backend.draw_status_bar(bar_rect, &bar, None, None);
         }
+
+        self.render_footer(backend, vp);
     }
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
@@ -132,16 +255,109 @@ impl AppLogic for TerminalApp {
                 }
             }
 
+            // ── Scrollbar mouse-down: start drag ──────────────────────────────
+            UiEvent::MouseDown {
+                button: MouseButton::Left,
+                position,
+                ..
+            } => {
+                let vp = self.last_viewport;
+                let term_h = Self::term_height(vp);
+                let sb_col = Self::scrollbar_col(vp);
+
+                let in_scrollbar = position.x >= sb_col && position.y >= 0.0 && position.y < term_h;
+
+                if in_scrollbar {
+                    if let Some(ref sess) = self.session {
+                        let total = sess.history_len() + sess.rows as usize;
+                        let visible = sess.rows as usize;
+                        if total > visible {
+                            // Start drag only when the scrollbar is visible.
+                            self.scrollbar_drag = Some(ScrollbarDrag {
+                                track_y: 0.0,
+                                track_h: term_h,
+                                total,
+                                visible,
+                            });
+                            self.apply_scrollbar_drag(position.y);
+                            return Reaction::Redraw;
+                        }
+                    }
+                }
+            }
+
+            // ── Scrollbar mouse-move: update drag ─────────────────────────────
+            UiEvent::MouseMoved {
+                position,
+                buttons: ButtonMask { left: true, .. },
+            } => {
+                if self.scrollbar_drag.is_some() {
+                    self.apply_scrollbar_drag(position.y);
+                    return Reaction::Redraw;
+                }
+            }
+
+            // ── Mouse-up: end drag ─────────────────────────────────────────────
+            UiEvent::MouseUp {
+                button: MouseButton::Left,
+                ..
+            } => {
+                if self.scrollbar_drag.take().is_some() {
+                    return Reaction::Redraw;
+                }
+            }
+
             // ── Bracketed paste ───────────────────────────────────────────────
             UiEvent::ClipboardPaste(text) => {
                 if let Some(ref mut sess) = self.session {
-                    // Wrap in bracketed-paste markers so the shell handles it
-                    // correctly (avoids interpreting pasted newlines as commands).
-                    let mut bytes = b"\x1b[200~".to_vec();
-                    bytes.extend_from_slice(text.as_bytes());
-                    bytes.extend_from_slice(b"\x1b[201~");
-                    sess.write_input(&bytes);
-                    sess.scroll_reset();
+                    if !sess.exited {
+                        // Wrap in bracketed-paste markers so the shell handles it
+                        // correctly (avoids interpreting pasted newlines as commands).
+                        let mut bytes = b"\x1b[200~".to_vec();
+                        bytes.extend_from_slice(text.as_bytes());
+                        bytes.extend_from_slice(b"\x1b[201~");
+                        sess.write_input(&bytes);
+                        sess.scroll_reset();
+                    }
+                }
+                return Reaction::Redraw;
+            }
+
+            // ── Shift+PageUp: scroll back one page ────────────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::PageUp),
+                modifiers,
+                ..
+            } if modifiers.shift => {
+                if let Some(ref mut sess) = self.session {
+                    let page = sess.rows as usize;
+                    sess.scroll_up(page);
+                }
+                return Reaction::Redraw;
+            }
+
+            // ── Shift+PageDown: scroll forward one page ───────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::PageDown),
+                modifiers,
+                ..
+            } if modifiers.shift => {
+                if let Some(ref mut sess) = self.session {
+                    let page = sess.rows as usize;
+                    sess.scroll_down(page);
+                }
+                return Reaction::Redraw;
+            }
+
+            // ── Shift+Home: jump to oldest history ────────────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::Home),
+                modifiers,
+                ..
+            } if modifiers.shift => {
+                if let Some(ref mut sess) = self.session {
+                    // set_scroll_offset clamps to history_len() internally.
+                    sess.set_scroll_offset(usize::MAX);
                 }
                 return Reaction::Redraw;
             }
@@ -149,6 +365,10 @@ impl AppLogic for TerminalApp {
             // ── Key input ─────────────────────────────────────────────────────
             UiEvent::KeyPressed { key, modifiers, .. } => {
                 if let Some(ref mut sess) = self.session {
+                    // FIX 1: dead PTY — swallow all key input.
+                    if sess.exited {
+                        return Reaction::Continue;
+                    }
                     // Any key press returns to live view.
                     sess.scroll_reset();
                     if let Some(bytes) = key_to_pty_bytes(key, modifiers) {
@@ -161,6 +381,10 @@ impl AppLogic for TerminalApp {
             // ── Printable characters typed ────────────────────────────────────
             UiEvent::CharTyped(ch) => {
                 if let Some(ref mut sess) = self.session {
+                    // FIX 1: dead PTY — swallow all character input.
+                    if sess.exited {
+                        return Reaction::Continue;
+                    }
                     sess.scroll_reset();
                     let mut buf = [0u8; 4];
                     let s = ch.encode_utf8(&mut buf);
@@ -404,5 +628,73 @@ mod tests {
     fn caps_lock_is_none() {
         let bytes = key_to_pty_bytes(Key::Named(NamedKey::CapsLock), Modifiers::default());
         assert!(bytes.is_none());
+    }
+
+    // ── Scrollbar drag math ───────────────────────────────────────────────────
+
+    /// Helper that mimics the offset computation in `apply_scrollbar_drag`.
+    fn drag_to_offset(y: f32, track_y: f32, track_h: f32, total: usize, visible: usize) -> usize {
+        if track_h <= 0.0 {
+            return 0;
+        }
+        let max_scroll = total.saturating_sub(visible);
+        let fraction = ((y - track_y) / track_h).clamp(0.0, 1.0);
+        ((1.0 - fraction) * max_scroll as f32).round() as usize
+    }
+
+    #[test]
+    fn drag_at_bottom_gives_live_view() {
+        // When the thumb is at the bottom of the track (fraction = 1),
+        // the offset should be 0 (live view) for an inverted scrollbar.
+        let offset = drag_to_offset(20.0, 0.0, 20.0, 50, 20);
+        assert_eq!(offset, 0, "bottom of track → live view (offset 0)");
+    }
+
+    #[test]
+    fn drag_at_top_gives_max_offset() {
+        // When the thumb is at the top (fraction = 0), offset = total - visible.
+        let offset = drag_to_offset(0.0, 0.0, 20.0, 50, 20);
+        assert_eq!(offset, 30, "top of track → max scroll offset");
+    }
+
+    #[test]
+    fn drag_at_midpoint_gives_half_offset() {
+        // Middle of track → half of max_scroll.
+        let offset = drag_to_offset(10.0, 0.0, 20.0, 50, 20);
+        // fraction = 0.5 → (1 - 0.5) * 30 = 15
+        assert_eq!(offset, 15);
+    }
+
+    #[test]
+    fn drag_clamped_below_zero() {
+        // Y above track top should clamp to max offset.
+        let offset = drag_to_offset(-5.0, 0.0, 20.0, 50, 20);
+        assert_eq!(offset, 30);
+    }
+
+    #[test]
+    fn drag_clamped_above_track_height() {
+        // Y below track bottom should clamp to offset 0 (live view).
+        let offset = drag_to_offset(100.0, 0.0, 20.0, 50, 20);
+        assert_eq!(offset, 0);
+    }
+
+    // ── viewport_to_pty reserves footer row ───────────────────────────────────
+
+    #[test]
+    fn viewport_to_pty_reserves_footer() {
+        let vp = Viewport::new(80.0, 24.0, 1.0);
+        let (cols, rows) = TerminalApp::viewport_to_pty(vp);
+        assert_eq!(cols, 80);
+        // height 24 minus FOOTER_ROWS 1 = 23
+        assert_eq!(rows, 23);
+    }
+
+    #[test]
+    fn viewport_to_pty_minimum_rows() {
+        // Very small terminal — rows must not go below 3.
+        let vp = Viewport::new(80.0, 3.0, 1.0);
+        let (_cols, rows) = TerminalApp::viewport_to_pty(vp);
+        assert_eq!(rows, 3); // max(3.0 - 1.0 = 2.0, 3.0) = 3
     }
 }

--- a/quadraui/examples/common/terminal_app.rs
+++ b/quadraui/examples/common/terminal_app.rs
@@ -1,0 +1,408 @@
+//! Backend-agnostic `AppLogic` for the terminal engine example
+//! ([`tui_terminal`]).
+//!
+//! [`TerminalApp`] spawns a single interactive shell session via
+//! [`TerminalSession`] and drives it through the standard
+//! `AppLogic::render` / `AppLogic::handle` / `AppLogic::tick` pattern.
+//!
+//! Controls:
+//! - All printable characters are forwarded to the PTY.
+//! - Arrow keys, Tab, Backspace, Enter, Delete, Home, End, PgUp/PgDn
+//!   are translated to the appropriate VT100 escape sequences.
+//! - Ctrl+C / Ctrl+D / Ctrl+Z forward as terminal control bytes.
+//! - Scroll wheel scrolls the history (3 rows per notch).
+//! - Window resize triggers a PTY resize.
+//! - Ctrl+Q quits.
+//! - Bracketed paste is forwarded verbatim.
+
+use quadraui::terminal_engine::{default_shell, TerminalSession};
+use quadraui::{
+    AppLogic, Backend, Key, Modifiers, NamedKey, Reaction, Rect, ScrollDelta, UiEvent, Viewport,
+    WidgetId,
+};
+
+/// Single-session terminal example app.
+pub struct TerminalApp {
+    session: Option<TerminalSession>,
+    last_viewport: Viewport,
+    /// Status line message (shown only when session is absent).
+    error_msg: String,
+}
+
+impl TerminalApp {
+    pub fn new() -> Self {
+        Self {
+            session: None,
+            last_viewport: Viewport::default(),
+            error_msg: String::new(),
+        }
+    }
+
+    /// Return the PTY dimensions (cols, rows) from a viewport.
+    fn viewport_to_pty(vp: Viewport) -> (u16, u16) {
+        // TUI backend: viewport units are cells (f32 but always integral).
+        let cols = vp.width.max(10.0) as u16;
+        let rows = vp.height.max(3.0) as u16;
+        (cols, rows)
+    }
+}
+
+impl AppLogic for TerminalApp {
+    type AreaId = ();
+
+    fn setup(&mut self, backend: &mut dyn Backend) {
+        let vp = backend.viewport();
+        self.last_viewport = vp;
+        let (cols, rows) = Self::viewport_to_pty(vp);
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+        let shell = default_shell();
+        match TerminalSession::spawn(cols, rows, &shell, &cwd, 10_000) {
+            Ok(sess) => self.session = Some(sess),
+            Err(e) => self.error_msg = format!("Failed to spawn PTY: {e}"),
+        }
+    }
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let vp = backend.viewport();
+        let rect = Rect::new(0.0, 0.0, vp.width, vp.height);
+
+        if let Some(ref sess) = self.session {
+            let total = sess.history_len() + sess.rows as usize;
+            let sb = if total > sess.rows as usize {
+                Some(sess.scrollbar_state(None))
+            } else {
+                None
+            };
+            let snapshot = sess.to_terminal(WidgetId::new("terminal:0"), sb);
+            backend.draw_terminal(rect, &snapshot);
+        } else {
+            // No session — show an error in the status bar.
+            use quadraui::{Color, StatusBar, StatusBarSegment};
+            let msg = if self.error_msg.is_empty() {
+                "Spawning terminal…".to_string()
+            } else {
+                self.error_msg.clone()
+            };
+            let bar = StatusBar {
+                id: WidgetId::new("status"),
+                left_segments: vec![StatusBarSegment {
+                    text: format!("  {msg}  "),
+                    fg: Color::rgb(255, 80, 80),
+                    bg: Color::rgb(40, 40, 40),
+                    bold: false,
+                    action_id: None,
+                }],
+                right_segments: vec![],
+            };
+            let bar_rect = Rect::new(0.0, rect.height - 1.0, rect.width, 1.0);
+            backend.draw_status_bar(bar_rect, &bar, None, None);
+        }
+    }
+
+    fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+        match event {
+            // ── Quit ─────────────────────────────────────────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Char('q'),
+                modifiers: Modifiers { ctrl: true, .. },
+                ..
+            } => return Reaction::Exit,
+
+            // ── Resize ───────────────────────────────────────────────────────
+            UiEvent::WindowResized { viewport } => {
+                self.last_viewport = viewport;
+                if let Some(ref mut sess) = self.session {
+                    let (cols, rows) = Self::viewport_to_pty(viewport);
+                    sess.resize(cols, rows);
+                }
+                return Reaction::Redraw;
+            }
+
+            // ── Scroll wheel ─────────────────────────────────────────────────
+            UiEvent::Scroll { delta, .. } => {
+                if let Some(ref mut sess) = self.session {
+                    // Positive y = scroll up (into history).
+                    // Negative y = scroll down (toward live).
+                    if delta.y > 0.0 {
+                        sess.scroll_up(3);
+                    } else if delta.y < 0.0 {
+                        sess.scroll_down(3);
+                    }
+                    return Reaction::Redraw;
+                }
+            }
+
+            // ── Bracketed paste ───────────────────────────────────────────────
+            UiEvent::ClipboardPaste(text) => {
+                if let Some(ref mut sess) = self.session {
+                    // Wrap in bracketed-paste markers so the shell handles it
+                    // correctly (avoids interpreting pasted newlines as commands).
+                    let mut bytes = b"\x1b[200~".to_vec();
+                    bytes.extend_from_slice(text.as_bytes());
+                    bytes.extend_from_slice(b"\x1b[201~");
+                    sess.write_input(&bytes);
+                    sess.scroll_reset();
+                }
+                return Reaction::Redraw;
+            }
+
+            // ── Key input ─────────────────────────────────────────────────────
+            UiEvent::KeyPressed { key, modifiers, .. } => {
+                if let Some(ref mut sess) = self.session {
+                    // Any key press returns to live view.
+                    sess.scroll_reset();
+                    if let Some(bytes) = key_to_pty_bytes(key, modifiers) {
+                        sess.write_input(&bytes);
+                    }
+                }
+                return Reaction::Redraw;
+            }
+
+            // ── Printable characters typed ────────────────────────────────────
+            UiEvent::CharTyped(ch) => {
+                if let Some(ref mut sess) = self.session {
+                    sess.scroll_reset();
+                    let mut buf = [0u8; 4];
+                    let s = ch.encode_utf8(&mut buf);
+                    sess.write_input(s.as_bytes());
+                }
+                return Reaction::Redraw;
+            }
+
+            _ => {}
+        }
+
+        // Suppress the unused-variable warning from the compiler on
+        // backends that don't provide viewport inline with events.
+        let _ = backend.viewport();
+        Reaction::Continue
+    }
+
+    fn tick(&mut self, _backend: &mut dyn Backend) -> Reaction {
+        if let Some(ref mut sess) = self.session {
+            if sess.poll() {
+                return Reaction::Redraw;
+            }
+        }
+        Reaction::Continue
+    }
+}
+
+// ── Key-to-PTY-bytes conversion ───────────────────────────────────────────────
+
+/// Convert a [`Key`] + [`Modifiers`] to the byte sequence sent to the PTY.
+///
+/// Covers the common VT100 / xterm-256color escape sequences. Keys that
+/// have no meaningful PTY encoding (e.g. CapsLock) return `None`.
+fn key_to_pty_bytes(key: Key, mods: Modifiers) -> Option<Vec<u8>> {
+    match key {
+        Key::Char(ch) => {
+            if mods.ctrl {
+                // Ctrl+A-Z → bytes 0x01..0x1A.
+                let c = ch.to_ascii_uppercase();
+                if c.is_ascii_alphabetic() {
+                    return Some(vec![c as u8 - b'@']);
+                }
+                // Ctrl+[ → ESC, Ctrl+\ → FS, Ctrl+] → GS, Ctrl+^ → RS, Ctrl+_ → US.
+                match ch {
+                    '[' => return Some(vec![0x1b]),
+                    '\\' => return Some(vec![0x1c]),
+                    ']' => return Some(vec![0x1d]),
+                    '^' => return Some(vec![0x1e]),
+                    '_' => return Some(vec![0x1f]),
+                    _ => {}
+                }
+            }
+            // Regular printable character — encode as UTF-8.
+            let mut buf = [0u8; 4];
+            let s = ch.encode_utf8(&mut buf);
+            Some(s.as_bytes().to_vec())
+        }
+
+        Key::Named(named) => named_key_bytes(named, mods),
+    }
+}
+
+/// Map named keys to their VT100 escape sequences.
+fn named_key_bytes(key: NamedKey, mods: Modifiers) -> Option<Vec<u8>> {
+    // Modifier prefix for xterm sequences: 1=plain 2=shift 3=alt 4=shift+alt
+    // 5=ctrl 6=shift+ctrl 7=alt+ctrl 8=shift+alt+ctrl.
+    let mod_param = modifier_param(mods);
+
+    match key {
+        NamedKey::Enter => Some(b"\r".to_vec()),
+        NamedKey::Tab => {
+            if mods.shift {
+                Some(b"\x1b[Z".to_vec()) // Back-tab
+            } else {
+                Some(b"\t".to_vec())
+            }
+        }
+        NamedKey::BackTab => Some(b"\x1b[Z".to_vec()),
+        NamedKey::Backspace => Some(b"\x7f".to_vec()),
+        NamedKey::Delete => Some(xterm_seq(b"3", mod_param)),
+        NamedKey::Escape => Some(b"\x1b".to_vec()),
+        NamedKey::Up => Some(xterm_cursor_seq(b"A", mod_param)),
+        NamedKey::Down => Some(xterm_cursor_seq(b"B", mod_param)),
+        NamedKey::Right => Some(xterm_cursor_seq(b"C", mod_param)),
+        NamedKey::Left => Some(xterm_cursor_seq(b"D", mod_param)),
+        NamedKey::Home => Some(xterm_seq(b"1", mod_param)),
+        NamedKey::End => Some(xterm_seq(b"4", mod_param)),
+        NamedKey::Insert => Some(xterm_seq(b"2", mod_param)),
+        NamedKey::PageUp => Some(xterm_seq(b"5", mod_param)),
+        NamedKey::PageDown => Some(xterm_seq(b"6", mod_param)),
+        NamedKey::F(n) => f_key_bytes(n, mod_param),
+        // Keys with no PTY mapping.
+        NamedKey::CapsLock | NamedKey::NumLock | NamedKey::ScrollLock | NamedKey::Menu => None,
+    }
+}
+
+/// Build an xterm modifier parameter (1-based; plain = `None`).
+fn modifier_param(mods: Modifiers) -> Option<u8> {
+    // mod_param = 1 + shift + 2*alt + 4*ctrl
+    let n: u8 = 1
+        + if mods.shift { 1 } else { 0 }
+        + if mods.alt { 2 } else { 0 }
+        + if mods.ctrl { 4 } else { 0 };
+    if n == 1 {
+        None
+    } else {
+        Some(n)
+    }
+}
+
+/// Build `\x1b[<code>~` or `\x1b[1;<mod><code>~` for tilde-terminated sequences.
+fn xterm_seq(code: &[u8], mod_param: Option<u8>) -> Vec<u8> {
+    let mut v = b"\x1b[".to_vec();
+    if let Some(m) = mod_param {
+        v.push(b'1');
+        v.push(b';');
+        v.push(b'0' + m);
+    }
+    v.extend_from_slice(code);
+    v.push(b'~');
+    v
+}
+
+/// Build cursor-movement sequences: `\x1b[<letter>` or `\x1b[1;<mod><letter>`.
+fn xterm_cursor_seq(letter: &[u8], mod_param: Option<u8>) -> Vec<u8> {
+    match mod_param {
+        None => {
+            let mut v = b"\x1b[".to_vec();
+            v.extend_from_slice(letter);
+            v
+        }
+        Some(m) => {
+            let mut v = b"\x1b[1;".to_vec();
+            v.push(b'0' + m);
+            v.extend_from_slice(letter);
+            v
+        }
+    }
+}
+
+/// Function-key byte sequences (xterm encoding).
+fn f_key_bytes(n: u8, mod_param: Option<u8>) -> Option<Vec<u8>> {
+    // F1-F4 use SS3 sequences; F5-F12 use CSI sequences.
+    let bytes = match n {
+        1 => xterm_cursor_seq(b"P", mod_param), // \x1bOP or \x1b[1;mP
+        2 => xterm_cursor_seq(b"Q", mod_param),
+        3 => xterm_cursor_seq(b"R", mod_param),
+        4 => xterm_cursor_seq(b"S", mod_param),
+        5 => xterm_seq(b"15", mod_param),
+        6 => xterm_seq(b"17", mod_param),
+        7 => xterm_seq(b"18", mod_param),
+        8 => xterm_seq(b"19", mod_param),
+        9 => xterm_seq(b"20", mod_param),
+        10 => xterm_seq(b"21", mod_param),
+        11 => xterm_seq(b"23", mod_param),
+        12 => xterm_seq(b"24", mod_param),
+        _ => return None, // F13+ not commonly used
+    };
+    Some(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctrl_c_is_etx() {
+        let bytes = key_to_pty_bytes(
+            Key::Char('c'),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(bytes, Some(vec![0x03])); // ETX
+    }
+
+    #[test]
+    fn ctrl_d_is_eot() {
+        let bytes = key_to_pty_bytes(
+            Key::Char('d'),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(bytes, Some(vec![0x04])); // EOT
+    }
+
+    #[test]
+    fn printable_char_passes_through() {
+        let bytes = key_to_pty_bytes(Key::Char('a'), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"a");
+    }
+
+    #[test]
+    fn enter_is_cr() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::Enter), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\r");
+    }
+
+    #[test]
+    fn up_arrow_plain() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::Up), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\x1b[A");
+    }
+
+    #[test]
+    fn up_arrow_ctrl() {
+        let bytes = key_to_pty_bytes(
+            Key::Named(NamedKey::Up),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // ctrl mod_param = 5 → "\x1b[1;5A"
+        assert_eq!(bytes, b"\x1b[1;5A");
+    }
+
+    #[test]
+    fn f1_plain() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::F(1)), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\x1b[P");
+    }
+
+    #[test]
+    fn delete_plain() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::Delete), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\x1b[3~");
+    }
+
+    #[test]
+    fn page_up_plain() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::PageUp), Modifiers::default()).unwrap();
+        assert_eq!(bytes, b"\x1b[5~");
+    }
+
+    #[test]
+    fn caps_lock_is_none() {
+        let bytes = key_to_pty_bytes(Key::Named(NamedKey::CapsLock), Modifiers::default());
+        assert!(bytes.is_none());
+    }
+}

--- a/quadraui/examples/gtk_terminal.rs
+++ b/quadraui/examples/gtk_terminal.rs
@@ -1,0 +1,15 @@
+//! Live terminal emulator — GTK example for the `terminal_engine` primitive.
+//!
+//! Paired with `tui_terminal.rs` — uses the same [`TerminalApp`] `AppLogic`.
+//! See `examples/common/terminal_app.rs` for the backend-agnostic logic.
+//!
+//! ```sh
+//! cargo run --example gtk_terminal --features gtk,terminal
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::gtk::run(common::TerminalApp::new())
+}

--- a/quadraui/examples/tui_terminal.rs
+++ b/quadraui/examples/tui_terminal.rs
@@ -1,0 +1,30 @@
+//! Live terminal emulator — TUI example for the `terminal_engine` primitive.
+//!
+//! Spawns an interactive shell (reads `$SHELL`, falls back to `/bin/bash`)
+//! and renders its output through [`quadraui::terminal_engine::TerminalSession`]
+//! into the standard [`quadraui::Terminal`] cell-grid primitive, painted by
+//! the existing [`quadraui::tui::draw_terminal`] rasteriser.
+//!
+//! This example is the acceptance smoke-test for issue #279.
+//!
+//! # Controls
+//!
+//! | Key             | Action                                 |
+//! |-----------------|----------------------------------------|
+//! | Ctrl+Q          | Quit                                   |
+//! | Any printable   | Forward to shell                       |
+//! | Arrow keys      | Forward (or navigate history with Scroll) |
+//! | Scroll wheel    | Scroll into history / back to live     |
+//! | Ctrl+C / Ctrl+D | Forward terminal-control bytes         |
+//! | Bracketed paste | Forward verbatim                       |
+//!
+//! ```sh
+//! cargo run --example tui_terminal --features tui,terminal
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::io::Result<()> {
+    quadraui::tui::run(common::TerminalApp::new())
+}

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -90,6 +90,12 @@ pub mod shell;
 pub mod theme;
 pub mod types;
 
+// ── Terminal engine (PTY + vt100 + scrollback) ───────────────────────────────
+// Gated behind the `terminal` feature so non-terminal consumers don't pull in
+// portable-pty / vt100.
+#[cfg(feature = "terminal")]
+pub mod terminal_engine;
+
 // ── Per-backend rasterisers (#223) ──────────────────────────────────────────
 // Public `draw_*` rasterisers, gated behind feature flags so apps that only
 // consume the data layer don't pull in ratatui / gtk4. Lifted out of vimcode

--- a/quadraui/src/primitives/dialog.rs
+++ b/quadraui/src/primitives/dialog.rs
@@ -308,8 +308,7 @@ impl Dialog {
                 (None, None)
             };
 
-        let button_row_bounds =
-            Rect::new(content_x, cursor_y, content_w, button_block_h);
+        let button_row_bounds = Rect::new(content_x, cursor_y, content_w, button_block_h);
 
         let mut visible_buttons: Vec<VisibleDialogButton> = Vec::new();
         let mut hit_regions: Vec<(Rect, DialogHit)> = Vec::new();

--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -359,6 +359,18 @@ impl TerminalSession {
         self.exit_code
     }
 
+    /// Returns `true` when the cursor should be rendered visible.
+    ///
+    /// The cursor is suppressed when:
+    /// - The child process has exited ([`exited`](Self::exited) is `true`), or
+    /// - The view is scrolled into history (`scroll_offset > 0`).
+    ///
+    /// Use this to gate cursor rendering in the app layer instead of
+    /// relying on cell-level `is_cursor` flags alone.
+    pub fn cursor_visible(&self) -> bool {
+        !self.exited && self.scroll_offset == 0
+    }
+
     // ── Text scrape ───────────────────────────────────────────────────────────
 
     /// Extract the current vt100 live screen as plain text.
@@ -716,7 +728,8 @@ impl TerminalSession {
                                         (' ', (229, 229, 229), (30, 30, 30), false, false, false)
                                     };
 
-                                let is_cursor = scroll_offset == 0
+                                let is_cursor = !self.exited
+                                    && scroll_offset == 0
                                     && cursor_active
                                     && live_r == cursor_row
                                     && cu == cursor_col;
@@ -986,6 +999,70 @@ mod tests {
         let (r, g, b) = map_vt100_color(vt100::Color::Idx(196), false);
         // Index 196 = pure red (from cube).
         assert_eq!((r, g, b), (255, 0, 0));
+    }
+
+    // ── cursor_visible integration tests (require a real PTY / Unix shell) ────
+
+    /// After the child exits, `cursor_visible()` must return `false`
+    /// regardless of the scroll offset.
+    #[test]
+    #[cfg(unix)]
+    fn cursor_hidden_after_exit() {
+        let cwd = std::env::temp_dir();
+        let mut sess = TerminalSession::spawn(80, 24, "/bin/sh", &cwd, 1000).expect("spawn failed");
+
+        // Verify cursor is visible before exit (scroll_offset = 0, not exited).
+        assert!(
+            sess.cursor_visible(),
+            "cursor should be visible before exit"
+        );
+
+        // Exit the shell.
+        sess.send_str("exit 0\n");
+        let exited = poll_until(&mut sess, 5000, |s| s.exited);
+        assert!(exited, "shell did not exit within timeout");
+
+        // After exit, cursor must be hidden.
+        assert!(
+            !sess.cursor_visible(),
+            "cursor should be hidden after shell exits"
+        );
+    }
+
+    /// When scrolled into history, `cursor_visible()` returns `false`.
+    #[test]
+    #[cfg(unix)]
+    fn cursor_hidden_when_scrolled() {
+        let cwd = std::env::temp_dir();
+        let mut sess = TerminalSession::spawn(80, 24, "/bin/sh", &cwd, 1000).expect("spawn failed");
+
+        // Generate some history so we can scroll.
+        for _ in 0..30 {
+            sess.send_str("echo line\n");
+        }
+        let _ = poll_until(&mut sess, 5000, |s| s.history_len() > 0);
+
+        // At live view (scroll_offset = 0), cursor should be visible.
+        assert!(
+            sess.cursor_visible(),
+            "cursor should be visible at live view"
+        );
+
+        // Scroll up into history.
+        sess.scroll_up(5);
+        assert!(
+            !sess.cursor_visible(),
+            "cursor should be hidden when scrolled into history"
+        );
+
+        // Scroll back to live view.
+        sess.scroll_reset();
+        assert!(
+            sess.cursor_visible(),
+            "cursor should be visible again after scroll_reset"
+        );
+
+        sess.send_str("exit\n");
     }
 
     // ── Integration tests (require a real PTY / Unix shell) ───────────────────

--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -208,19 +208,33 @@ pub struct TerminalSession {
     /// PTY output bytes from the background reader thread.
     rx: Receiver<Vec<u8>>,
     /// Current terminal width in columns.
-    pub cols: u16,
+    ///
+    /// Read via [`cols()`](Self::cols); change only through [`resize()`](Self::resize)
+    /// to keep the vt100 parser and PTY master in sync.
+    cols: u16,
     /// Current terminal height in rows.
-    pub rows: u16,
+    ///
+    /// Read via [`rows()`](Self::rows); change only through [`resize()`](Self::resize).
+    rows: u16,
     /// Mouse text selection, if any.
     pub selection: Option<TerminalSelection>,
     /// `true` once the child process has exited.
-    pub exited: bool,
+    ///
+    /// Read via [`is_exited()`](Self::is_exited). Set only by [`poll()`](Self::poll)
+    /// when `child.try_wait()` returns a status — setting it externally would
+    /// desynchronise the exit-code state.
+    exited: bool,
     /// Exit code of the child process once it has exited, or `None` while
     /// still running. `0` conventionally means success.
     exit_code: Option<u32>,
     /// How many rows above the live bottom the user has scrolled.
     /// `0` = live view; maximum = `history.len()`.
-    pub scroll_offset: usize,
+    ///
+    /// Read via [`scroll_offset()`](Self::scroll_offset); change through
+    /// [`set_scroll_offset()`](Self::set_scroll_offset) /
+    /// [`scroll_up()`](Self::scroll_up) / [`scroll_down()`](Self::scroll_down)
+    /// so that `parser.set_scrollback(0)` is always called consistently.
+    scroll_offset: usize,
     /// Scrollback ring buffer (oldest at index 0, newest at the back).
     history: VecDeque<Vec<HistCell>>,
     /// Maximum number of rows kept in `history` (`0` = unlimited — not
@@ -350,11 +364,37 @@ impl TerminalSession {
 
     // ── Exit status ───────────────────────────────────────────────────────────
 
+    /// Current terminal width in columns.
+    pub fn cols(&self) -> u16 {
+        self.cols
+    }
+
+    /// Current terminal height in rows.
+    pub fn rows(&self) -> u16 {
+        self.rows
+    }
+
+    /// `true` once the child process has exited.
+    ///
+    /// Use [`exit_code()`](Self::exit_code) for the numeric exit status.
+    pub fn is_exited(&self) -> bool {
+        self.exited
+    }
+
+    /// Current scroll offset (rows above the live bottom).
+    ///
+    /// `0` = live view; maximum = [`history_len()`](Self::history_len).
+    /// Change via [`set_scroll_offset()`](Self::set_scroll_offset) /
+    /// [`scroll_up()`](Self::scroll_up) / [`scroll_down()`](Self::scroll_down).
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
     /// Exit code of the child process, or `None` while still running.
     ///
     /// `0` conventionally means success. Populated by the first [`poll`](Self::poll)
-    /// call that observes the child exiting. Check [`exited`](Self::exited) first
-    /// if you only need a boolean; this method returns the actual numeric code.
+    /// call that observes the child exiting. Check [`is_exited()`](Self::is_exited)
+    /// first if you only need a boolean; this method returns the actual numeric code.
     pub fn exit_code(&self) -> Option<u32> {
         self.exit_code
     }
@@ -991,13 +1031,9 @@ mod tests {
     }
 
     #[test]
-    fn scrollbar_state_inverted() {
-        // A synthetic test without a real PTY — just checks the
-        // scrollbar_state API shape using hand-crafted history.
-        // We can't spawn a TerminalSession in unit tests without a
-        // PTY, but we can test the pure helper logic above.
+    fn map_vt100_idx_196_is_pure_red() {
+        // Colour index 196 = r=5,g=0,b=0 in the 6×6×6 cube → (255, 0, 0).
         let (r, g, b) = map_vt100_color(vt100::Color::Idx(196), false);
-        // Index 196 = pure red (from cube).
         assert_eq!((r, g, b), (255, 0, 0));
     }
 

--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -1,0 +1,1090 @@
+//! PTY + vt100 + scrollback engine for embedded terminal emulators.
+//!
+//! Provides [`TerminalSession`] (single pane) and [`TerminalManager`]
+//! (multi-tab) that own the PTY process, background reader thread,
+//! vt100 screen parser, and scrollback ring buffer. Paint output is a
+//! [`crate::Terminal`] snapshot — directly consumable by the existing
+//! [`crate::tui::draw_terminal`] / `Backend::draw_terminal` rasterisers.
+//!
+//! # Feature gate
+//!
+//! This module is compiled only when the `terminal` Cargo feature is
+//! enabled. The rasteriser lives in [`crate::primitives::terminal`] and
+//! is always available (no extra feature needed to paint snapshots you
+//! obtained elsewhere).
+//!
+//! # Quick start
+//!
+//! ```ignore
+//! use quadraui::terminal_engine::{TerminalSession, default_shell};
+//!
+//! let cwd = std::env::current_dir()?;
+//! let mut session =
+//!     TerminalSession::spawn(80, 24, &default_shell(), &cwd, 5_000)?;
+//!
+//! // In your event loop tick():
+//! if session.poll() {
+//!     let sb = session.scrollbar_state(None);
+//!     let snapshot = session.to_terminal(WidgetId::new("term:0"), Some(sb));
+//!     // pass snapshot to Backend::draw_terminal(rect, &snapshot)
+//! }
+//!
+//! // Forward keyboard input:
+//! session.write_input(b"ls\n");
+//!
+//! // Resize on layout change:
+//! session.resize(120, 40);
+//! ```
+//!
+//! # Multi-tab / multi-pane
+//!
+//! [`TerminalManager`] wraps a `Vec<TerminalSession>` and tracks the
+//! active index. Tab-switching keybindings and split-pane layouts are
+//! the **consuming app's** responsibility — this type exposes only the
+//! data-management API.
+//!
+//! # Design decisions
+//!
+//! - The vt100 parser is always kept at `scrollback = 0` (live view).
+//!   Lines that scroll off the screen are captured into a private
+//!   [`VecDeque`] ring buffer instead — this avoids fighting with the
+//!   vt100 crate's own bounded scrollback buffer and gives us full
+//!   control over the history capacity.
+//! - [`TerminalSession::to_terminal`] is the only public snapshot
+//!   builder. Find-match overlays (`is_find_match`, `is_find_active`)
+//!   are left as `false` — callers that implement in-terminal search
+//!   can post-process the returned `Terminal::cells`.
+//! - The cross-backend portability commitment: `TerminalSession` is
+//!   backend-agnostic. The GTK backend can call `to_terminal()` just
+//!   as easily as the TUI backend.
+
+use std::collections::VecDeque;
+use std::io::Write;
+use std::path::Path;
+use std::sync::mpsc::{self, Receiver};
+
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+
+use crate::primitives::terminal::{Terminal, TerminalCell, TerminalScrollbar};
+use crate::types::{Color, WidgetId};
+
+// ── Internal history cell ─────────────────────────────────────────────────────
+
+/// A single captured terminal cell in the scrollback ring buffer.
+///
+/// Uses `vt100::Color` directly to defer RGB resolution until paint time,
+/// matching the approach in vimcode's `HistCell`.
+#[derive(Clone, Copy)]
+struct HistCell {
+    ch: char,
+    fg: vt100::Color,
+    bg: vt100::Color,
+    bold: bool,
+    italic: bool,
+    underline: bool,
+}
+
+impl Default for HistCell {
+    fn default() -> Self {
+        HistCell {
+            ch: ' ',
+            fg: vt100::Color::Default,
+            bg: vt100::Color::Default,
+            bold: false,
+            italic: false,
+            underline: false,
+        }
+    }
+}
+
+// ── Selection ─────────────────────────────────────────────────────────────────
+
+/// Mouse text-selection state for a terminal pane.
+///
+/// All coordinates are 0-based into the **visible grid** (not into history).
+/// End-column is inclusive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalSelection {
+    pub start_row: u16,
+    pub start_col: u16,
+    pub end_row: u16,
+    pub end_col: u16,
+}
+
+/// Normalise a selection so `(r0, c0) ≤ (r1, c1)` in reading order.
+fn normalize_selection(sel: &TerminalSelection) -> (u16, u16, u16, u16) {
+    if (sel.start_row, sel.start_col) <= (sel.end_row, sel.end_col) {
+        (sel.start_row, sel.start_col, sel.end_row, sel.end_col)
+    } else {
+        (sel.end_row, sel.end_col, sel.start_row, sel.start_col)
+    }
+}
+
+// ── Colour helpers ────────────────────────────────────────────────────────────
+
+/// Map a `vt100::Color` to an RGB triple.
+///
+/// `Default` resolves to dark-theme terminal defaults matching the
+/// vimcode OneDark baseline (`#e5e5e5` fg, `#1e1e1e` bg). Callers
+/// that want theme-aware colours should post-process cells after
+/// calling [`TerminalSession::to_terminal`].
+fn map_vt100_color(color: vt100::Color, is_bg: bool) -> (u8, u8, u8) {
+    match color {
+        vt100::Color::Default => {
+            if is_bg {
+                (30, 30, 30) // terminal background (~#1e1e1e)
+            } else {
+                (229, 229, 229) // terminal foreground (~#e5e5e5)
+            }
+        }
+        vt100::Color::Rgb(r, g, b) => (r, g, b),
+        vt100::Color::Idx(n) => xterm_256_color(n),
+    }
+}
+
+/// Standard xterm 256-colour palette lookup.
+fn xterm_256_color(n: u8) -> (u8, u8, u8) {
+    // System colours 0-15.
+    const SYSTEM: [(u8, u8, u8); 16] = [
+        (0, 0, 0),
+        (128, 0, 0),
+        (0, 128, 0),
+        (128, 128, 0),
+        (0, 0, 128),
+        (128, 0, 128),
+        (0, 128, 128),
+        (192, 192, 192),
+        (128, 128, 128),
+        (255, 0, 0),
+        (0, 255, 0),
+        (255, 255, 0),
+        (0, 0, 255),
+        (255, 0, 255),
+        (0, 255, 255),
+        (255, 255, 255),
+    ];
+    if n < 16 {
+        return SYSTEM[n as usize];
+    }
+    // 6×6×6 colour cube: indices 16-231.
+    if n < 232 {
+        let idx = n - 16;
+        let b = idx % 6;
+        let g = (idx / 6) % 6;
+        let r = idx / 36;
+        let to_byte = |v: u8| if v == 0 { 0 } else { 55 + v * 40 };
+        return (to_byte(r), to_byte(g), to_byte(b));
+    }
+    // Greyscale ramp: indices 232-255.
+    let gray = 8 + (n - 232) * 10;
+    (gray, gray, gray)
+}
+
+// ── TerminalSession ───────────────────────────────────────────────────────────
+
+/// A single PTY-backed terminal session: PTY process, reader thread,
+/// vt100 parser, and scrollback ring buffer.
+///
+/// Call [`poll`](Self::poll) each frame tick to drain PTY output, then
+/// [`to_terminal`](Self::to_terminal) to build a paint snapshot.
+///
+/// ## Scrollback model
+///
+/// The vt100 parser is kept at `scrollback = 0` (live view) at all
+/// times. Lines that scroll off the live screen are captured into an
+/// internal [`VecDeque`] ring. Calling
+/// [`scroll_up`](Self::scroll_up) / [`scroll_down`](Self::scroll_down)
+/// adjusts `scroll_offset`; the snapshot builder blends history rows
+/// and live rows accordingly.
+pub struct TerminalSession {
+    /// VT100 screen parser — always at `scrollback = 0` (live view).
+    parser: vt100::Parser,
+    /// Write half of the PTY master — sends keyboard input to the shell.
+    writer: Box<dyn Write + Send>,
+    /// PTY master — kept alive for `resize()` calls (SIGWINCH).
+    master: Box<dyn MasterPty + Send>,
+    /// Child shell process.
+    child: Box<dyn Child + Send + Sync>,
+    /// PTY output bytes from the background reader thread.
+    rx: Receiver<Vec<u8>>,
+    /// Current terminal width in columns.
+    pub cols: u16,
+    /// Current terminal height in rows.
+    pub rows: u16,
+    /// Mouse text selection, if any.
+    pub selection: Option<TerminalSelection>,
+    /// `true` once the child process has exited.
+    pub exited: bool,
+    /// Exit code of the child process once it has exited, or `None` while
+    /// still running. `0` conventionally means success.
+    exit_code: Option<u32>,
+    /// How many rows above the live bottom the user has scrolled.
+    /// `0` = live view; maximum = `history.len()`.
+    pub scroll_offset: usize,
+    /// Scrollback ring buffer (oldest at index 0, newest at the back).
+    history: VecDeque<Vec<HistCell>>,
+    /// Maximum number of rows kept in `history` (`0` = unlimited — not
+    /// recommended for long-lived sessions).
+    history_capacity: usize,
+}
+
+impl TerminalSession {
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    /// Spawn a new interactive shell session.
+    ///
+    /// - `cols`, `rows` — initial PTY dimensions.
+    /// - `shell` — shell binary path (e.g. `"/bin/bash"`). Use
+    ///   [`default_shell`] to read `$SHELL`.
+    /// - `cwd` — working directory for the shell process.
+    /// - `history_capacity` — maximum scrollback lines to retain.
+    ///   `0` means unlimited (use a large finite value for production).
+    pub fn spawn(
+        cols: u16,
+        rows: u16,
+        shell: &str,
+        cwd: &Path,
+        history_capacity: usize,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let pty_system = native_pty_system();
+        let pair = pty_system.openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+
+        let mut cmd = CommandBuilder::new(shell);
+        cmd.env("TERM", "xterm-256color");
+        cmd.cwd(cwd);
+        let child = pair.slave.spawn_command(cmd)?;
+
+        let writer = pair.master.take_writer()?;
+        let reader = pair.master.try_clone_reader()?;
+        let master = pair.master;
+
+        // Background reader thread: pushes PTY bytes to the main thread
+        // via a channel without blocking the event loop.
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+        std::thread::spawn(move || {
+            use std::io::Read;
+            let mut reader = reader;
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if tx.send(buf[..n].to_vec()).is_err() {
+                            break; // main thread dropped the session
+                        }
+                    }
+                }
+            }
+        });
+
+        // 1 000-line internal vt100 scrollback — used only to read back
+        // the rows that just scrolled off the live screen into `history`.
+        // We never call `set_scrollback()` for user-facing scrolling.
+        let parser = vt100::Parser::new(rows, cols, 1000);
+
+        Ok(Self {
+            parser,
+            writer,
+            master,
+            child,
+            rx,
+            cols,
+            rows,
+            selection: None,
+            exited: false,
+            exit_code: None,
+            scroll_offset: 0,
+            history: VecDeque::new(),
+            history_capacity,
+        })
+    }
+
+    // ── I/O ──────────────────────────────────────────────────────────────────
+
+    /// Drain pending PTY output and feed it to the vt100 parser.
+    ///
+    /// Lines that scroll off the live screen are captured into the
+    /// scrollback ring buffer. Also polls child-process exit status.
+    ///
+    /// Returns `true` when any new data was processed — the caller
+    /// should trigger a repaint.
+    pub fn poll(&mut self) -> bool {
+        let mut changed = false;
+        while let Ok(data) = self.rx.try_recv() {
+            changed = true;
+            self.process_with_capture(&data);
+        }
+        if !self.exited {
+            if let Ok(Some(status)) = self.child.try_wait() {
+                self.exited = true;
+                self.exit_code = Some(status.exit_code());
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    /// Send raw bytes as keyboard input to the shell.
+    ///
+    /// The bytes are written directly to the PTY master write-end.
+    /// Callers are responsible for encoding key presses into the
+    /// appropriate escape sequences (see the `key_to_pty_bytes` helper
+    /// in the `tui_terminal` example).
+    pub fn write_input(&mut self, data: &[u8]) {
+        let _ = self.writer.write_all(data);
+        let _ = self.writer.flush();
+    }
+
+    /// Send a UTF-8 string as input to the shell.
+    ///
+    /// Convenience wrapper around [`write_input`](Self::write_input).
+    /// The coordinator uses this to inject prompts programmatically.
+    pub fn send_str(&mut self, s: &str) {
+        self.write_input(s.as_bytes());
+    }
+
+    // ── Exit status ───────────────────────────────────────────────────────────
+
+    /// Exit code of the child process, or `None` while still running.
+    ///
+    /// `0` conventionally means success. Populated by the first [`poll`](Self::poll)
+    /// call that observes the child exiting. Check [`exited`](Self::exited) first
+    /// if you only need a boolean; this method returns the actual numeric code.
+    pub fn exit_code(&self) -> Option<u32> {
+        self.exit_code
+    }
+
+    // ── Text scrape ───────────────────────────────────────────────────────────
+
+    /// Extract the current vt100 live screen as plain text.
+    ///
+    /// Returns one line per screen row, trailing whitespace stripped.
+    /// Completely blank rows at the **bottom** of the screen are omitted.
+    /// This is the "what does the visible terminal look like right now?"
+    /// getter — useful for programmatic drivers that need to scrape output
+    /// (e.g. detecting a shell prompt line) without maintaining a full
+    /// cell snapshot.
+    pub fn screen_text(&self) -> String {
+        let screen = self.parser.screen();
+        let mut lines: Vec<String> = (0..self.rows)
+            .map(|r| {
+                let mut line = String::new();
+                for c in 0..self.cols {
+                    if let Some(cell) = screen.cell(r, c) {
+                        let s = cell.contents();
+                        if s.is_empty() {
+                            line.push(' ');
+                        } else {
+                            line.push_str(&s);
+                        }
+                    } else {
+                        line.push(' ');
+                    }
+                }
+                line.trim_end().to_string()
+            })
+            .collect();
+        // Drop trailing blank rows.
+        while lines.last().is_some_and(|l: &String| l.is_empty()) {
+            lines.pop();
+        }
+        lines.join("\n")
+    }
+
+    /// Extract all captured scrollback history as plain text.
+    ///
+    /// Returns one line per history row (oldest first), trailing
+    /// whitespace stripped, joined by newlines. Does **not** include the
+    /// live screen — call [`screen_text`](Self::screen_text) for that, or
+    /// [`full_text`](Self::full_text) for both together.
+    pub fn scrollback_text(&self) -> String {
+        let mut lines: Vec<String> = self
+            .history
+            .iter()
+            .map(|row| {
+                let mut line = String::new();
+                for hc in row {
+                    line.push(hc.ch);
+                }
+                line.trim_end().to_string()
+            })
+            .collect();
+        // Drop trailing blank rows.
+        while lines.last().is_some_and(|l: &String| l.is_empty()) {
+            lines.pop();
+        }
+        lines.join("\n")
+    }
+
+    /// Concatenate [`scrollback_text`](Self::scrollback_text) and
+    /// [`screen_text`](Self::screen_text) into a single string, separated
+    /// by a newline when both are non-empty.
+    ///
+    /// Useful for coordinator scraping: scan `full_text()` for a prompt or
+    /// completion marker after each `poll()` cycle.
+    pub fn full_text(&self) -> String {
+        let hist = self.scrollback_text();
+        let live = self.screen_text();
+        match (hist.is_empty(), live.is_empty()) {
+            (true, _) => live,
+            (_, true) => hist,
+            _ => format!("{hist}\n{live}"),
+        }
+    }
+
+    // ── Resize ───────────────────────────────────────────────────────────────
+
+    /// Resize the PTY and update the vt100 parser dimensions.
+    ///
+    /// Sends SIGWINCH to the child process so running programs
+    /// (e.g. `vim`, `htop`) re-layout their output.
+    pub fn resize(&mut self, cols: u16, rows: u16) {
+        self.cols = cols;
+        self.rows = rows;
+        self.parser.set_size(rows, cols);
+        let _ = self.master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+    }
+
+    // ── Scrollback ───────────────────────────────────────────────────────────
+
+    /// Number of scrollback rows captured so far.
+    pub fn history_len(&self) -> usize {
+        self.history.len()
+    }
+
+    /// Set the scroll offset.
+    ///
+    /// `0` = live view. `history_len()` = oldest available row at the top.
+    /// Clamped to `[0, history_len()]`.
+    pub fn set_scroll_offset(&mut self, offset: usize) {
+        self.scroll_offset = offset.min(self.history.len());
+        // Keep the vt100 parser at the live view at all times.
+        self.parser.set_scrollback(0);
+    }
+
+    /// Scroll up into history by `n` rows.
+    pub fn scroll_up(&mut self, n: usize) {
+        let new = self.scroll_offset.saturating_add(n);
+        self.set_scroll_offset(new);
+    }
+
+    /// Scroll down toward the live view by `n` rows.
+    pub fn scroll_down(&mut self, n: usize) {
+        let new = self.scroll_offset.saturating_sub(n);
+        self.set_scroll_offset(new);
+    }
+
+    /// Return to the live view (`scroll_offset = 0`).
+    pub fn scroll_reset(&mut self) {
+        self.set_scroll_offset(0);
+    }
+
+    // ── Selection helpers ─────────────────────────────────────────────────────
+
+    /// Extract selected text from the live vt100 screen.
+    ///
+    /// Returns `None` when there is no selection or when the user is
+    /// scrolled into history (selection is only tracked in the live
+    /// screen coordinate space).
+    pub fn selected_text(&self) -> Option<String> {
+        if self.scroll_offset != 0 {
+            return None;
+        }
+        let sel = self.selection.as_ref()?;
+        let screen = self.parser.screen();
+        let (r0, c0, r1, c1) = normalize_selection(sel);
+        let mut lines: Vec<String> = Vec::new();
+        for row in r0..=r1 {
+            let mut line = String::new();
+            let col_start = if row == r0 { c0 } else { 0 };
+            let col_end = if row == r1 {
+                c1
+            } else {
+                self.cols.saturating_sub(1)
+            };
+            for col in col_start..=col_end {
+                if let Some(cell) = screen.cell(row, col) {
+                    let s = cell.contents();
+                    if s.is_empty() {
+                        line.push(' ');
+                    } else {
+                        line.push_str(&s);
+                    }
+                }
+            }
+            lines.push(line.trim_end().to_string());
+        }
+        Some(lines.join("\n"))
+    }
+
+    // ── Snapshot ──────────────────────────────────────────────────────────────
+
+    /// Build a paint snapshot for [`Backend::draw_terminal`].
+    ///
+    /// Pass `Some(scrollbar)` (e.g. from [`scrollbar_state`](Self::scrollbar_state))
+    /// to show a scrollbar when the history is non-empty.
+    pub fn to_terminal(&self, id: WidgetId, scrollbar: Option<TerminalScrollbar>) -> Terminal {
+        Terminal {
+            id,
+            cells: self.build_rows(true),
+            scrollbar,
+        }
+    }
+
+    /// Build a `TerminalScrollbar` reflecting the current scrollback state.
+    ///
+    /// - `scrollbar_width`: visual width in backend-native units.
+    ///   `None` → backend default (1 TUI cell, ~8 px GTK).
+    ///
+    /// The scrollbar uses `inverted = true` so that offset `0` (live view)
+    /// places the thumb at the track bottom, matching normal terminal UX.
+    pub fn scrollbar_state(&self, scrollbar_width: Option<u16>) -> TerminalScrollbar {
+        let total = self.history.len() + self.rows as usize;
+        TerminalScrollbar {
+            total_lines: total,
+            visible_lines: self.rows as usize,
+            scroll_offset: self.scroll_offset,
+            inverted: true,
+            width: scrollbar_width,
+        }
+    }
+
+    // ── Private implementation ────────────────────────────────────────────────
+
+    /// Process a data chunk, splitting at `rows`-newline boundaries so
+    /// that each sub-chunk causes at most `rows` lines to scroll off
+    /// the live screen — the safe maximum for vt100's scrollback read-back.
+    fn process_with_capture(&mut self, data: &[u8]) {
+        let max_nl = self.rows as usize;
+        let mut start = 0;
+        let mut nl_count = 0;
+
+        for (i, &b) in data.iter().enumerate() {
+            if b == b'\n' {
+                nl_count += 1;
+                if nl_count >= max_nl {
+                    self.parser.process(&data[start..=i]);
+                    self.capture_scrolled_rows(nl_count);
+                    start = i + 1;
+                    nl_count = 0;
+                }
+            }
+        }
+        if start < data.len() {
+            let chunk = &data[start..];
+            let remaining_nl = chunk.iter().filter(|&&b| b == b'\n').count();
+            self.parser.process(chunk);
+            if remaining_nl > 0 {
+                self.capture_scrolled_rows(remaining_nl);
+            }
+        }
+    }
+
+    /// Read the rows that just scrolled off the live screen top and append
+    /// them to `self.history`.
+    ///
+    /// Temporarily shifts the vt100 viewport to see the rows that just
+    /// scrolled off (they're still in the vt100 internal scrollback at
+    /// this point), reads them, then restores the live view.
+    fn capture_scrolled_rows(&mut self, n_newlines: usize) {
+        let to_capture = n_newlines.min(self.rows as usize);
+        self.parser.set_scrollback(to_capture);
+        {
+            let screen = self.parser.screen();
+            for r in 0..to_capture as u16 {
+                let row: Vec<HistCell> = (0..self.cols)
+                    .map(|c| match screen.cell(r, c) {
+                        Some(cell) => {
+                            let raw = cell.contents();
+                            HistCell {
+                                ch: raw.chars().next().unwrap_or(' '),
+                                fg: cell.fgcolor(),
+                                bg: cell.bgcolor(),
+                                bold: cell.bold(),
+                                italic: cell.italic(),
+                                underline: cell.underline(),
+                            }
+                        }
+                        None => HistCell::default(),
+                    })
+                    .collect();
+                if self.history_capacity > 0 && self.history.len() >= self.history_capacity {
+                    self.history.pop_front();
+                }
+                self.history.push_back(row);
+            }
+        }
+        self.parser.set_scrollback(0);
+    }
+
+    /// Build the full cell grid for the current view.
+    ///
+    /// Blends history rows (when `scroll_offset > 0`) with live screen rows.
+    /// `cursor_active` controls whether the vt100 cursor position is marked
+    /// `is_cursor = true` in the snapshot.
+    fn build_rows(&self, cursor_active: bool) -> Vec<Vec<TerminalCell>> {
+        let screen = self.parser.screen();
+        let (cursor_row, cursor_col) = screen.cursor_position();
+        let rows_count = self.rows as usize;
+        let cols_count = self.cols as usize;
+        let scroll_offset = self.scroll_offset;
+        let hist_len = self.history.len();
+
+        // Selection is only available in live view (scroll_offset == 0).
+        let sel_bounds = if scroll_offset == 0 {
+            self.selection.as_ref().map(normalize_selection)
+        } else {
+            None
+        };
+
+        (0..rows_count)
+            .map(|display_r| {
+                (0..cols_count)
+                    .map(|c| {
+                        let cu = c as u16;
+
+                        let (ch, fg, bg, bold, italic, underline, is_cursor, selected) =
+                            if display_r < scroll_offset {
+                                // Row is in the scrollback history.
+                                let hist_idx_signed =
+                                    hist_len as isize - scroll_offset as isize + display_r as isize;
+                                if hist_idx_signed >= 0 {
+                                    if let Some(hist_row) =
+                                        self.history.get(hist_idx_signed as usize)
+                                    {
+                                        let hc = hist_row.get(c).copied().unwrap_or_default();
+                                        (
+                                            hc.ch,
+                                            map_vt100_color(hc.fg, false),
+                                            map_vt100_color(hc.bg, true),
+                                            hc.bold,
+                                            hc.italic,
+                                            hc.underline,
+                                            false,
+                                            false,
+                                        )
+                                    } else {
+                                        (
+                                            ' ',
+                                            (229, 229, 229),
+                                            (30, 30, 30),
+                                            false,
+                                            false,
+                                            false,
+                                            false,
+                                            false,
+                                        )
+                                    }
+                                } else {
+                                    (
+                                        ' ',
+                                        (229, 229, 229),
+                                        (30, 30, 30),
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                    )
+                                }
+                            } else {
+                                // Row is in the live vt100 screen.
+                                let live_r = (display_r - scroll_offset) as u16;
+                                let (ch, fg, bg, bold, italic, underline) =
+                                    if let Some(cell) = screen.cell(live_r, cu) {
+                                        let contents = cell.contents();
+                                        let ch = contents.chars().next().unwrap_or(' ');
+                                        (
+                                            ch,
+                                            map_vt100_color(cell.fgcolor(), false),
+                                            map_vt100_color(cell.bgcolor(), true),
+                                            cell.bold(),
+                                            cell.italic(),
+                                            cell.underline(),
+                                        )
+                                    } else {
+                                        (' ', (229, 229, 229), (30, 30, 30), false, false, false)
+                                    };
+
+                                let is_cursor = scroll_offset == 0
+                                    && cursor_active
+                                    && live_r == cursor_row
+                                    && cu == cursor_col;
+
+                                let selected = sel_bounds.is_some_and(|(r0, c0, r1, c1)| {
+                                    if r0 == r1 {
+                                        live_r == r0 && cu >= c0 && cu <= c1
+                                    } else if live_r == r0 {
+                                        cu >= c0
+                                    } else if live_r == r1 {
+                                        cu <= c1
+                                    } else {
+                                        live_r > r0 && live_r < r1
+                                    }
+                                });
+
+                                (ch, fg, bg, bold, italic, underline, is_cursor, selected)
+                            };
+
+                        TerminalCell {
+                            ch,
+                            fg: Color::rgb(fg.0, fg.1, fg.2),
+                            bg: Color::rgb(bg.0, bg.1, bg.2),
+                            bold,
+                            italic,
+                            underline,
+                            selected,
+                            is_cursor,
+                            is_find_match: false,
+                            is_find_active: false,
+                        }
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+// ── TerminalManager ───────────────────────────────────────────────────────────
+
+/// Multi-tab terminal manager.
+///
+/// Owns a `Vec<TerminalSession>` and tracks the active index. Provides
+/// CRUD methods for sessions and a [`poll_all`](Self::poll_all) helper
+/// for the event-loop tick.
+///
+/// ## Keybindings and coupling
+///
+/// Alt+1-9 tab switching, Ctrl+W close, and split-pane keybindings are
+/// **not** part of this type. Consuming apps implement those in their
+/// `AppLogic::handle` method and call the appropriate methods here.
+pub struct TerminalManager {
+    /// All open sessions.
+    pub sessions: Vec<TerminalSession>,
+    /// Index of the currently-active session.
+    pub active: usize,
+}
+
+impl TerminalManager {
+    /// Create a new manager with no open sessions.
+    pub fn new() -> Self {
+        Self {
+            sessions: Vec::new(),
+            active: 0,
+        }
+    }
+
+    /// Reference to the active session, or `None` if empty.
+    pub fn active_session(&self) -> Option<&TerminalSession> {
+        self.sessions.get(self.active)
+    }
+
+    /// Mutable reference to the active session, or `None` if empty.
+    pub fn active_session_mut(&mut self) -> Option<&mut TerminalSession> {
+        self.sessions.get_mut(self.active)
+    }
+
+    /// Spawn a new session and make it active. Returns the new index.
+    pub fn new_session(
+        &mut self,
+        cols: u16,
+        rows: u16,
+        shell: &str,
+        cwd: &Path,
+        history_capacity: usize,
+    ) -> Result<usize, Box<dyn std::error::Error>> {
+        let session = TerminalSession::spawn(cols, rows, shell, cwd, history_capacity)?;
+        self.sessions.push(session);
+        self.active = self.sessions.len() - 1;
+        Ok(self.active)
+    }
+
+    /// Close the active session. The adjacent session becomes active;
+    /// `active` is reset to `0` when the last session is removed.
+    pub fn close_active(&mut self) {
+        if self.sessions.is_empty() {
+            return;
+        }
+        self.sessions.remove(self.active);
+        if self.sessions.is_empty() {
+            self.active = 0;
+        } else {
+            self.active = self.active.min(self.sessions.len() - 1);
+        }
+    }
+
+    /// Switch to session `idx` (clamped to `[0, len-1]`).
+    pub fn switch_to(&mut self, idx: usize) {
+        if !self.sessions.is_empty() {
+            self.active = idx.min(self.sessions.len() - 1);
+        }
+    }
+
+    /// Poll every session for PTY output. Returns `true` when any
+    /// session produced new data (the caller should schedule a repaint).
+    pub fn poll_all(&mut self) -> bool {
+        self.sessions.iter_mut().fold(false, |acc, s| {
+            let changed = s.poll();
+            acc || changed
+        })
+    }
+
+    /// Number of open sessions.
+    pub fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// `true` when there are no open sessions.
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+}
+
+impl Default for TerminalManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Utility ───────────────────────────────────────────────────────────────────
+
+/// Return the user's preferred shell.
+///
+/// Reads `$SHELL`; falls back to `/bin/bash` on Unix and
+/// `powershell.exe` on Windows.
+pub fn default_shell() -> String {
+    if let Ok(shell) = std::env::var("SHELL") {
+        return shell;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "powershell.exe".to_string()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "/bin/bash".to_string()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xterm_256_system_colors() {
+        // Colour 0 = black.
+        assert_eq!(xterm_256_color(0), (0, 0, 0));
+        // Colour 15 = white.
+        assert_eq!(xterm_256_color(15), (255, 255, 255));
+    }
+
+    #[test]
+    fn xterm_256_cube_first() {
+        // Colour 16: r=0, g=0, b=0 in the cube → (0, 0, 0).
+        assert_eq!(xterm_256_color(16), (0, 0, 0));
+    }
+
+    #[test]
+    fn xterm_256_cube_pure_red() {
+        // r=5, g=0, b=0 → index 16 + 36*5 = 196.
+        let (r, g, b) = xterm_256_color(196);
+        assert_eq!(r, 55 + 5 * 40); // 255
+        assert_eq!(g, 0);
+        assert_eq!(b, 0);
+    }
+
+    #[test]
+    fn xterm_256_greyscale() {
+        // Colour 232 = darkest grey (8, 8, 8).
+        assert_eq!(xterm_256_color(232), (8, 8, 8));
+        // Colour 255 = lightest grey (238 = 8 + 23*10).
+        assert_eq!(xterm_256_color(255), (238, 238, 238));
+    }
+
+    #[test]
+    fn map_vt100_default_colors() {
+        let (r, g, b) = map_vt100_color(vt100::Color::Default, false);
+        assert_eq!((r, g, b), (229, 229, 229)); // fg default
+        let (r, g, b) = map_vt100_color(vt100::Color::Default, true);
+        assert_eq!((r, g, b), (30, 30, 30)); // bg default
+    }
+
+    #[test]
+    fn map_vt100_rgb() {
+        let (r, g, b) = map_vt100_color(vt100::Color::Rgb(1, 2, 3), false);
+        assert_eq!((r, g, b), (1, 2, 3));
+    }
+
+    #[test]
+    fn normalize_selection_already_ordered() {
+        let sel = TerminalSelection {
+            start_row: 1,
+            start_col: 5,
+            end_row: 3,
+            end_col: 10,
+        };
+        assert_eq!(normalize_selection(&sel), (1, 5, 3, 10));
+    }
+
+    #[test]
+    fn normalize_selection_reversed() {
+        let sel = TerminalSelection {
+            start_row: 3,
+            start_col: 10,
+            end_row: 1,
+            end_col: 5,
+        };
+        assert_eq!(normalize_selection(&sel), (1, 5, 3, 10));
+    }
+
+    #[test]
+    fn terminal_manager_new_is_empty() {
+        let mgr = TerminalManager::new();
+        assert!(mgr.is_empty());
+        assert_eq!(mgr.len(), 0);
+        assert!(mgr.active_session().is_none());
+    }
+
+    #[test]
+    fn terminal_manager_close_active_on_empty_is_noop() {
+        let mut mgr = TerminalManager::new();
+        mgr.close_active(); // should not panic
+        assert!(mgr.is_empty());
+    }
+
+    #[test]
+    fn terminal_manager_switch_to_empty_is_noop() {
+        let mut mgr = TerminalManager::new();
+        mgr.switch_to(5); // should not panic
+        assert_eq!(mgr.active, 0);
+    }
+
+    #[test]
+    fn default_shell_is_nonempty() {
+        let shell = default_shell();
+        assert!(!shell.is_empty());
+    }
+
+    #[test]
+    fn scrollbar_state_inverted() {
+        // A synthetic test without a real PTY — just checks the
+        // scrollbar_state API shape using hand-crafted history.
+        // We can't spawn a TerminalSession in unit tests without a
+        // PTY, but we can test the pure helper logic above.
+        let (r, g, b) = map_vt100_color(vt100::Color::Idx(196), false);
+        // Index 196 = pure red (from cube).
+        assert_eq!((r, g, b), (255, 0, 0));
+    }
+
+    // ── Integration tests (require a real PTY / Unix shell) ───────────────────
+
+    /// Helper: poll `session` until `predicate(&session)` is true or
+    /// `max_ms` milliseconds elapse. Returns whether the predicate was satisfied.
+    #[cfg(unix)]
+    fn poll_until(
+        sess: &mut TerminalSession,
+        max_ms: u64,
+        predicate: impl Fn(&TerminalSession) -> bool,
+    ) -> bool {
+        let start = std::time::Instant::now();
+        let limit = std::time::Duration::from_millis(max_ms);
+        while start.elapsed() < limit {
+            sess.poll();
+            if predicate(sess) {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        false
+    }
+
+    /// Spawn a session that runs `echo hello` and verify:
+    ///   1. `screen_text()` eventually contains "hello"
+    ///   2. The process exits with code 0
+    ///   3. `exit_code()` returns `Some(0)` after exit
+    #[test]
+    #[cfg(unix)]
+    fn session_send_str_screen_text_and_exit_code() {
+        let cwd = std::env::temp_dir();
+        // Use sh -c so we get a short-lived process with predictable output.
+        let mut sess =
+            TerminalSession::spawn(80, 24, "/bin/sh", &cwd, 1000).expect("failed to spawn /bin/sh");
+
+        // Before process exits, exit_code is None.
+        // Send a command that outputs a known string then exits.
+        sess.send_str("echo __marker__\nexit 0\n");
+
+        // Poll until the marker appears in the visible screen or history,
+        // or the process exits — whichever comes first (max 5 s).
+        let found = poll_until(&mut sess, 5000, |s| {
+            s.full_text().contains("__marker__") || s.exited
+        });
+        assert!(
+            found,
+            "marker '__marker__' never appeared in terminal output"
+        );
+
+        // Process should have exited with code 0.
+        let exited = poll_until(&mut sess, 3000, |s| s.exited);
+        assert!(exited, "process did not exit within timeout");
+        assert_eq!(sess.exit_code(), Some(0), "expected exit code 0");
+
+        // Verify the screen or scrollback text contained the marker.
+        let text = sess.full_text();
+        assert!(
+            text.contains("__marker__"),
+            "full_text() does not contain '__marker__'; got: {text:?}"
+        );
+    }
+
+    /// Verify that `send_str` is equivalent to `write_input` for ASCII text.
+    #[test]
+    #[cfg(unix)]
+    fn send_str_is_write_input_for_ascii() {
+        let cwd = std::env::temp_dir();
+        let mut sess =
+            TerminalSession::spawn(80, 10, "/bin/sh", &cwd, 100).expect("failed to spawn /bin/sh");
+
+        // Both methods should deliver the same bytes to the PTY.
+        // We test that send_str doesn't panic or error.
+        sess.send_str("echo ok\n");
+        let _ = poll_until(&mut sess, 2000, |s| {
+            s.full_text().contains("ok") || s.exited
+        });
+        // Just verify no panic occurred and the session is still valid.
+        assert!(sess.cols > 0 && sess.rows > 0);
+        sess.send_str("exit\n");
+    }
+
+    /// Verify that `screen_text()` returns non-empty content after the shell
+    /// produces output, and that it strips trailing blank rows.
+    #[test]
+    #[cfg(unix)]
+    fn screen_text_strips_trailing_blanks() {
+        let cwd = std::env::temp_dir();
+        let mut sess =
+            TerminalSession::spawn(80, 10, "/bin/sh", &cwd, 100).expect("failed to spawn /bin/sh");
+
+        // Wait for the shell prompt (any output at all).
+        let _ = poll_until(&mut sess, 3000, |s| !s.screen_text().is_empty());
+        let text = sess.screen_text();
+        // Must not end with a blank line.
+        assert!(
+            !text.ends_with('\n'),
+            "screen_text() should not end with a newline; got: {text:?}"
+        );
+        sess.send_str("exit\n");
+    }
+}


### PR DESCRIPTION
Closes #279

Automated PR opened by coordinator for review of issue #279.