### PR TITLE
#223: ButtonBar primitive: row of buttons with focus/hover states and hit-test

### DIFF
--- a/quadraui/examples/common/form_groups.rs
+++ b/quadraui/examples/common/form_groups.rs
@@ -170,6 +170,7 @@ impl FormGroupsApp {
                             },
                         ],
                         bg: None,
+                        focused_index: None,
                     }),
                     hint: StyledText::default(),
                     disabled: false,

--- a/quadraui/examples/common/sidebar_panel_app.rs
+++ b/quadraui/examples/common/sidebar_panel_app.rs
@@ -114,6 +114,7 @@ impl SidebarPanelApp {
                 },
             ],
             bg: None,
+            focused_index: None,
         }
     }
 

--- a/quadraui/examples/common/toolbar_app.rs
+++ b/quadraui/examples/common/toolbar_app.rs
@@ -8,9 +8,12 @@
 //! - A `Separator` between button groups
 //! - A non-clickable `Label` showing live state ("paused" / "running")
 //! - Hover state (highlight tracks the mouse cursor)
+//! - **Keyboard focus** (Tab / Shift-Tab cycles focus, Enter / Space activates)
 //!
 //! Controls:
 //! - Click an action button       fire it
+//! - Tab / Shift-Tab              move keyboard focus between enabled buttons
+//! - Enter / Space                activate the focused button
 //! - 1 / 2 / 3 / 4               keyboard shortcuts for the four enabled actions
 //! - q / Esc                     quit
 
@@ -33,6 +36,13 @@ pub struct ToolbarApp {
     /// `WidgetId` of the action currently held down by the user (between
     /// `MouseDown` and `MouseUp`). Drives the pressed highlight.
     pressed_id: Option<WidgetId>,
+    /// Index into `self.toolbar().buttons` of the keyboard-focused button,
+    /// or `None` when the toolbar has no keyboard focus.
+    ///
+    /// Tab / Shift-Tab advance this through the list of *enabled* action
+    /// buttons (skipping separators, labels, and disabled actions).
+    /// Enter / Space activate the focused button.
+    focused_index: Option<usize>,
 }
 
 impl ToolbarApp {
@@ -40,9 +50,10 @@ impl ToolbarApp {
         Self {
             filter_active: false,
             running: true,
-            last_message: "Click a button or press 1/2/3/4. q=quit".into(),
+            last_message: "Click, Tab to focus, Enter to activate. q=quit".into(),
             hovered_id: None,
             pressed_id: None,
+            focused_index: None,
         }
     }
 
@@ -114,6 +125,7 @@ impl ToolbarApp {
             ],
             // `None` lets the backend pick its theme default (header_bg).
             bg: None,
+            focused_index: self.focused_index,
         }
     }
 
@@ -171,6 +183,77 @@ impl ToolbarApp {
             }
         }
     }
