### PR TITLE
fix: scrub TMUX/TMUX_PANE from embedded-terminal child env

### DIFF
--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -364,6 +364,16 @@ impl TerminalSession {
 
         let mut cmd = CommandBuilder::new(shell);
         cmd.env("TERM", "xterm-256color");
+        // Present the embedded terminal as a clean, top-level terminal. When
+        // the host app (e.g. coord-tui) is itself launched from inside tmux,
+        // the spawned shell would otherwise inherit $TMUX/$TMUX_PANE and any
+        // tmux command run here would be treated as *nested* in the host's
+        // outer session — e.g. `tmux attach-session` refuses ("sessions should
+        // be nested with care") and `switch-client` hijacks the host's outer
+        // client instead of rendering in this pane. Scrubbing them makes an
+        // interactive session launched in this pane attach in-pane as expected.
+        cmd.env_remove("TMUX");
+        cmd.env_remove("TMUX_PANE");
         cmd.cwd(cwd);
         let child = pair.slave.spawn_command(cmd)?;
 


### PR DESCRIPTION
## Problem
When the host app (coord-tui) is launched from inside tmux, the embedded terminal's spawned shell inherited `$TMUX`/`$TMUX_PANE`, so a tmux command run in the pane was treated as nested in the host's **outer** session: `tmux attach-session` refuses ("sessions should be nested with care") and `switch-client` hijacks the host's outer client instead of rendering in the pane. This blocked hosting an interactive `claude` session inside the TUI's per-issue Terminal tab.

## Fix
`cmd.env_remove("TMUX")` / `env_remove("TMUX_PANE")` on the embedded-terminal `CommandBuilder` (`terminal_engine.rs`) so the pane presents as a clean top-level terminal and an in-pane `attach-session` works. Host-side OSC52 clipboard detection reads the host process env, not the child's, so it's unaffected.

## Verified
Confirmed in-pane: an interactive `coord assign --interactive --review-of …` launched from coord-tui's Terminal tab now renders the Claude session **in the pane** (Claude Max, no nesting error).