### PR TITLE
#375: TabGroupController: TUI drag-start panics / causes exit when beginning a tab drag

### DIFF
--- a/quadraui/examples/common/tab_group_demo.rs
+++ b/quadraui/examples/common/tab_group_demo.rs
@@ -278,7 +278,15 @@ impl AppLogic for TabGroupDemo {
                 }
                 // Promote a pending tab drag to an active drag once the cursor
                 // has moved far enough from the press point.
-                if let Some((sx, sy)) = *self.tab_drag_pending_pos.borrow() {
+                //
+                // Copy the pending position into a local variable so the
+                // immutable `Ref` returned by `.borrow()` is dropped
+                // immediately (at the `;`), before any `borrow_mut()` call
+                // inside the block. Keeping the `Ref` alive in the `if let`
+                // scrutinee and then calling `borrow_mut()` in the same block
+                // panics with "RefCell already borrowed" (#375).
+                let pending_pos = *self.tab_drag_pending_pos.borrow();
+                if let Some((sx, sy)) = pending_pos {
                     let dx = (position.x - sx).abs();
                     let dy = (position.y - sy).abs();
                     if dx > TAB_DRAG_THRESHOLD || dy > TAB_DRAG_THRESHOLD {

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -560,3 +560,40 @@ fn toolbar_q_exits() {
     driver.type_char('q');
     assert!(driver.exited(), "'q' should exit the toolbar demo");
 }
+
+/// Regression test for #375.
+///
+/// Before the fix, crossing `TAB_DRAG_THRESHOLD` during a `MouseMoved` event
+/// panicked with "RefCell already borrowed":
+/// `if let Some((sx, sy)) = *self.tab_drag_pending_pos.borrow()` held an
+/// immutable `Ref` alive for the whole block, and the subsequent
+/// `*self.tab_drag_pending_pos.borrow_mut() = None` inside that block tried
+/// to create a mutable borrow of the same `RefCell`, which panics at runtime.
+///
+/// After the fix the pending position is copied into a local `let` binding
+/// (dropping the `Ref` immediately), so the mutable borrow succeeds.
+#[test]
+fn tab_group_drag_start_does_not_panic() {
+    let mut driver = TuiDriver::new(TabGroupDemo::new(), 120, 30);
+    let before = driver.screen();
+    let (x, y) = driver
+        .find("main.rs")
+        .unwrap_or_else(|| panic!("main.rs tab not found:\n{before}"));
+
+    // MouseDown on the tab primes the drag (sets tab_drag_pending_pos).
+    driver.mouse_down(x, y);
+    assert!(!driver.exited(), "mouse_down should not cause exit");
+
+    // MouseMove past TAB_DRAG_THRESHOLD promotes the pending drag to an
+    // active drag. Before the fix this panicked; after it succeeds and
+    // causes a redraw (status shows "tab drag start").
+    driver.mouse_move(x + 3.0, y);
+    assert!(
+        !driver.exited(),
+        "mouse_move into drag should not cause exit"
+    );
+
+    // MouseUp completes the drag cycle without further panic.
+    driver.mouse_up(x + 3.0, y);
+    assert!(!driver.exited(), "mouse_up should not cause exit");
+}


### PR DESCRIPTION
Closes #375

Automated merge from the coordinator for assignment 98def04f0ba7 on issue #375.

Worker branch: `issue-375-tabgroupcontroller-tui-drag-start-panics` → `develop`.