+
+    /// Return the indices of all enabled `Action` buttons in the current
+    /// toolbar, in order. Used by Tab navigation to skip separators, labels,
+    /// and disabled actions.
+    fn focusable_indices(&self) -> Vec<usize> {
+        self.toolbar()
+            .buttons
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, btn)| match btn {
+                ToolbarButton::Action { enabled, .. } if enabled => Some(i),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Advance keyboard focus to the next (or previous) focusable button.
+    ///
+    /// `forward`: `true` for Tab, `false` for Shift-Tab.
+    ///
+    /// When no button has focus, Tab lands on the first focusable button;
+    /// Shift-Tab lands on the last. Focus wraps around.
+    fn advance_focus(&mut self, forward: bool) {
+        let candidates = self.focusable_indices();
+        if candidates.is_empty() {
+            return;
+        }
+        self.focused_index = Some(match self.focused_index {
+            None => {
+                if forward {
+                    candidates[0]
+                } else {
+                    *candidates.last().unwrap()
+                }
+            }
+            Some(current) => {
+                let pos = candidates.iter().position(|&i| i == current);
+                match pos {
+                    None => candidates[0], // stale index (e.g. button just disabled)
+                    Some(p) => {
+                        let next = if forward {
+                            (p + 1) % candidates.len()
+                        } else {
+                            (p + candidates.len() - 1) % candidates.len()
+                        };
+                        candidates[next]
+                    }
+                }
+            }
+        });
+    }
+
+    /// Activate the currently focused button (Enter / Space). No-op when
+    /// no button has focus.
+    fn activate_focused(&mut self) -> bool {
+        let idx = match self.focused_index {
+            Some(i) => i,
+            None => return false,
+        };
+        let bar = self.toolbar();
+        if let Some(btn) = bar.buttons.get(idx) {
+            if let ToolbarButton::Action { id, enabled, .. } = btn {
+                if *enabled {
+                    let id = id.clone();
+                    self.dispatch(&id);
+                    return true;
+                }
+            }
+        }
+        false
+    }
 }
 
 impl Default for ToolbarApp {
@@ -220,6 +303,7 @@ impl AppLogic for ToolbarApp {
 
     fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
         match event {
+            // ── Quit ──────────────────────────────────────────────────────────
             UiEvent::KeyPressed {
                 key: Key::Char('q'),
                 ..
@@ -229,6 +313,41 @@ impl AppLogic for ToolbarApp {
                 ..
             } => Reaction::Exit,
 
+            // ── Tab / Shift-Tab: cycle keyboard focus ──────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::Tab),
+                modifiers,
+                ..
+            } => {
+                let forward = !modifiers.shift;
+                self.advance_focus(forward);
+                let focused_label = self.focused_index.and_then(|idx| {
+                    let bar = self.toolbar();
+                    bar.buttons.into_iter().nth(idx).and_then(|btn| match btn {
+                        ToolbarButton::Action { label, .. } => Some(label),
+                        _ => None,
+                    })
+                });
+                self.last_message = match focused_label {
+                    Some(l) => format!("Focused: {l} (Enter to activate)"),
+                    None => "Focus cleared".into(),
+                };
+                Reaction::Redraw
+            }
+
+            // ── Enter / Space: activate focused button ─────────────────────
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::Enter) | Key::Char(' '),
+                ..
+            } => {
+                if self.activate_focused() {
+                    Reaction::Redraw
+                } else {
+                    Reaction::Continue
+                }
+            }
+
+            // ── Number shortcuts for individual buttons ────────────────────
             UiEvent::KeyPressed {
                 key: Key::Char(c), ..
             } => {
@@ -258,6 +377,7 @@ impl AppLogic for ToolbarApp {
                 Reaction::Continue
             }
 
+            // ── Mouse: hover / press / release ────────────────────────────
             UiEvent::MouseMoved { position, .. } => {
                 let rect = Self::toolbar_rect(backend);
                 let bar = self.toolbar();

--- a/quadraui/examples/common/toolbar_app.rs
+++ b/quadraui/examples/common/toolbar_app.rs
@@ -313,14 +313,34 @@ impl AppLogic for ToolbarApp {
                 ..
             } => Reaction::Exit,
 
-            // ── Tab / Shift-Tab: cycle keyboard focus ──────────────────────
+            // ── Tab: move keyboard focus forward ───────────────────────────
             UiEvent::KeyPressed {
                 key: Key::Named(NamedKey::Tab),
-                modifiers,
                 ..
             } => {
-                let forward = !modifiers.shift;
-                self.advance_focus(forward);
+                self.advance_focus(true);
+                let focused_label = self.focused_index.and_then(|idx| {
+                    let bar = self.toolbar();
+                    bar.buttons.into_iter().nth(idx).and_then(|btn| match btn {
+                        ToolbarButton::Action { label, .. } => Some(label),
+                        _ => None,
+                    })
+                });
+                self.last_message = match focused_label {
+                    Some(l) => format!("Focused: {l} (Enter to activate)"),
+                    None => "Focus cleared".into(),
+                };
+                Reaction::Redraw
+            }
+
+            // ── Shift-Tab (BackTab): move keyboard focus backward ──────────
+            // Real terminals (crossterm, GTK) send Shift-Tab as
+            // `NamedKey::BackTab` with no shift modifier — not as Tab + shift.
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::BackTab),
+                ..
+            } => {
+                self.advance_focus(false);
                 let focused_label = self.focused_index.and_then(|idx| {
                     let bar = self.toolbar();
                     bar.buttons.into_iter().nth(idx).and_then(|btn| match btn {

--- a/quadraui/src/compose/form_controller.rs
+++ b/quadraui/src/compose/form_controller.rs
@@ -822,6 +822,7 @@ mod tests {
                 },
             ],
             bg: None,
+            focused_index: None,
         });
 
         // Clicking the first button should emit ToolbarButtonClicked with
@@ -868,6 +869,7 @@ mod tests {
                 tooltip: String::new(),
             }],
             bg: None,
+            focused_index: None,
         });
 
         // form_click_event matches by id, not by enabled state.

