### PR TITLE
#368: ActivityBar: add keyboard-focus protocol (j/k/l/h navigation, GTK + TUI)

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -501,3 +501,13 @@ required-features = ["tui"]
 name = "gtk_tabgroup"
 path = "examples/gtk_tabgroup.rs"
 required-features = ["gtk"]
+
+[[example]]
+name = "tui_activity_nav"
+path = "examples/tui_activity_nav.rs"
+required-features = ["tui"]
+
+[[example]]
+name = "gtk_activity_nav"
+path = "examples/gtk_activity_nav.rs"
+required-features = ["gtk"]

--- a/quadraui/examples/common/activity_nav.rs
+++ b/quadraui/examples/common/activity_nav.rs
@@ -1,0 +1,292 @@
+//! Backend-agnostic app logic for the activity-bar keyboard-navigation demo
+//! (`tui_activity_nav` / `gtk_activity_nav`).
+//!
+//! `ActivityNavApp` demonstrates the full keyboard-focus round-trip that
+//! [`ActivityBar::is_keyboard_focused`] enables:
+//!
+//! 1. The "editor" area starts with focus (a simulated text cursor blinks).
+//! 2. Press **Tab** → activity bar gains focus; cursor appears on the first
+//!    item and the status bar shows "Activity bar focused".
+//! 3. **j** / **↓** → cursor moves down the icon list.
+//! 4. **k** / **↑** → cursor moves up.
+//! 5. **l** / **Enter** → activates the highlighted item (prints its name in
+//!    the status bar) and returns focus to the editor.
+//! 6. **Esc** / **h** / **←** → dismisses the bar focus without activating.
+//! 7. **q** → quit.
+//!
+//! Controls (when editor area is focused):
+//!
+//! | Key | Action |
+//! |-----|--------|
+//! | Tab | Focus the activity bar |
+//! | q   | Quit |
+//!
+//! Controls (when activity bar is focused):
+//!
+//! | Key | Action |
+//! |-----|--------|
+//! | j / ↓ | Move cursor down |
+//! | k / ↑ | Move cursor up |
+//! | l / Enter | Activate item, return focus to editor |
+//! | Esc / h / ← | Return focus to editor |
+
+use quadraui::{
+    ActivityBar, ActivityBarEvent, ActivityItem, AppLogic, Backend, Color, Key, NamedKey, Reaction,
+    Rect, StatusBar, StatusBarSegment, UiEvent, WidgetId,
+};
+
+/// Item descriptor for the demo bar.
+struct NavItem {
+    id: &'static str,
+    icon: &'static str,
+    label: &'static str,
+}
+
+const ITEMS: &[NavItem] = &[
+    NavItem {
+        id: "nav:explorer",
+        icon: "⬡",
+        label: "Explorer",
+    },
+    NavItem {
+        id: "nav:search",
+        icon: "⌕",
+        label: "Search",
+    },
+    NavItem {
+        id: "nav:git",
+        icon: "⎇",
+        label: "Source Control",
+    },
+    NavItem {
+        id: "nav:debug",
+        icon: "⬤",
+        label: "Debug",
+    },
+    NavItem {
+        id: "nav:extensions",
+        icon: "⬡",
+        label: "Extensions",
+    },
+];
+
+pub struct ActivityNavApp {
+    /// `true` when the activity bar has keyboard focus.
+    bar_focused: bool,
+    /// Index (into `ITEMS`) of the keyboard cursor inside the bar. Only
+    /// meaningful while `bar_focused` is `true`.
+    cursor: usize,
+    /// Status-line message echoing the last action.
+    message: String,
+    /// Currently active (highlighted with accent) item index.
+    active_idx: Option<usize>,
+}
+
+impl ActivityNavApp {
+    pub fn new() -> Self {
+        Self {
+            bar_focused: false,
+            cursor: 0,
+            message: "Tab = focus bar  |  q = quit".into(),
+            active_idx: Some(0),
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    fn bar(&self) -> ActivityBar {
+        let items: Vec<ActivityItem> = ITEMS
+            .iter()
+            .enumerate()
+            .map(|(i, ni)| ActivityItem {
+                id: WidgetId::new(ni.id),
+                icon: ni.icon.into(),
+                tooltip: ni.label.into(),
+                is_active: self.active_idx == Some(i),
+                is_keyboard_selected: self.bar_focused && self.cursor == i,
+            })
+            .collect();
+
+        ActivityBar {
+            id: WidgetId::new("demo:activity-bar"),
+            top_items: items,
+            bottom_items: vec![],
+            active_accent: Some(Color::rgb(100, 150, 255)),
+            selection_bg: Some(Color::rgb(70, 70, 100)),
+            is_keyboard_focused: self.bar_focused,
+        }
+    }
+
+    fn status_bar(&self) -> StatusBar {
+        let left_text = format!("  {} ", self.message);
+        let right_text = if self.bar_focused {
+            " j/k=move  l/Enter=activate  Esc=back ".into()
+        } else {
+            " Tab=focus bar  q=quit ".into()
+        };
+        let left_bg = if self.bar_focused {
+            Color::rgb(80, 60, 130)
+        } else {
+            Color::rgb(40, 80, 120)
+        };
+        StatusBar {
+            id: WidgetId::new("demo:status"),
+            left_segments: vec![StatusBarSegment {
+                text: left_text,
+                fg: Color::rgb(255, 255, 255),
+                bg: left_bg,
+                bold: false,
+                action_id: None,
+            }],
+            right_segments: vec![StatusBarSegment {
+                text: right_text,
+                fg: Color::rgb(200, 200, 200),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+        }
+    }
+
+    fn move_cursor(&mut self, delta: i32) {
+        let n = ITEMS.len() as i32;
+        self.cursor = ((self.cursor as i32 + delta).rem_euclid(n)) as usize;
+        self.message = format!("↕ cursor at {}", ITEMS[self.cursor].label);
+    }
+
+    fn activate(&mut self) {
+        let label = ITEMS[self.cursor].label;
+        self.active_idx = Some(self.cursor);
+        self.message = format!("Activated: {}", label);
+        self.bar_focused = false;
+    }
+
+    fn focus_bar(&mut self) {
+        self.bar_focused = true;
+        self.cursor = 0;
+        self.message = format!("Activity bar focused  (cursor: {})", ITEMS[0].label);
+    }
+
+    fn focus_out(&mut self) {
+        self.bar_focused = false;
+        self.message = "Focus returned to editor".into();
+    }
+
+    /// Handle a key event while the activity bar is focused. Returns `true`
+    /// if the event was consumed.
+    fn handle_bar_key(&mut self, key_str: &str) -> bool {
+        match key_str {
+            "j" | "Down" => {
+                self.move_cursor(1);
+                true
+            }
+            "k" | "Up" => {
+                self.move_cursor(-1);
+                true
+            }
+            "l" | "Enter" => {
+                self.activate();
+                true
+            }
+            "Escape" | "h" | "Left" => {
+                self.focus_out();
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Default for ActivityNavApp {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppLogic for ActivityNavApp {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let vp = backend.viewport();
+        let lh = backend.line_height();
+
+        // Activity bar: left strip, full height minus status bar.
+        let bar_w = lh * 3.0;
+        let bar_rect = Rect::new(0.0, 0.0, bar_w, vp.height - lh);
+        let _ = backend.draw_activity_bar(bar_rect, &self.bar(), None);
+
+        // "Editor" content area (placeholder).
+        let editor_rect = Rect::new(bar_w, 0.0, vp.width - bar_w, vp.height - lh);
+        let editor_label = if self.bar_focused {
+            "  [ activity bar has focus — use j/k/l/Esc ]"
+        } else {
+            "  [ editor area has focus — press Tab to focus the bar ]"
+        };
+        let _ = backend.draw_status_bar(
+            editor_rect,
+            &StatusBar {
+                id: WidgetId::new("demo:editor-area"),
+                left_segments: vec![StatusBarSegment {
+                    text: editor_label.into(),
+                    fg: Color::rgb(180, 180, 180),
+                    bg: Color::rgb(30, 30, 30),
+                    bold: false,
+                    action_id: None,
+                }],
+                right_segments: vec![],
+            },
+            None,
+            None,
+        );
+
+        // Status bar at the bottom.
+        let status_rect = Rect::new(0.0, vp.height - lh, vp.width, lh);
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
+    }
+
+    fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
+        match event {
+            // ── Quit ───────────────────────────────────────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Char('q'),
+                ..
+            }
+            | UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::Escape),
+                ..
+            } if !self.bar_focused => Reaction::Exit,
+
+            // ── Tab → focus the activity bar ───────────────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::Tab),
+                ..
+            } if !self.bar_focused => {
+                self.focus_bar();
+                Reaction::Redraw
+            }
+
+            // ── Activity bar key events (emitted by the backend when
+            //    is_keyboard_focused = true) ─────────────────────────────────
+            UiEvent::ActivityBar(_id, ActivityBarEvent::KeyPressed { key, .. }) => {
+                if self.handle_bar_key(&key) {
+                    Reaction::Redraw
+                } else {
+                    Reaction::Continue
+                }
+            }
+
+            // ── Activity bar click → activate immediately ──────────────────
+            UiEvent::ActivityBar(_id, ActivityBarEvent::ItemClicked { id }) => {
+                if let Some(idx) = ITEMS.iter().position(|ni| ni.id == id.as_str()) {
+                    self.cursor = idx;
+                    self.activate();
+                    return Reaction::Redraw;
+                }
+                Reaction::Continue
+            }
+
+            UiEvent::WindowResized { .. } => Reaction::Redraw,
+            _ => Reaction::Continue,
+        }
+    }
+}

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -33,6 +33,7 @@ pub mod terminal_app;
 #[cfg(feature = "terminal")]
 pub use terminal_app::TerminalApp;
 
+pub mod activity_nav;
 pub mod ai_transcript;
 pub mod appshell_demo;
 pub mod bottom_panel_demo;
@@ -67,6 +68,7 @@ pub mod text_input_demo;
 pub mod toast_app;
 pub mod toolbar_app;
 
+pub use activity_nav::ActivityNavApp;
 pub use ai_transcript::AiTranscript;
 pub use chart_app::ChartApp;
 pub use chat_demo::ChatDemo;

--- a/quadraui/examples/gtk_activity_nav.rs
+++ b/quadraui/examples/gtk_activity_nav.rs
@@ -1,0 +1,27 @@
+//! Activity-bar keyboard navigation demo — GTK backend.
+//!
+//! Demonstrates [`quadraui::ActivityBar::is_keyboard_focused`]: the runner's
+//! window-level `EventControllerKey` intercepts key events and emits
+//! `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })` when a bar
+//! declares keyboard focus. This avoids the `grab_focus()` / sibling-DA
+//! focus-stealing problem described in vimcode#494.
+//!
+//! Controls:
+//! - **Tab**          → focus the activity bar (cursor appears on first item)
+//! - **j** / **↓**   → move cursor down
+//! - **k** / **↑**   → move cursor up
+//! - **l** / **Enter**→ activate highlighted item, return focus
+//! - **Esc** / **h**  → return focus without activating
+//!
+//! Click an activity bar item directly to activate it without keyboard focus.
+//!
+//! ```sh
+//! cargo run --example gtk_activity_nav --features gtk
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::gtk::run(common::ActivityNavApp::new())
+}

--- a/quadraui/examples/tui_activity_nav.rs
+++ b/quadraui/examples/tui_activity_nav.rs
@@ -1,0 +1,25 @@
+//! Activity-bar keyboard navigation demo — TUI backend.
+//!
+//! Demonstrates [`quadraui::ActivityBar::is_keyboard_focused`]: the backend
+//! emits `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })`
+//! instead of a raw `UiEvent::KeyPressed` when a bar declares keyboard focus,
+//! so navigation logic stays entirely in app code.
+//!
+//! Controls:
+//! - **Tab**          → focus the activity bar (cursor appears on first item)
+//! - **j** / **↓**   → move cursor down
+//! - **k** / **↑**   → move cursor up
+//! - **l** / **Enter**→ activate highlighted item, return focus
+//! - **Esc** / **h**  → return focus without activating
+//! - **q** / **Esc** (editor area) → quit
+//!
+//! ```sh
+//! cargo run --example tui_activity_nav --features tui
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::io::Result<()> {
+    quadraui::tui::run(common::ActivityNavApp::new())
+}

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -374,6 +374,7 @@ impl AppShell {
             bottom_items,
             active_accent: None,
             selection_bg: None,
+            is_keyboard_focused: false,
         }
     }
 

--- a/quadraui/src/gtk/activity_bar.rs
+++ b/quadraui/src/gtk/activity_bar.rs
@@ -115,6 +115,19 @@ pub fn draw_activity_bar(
 
         let is_hovered = hovered_idx == Some(flat_idx);
 
+        // Keyboard-selection highlight: fill the row with a visible tint
+        // so the user can see which item the cursor is on. Drawn before
+        // hover so that hover-on-selected still shows the selection.
+        if item.is_keyboard_selected {
+            let sel_bg = {
+                let c = theme.tab_bar_bg.lighten(0.20);
+                (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0)
+            };
+            cr.set_source_rgb(sel_bg.0, sel_bg.1, sel_bg.2);
+            cr.rectangle(0.0, y, width, row_h);
+            cr.fill().ok();
+        }
+
         if is_hovered {
             cr.set_source_rgb(hover_bg.0, hover_bg.1, hover_bg.2);
             cr.rectangle(0.0, y, width, row_h);
@@ -129,7 +142,7 @@ pub fn draw_activity_bar(
 
         pango_layout.set_text(&item.icon);
         let (iw, ih) = pango_layout.pixel_size();
-        let fg = if item.is_active || is_hovered {
+        let fg = if item.is_active || is_hovered || item.is_keyboard_selected {
             active_fg
         } else {
             inactive_fg

--- a/quadraui/src/gtk/activity_bar.rs
+++ b/quadraui/src/gtk/activity_bar.rs
@@ -115,21 +115,26 @@ pub fn draw_activity_bar(
 
         let is_hovered = hovered_idx == Some(flat_idx);
 
-        // Keyboard-selection highlight: fill the row with a visible tint
-        // so the user can see which item the cursor is on. Drawn before
-        // hover so that hover-on-selected still shows the selection.
-        if item.is_keyboard_selected {
-            let sel_bg = {
-                let c = theme.tab_bar_bg.lighten(0.20);
-                (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0)
-            };
-            cr.set_source_rgb(sel_bg.0, sel_bg.1, sel_bg.2);
+        // Hover tint (lower priority: painted first so selection can win).
+        if is_hovered {
+            cr.set_source_rgb(hover_bg.0, hover_bg.1, hover_bg.2);
             cr.rectangle(0.0, y, width, row_h);
             cr.fill().ok();
         }
 
-        if is_hovered {
-            cr.set_source_rgb(hover_bg.0, hover_bg.1, hover_bg.2);
+        // Keyboard-selection highlight: painted *after* hover so the brighter
+        // selection tint (lighten 0.20, or `bar.selection_bg`) always wins over
+        // the dimmer hover tint (lighten 0.10) when the cursor sits on a hovered
+        // row.
+        if item.is_keyboard_selected {
+            let sel_bg = bar
+                .selection_bg
+                .map(|c| (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0))
+                .unwrap_or_else(|| {
+                    let c = theme.tab_bar_bg.lighten(0.20);
+                    (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0)
+                });
+            cr.set_source_rgb(sel_bg.0, sel_bg.1, sel_bg.2);
             cr.rectangle(0.0, y, width, row_h);
             cr.fill().ok();
         }

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -151,6 +151,13 @@ pub struct GtkBackend {
     /// `clear_selection_display` so Ctrl-A still targets the right
     /// region after Ctrl-C or a plain click.
     last_text_region_id: Option<WidgetId>,
+    /// `WidgetId` of the `ActivityBar` that declared `is_keyboard_focused`
+    /// during the most recent render pass. Cleared by `begin_frame` and
+    /// re-set by `draw_activity_bar`. The GTK runner reads this in the
+    /// window-level key handler to convert `KeyPressed` events into
+    /// `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })` so
+    /// consumers receive typed key events without fighting GTK widget focus.
+    focused_activity_bar: Option<WidgetId>,
 }
 
 /// Active text selection state for the GTK backend. Stores the region id
@@ -189,6 +196,7 @@ impl GtkBackend {
             text_regions: Vec::new(),
             active_selection: None,
             last_text_region_id: None,
+            focused_activity_bar: None,
         }
     }
 
@@ -266,6 +274,15 @@ impl GtkBackend {
     /// to paint a full-DA background before each frame.
     pub fn current_theme(&self) -> &crate::Theme {
         &self.current_theme
+    }
+
+    /// Return the `WidgetId` of the `ActivityBar` that declared
+    /// `is_keyboard_focused = true` during the most recent render pass,
+    /// or `None` if no bar is focused. Called by the GTK runner's key
+    /// handler to decide whether to redirect a `KeyPressed` event into
+    /// `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })`.
+    pub(crate) fn focused_activity_bar_id(&self) -> Option<&WidgetId> {
+        self.focused_activity_bar.as_ref()
     }
 
     /// Update the cached Pango line height (in DIPs). Call once per
@@ -771,6 +788,10 @@ impl Backend for GtkBackend {
         // Clear per-frame text regions so stale registrations from the
         // previous frame don't linger. Mirrors TuiBackend::begin_frame.
         self.text_regions.clear();
+        // Clear the focused activity bar — re-set by draw_activity_bar
+        // during the render pass if still focused. Same lifecycle as
+        // text_regions.
+        self.focused_activity_bar = None;
     }
 
     fn register_text_region(&mut self, region: TextRegion) {
@@ -1110,6 +1131,11 @@ impl Backend for GtkBackend {
         bar: &ActivityBar,
         hovered_idx: Option<usize>,
     ) -> Vec<crate::ActivityBarRowHit> {
+        // Track keyboard focus so the GTK runner's key handler can
+        // redirect KeyPressed events to this bar.
+        if bar.is_keyboard_focused {
+            self.focused_activity_bar = Some(bar.id.clone());
+        }
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_activity_bar called outside enter_frame_scope");

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -277,6 +277,41 @@ fn activate<A: AppLogic + 'static>(
                 }
             }
 
+            // ── ActivityBar keyboard focus intercept ────────────────
+            //
+            // When an `ActivityBar` declared `is_keyboard_focused = true`
+            // during the last render pass, redirect every `KeyPressed`
+            // event to it as `UiEvent::ActivityBar(id, KeyPressed { … })`
+            // so the app receives typed key events through a stable channel.
+            //
+            // This runs at the window-level `EventControllerKey` (already
+            // attached to the window above), so it does NOT call
+            // `grab_focus()` on any `DrawingArea` and cannot silence other
+            // key controllers — the root cause of the vimcode#494 failure.
+            if let UiEvent::KeyPressed {
+                ref key, modifiers, ..
+            } = ev
+            {
+                let focused_bar = backend.borrow().focused_activity_bar_id().cloned();
+                if let Some(bar_id) = focused_bar {
+                    let key_str = crate::primitives::activity_bar::key_to_activity_bar_string(key);
+                    let bar_ev = UiEvent::ActivityBar(
+                        bar_id,
+                        crate::ActivityBarEvent::KeyPressed {
+                            key: key_str,
+                            modifiers,
+                        },
+                    );
+                    let reaction = {
+                        let mut backend_mut = backend.borrow_mut();
+                        let mut app_mut = app.borrow_mut();
+                        app_mut.handle(bar_ev, &mut *backend_mut)
+                    };
+                    apply_reaction(reaction, &da_for_redraw, &window_for_close);
+                    return glib::Propagation::Stop;
+                }
+            }
+
             let reaction = {
                 let mut backend_mut = backend.borrow_mut();
                 let mut app_mut = app.borrow_mut();

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -1011,6 +1011,7 @@ mod tests {
             }],
             active_accent: Some(Color::rgb(120, 180, 255)),
             selection_bg: Some(Color::rgb(80, 80, 80)),
+            is_keyboard_focused: false,
         };
         let json = serde_json::to_string(&bar).unwrap();
         let back: ActivityBar = serde_json::from_str(&json).unwrap();
@@ -3248,6 +3249,7 @@ mod tests {
             bottom_items: vec![],
             active_accent: None,
             selection_bg: None,
+            is_keyboard_focused: false,
         };
         let layout = bar.layout(3.0, 20.0, 1.0);
         assert_eq!(layout.visible_items.len(), 0);
@@ -3265,6 +3267,7 @@ mod tests {
             bottom_items: vec![],
             active_accent: None,
             selection_bg: None,
+            is_keyboard_focused: false,
         };
         let layout = bar.layout(3.0, 10.0, 1.0);
         assert_eq!(layout.visible_items.len(), 2);
@@ -3285,6 +3288,7 @@ mod tests {
             bottom_items: vec![make_activity_item("activity:settings", 'G')],
             active_accent: None,
             selection_bg: None,
+            is_keyboard_focused: false,
         };
         // Viewport 10, items 1 each. Top at y=0, bottom at y=9.
         let layout = bar.layout(3.0, 10.0, 1.0);
@@ -3326,6 +3330,7 @@ mod tests {
                 .collect(),
             active_accent: None,
             selection_bg: None,
+            is_keyboard_focused: false,
         };
         let layout = bar.layout(3.0, 6.0, 1.0);
         let top_count = layout
@@ -3356,6 +3361,7 @@ mod tests {
             bottom_items: vec![make_activity_item("activity:settings", 'G')],
             active_accent: None,
             selection_bg: None,
+            is_keyboard_focused: false,
         };
         let layout = bar.layout(48.0, 200.0, 48.0);
         // Top items at y = 0, 48, 96. Settings at y = 200 - 48 = 152.

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -187,6 +187,7 @@ mod tests {
             }],
             active_accent: Some(Color::rgb(80, 140, 255)),
             selection_bg: None,
+            is_keyboard_focused: false,
         }
     }
 

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -50,6 +50,23 @@ pub struct ActivityBar {
     /// `None` = backends fall back to their own default.
     #[serde(default)]
     pub selection_bg: Option<Color>,
+    /// When `true` the bar is accepting keyboard input. Both TUI and GTK
+    /// backends intercept key events and emit
+    /// [`ActivityBarEvent::KeyPressed`] (wrapped in
+    /// [`crate::UiEvent::ActivityBar`]) rather than forwarding them as raw
+    /// [`crate::UiEvent::KeyPressed`] events.
+    ///
+    /// **GTK note**: the runner already attaches its `EventControllerKey` to
+    /// the window (not a sibling `DrawingArea`), so setting this flag does
+    /// *not* call `grab_focus()` on any widget and does not interfere with
+    /// other key controllers.
+    ///
+    /// Navigation logic (`j`/`k` move cursor, `l`/`Enter` activate, `Esc`/`h`
+    /// dismiss focus) stays in the consumer. The bar delivers every key as
+    /// [`ActivityBarEvent::KeyPressed`] so the app can map keys to its own
+    /// engine calls (`activity_bar_move_up`, `focus_out`, etc.).
+    #[serde(default)]
+    pub is_keyboard_focused: bool,
 }
 
 /// One icon entry in an `ActivityBar`.
@@ -253,4 +270,56 @@ pub enum ActivityBarEvent {
     /// A key was pressed with the activity bar focused and the primitive
     /// didn't consume it.
     KeyPressed { key: String, modifiers: Modifiers },
+}
+
+/// Convert a [`crate::Key`] to the string form carried in
+/// [`ActivityBarEvent::KeyPressed`].
+///
+/// - Printable characters map to their single-character string (`"j"`, `"k"`, …).
+/// - Named keys use TitleCase names (`"Escape"`, `"Enter"`, `"Up"`, …).
+///
+/// Both the TUI and GTK backends use this helper so the emitted key strings
+/// are identical regardless of which backend is active.
+pub fn key_to_activity_bar_string(key: &crate::event::Key) -> String {
+    use crate::event::{Key, NamedKey};
+    match key {
+        Key::Char(c) => c.to_string(),
+        Key::Named(named) => {
+            let s = match named {
+                NamedKey::Escape => "Escape",
+                NamedKey::Tab => "Tab",
+                NamedKey::BackTab => "BackTab",
+                NamedKey::Enter => "Enter",
+                NamedKey::Backspace => "Backspace",
+                NamedKey::Delete => "Delete",
+                NamedKey::Insert => "Insert",
+                NamedKey::Home => "Home",
+                NamedKey::End => "End",
+                NamedKey::PageUp => "PageUp",
+                NamedKey::PageDown => "PageDown",
+                NamedKey::Up => "Up",
+                NamedKey::Down => "Down",
+                NamedKey::Left => "Left",
+                NamedKey::Right => "Right",
+                NamedKey::F(1) => "F1",
+                NamedKey::F(2) => "F2",
+                NamedKey::F(3) => "F3",
+                NamedKey::F(4) => "F4",
+                NamedKey::F(5) => "F5",
+                NamedKey::F(6) => "F6",
+                NamedKey::F(7) => "F7",
+                NamedKey::F(8) => "F8",
+                NamedKey::F(9) => "F9",
+                NamedKey::F(10) => "F10",
+                NamedKey::F(11) => "F11",
+                NamedKey::F(12) => "F12",
+                NamedKey::F(_) => "F?",
+                NamedKey::CapsLock => "CapsLock",
+                NamedKey::NumLock => "NumLock",
+                NamedKey::ScrollLock => "ScrollLock",
+                NamedKey::Menu => "Menu",
+            };
+            s.to_string()
+        }
+    }
 }

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -84,9 +84,12 @@ pub struct ActivityItem {
     pub tooltip: String,
     #[serde(default)]
     pub is_active: bool,
-    /// Keyboard-focused selection highlight (used by TUI when the activity
-    /// bar has `toolbar_focused`). GTK rarely sets this — native buttons
-    /// manage their own focus rings.
+    /// Keyboard-focused selection highlight. Both the TUI and GTK rasterizers
+    /// honour this flag: TUI applies `Modifier::REVERSED` (or paints
+    /// `ActivityBar::selection_bg` when set); GTK fills the row with a
+    /// brightened background tint (or `ActivityBar::selection_bg` when set).
+    /// Set this on the item whose index matches the app's keyboard cursor while
+    /// `ActivityBar::is_keyboard_focused` is `true`.
     #[serde(default)]
     pub is_keyboard_selected: bool,
 }
@@ -280,7 +283,11 @@ pub enum ActivityBarEvent {
 ///
 /// Both the TUI and GTK backends use this helper so the emitted key strings
 /// are identical regardless of which backend is active.
-pub fn key_to_activity_bar_string(key: &crate::event::Key) -> String {
+///
+/// This is `pub(crate)` because external consumers receive the already-normalised
+/// string from [`ActivityBarEvent::KeyPressed::key`] — they have no reason to call
+/// the conversion helper directly.
+pub(crate) fn key_to_activity_bar_string(key: &crate::event::Key) -> String {
     use crate::event::{Key, NamedKey};
     match key {
         Key::Char(c) => c.to_string(),

--- a/quadraui/src/tui/activity_bar.rs
+++ b/quadraui/src/tui/activity_bar.rs
@@ -33,6 +33,10 @@ pub fn draw_activity_bar(
     let active_fg = qc(theme.foreground);
     let inactive_fg = qc(theme.inactive_fg);
     let hover_bg = qc(theme.tab_bar_bg.lighten(0.10));
+    // Explicit keyboard-selection background when the bar sets `selection_bg`.
+    // `None` → fall back to `Modifier::REVERSED` after the icon paint (terminal-
+    // agnostic inversion that works in every colour scheme).
+    let sel_explicit_bg: Option<ratatui::style::Color> = bar.selection_bg.map(qc);
 
     // Fill background.
     for row in area.y..area.y + area.height {
@@ -64,15 +68,28 @@ pub fn draw_activity_bar(
         };
 
         let is_hovered = hovered_idx == Some(flat_idx);
-        let row_bg = if is_hovered { hover_bg } else { bg };
-        let fg = if item.is_active || is_hovered {
+        // Effective row background priority: explicit keyboard-selection >
+        // hover > default. When keyboard-selected without an explicit
+        // `selection_bg`, the row uses the default bg and REVERSED is applied
+        // after the icon paint (so all cells invert, giving a clear cursor
+        // in any terminal colour scheme).
+        let row_bg = if item.is_keyboard_selected {
+            sel_explicit_bg.unwrap_or(if is_hovered { hover_bg } else { bg })
+        } else if is_hovered {
+            hover_bg
+        } else {
+            bg
+        };
+        let fg = if item.is_active || is_hovered || item.is_keyboard_selected {
             active_fg
         } else {
             inactive_fg
         };
 
-        // Row background (hover tint).
-        if is_hovered {
+        // Row background fill (hover tint or explicit keyboard-selection bg).
+        // Both use the same `row_bg` computed above, but we only fill when
+        // there is actually a tint to apply.
+        if is_hovered || (item.is_keyboard_selected && sel_explicit_bg.is_some()) {
             for col in area.x..sep_col {
                 set_cell(buf, col, y, ' ', fg, row_bg);
             }
@@ -96,8 +113,9 @@ pub fn draw_activity_bar(
             set_cell(buf, content_start, y, icon_ch, fg, row_bg);
         }
 
-        // Keyboard selection highlight.
-        if item.is_keyboard_selected {
+        // Keyboard selection highlight — REVERSED fallback when no explicit
+        // `selection_bg`. Applied last so it overrides any earlier colour.
+        if item.is_keyboard_selected && sel_explicit_bg.is_none() {
             for col in area.x..sep_col {
                 let cell = &mut buf[(col, y)];
                 cell.modifier |= Modifier::REVERSED;

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -135,6 +135,13 @@ pub struct TuiBackend {
     /// `clear_selection_display` so Ctrl-A still targets the right
     /// region after Ctrl-C or a plain click.
     last_text_region_id: Option<WidgetId>,
+    /// `WidgetId` of the `ActivityBar` that declared `is_keyboard_focused`
+    /// during the most recent render pass. Set by `draw_activity_bar`;
+    /// cleared at the start of each frame by `begin_frame` (same lifecycle
+    /// as `text_regions`). When `Some`, `apply_dispatch` converts incoming
+    /// `KeyPressed` events to `UiEvent::ActivityBar(id, KeyPressed { … })`
+    /// so app logic receives activity-bar keys through a typed channel.
+    focused_activity_bar: Option<WidgetId>,
 }
 
 impl TuiBackend {
@@ -160,6 +167,7 @@ impl TuiBackend {
             active_selection: None,
             cached_selection_text: String::new(),
             last_text_region_id: None,
+            focused_activity_bar: None,
         }
     }
 
@@ -542,6 +550,29 @@ impl TuiBackend {
                         button,
                     ));
                 }
+                // When an ActivityBar has `is_keyboard_focused`, redirect
+                // raw `KeyPressed` events to it so the app receives
+                // `UiEvent::ActivityBar(id, KeyPressed { … })` instead of
+                // `UiEvent::KeyPressed { … }`. This runs before the
+                // accelerator pass so the bar can intercept any key.
+                // When an ActivityBar has `is_keyboard_focused`, redirect
+                // raw `KeyPressed` events to it so the app receives
+                // `UiEvent::ActivityBar(id, KeyPressed { … })` instead of
+                // `UiEvent::KeyPressed { … }`. This runs before the
+                // accelerator pass so the bar can intercept any key.
+                UiEvent::KeyPressed { key, modifiers, .. }
+                    if self.focused_activity_bar.is_some() =>
+                {
+                    let id = self.focused_activity_bar.clone().unwrap();
+                    let key_str = crate::primitives::activity_bar::key_to_activity_bar_string(&key);
+                    out.push(UiEvent::ActivityBar(
+                        id,
+                        crate::ActivityBarEvent::KeyPressed {
+                            key: key_str,
+                            modifiers,
+                        },
+                    ));
+                }
                 other => out.push(other),
             }
         }
@@ -701,6 +732,9 @@ impl Backend for TuiBackend {
         // Clear per-frame text regions so stale registrations from the
         // previous frame don't linger.
         self.text_regions.clear();
+        // Clear the focused activity bar — re-set by draw_activity_bar
+        // during the render pass if still focused.
+        self.focused_activity_bar = None;
     }
 
     fn register_text_region(&mut self, region: TextRegion) {
@@ -987,6 +1021,12 @@ impl Backend for TuiBackend {
         bar: &ActivityBar,
         hovered_idx: Option<usize>,
     ) -> Vec<crate::ActivityBarRowHit> {
+        // Track keyboard focus: if this bar declares `is_keyboard_focused`,
+        // record its id so `apply_dispatch` can convert incoming `KeyPressed`
+        // events to `UiEvent::ActivityBar(id, KeyPressed { … })`.
+        if bar.is_keyboard_focused {
+            self.focused_activity_bar = Some(bar.id.clone());
+        }
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
         let frame = self
@@ -2649,6 +2689,103 @@ mod tests {
         assert!(
             backend.active_text_selection().is_none(),
             "no selection should be set when select_all returns false"
+        );
+    }
+
+    // ── ActivityBar keyboard focus tests ─────────────────────────────────────
+
+    /// `begin_frame` clears the focused activity bar so stale state from
+    /// the previous render doesn't persist.
+    #[test]
+    fn focused_activity_bar_cleared_on_begin_frame() {
+        let mut backend = TuiBackend::new();
+        backend.focused_activity_bar = Some(WidgetId::new("demo:bar"));
+        backend.begin_frame(Viewport::default());
+        assert!(
+            backend.focused_activity_bar.is_none(),
+            "focused_activity_bar must be cleared by begin_frame"
+        );
+    }
+
+    /// When an `ActivityBar` with `is_keyboard_focused = true` is drawn,
+    /// `apply_dispatch` converts the next `KeyPressed` into
+    /// `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })`.
+    #[test]
+    fn activity_bar_focused_redirects_key_presses() {
+        use crate::ActivityBarEvent;
+
+        let mut backend = TuiBackend::new();
+        // Simulate the render pass recording a focused bar.
+        backend.focused_activity_bar = Some(WidgetId::new("demo:bar"));
+
+        let raw = vec![UiEvent::KeyPressed {
+            key: Key::Char('j'),
+            modifiers: Modifiers::default(),
+            repeat: false,
+        }];
+        let out = backend.apply_dispatch(raw);
+        assert_eq!(
+            out.len(),
+            1,
+            "one input event must produce one output event"
+        );
+        match &out[0] {
+            UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { key, modifiers }) => {
+                assert_eq!(id.as_str(), "demo:bar");
+                assert_eq!(key, "j");
+                assert_eq!(*modifiers, Modifiers::default());
+            }
+            other => panic!("expected UiEvent::ActivityBar KeyPressed, got {other:?}"),
+        }
+    }
+
+    /// Without a focused activity bar, raw `KeyPressed` events pass through
+    /// unchanged (no accidental interception).
+    #[test]
+    fn activity_bar_unfocused_passes_key_presses_through() {
+        let mut backend = TuiBackend::new();
+        // No focused bar.
+        assert!(backend.focused_activity_bar.is_none());
+
+        let raw = vec![UiEvent::KeyPressed {
+            key: Key::Char('j'),
+            modifiers: Modifiers::default(),
+            repeat: false,
+        }];
+        let out = backend.apply_dispatch(raw);
+        assert_eq!(out.len(), 1);
+        assert!(
+            matches!(
+                &out[0],
+                UiEvent::KeyPressed {
+                    key: Key::Char('j'),
+                    ..
+                }
+            ),
+            "key must pass through unchanged when no bar is focused"
+        );
+    }
+
+    /// `key_to_activity_bar_string` maps printable chars and common
+    /// named keys to their expected string forms.
+    #[test]
+    fn key_to_activity_bar_string_maps_correctly() {
+        use crate::primitives::activity_bar::key_to_activity_bar_string;
+
+        assert_eq!(key_to_activity_bar_string(&Key::Char('j')), "j");
+        assert_eq!(key_to_activity_bar_string(&Key::Char('K')), "K");
+        assert_eq!(
+            key_to_activity_bar_string(&Key::Named(NamedKey::Escape)),
+            "Escape"
+        );
+        assert_eq!(
+            key_to_activity_bar_string(&Key::Named(NamedKey::Enter)),
+            "Enter"
+        );
+        assert_eq!(key_to_activity_bar_string(&Key::Named(NamedKey::Up)), "Up");
+        assert_eq!(
+            key_to_activity_bar_string(&Key::Named(NamedKey::Down)),
+            "Down"
         );
     }
 }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -555,11 +555,6 @@ impl TuiBackend {
                 // `UiEvent::ActivityBar(id, KeyPressed { … })` instead of
                 // `UiEvent::KeyPressed { … }`. This runs before the
                 // accelerator pass so the bar can intercept any key.
-                // When an ActivityBar has `is_keyboard_focused`, redirect
-                // raw `KeyPressed` events to it so the app receives
-                // `UiEvent::ActivityBar(id, KeyPressed { … })` instead of
-                // `UiEvent::KeyPressed { … }`. This runs before the
-                // accelerator pass so the bar can intercept any key.
                 UiEvent::KeyPressed { key, modifiers, .. }
                     if self.focused_activity_bar.is_some() =>
                 {


### PR DESCRIPTION
Closes #368

Automated merge from the coordinator for assignment 2543bc3b8067 on issue #368.

Worker branch: `issue-368-activitybar-add-keyboard-focus-protocol` → `develop`.