### PR TITLE
#358: tab_group_demo: tab-click activation broken — MouseDown drag-start swallows plain clicks (deferred from #349)

### DIFF
--- a/quadraui/examples/common/frame_demo.rs
+++ b/quadraui/examples/common/frame_demo.rs
@@ -156,7 +156,9 @@ impl FrameDemo {
                 action_id: None,
             }],
             right_segments: vec![StatusBarSegment {
-                text: " ←/→ or h/l = h-scroll | j/k = move (v-scrolls) | v = toggle v-bar | q=quit ".into(),
+                text:
+                    " ←/→ or h/l = h-scroll | j/k = move (v-scrolls) | v = toggle v-bar | q=quit "
+                        .into(),
                 fg,
                 bg,
                 bold: false,

--- a/quadraui/examples/common/tab_group_demo.rs
+++ b/quadraui/examples/common/tab_group_demo.rs
@@ -24,6 +24,11 @@ use quadraui::{
     StatusBarSegment, UiEvent, WidgetId,
 };
 
+/// Minimum cursor movement (backend units: pixels for GTK, character cells for
+/// TUI) required to commit a primed tab drag.  Below this distance a
+/// mouse-down/up on a tab body is treated as a plain click (tab activation).
+const TAB_DRAG_THRESHOLD: f32 = 2.0;
+
 // ── Content widgets ───────────────────────────────────────────────────────────
 
 /// A content widget that fills its area with a labelled status bar.
@@ -69,8 +74,13 @@ pub struct TabGroupDemo {
     last_bounds: RefCell<Rect>,
     /// True while a divider drag is in progress.
     divider_dragging: RefCell<bool>,
-    /// True while a tab drag is in progress.
+    /// True while a tab drag is in progress (threshold crossed).
     tab_dragging: RefCell<bool>,
+    /// Mouse-down position when a tab drag has been primed but the cursor
+    /// hasn't yet crossed [`TAB_DRAG_THRESHOLD`].  `None` when there is no
+    /// pending drag.  On `MouseUp` without crossing the threshold this is
+    /// treated as a plain click.
+    tab_drag_pending_pos: RefCell<Option<(f32, f32)>>,
     /// Counter used to make new-tab IDs unique.
     next_tab_id: RefCell<usize>,
 }
@@ -116,6 +126,7 @@ impl TabGroupDemo {
             last_bounds: RefCell::new(Rect::new(0.0, 0.0, 100.0, 20.0)),
             divider_dragging: RefCell::new(false),
             tab_dragging: RefCell::new(false),
+            tab_drag_pending_pos: RefCell::new(None),
             next_tab_id: RefCell::new(10),
         }
     }
@@ -183,9 +194,10 @@ impl AppLogic for TabGroupDemo {
                 key: Key::Named(NamedKey::Escape),
                 ..
             } => {
-                // Cancel any active tab drag on Escape.
+                // Cancel any active or pending tab drag on Escape / q.
                 self.group.borrow_mut().cancel_tab_drag();
                 *self.tab_dragging.borrow_mut() = false;
+                *self.tab_drag_pending_pos.borrow_mut() = None;
                 Reaction::Exit
             }
 
@@ -222,17 +234,19 @@ impl AppLogic for TabGroupDemo {
                 Reaction::Redraw
             }
 
-            // ── Mouse down: try tab drag first, then divider, then click ──
+            // ── Mouse down: prime tab drag, then divider, then click ──────
             UiEvent::MouseDown { position, .. } => {
-                // 1. Try to start a tab drag.
+                // 1. Prime a tab drag — but do NOT commit it yet.  We wait for
+                //    the cursor to cross TAB_DRAG_THRESHOLD before starting the
+                //    visual drag so that a plain click still activates the tab.
                 if self
                     .group
                     .borrow_mut()
                     .handle_tab_drag_start(position.x, position.y)
                 {
-                    *self.tab_dragging.borrow_mut() = true;
-                    *self.last_event.borrow_mut() = "tab drag start".into();
-                    return Reaction::Redraw;
+                    *self.tab_drag_pending_pos.borrow_mut() = Some((position.x, position.y));
+                    // Don't redraw — no visible change yet.
+                    return Reaction::Continue;
                 }
 
                 // 2. Try to start a divider drag.
@@ -261,6 +275,23 @@ impl AppLogic for TabGroupDemo {
                         .borrow_mut()
                         .handle_tab_drag_move(position.x, position.y);
                     return Reaction::Redraw;
+                }
+                // Promote a pending tab drag to an active drag once the cursor
+                // has moved far enough from the press point.
+                if let Some((sx, sy)) = *self.tab_drag_pending_pos.borrow() {
+                    let dx = (position.x - sx).abs();
+                    let dy = (position.y - sy).abs();
+                    if dx > TAB_DRAG_THRESHOLD || dy > TAB_DRAG_THRESHOLD {
+                        *self.tab_drag_pending_pos.borrow_mut() = None;
+                        *self.tab_dragging.borrow_mut() = true;
+                        *self.last_event.borrow_mut() = "tab drag start".into();
+                        self.group
+                            .borrow_mut()
+                            .handle_tab_drag_move(position.x, position.y);
+                        return Reaction::Redraw;
+                    }
+                    // Still within threshold — don't update the display.
+                    return Reaction::Continue;
                 }
                 if *self.divider_dragging.borrow() {
                     let bounds = *self.last_bounds.borrow();
@@ -295,6 +326,17 @@ impl AppLogic for TabGroupDemo {
                         for ev in evs {
                             self.handle_tab_group_event(ev);
                         }
+                    }
+                    return Reaction::Redraw;
+                }
+                // A tab was pressed but the cursor never crossed the threshold
+                // → cancel the primed drag and treat the gesture as a click.
+                if self.tab_drag_pending_pos.borrow().is_some() {
+                    *self.tab_drag_pending_pos.borrow_mut() = None;
+                    self.group.borrow_mut().cancel_tab_drag();
+                    if let Some(ev) = self.group.borrow_mut().handle_click(position.x, position.y) {
+                        *self.last_event.borrow_mut() = format_event(&ev);
+                        self.handle_tab_group_event(ev);
                     }
                     return Reaction::Redraw;
                 }

--- a/quadraui/src/tui/list.rs
+++ b/quadraui/src/tui/list.rs
@@ -899,14 +899,24 @@ mod tests {
         let area = Rect::new(0, 0, 10, 10);
         let mut buf_top = Buffer::empty(area);
         let mut buf_bot = Buffer::empty(area);
-        draw_list(&mut buf_top, area, &make_vlist(30, 0), &Theme::default(), false);
-        draw_list(&mut buf_bot, area, &make_vlist(30, 20), &Theme::default(), false);
+        draw_list(
+            &mut buf_top,
+            area,
+            &make_vlist(30, 0),
+            &Theme::default(),
+            false,
+        );
+        draw_list(
+            &mut buf_bot,
+            area,
+            &make_vlist(30, 20),
+            &Theme::default(),
+            false,
+        );
 
         let first_thumb = |buf: &Buffer| (0..10u16).find(|&y| cell_char(buf, 9, y) == '█');
-        let thumb_top =
-            first_thumb(&buf_top).expect("thumb '█' must paint at scroll_offset=0");
-        let thumb_bot =
-            first_thumb(&buf_bot).expect("thumb '█' must paint at scroll_offset=20");
+        let thumb_top = first_thumb(&buf_top).expect("thumb '█' must paint at scroll_offset=0");
+        let thumb_bot = first_thumb(&buf_bot).expect("thumb '█' must paint at scroll_offset=20");
         assert!(
             thumb_bot > thumb_top,
             "v-scrollbar thumb must move DOWN as scroll_offset grows \
@@ -914,5 +924,4 @@ mod tests {
              'thumb hardcoded at gutter top' failure class (Rule 6)",
         );
     }
-
 }

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -22,6 +22,8 @@ mod panel_app;
 mod pipeline_app;
 #[path = "../examples/common/selection_app.rs"]
 mod selection_app;
+#[path = "../examples/common/tab_group_demo.rs"]
+mod tab_group_demo;
 #[path = "../examples/common/text_input_demo.rs"]
 mod text_input_demo;
 
@@ -30,6 +32,7 @@ use mini_app::MiniApp;
 use panel_app::PanelApp;
 use pipeline_app::PipelineApp;
 use selection_app::SelectionDemo;
+use tab_group_demo::TabGroupDemo;
 use text_input_demo::TextInputDemo;
 
 // ─── PipelineApp: mouse + keyboard + reset ──────────────────────────────────
@@ -371,4 +374,47 @@ fn shell_runner_path_ctrl_a_selects_all() {
         screen.contains("quick") || screen.contains("brown"),
         "copied preview should contain text from the first content line:\n{screen}"
     );
+}
+
+// ─── TabGroupDemo: tab-click activation + keyboard exit ─────────────────────
+
+/// Regression test for #358.
+///
+/// Before the fix, `MouseDown` on a tab body primed a drag and returned early.
+/// `MouseUp` at the same position (no cursor movement) reached
+/// `handle_tab_drop`, which returned an empty `Vec` → status "tab drag
+/// cancelled" — no activation.
+///
+/// After the fix, a down/up pair with no movement past `TAB_DRAG_THRESHOLD`
+/// cancels the primed drag and falls through to `handle_click`, restoring
+/// tab-activation behaviour.
+#[test]
+fn tab_group_click_inactive_tab_activates_it() {
+    let mut driver = TuiDriver::new(TabGroupDemo::new(), 120, 30);
+
+    // Initial state: "main.rs" (p0:t0) is active; "lib.rs" (p0:t1) is
+    // the inactive second tab and must be visible in the tab bar.
+    let before = driver.screen();
+    let (x, y) = driver
+        .find("lib.rs")
+        .unwrap_or_else(|| panic!("lib.rs tab must be visible on initial render:\n{before}"));
+
+    // Plain click: mouse-down then mouse-up at the exact same position —
+    // no MouseMoved in between, so the drag stays in the pending state and
+    // the threshold is never crossed.
+    driver.mouse_down(x, y);
+    driver.mouse_up(x, y);
+
+    let after = driver.screen();
+    assert!(
+        after.contains("activated tab"),
+        "clicking lib.rs should activate it (status bar must say 'activated tab …'):\n{after}"
+    );
+}
+
+#[test]
+fn tab_group_q_exits() {
+    let mut driver = TuiDriver::new(TabGroupDemo::new(), 120, 30);
+    driver.type_char('q');
+    assert!(driver.exited(), "'q' should exit the tab group demo");
 }


### PR DESCRIPTION
Closes #358

Automated merge from the coordinator for assignment c0511a4060b1 on issue #358.

Worker branch: `issue-358-tab-group-demo-tab-click-activation-brok` → `develop`.