--- a/quadraui/src/compose/toolbar_hover_tracker.rs
+++ b/quadraui/src/compose/toolbar_hover_tracker.rs
@@ -126,6 +126,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "A"), mk_action("b", "B")],
             bg: None,
+            focused_index: None,
         };
         bar.layout(0.0, 0.0, 40.0, 1.0, |_| ToolbarItemMeasure::new(6.0))
     }

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -2416,6 +2416,7 @@ mod tests {
                         },
                     ],
                     bg: None,
+                    focused_index: None,
                 }),
                 hint: StyledText::default(),
                 disabled: false,

--- a/quadraui/src/gtk/toolbar.rs
+++ b/quadraui/src/gtk/toolbar.rs
@@ -8,15 +8,22 @@
 //!
 //! ## Per-state colouring
 //!
+//! Priority (highest first): pressed → hovered → focused → is_active → enabled.
+//!
 //! | State              | Foreground             | Background           |
 //! |--------------------|------------------------|----------------------|
 //! | Action, enabled    | `theme.foreground`     | `bar_bg`             |
 //! | Action, disabled   | `theme.muted_fg`       | `bar_bg`             |
 //! | Action, is_active  | `theme.foreground`     | `theme.selected_bg`  |
+//! | Action, focused    | `theme.foreground`     | `bar_bg` + ring      |
 //! | Action, hovered    | `theme.hover_fg`       | `theme.hover_bg`     |
 //! | Action, pressed    | `theme.foreground`     | `theme.selected_bg`  |
 //! | Separator          | `theme.muted_fg`       | `bar_bg`             |
 //! | Label              | `Label.fg` or `muted`  | `bar_bg`             |
+//!
+//! Keyboard-focused buttons (via [`crate::primitives::toolbar::Toolbar::focused_index`])
+//! receive a `theme.accent_fg`-coloured rounded-rect stroke drawn on top of the
+//! button background. Hover / pressed still take visual priority over focus.
 //!
 //! `bar_bg` is `Toolbar.bg.unwrap_or(theme.header_bg)`.
 
@@ -174,8 +181,10 @@ pub fn draw_toolbar(
             } => {
                 let is_hovered = *enabled && hovered_id == Some(id);
                 let is_pressed = *enabled && pressed_id == Some(id);
+                let is_focused = *enabled && bar.focused_index == Some(vis.item_idx);
 
                 // Highlight background for hover/pressed/active states.
+                // Priority: pressed > hovered > focused > is_active.
                 let highlight = if is_pressed || *is_active {
                     Some(theme.selected_bg)
                 } else if is_hovered {
@@ -194,6 +203,22 @@ pub fn draw_toolbar(
                         CORNER_RADIUS,
                     );
                     cr.fill().ok();
+                }
+
+                // Focus ring: drawn when focused and not already
+                // visually dominated by hover or pressed highlight.
+                if is_focused && !is_hovered && !is_pressed && !*is_active {
+                    set_source(cr, theme.accent_fg);
+                    cr.set_line_width(1.0);
+                    rounded_rect_path(
+                        cr,
+                        item_x + 1.5,
+                        item_y + 1.5,
+                        item_w - 3.0,
+                        item_h - 3.0,
+                        CORNER_RADIUS,
+                    );
+                    cr.stroke().ok();
                 }
 
                 // Foreground.

--- a/quadraui/src/macos/toolbar.rs
+++ b/quadraui/src/macos/toolbar.rs
@@ -3,9 +3,13 @@
 //! Paints a horizontal strip of clickable action buttons using Core
 //! Graphics + Core Text. Mirrors the TUI / GTK rasterisers' look:
 //! enabled actions render in `theme.foreground`, disabled in
-//! `theme.muted_fg`, hovered actions get a `theme.hover_bg` tint, and
-//! active / pressed actions get `theme.selected_bg`. Separators draw
-//! as a thin vertical line; labels paint as plain text.
+//! `theme.muted_fg`, hovered actions get a `theme.hover_bg` tint,
+//! active / pressed actions get `theme.selected_bg`, and
+//! keyboard-focused actions (via `Toolbar::focused_index`) receive a
+//! `theme.accent_fg`-coloured rounded-rect focus ring. Separators
+//! draw as a thin vertical line; labels paint as plain text.
+//!
+//! Priority (highest first): pressed → hovered → focused → is_active → enabled.
 //!
 //! Per D6: layout policy lives in [`crate::primitives::toolbar::Toolbar::layout`];
 //! this rasteriser paints what that returns and provides the
@@ -129,7 +133,9 @@ pub unsafe fn draw_toolbar(
             } => {
                 let is_hovered = *enabled && hovered_id == Some(id);
                 let is_pressed = *enabled && pressed_id == Some(id);
+                let is_focused = *enabled && bar.focused_index == Some(vis.item_idx);
 
+                // Background fill: pressed/active > hovered > no fill.
                 if is_pressed || *is_active {
                     fill_rect(
                         ctx,
@@ -147,6 +153,18 @@ pub unsafe fn draw_toolbar(
                         item_w - 4.0,
                         item_h - 4.0,
                         theme.hover_bg,
+                    );
+                }
+
+                // Focus ring: drawn when focused and not already
+                // dominated by hover / pressed highlight.
+                if is_focused && !is_hovered && !is_pressed && !*is_active {
+                    set_stroke_color(ctx, theme.accent_fg);
+                    CGContextSetLineWidth(ctx, 1.0);
+                    // Simple rectangle focus ring (2 px inset on each side).
+                    CGContextStrokeRect(
+                        ctx,
+                        cgrect(item_x + 2.0, item_y + 2.0, item_w - 4.0, item_h - 4.0),
                     );
                 }
 
@@ -241,4 +259,5 @@ extern "C" {
         y: core_graphics::base::CGFloat,
     );
     fn CGContextStrokePath(c: CGContextRef);
+    fn CGContextStrokeRect(c: CGContextRef, rect: CGRect);
 }

--- a/quadraui/src/primitives/dialog.rs
+++ b/quadraui/src/primitives/dialog.rs
@@ -473,6 +473,7 @@ mod tests {
                 },
             ],
             bg: None,
+            focused_index: None,
         });
         let json = serde_json::to_string(&input).unwrap();
         let back: DialogInput = serde_json::from_str(&json).unwrap();
@@ -507,6 +508,7 @@ mod tests {
                 tooltip: String::new(),
             }],
             bg: None,
+            focused_index: None,
         })));
         let layout = d.layout(viewport(), measure_with_input(), |_| {
             ToolbarItemMeasure::new(10.0)
@@ -561,6 +563,7 @@ mod tests {
                 tooltip: String::new(),
             }],
             bg: None,
+            focused_index: None,
         })));
         let layout = d.layout(viewport(), measure_with_input(), |_| {
             ToolbarItemMeasure::new(60.0)

--- a/quadraui/src/primitives/sidebar_panel.rs
+++ b/quadraui/src/primitives/sidebar_panel.rs
@@ -264,6 +264,7 @@ mod tests {
                 id: WidgetId::new("sb:toolbar"),
                 buttons: vec![mk_action("a", "Refine"), mk_action("b", "Drop")],
                 bg: None,
+                focused_index: None,
             }),
             toolbar_height: None,
         }
@@ -316,6 +317,7 @@ mod tests {
                 id: WidgetId::new("sb:toolbar"),
                 buttons: vec![], // empty!
                 bg: None,
+                focused_index: None,
             }),
             toolbar_height: None,
         };

--- a/quadraui/src/primitives/toolbar.rs
+++ b/quadraui/src/primitives/toolbar.rs
@@ -71,6 +71,20 @@ pub struct Toolbar {
     /// toolbar reads as foreground chrome).
     #[serde(default)]
     pub bg: Option<Color>,
+    /// Index of the keyboard-focused button within [`Self::buttons`].
+    ///
+    /// When `Some(i)`, backends render the button at that index with a
+    /// distinct focus highlight (e.g. accent-coloured background on TUI,
+    /// a focus ring on GTK/macOS) so keyboard users know which button
+    /// Enter or Space will activate.
+    ///
+    /// The host app is responsible for advancing this via Tab / Shift-Tab
+    /// and activating via Enter / Space. Only `Action` buttons with
+    /// `enabled == true` should ever be assigned here; rasterisers skip
+    /// the focus highlight silently if the index points at a non-action
+    /// or disabled item.
+    #[serde(default)]
+    pub focused_index: Option<usize>,
 }
 
 /// One item in a [`Toolbar`].
@@ -317,6 +331,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![],
             bg: None,
+            focused_index: None,
         };
         let layout = bar.layout(0.0, 0.0, 80.0, 1.0, cell_measure());
         assert!(layout.visible_items.is_empty());
@@ -329,6 +344,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "Refine", true), mk_action("b", "Drop", true)],
             bg: None,
+            focused_index: None,
         };
         let layout = bar.layout(0.0, 0.0, 80.0, 1.0, cell_measure());
         assert_eq!(layout.visible_items.len(), 2);
@@ -345,6 +361,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("refine", "Refine", true)],
             bg: None,
+            focused_index: None,
         };
         let layout = bar.layout(0.0, 0.0, 80.0, 1.0, cell_measure());
         let r = layout.visible_items[0].bounds;
@@ -361,6 +378,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("refine", "Refine", false)],
             bg: None,
+            focused_index: None,
         };
         let layout = bar.layout(0.0, 0.0, 80.0, 1.0, cell_measure());
         assert!(!layout.visible_items[0].clickable);
@@ -380,6 +398,7 @@ mod tests {
                 },
             ],
             bg: None,
+            focused_index: None,
         };
         let layout = bar.layout(0.0, 0.0, 80.0, 1.0, cell_measure());
         assert!(!layout.visible_items[0].clickable);
@@ -407,6 +426,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_wide("a"), mk_wide("b")],
             bg: None,
+            focused_index: None,
         };
         // Use a fixed 6-cell measurer so the second button is clipped.
         let measure = |_: &ToolbarButton| ToolbarItemMeasure::new(6.0);
@@ -426,6 +446,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "X", true)],
             bg: None,
+            focused_index: None,
         };
         let layout = bar.layout(0.0, 0.0, 0.0, 1.0, cell_measure());
         assert_eq!(layout.visible_items.len(), 1);
@@ -441,6 +462,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "X", true)],
             bg: None,
+            focused_index: None,
         };
         let layout = bar.layout(10.0, 5.0, 80.0, 1.0, cell_measure());
         assert_eq!(layout.bar_bounds.x, 10.0);
@@ -481,6 +503,7 @@ mod tests {
                 },
             ],
             bg: Some(Color::rgb(40, 40, 40)),
+            focused_index: None,
         };
         let json = serde_json::to_string(&bar).unwrap();
         let back: Toolbar = serde_json::from_str(&json).unwrap();

--- a/quadraui/src/tui/dialog.rs
+++ b/quadraui/src/tui/dialog.rs
@@ -387,6 +387,7 @@ mod tests {
                     },
                 ],
                 bg: None,
+                focused_index: None,
             })),
         }
     }
@@ -505,6 +506,7 @@ mod tests {
                 ToolbarButton::Separator,
             ],
             bg: None,
+            focused_index: None,
         });
         let json = serde_json::to_string(&input).unwrap();
         let back: DialogInput = serde_json::from_str(&json).unwrap();

--- a/quadraui/src/tui/form.rs
+++ b/quadraui/src/tui/form.rs
@@ -1452,6 +1452,7 @@ mod tests {
                         },
                     ],
                     bg: None,
+                    focused_index: None,
                 }),
                 hint: label(""),
                 disabled: false,
@@ -1565,6 +1566,7 @@ mod tests {
                 ToolbarButton::Separator,
             ],
             bg: None,
+            focused_index: None,
         });
         let json = serde_json::to_string(&kind).unwrap();
         let back: FieldKind = serde_json::from_str(&json).unwrap();

--- a/quadraui/src/tui/sidebar_panel.rs
+++ b/quadraui/src/tui/sidebar_panel.rs
@@ -101,6 +101,7 @@ mod tests {
                     tooltip: String::new(),
                 }],
                 bg: None,
+                focused_index: None,
             }),
             toolbar_height: None,
         }

--- a/quadraui/src/tui/toolbar.rs
+++ b/quadraui/src/tui/toolbar.rs
@@ -6,17 +6,24 @@
 //!
 //! ## Per-state colouring
 //!
-//! | State              | Foreground             | Background         |
-//! |--------------------|------------------------|--------------------|
-//! | Action, enabled    | `theme.foreground`     | `bar_bg`           |
-//! | Action, disabled   | `theme.muted_fg`       | `bar_bg`           |
-//! | Action, is_active  | `theme.foreground`     | `theme.selected_bg`|
-//! | Action, hovered    | `theme.hover_fg`       | `theme.hover_bg`   |
-//! | Action, pressed    | `theme.foreground`     | `theme.selected_bg`|
-//! | Separator          | `theme.muted_fg`       | `bar_bg`           |
-//! | Label              | `Label.fg` or `muted_fg`| `bar_bg`          |
+//! Priority (highest first): pressed → hovered → focused → is_active → enabled.
+//!
+//! | State              | Foreground             | Background          |
+//! |--------------------|------------------------|---------------------|
+//! | Action, enabled    | `theme.foreground`     | `bar_bg`            |
+//! | Action, disabled   | `theme.muted_fg`       | `bar_bg`            |
+//! | Action, is_active  | `theme.foreground`     | `theme.selected_bg` |
+//! | Action, focused    | `theme.foreground`     | `theme.accent_bg`   |
+//! | Action, hovered    | `theme.hover_fg`       | `theme.hover_bg`    |
+//! | Action, pressed    | `theme.foreground`     | `theme.selected_bg` |
+//! | Separator          | `theme.muted_fg`       | `bar_bg`            |
+//! | Label              | `Label.fg` or `muted_fg`| `bar_bg`           |
 //!
 //! `bar_bg` is `Toolbar.bg.unwrap_or(theme.header_bg)`.
+//!
+//! Focus is set via [`crate::primitives::toolbar::Toolbar::focused_index`].
+//! The host app advances focus with Tab / Shift-Tab and activates with
+//! Enter / Space; this rasteriser is purely declarative.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -107,6 +114,7 @@ pub fn draw_toolbar(
     let hover_bg = qc(theme.hover_bg);
     let hover_fg = qc(theme.hover_fg);
     let active_bg = qc(theme.selected_bg);
+    let focus_bg = qc(theme.accent_bg);
 
     // Vertically centre text on rects taller than 1 row. With even
     // heights the row above centre wins (matches GTK's
@@ -142,12 +150,16 @@ pub fn draw_toolbar(
             } => {
                 let is_hovered = *enabled && hovered_id == Some(id);
                 let is_pressed = *enabled && pressed_id == Some(id);
+                let is_focused = *enabled && bar.focused_index == Some(vis.item_idx);
+                // Priority: pressed > hovered > focused > is_active > enabled.
                 let (cell_fg, cell_bg) = if !*enabled {
                     (muted, bar_bg)
                 } else if is_pressed || *is_active {
                     (fg, active_bg)
                 } else if is_hovered {
                     (hover_fg, hover_bg)
+                } else if is_focused {
+                    (fg, focus_bg)
                 } else {
                     (fg, bar_bg)
                 };
@@ -263,6 +275,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "Refine", true)],
             bg: None,
+            focused_index: None,
         };
         let _layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         // First two cells should be `[` then ` `.
@@ -278,6 +291,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "Refine", true), mk_action("b", "Drop", true)],
             bg: None,
+            focused_index: None,
         };
         let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         // Click inside the first button.
@@ -304,6 +318,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "Refine", false)],
             bg: None,
+            focused_index: None,
         };
         let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         let b = layout.visible_items[0].bounds;
@@ -318,6 +333,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![ToolbarButton::Separator],
             bg: None,
+            focused_index: None,
         };
         let _layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         // First cell is space, second is the pipe char.
@@ -336,6 +352,7 @@ mod tests {
                 fg: None,
             }],
             bg: None,
+            focused_index: None,
         };
         let _layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         assert_eq!(cell_char(&buf, 0, 0), '2');
@@ -352,6 +369,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "X", true)],
             bg: None,
+            focused_index: None,
         };
         let _ = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         assert_eq!(cell_char(&buf, 0, 0), ' ');
@@ -369,6 +387,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "Go", true)],
             bg: None,
+            focused_index: None,
         };
         let _ = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
 
@@ -401,6 +420,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "Go", true)],
             bg: None,
+            focused_index: None,
         };
         let _ = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         // Row 1 col 0 should be `[`.
@@ -418,6 +438,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![mk_action("a", "Go", true)],
             bg: None,
+            focused_index: None,
         };
         let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         let r = layout.visible_items[0].bounds;
@@ -440,6 +461,7 @@ mod tests {
             id: WidgetId::new("tb"),
             buttons: vec![ToolbarButton::Separator],
             bg: None,
+            focused_index: None,
         };
         let _ = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         // The │ glyph should appear on every row at column 1.
@@ -469,6 +491,7 @@ mod tests {
                 tooltip: String::new(),
             }],
             bg: None,
+            focused_index: None,
         };
         let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         assert_eq!(layout.visible_items[0].bounds.width, 5.0);
@@ -499,6 +522,7 @@ mod tests {
                 tooltip: String::new(),
             }],
             bg: None,
+            focused_index: None,
         };
         let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         // "[ " (2) + icon (2 cells) + " " (1) + "Go" (2) + " ]" (2) = 9

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -482,26 +482,25 @@ fn toolbar_tab_cycles_through_enabled_buttons() {
 fn toolbar_shift_tab_goes_backward() {
     // Pressing Tab then Shift-Tab should move focus forward then back,
     // ending up on the same button as the first Tab.
+    //
+    // Shift-Tab is dispatched as `NamedKey::BackTab` (no shift modifier) —
+    // that is exactly what crossterm, GTK, and macOS backends emit for the
+    // real Shift-Tab keypress. Using BackTab here covers the real terminal
+    // path and prevents the false-green that a synthetic Tab+shift event
+    // would produce (Tab+shift was swallowed silently by the old handler).
     let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
 
     driver.press_named(NamedKey::Tab);
     let after_tab = driver.screen();
 
     driver.press_named(NamedKey::Tab);
-    // Now focused on the second button — Shift-Tab should go back.
-    driver.dispatch(quadraui::UiEvent::KeyPressed {
-        key: quadraui::Key::Named(NamedKey::Tab),
-        modifiers: quadraui::Modifiers {
-            shift: true,
-            ..Default::default()
-        },
-        repeat: false,
-    });
+    // Now focused on the second button — BackTab should go back to the first.
+    driver.press_named(NamedKey::BackTab);
 
     let after_shift_tab = driver.screen();
     assert_eq!(
         after_tab, after_shift_tab,
-        "Shift-Tab should return focus to the same button Tab first landed on"
+        "Shift-Tab (BackTab) should return focus to the same button Tab first landed on"
     );
 }
 

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -12,6 +12,10 @@
 use quadraui::tui::testing::{driver_with_shell, TuiDriver};
 use quadraui::NamedKey;
 
+#[path = "../examples/common/toolbar_app.rs"]
+mod toolbar_app;
+use toolbar_app::ToolbarApp;
+
 #[path = "../examples/common/demo.rs"]
 mod demo;
 #[path = "../examples/common/mini_app.rs"]
@@ -417,4 +421,143 @@ fn tab_group_q_exits() {
     let mut driver = TuiDriver::new(TabGroupDemo::new(), 120, 30);
     driver.type_char('q');
     assert!(driver.exited(), "'q' should exit the tab group demo");
+}
+
+// ─── ToolbarApp: focus, Tab, Enter, click ───────────────────────────────────
+
+#[test]
+fn toolbar_initial_screen_paints_action_buttons() {
+    // Confirm the four action-button labels are all visible after the
+    // first render — no interaction required.
+    let driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+    let screen = driver.screen();
+    assert!(driver.screen_contains("Pause"), "Pause button:\n{screen}");
+    assert!(driver.screen_contains("Filter"), "Filter button:\n{screen}");
+    assert!(driver.screen_contains("Reset"), "Reset button:\n{screen}");
+    // "Debug" is disabled but must still be visible (dimmed).
+    assert!(
+        driver.screen_contains("Debug"),
+        "Debug (disabled) button:\n{screen}"
+    );
+}
+
+#[test]
+fn toolbar_tab_moves_focus_to_first_enabled_button() {
+    // Initially no button is focused. First Tab should land on the first
+    // *enabled* action button (index 1: "Pause", because "Continue" starts
+    // disabled when running == true).
+    let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+    driver.press_named(NamedKey::Tab);
+    // Status bar should confirm what was focused.
+    assert!(
+        driver.screen_contains("Focused:"),
+        "after Tab the status should say 'Focused: …':\n{}",
+        driver.screen()
+    );
+}
+
+#[test]
+fn toolbar_tab_cycles_through_enabled_buttons() {
+    // Pressing Tab repeatedly should cycle focus through all enabled buttons
+    // and eventually wrap back to the first one. We don't assert exact order
+    // here — just that each Tab changes the status message.
+    let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+
+    driver.press_named(NamedKey::Tab);
+    let after_tab1 = driver.screen();
+    driver.press_named(NamedKey::Tab);
+    let after_tab2 = driver.screen();
+    driver.press_named(NamedKey::Tab);
+    let after_tab3 = driver.screen();
+
+    // Each Tab should produce a different status line (focus moved).
+    assert_ne!(
+        after_tab1, after_tab2,
+        "second Tab should move focus to a different button"
+    );
+    assert_ne!(after_tab2, after_tab3, "third Tab should move focus again");
+}
+
+#[test]
+fn toolbar_shift_tab_goes_backward() {
+    // Pressing Tab then Shift-Tab should move focus forward then back,
+    // ending up on the same button as the first Tab.
+    let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+
+    driver.press_named(NamedKey::Tab);
+    let after_tab = driver.screen();
+
+    driver.press_named(NamedKey::Tab);
+    // Now focused on the second button — Shift-Tab should go back.
+    driver.dispatch(quadraui::UiEvent::KeyPressed {
+        key: quadraui::Key::Named(NamedKey::Tab),
+        modifiers: quadraui::Modifiers {
+            shift: true,
+            ..Default::default()
+        },
+        repeat: false,
+    });
+
+    let after_shift_tab = driver.screen();
+    assert_eq!(
+        after_tab, after_shift_tab,
+        "Shift-Tab should return focus to the same button Tab first landed on"
+    );
+}
+
+#[test]
+fn toolbar_enter_activates_focused_button() {
+    // Tab to first focused button (Pause in the default running==true
+    // state), then Enter — the status bar should reflect the Pause action.
+    let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+    driver.press_named(NamedKey::Tab);
+    // First focused button when running==true is "Pause" (index 1).
+    driver.press_named(NamedKey::Enter);
+    assert!(
+        driver.screen_contains("Paused"),
+        "Enter on focused Pause button should show 'Paused' in status:\n{}",
+        driver.screen()
+    );
+}
+
+#[test]
+fn toolbar_disabled_buttons_skipped_by_tab() {
+    // The "Debug" button is always disabled. Tab should never produce
+    // a status line that says "Focused: Debug".
+    let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+    // Press Tab enough times to wrap around all focusable buttons.
+    for _ in 0..10 {
+        driver.press_named(NamedKey::Tab);
+        assert!(
+            !driver.screen_contains("Focused: Debug"),
+            "Tab must never focus the disabled Debug button:\n{}",
+            driver.screen()
+        );
+    }
+}
+
+#[test]
+fn toolbar_click_fires_action_without_focus() {
+    // Clicking a visible button directly (no Tab needed) should fire the
+    // action — hover/click path is independent of keyboard focus.
+    let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+
+    let before = driver.screen();
+    let (x, y) = driver
+        .find("Filter")
+        .unwrap_or_else(|| panic!("Filter button must be visible:\n{before}"));
+    driver.click(x, y);
+
+    assert!(
+        driver.screen_contains("Filter"),
+        "clicking Filter should update the status:\n{}",
+        driver.screen()
+    );
+}
+
+#[test]
+fn toolbar_q_exits() {
+    let mut driver = TuiDriver::new(ToolbarApp::new(), 120, 10);
+    driver.type_char('q');
+    assert!(driver.exited(), "'q' should exit the toolbar demo");
 }


### PR DESCRIPTION
Closes #223

Automated merge from the coordinator for assignment 4d1dc32cfb5e on issue #223.

Worker branch: `issue-223-buttonbar-primitive-row-of-buttons-with` → `develop`.