### PR TITLE
#386: AppShell: keyboard-selectable activity bar (j/k across view icons + activate) — promote vimcode's pattern off the raw primitive

### DIFF
--- a/quadraui/examples/common/shell_app.rs
+++ b/quadraui/examples/common/shell_app.rs
@@ -12,7 +12,8 @@
 //! - click activity bar icons   toggle / switch panels
 //! - drag divider               resize sidebar
 //! - click sidebar rows         select row
-//! - `Tab` / `Shift+Tab`        cycle sidebar sections
+//! - `Tab`                       focus activity bar (j/k/Enter/Esc to navigate)
+//! - `Shift+Tab`                cycle sidebar sections
 //! - `↑` / `↓`                  scroll / select in sidebar
 //! - `q` / `Esc`                quit
 

--- a/quadraui/examples/common/shell_app.rs
+++ b/quadraui/examples/common/shell_app.rs
@@ -18,9 +18,9 @@
 
 use quadraui::compose::app_shell::{AppShell, AppShellEvent, PanelDefinition};
 use quadraui::{
-    AppLogic, Backend, Color, Decoration, Key, NamedKey, NavigationMode, Reaction, Rect,
-    SectionSize, SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBar, StatusBarSegment,
-    StyledText, TreePath, TreeRow, UiEvent, WidgetId,
+    ActivityBarEvent, AppLogic, Backend, Color, Decoration, Key, NamedKey, NavigationMode,
+    Reaction, Rect, SectionSize, SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBar,
+    StatusBarSegment, StyledText, TreeRow, UiEvent, WidgetId,
 };
 
 pub struct ShellApp {
@@ -77,7 +77,7 @@ impl ShellApp {
             explorer,
             search,
             git,
-            last_message: "Click activity bar icons | drag divider | q to quit".into(),
+            last_message: "Tab=focus bar | click icons | drag divider | q=quit".into(),
         }
     }
 
@@ -103,8 +103,17 @@ impl ShellApp {
 
     fn status_bar(&self) -> StatusBar {
         let fg = Color::rgb(220, 220, 220);
-        let bg = Color::rgb(0, 122, 204);
+        let bg = if self.shell.activity_keyboard_focused() {
+            Color::rgb(80, 60, 130)
+        } else {
+            Color::rgb(0, 122, 204)
+        };
         let dim_bg = Color::rgb(30, 30, 40);
+        let hint = if self.shell.activity_keyboard_focused() {
+            " j/k=move  l/Enter=activate  Esc=dismiss ".into()
+        } else {
+            " Tab=focus bar  q=quit ".into()
+        };
         StatusBar {
             id: WidgetId::new("shell-status"),
             left_segments: vec![StatusBarSegment {
@@ -115,7 +124,7 @@ impl ShellApp {
                 action_id: None,
             }],
             right_segments: vec![StatusBarSegment {
-                text: " q=quit | click icons | drag divider ".into(),
+                text: hint,
                 fg: Color::rgb(180, 180, 180),
                 bg: dim_bg,
                 bold: false,
@@ -215,6 +224,81 @@ impl AppLogic for ShellApp {
             }
             AppShellEvent::Consumed => return Reaction::Redraw,
             AppShellEvent::Ignored => {}
+        }
+
+        // ── Activity-bar keyboard navigation ─────────────────────────────
+        // When the bar is focused the backend emits ActivityBar events
+        // instead of raw KeyPressed; the consumer maps key strings to the
+        // AppShell navigation methods.
+        if let UiEvent::ActivityBar(_, ActivityBarEvent::KeyPressed { ref key, .. }) = event {
+            match key.as_str() {
+                "j" | "Down" => {
+                    self.shell.activity_select_next();
+                    self.last_message = format!(
+                        "Bar cursor → {}",
+                        self.shell
+                            .activity_selected_id()
+                            .map(|id| id.as_str())
+                            .unwrap_or("?")
+                    );
+                    return Reaction::Redraw;
+                }
+                "k" | "Up" => {
+                    self.shell.activity_select_prev();
+                    self.last_message = format!(
+                        "Bar cursor → {}",
+                        self.shell
+                            .activity_selected_id()
+                            .map(|id| id.as_str())
+                            .unwrap_or("?")
+                    );
+                    return Reaction::Redraw;
+                }
+                "l" | "Enter" => {
+                    if let Some(ev) = self.shell.activity_activate_selected() {
+                        self.shell.set_activity_keyboard_focused(false);
+                        match ev {
+                            AppShellEvent::PanelChanged { ref panel_id } => {
+                                self.last_message = format!("Panel: {}", panel_id.as_str());
+                            }
+                            AppShellEvent::SidebarHidden => {
+                                self.last_message = "Sidebar hidden".into();
+                            }
+                            AppShellEvent::BottomItemClicked { ref id } => {
+                                self.last_message = format!("Settings clicked ({})", id.as_str());
+                            }
+                            _ => {}
+                        }
+                    }
+                    return Reaction::Redraw;
+                }
+                "Escape" | "h" | "Left" => {
+                    self.shell.set_activity_keyboard_focused(false);
+                    self.last_message = "Focus returned to editor".into();
+                    return Reaction::Redraw;
+                }
+                _ => return Reaction::Continue,
+            }
+        }
+
+        // ── Tab → focus the activity bar ─────────────────────────────────
+        if let UiEvent::KeyPressed {
+            key: Key::Named(NamedKey::Tab),
+            ..
+        } = event
+        {
+            if !self.shell.activity_keyboard_focused() {
+                self.shell.set_activity_keyboard_focused(true);
+                self.shell.activity_set_cursor(0);
+                self.last_message = format!(
+                    "Activity bar focused ({})",
+                    self.shell
+                        .activity_selected_id()
+                        .map(|id| id.as_str())
+                        .unwrap_or("?")
+                );
+                return Reaction::Redraw;
+            }
         }
 
         // Forward events to the active sidebar panel.

--- a/quadraui/examples/common/shell_app.rs
+++ b/quadraui/examples/common/shell_app.rs
@@ -278,6 +278,10 @@ impl AppLogic for ShellApp {
                     self.last_message = "Focus returned to editor".into();
                     return Reaction::Redraw;
                 }
+                // Honour the global quit key even while the bar is focused
+                // so users are not stranded (the bar hints do not show q=quit
+                // when focused, but muscle memory is hard to break).
+                "q" => return Reaction::Exit,
                 _ => return Reaction::Continue,
             }
         }

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -388,6 +388,8 @@ impl AppShell {
     /// Unregister a panel by ID. Returns `true` if found and removed.
     /// Adjusts `active_panel` to keep the same panel selected (or clears
     /// it if the active panel was the one removed).
+    /// Also adjusts `activity_cursor` analogously so keyboard navigation
+    /// remains consistent after a dynamic removal.
     pub fn remove_panel(&mut self, id: &WidgetId) -> bool {
         let Some(idx) = self.panels.iter().position(|p| p.id == *id) else {
             return false;
@@ -404,6 +406,20 @@ impl AppShell {
             Some(a) if a > idx => Some(a - 1),
             other => other,
         };
+        // Mirror the same shift logic for the keyboard cursor. The removed
+        // panel occupied combined-index `idx`; everything after it shifts
+        // down by one.
+        let total = self.panels.len() + self.bottom_items.len();
+        if total == 0 {
+            self.activity_cursor = 0;
+            self.activity_keyboard_focused = false;
+        } else if self.activity_cursor > idx {
+            self.activity_cursor -= 1;
+        } else if self.activity_cursor == idx {
+            // The cursor was on the removed panel; clamp to the new range.
+            self.activity_cursor = self.activity_cursor.min(total - 1);
+        }
+        // activity_cursor < idx: no change needed.
         true
     }
 
@@ -419,11 +435,28 @@ impl AppShell {
     }
 
     /// Unregister a bottom item by ID.
+    /// Adjusts `activity_cursor` so keyboard navigation remains consistent
+    /// after a dynamic removal (mirrors `remove_panel`'s treatment of
+    /// `active_panel`).
     pub fn remove_bottom_item(&mut self, id: &WidgetId) -> bool {
         let Some(idx) = self.bottom_items.iter().position(|p| p.id == *id) else {
             return false;
         };
+        // Bottom items begin at combined index `np` in the top-then-bottom
+        // sequence, so the removed item's combined index is `np + idx`.
+        let np = self.panels.len();
+        let combined_idx = np + idx;
         self.bottom_items.remove(idx);
+        let total = np + self.bottom_items.len();
+        if total == 0 {
+            self.activity_cursor = 0;
+            self.activity_keyboard_focused = false;
+        } else if self.activity_cursor > combined_idx {
+            self.activity_cursor -= 1;
+        } else if self.activity_cursor == combined_idx {
+            self.activity_cursor = self.activity_cursor.min(total - 1);
+        }
+        // activity_cursor < combined_idx: no change needed.
         true
     }
 
@@ -1497,6 +1530,93 @@ mod tests {
     fn remove_nonexistent_panel_returns_false() {
         let mut s = shell();
         assert!(!s.remove_panel(&WidgetId::new("panel:nope")));
+    }
+
+    // ── activity_cursor adjustment on remove ────────────────────────
+
+    #[test]
+    fn remove_panel_before_cursor_shifts_cursor_down() {
+        // shell() has 3 panels (explorer=0, search=1, git=2) + 1 bottom (settings=3).
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        s.activity_set_cursor(2); // pointing at git (index 2)
+        s.remove_panel(&WidgetId::new("panel:explorer")); // remove index 0
+                                                          // cursor was > 0, so should decrement to 1 (still pointing at git)
+        assert_eq!(s.activity_cursor, 1);
+        assert_eq!(s.activity_selected_id(), Some(&WidgetId::new("panel:git")));
+    }
+
+    #[test]
+    fn remove_panel_after_cursor_leaves_cursor_unchanged() {
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        s.activity_set_cursor(0); // pointing at explorer (index 0)
+        s.remove_panel(&WidgetId::new("panel:search")); // remove index 1 (after cursor)
+        assert_eq!(s.activity_cursor, 0);
+        assert_eq!(
+            s.activity_selected_id(),
+            Some(&WidgetId::new("panel:explorer"))
+        );
+    }
+
+    #[test]
+    fn remove_panel_at_cursor_clamps_cursor() {
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        s.activity_set_cursor(2); // pointing at git (last panel, index 2)
+        s.remove_panel(&WidgetId::new("panel:git")); // remove the cursor item
+                                                     // New total = 2 panels + 1 bottom = 3; cursor was 2, clamped to 2.
+                                                     // Now index 2 is the bottom item (settings).
+        assert_eq!(s.activity_cursor, 2);
+        assert_eq!(
+            s.activity_selected_id(),
+            Some(&WidgetId::new("panel:settings"))
+        );
+    }
+
+    #[test]
+    fn remove_last_panel_while_focused_clears_focus() {
+        let mut s = AppShell::new(
+            vec![PanelDefinition {
+                id: WidgetId::new("panel:only"),
+                icon: "O".into(),
+                tooltip: "Only".into(),
+                title: "ONLY".into(),
+            }],
+            30.0,
+        );
+        s.set_activity_keyboard_focused(true);
+        s.remove_panel(&WidgetId::new("panel:only"));
+        assert!(!s.activity_keyboard_focused());
+        assert_eq!(s.activity_cursor, 0);
+    }
+
+    #[test]
+    fn remove_bottom_item_before_cursor_leaves_cursor_unchanged() {
+        // shell(): panels 0,1,2; bottom item at combined index 3.
+        // cursor at 3 (settings), remove settings → cursor was at removed item,
+        // clamp to new total (3 panels + 0 bottom = 3, but 3 is out of range → 2).
+        // This test checks cursor BEFORE the bottom item first.
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        s.activity_set_cursor(1); // pointing at search (panel index 1)
+        s.remove_bottom_item(&WidgetId::new("panel:settings")); // remove bottom at combined 3
+        assert_eq!(s.activity_cursor, 1); // cursor was before removed item
+        assert_eq!(
+            s.activity_selected_id(),
+            Some(&WidgetId::new("panel:search"))
+        );
+    }
+
+    #[test]
+    fn remove_bottom_item_at_cursor_clamps_cursor() {
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        s.activity_set_cursor(3); // pointing at settings (combined index 3)
+        s.remove_bottom_item(&WidgetId::new("panel:settings"));
+        // New total = 3; cursor was 3, clamped to 2 (last panel).
+        assert_eq!(s.activity_cursor, 2);
+        assert_eq!(s.activity_selected_id(), Some(&WidgetId::new("panel:git")));
     }
 
     #[test]

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -103,6 +103,19 @@ pub struct AppShell {
     /// which takes `&self`.
     cached_activity_hits: RefCell<Vec<ActivityBarRowHit>>,
     cached_activity_bar_bounds: RefCell<Option<Rect>>,
+    // ── Keyboard navigation state ─────────────────────────────────
+    /// Whether the activity bar currently holds keyboard focus. When
+    /// `true`, `build_activity_bar()` sets `is_keyboard_focused = true`
+    /// on the emitted [`ActivityBar`], causing the TUI and GTK backends
+    /// to redirect [`crate::UiEvent::KeyPressed`] events to
+    /// [`crate::UiEvent::ActivityBar`] events — so navigation logic
+    /// stays entirely in the consumer.
+    activity_keyboard_focused: bool,
+    /// Cursor position in the **logical item sequence**: top panels
+    /// (indices `0..panels.len()`) followed by bottom items
+    /// (indices `panels.len()..panels.len()+bottom_items.len()`).
+    /// Saturates at the ends; does not wrap.
+    activity_cursor: usize,
 }
 
 impl AppShell {
@@ -132,6 +145,8 @@ impl AppShell {
             bottom_panel_drag_offset: None,
             cached_activity_hits: RefCell::new(Vec::new()),
             cached_activity_bar_bounds: RefCell::new(None),
+            activity_keyboard_focused: false,
+            activity_cursor: 0,
         }
     }
 
@@ -212,6 +227,85 @@ impl AppShell {
 
     pub fn hovered_activity_idx(&self) -> Option<usize> {
         self.hovered_activity_idx
+    }
+
+    // ── Activity-bar keyboard navigation ─────────────────────────────
+
+    /// Returns `true` when the activity bar currently holds keyboard focus.
+    ///
+    /// When `true`, `build_activity_bar()` sets `is_keyboard_focused = true`
+    /// on the emitted [`ActivityBar`], causing both the TUI and GTK backends
+    /// to deliver key presses as
+    /// `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })` rather
+    /// than raw `UiEvent::KeyPressed`. The consumer maps those key strings to
+    /// the navigation methods below.
+    pub fn activity_keyboard_focused(&self) -> bool {
+        self.activity_keyboard_focused
+    }
+
+    /// Focus or unfocus the activity bar. Pair with
+    /// [`Self::activity_keyboard_focused`] and the navigation methods to
+    /// implement keyboard nav in a `ShellApp` consumer.
+    ///
+    /// Calling this does **not** reset the cursor — the cursor stays where
+    /// it was so repeated focus/blur round-trips feel natural. To reset to
+    /// the top item on focus, call
+    /// `set_activity_keyboard_focused(true)` then `activity_set_cursor(0)`.
+    pub fn set_activity_keyboard_focused(&mut self, focused: bool) {
+        self.activity_keyboard_focused = focused;
+    }
+
+    /// Move the keyboard cursor to the next item in the logical sequence
+    /// (top panels first, then bottom items). **Saturates** at the last
+    /// item — does not wrap to the top.
+    pub fn activity_select_next(&mut self) {
+        let total = self.panels.len() + self.bottom_items.len();
+        if total > 0 {
+            self.activity_cursor = (self.activity_cursor + 1).min(total - 1);
+        }
+    }
+
+    /// Move the keyboard cursor to the previous item. **Saturates** at
+    /// index 0 — does not wrap to the bottom.
+    pub fn activity_select_prev(&mut self) {
+        self.activity_cursor = self.activity_cursor.saturating_sub(1);
+    }
+
+    /// Set the keyboard cursor to an explicit index in the logical sequence.
+    /// Out-of-range values are clamped to the valid range `[0, total-1]`.
+    /// Has no effect when the panel + bottom-item lists are both empty.
+    pub fn activity_set_cursor(&mut self, idx: usize) {
+        let total = self.panels.len() + self.bottom_items.len();
+        if total > 0 {
+            self.activity_cursor = idx.min(total - 1);
+        }
+    }
+
+    /// Returns the [`WidgetId`] of the item currently under the keyboard
+    /// cursor, or `None` if there are no items at all.
+    ///
+    /// The logical sequence is top panels (`0..panels.len()`) followed by
+    /// bottom items (`panels.len()..`).
+    pub fn activity_selected_id(&self) -> Option<&WidgetId> {
+        let np = self.panels.len();
+        if self.activity_cursor < np {
+            Some(&self.panels[self.activity_cursor].id)
+        } else {
+            let bi = self.activity_cursor - np;
+            self.bottom_items.get(bi).map(|p| &p.id)
+        }
+    }
+
+    /// Activate the item currently under the keyboard cursor and return
+    /// the resulting [`AppShellEvent`], or `None` if there are no items.
+    ///
+    /// Equivalent to clicking the cursor item: top-panel items trigger the
+    /// same toggle / switch logic as a mouse click, bottom items emit
+    /// [`AppShellEvent::BottomItemClicked`]. Does **not** clear keyboard
+    /// focus — the consumer decides whether to do that.
+    pub fn activity_activate_selected(&mut self) -> Option<AppShellEvent> {
+        let id = self.activity_selected_id()?.clone();
+        Some(self.handle_activity_click(&id))
     }
 
     // ── Programmatic state control ───────────────────────────────────
@@ -342,7 +436,18 @@ impl AppShell {
     }
 
     /// Build the [`ActivityBar`] primitive from current panel state.
+    ///
+    /// When [`Self::activity_keyboard_focused`] is `true`:
+    /// - `ActivityBar::is_keyboard_focused` is set to `true`, causing both
+    ///   the TUI and GTK backends to route key events as
+    ///   `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })`.
+    /// - The item at [`Self::activity_cursor`] (in the top-then-bottom
+    ///   logical sequence) has `is_keyboard_selected = true`, painting the
+    ///   selection ring on that icon.
     pub fn build_activity_bar(&self) -> ActivityBar {
+        let np = self.panels.len();
+        let focused = self.activity_keyboard_focused;
+
         let top_items: Vec<ActivityItem> = self
             .panels
             .iter()
@@ -352,19 +457,20 @@ impl AppShell {
                 icon: p.icon.clone(),
                 tooltip: p.tooltip.clone(),
                 is_active: self.active_panel == Some(i) && self.sidebar_visible,
-                is_keyboard_selected: false,
+                is_keyboard_selected: focused && self.activity_cursor == i,
             })
             .collect();
 
         let bottom_items: Vec<ActivityItem> = self
             .bottom_items
             .iter()
-            .map(|p| ActivityItem {
+            .enumerate()
+            .map(|(j, p)| ActivityItem {
                 id: p.id.clone(),
                 icon: p.icon.clone(),
                 tooltip: p.tooltip.clone(),
                 is_active: false,
-                is_keyboard_selected: false,
+                is_keyboard_selected: focused && self.activity_cursor == np + j,
             })
             .collect();
 
@@ -374,7 +480,7 @@ impl AppShell {
             bottom_items,
             active_accent: None,
             selection_bg: None,
-            is_keyboard_focused: false,
+            is_keyboard_focused: focused,
         }
     }
 
@@ -1015,6 +1121,188 @@ mod tests {
         let bar = s.build_activity_bar();
         assert_eq!(bar.bottom_items.len(), 1);
         assert_eq!(bar.bottom_items[0].id, WidgetId::new("panel:settings"));
+    }
+
+    // ── Keyboard navigation ─────────────────────────────────────────
+
+    #[test]
+    fn keyboard_focus_off_by_default() {
+        let s = shell();
+        assert!(!s.activity_keyboard_focused());
+        let bar = s.build_activity_bar();
+        assert!(!bar.is_keyboard_focused);
+        assert!(bar.top_items.iter().all(|i| !i.is_keyboard_selected));
+        assert!(bar.bottom_items.iter().all(|i| !i.is_keyboard_selected));
+    }
+
+    #[test]
+    fn set_keyboard_focused_propagates_to_bar() {
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        assert!(s.activity_keyboard_focused());
+        let bar = s.build_activity_bar();
+        assert!(bar.is_keyboard_focused);
+    }
+
+    #[test]
+    fn build_activity_bar_marks_cursor_item_when_focused() {
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        // Default cursor = 0 (first top panel).
+        let bar = s.build_activity_bar();
+        assert!(bar.top_items[0].is_keyboard_selected);
+        assert!(!bar.top_items[1].is_keyboard_selected);
+        assert!(!bar.top_items[2].is_keyboard_selected);
+        assert!(!bar.bottom_items[0].is_keyboard_selected);
+    }
+
+    #[test]
+    fn build_activity_bar_no_selection_when_not_focused() {
+        let mut s = shell();
+        s.activity_cursor = 1;
+        // focused is false → no item should be selected
+        let bar = s.build_activity_bar();
+        assert!(bar.top_items.iter().all(|i| !i.is_keyboard_selected));
+    }
+
+    #[test]
+    fn select_next_advances_cursor_through_top_then_bottom() {
+        let mut s = shell(); // 3 top + 1 bottom
+        s.set_activity_keyboard_focused(true);
+        // cursor starts at 0
+        s.activity_select_next(); // → 1
+        assert_eq!(s.activity_cursor, 1);
+        s.activity_select_next(); // → 2
+        assert_eq!(s.activity_cursor, 2);
+        s.activity_select_next(); // → 3 (first bottom item)
+        assert_eq!(s.activity_cursor, 3);
+
+        let bar = s.build_activity_bar();
+        assert!(bar.bottom_items[0].is_keyboard_selected);
+        assert!(bar.top_items.iter().all(|i| !i.is_keyboard_selected));
+    }
+
+    #[test]
+    fn select_next_saturates_at_last_item() {
+        let mut s = shell(); // total = 4
+        s.set_activity_keyboard_focused(true);
+        for _ in 0..10 {
+            s.activity_select_next();
+        }
+        // Should saturate at 3 (last index: 3 top + 1 bottom − 1 = 3).
+        assert_eq!(s.activity_cursor, 3);
+    }
+
+    #[test]
+    fn select_prev_saturates_at_zero() {
+        let mut s = shell();
+        // cursor is already at 0
+        s.activity_select_prev();
+        assert_eq!(s.activity_cursor, 0);
+        s.activity_select_prev();
+        assert_eq!(s.activity_cursor, 0);
+    }
+
+    #[test]
+    fn select_prev_moves_cursor_up() {
+        let mut s = shell();
+        s.activity_cursor = 3; // bottom item
+        s.activity_select_prev();
+        assert_eq!(s.activity_cursor, 2);
+        s.activity_select_prev();
+        assert_eq!(s.activity_cursor, 1);
+        s.activity_select_prev();
+        assert_eq!(s.activity_cursor, 0);
+        s.activity_select_prev(); // saturates
+        assert_eq!(s.activity_cursor, 0);
+    }
+
+    #[test]
+    fn activity_set_cursor_clamps_to_valid_range() {
+        let mut s = shell(); // 4 items total
+        s.activity_set_cursor(100);
+        assert_eq!(s.activity_cursor, 3);
+        s.activity_set_cursor(0);
+        assert_eq!(s.activity_cursor, 0);
+    }
+
+    #[test]
+    fn activity_selected_id_top_items() {
+        let s = shell();
+        // cursor at 0 → first top panel
+        assert_eq!(
+            s.activity_selected_id(),
+            Some(&WidgetId::new("panel:explorer"))
+        );
+    }
+
+    #[test]
+    fn activity_selected_id_bottom_item() {
+        let mut s = shell();
+        s.activity_cursor = 3; // first (and only) bottom item
+        assert_eq!(
+            s.activity_selected_id(),
+            Some(&WidgetId::new("panel:settings"))
+        );
+    }
+
+    #[test]
+    fn activity_activate_selected_top_panel_emits_panel_changed() {
+        let mut s = shell();
+        s.activity_cursor = 1; // panel:search
+        let ev = s.activity_activate_selected().expect("should return Some");
+        assert_eq!(
+            ev,
+            AppShellEvent::PanelChanged {
+                panel_id: WidgetId::new("panel:search")
+            }
+        );
+        assert_eq!(s.active_panel_id(), Some(&WidgetId::new("panel:search")));
+    }
+
+    #[test]
+    fn activity_activate_selected_bottom_item_emits_bottom_clicked() {
+        let mut s = shell();
+        s.activity_cursor = 3; // panel:settings
+        let ev = s.activity_activate_selected().expect("should return Some");
+        assert_eq!(
+            ev,
+            AppShellEvent::BottomItemClicked {
+                id: WidgetId::new("panel:settings")
+            }
+        );
+    }
+
+    #[test]
+    fn activity_activate_selected_toggle_hides_sidebar() {
+        let mut s = shell();
+        // cursor at 0 (panel:explorer), which is already the active panel
+        let ev = s.activity_activate_selected().expect("should return Some");
+        assert_eq!(ev, AppShellEvent::SidebarHidden);
+        assert!(!s.sidebar_visible());
+    }
+
+    #[test]
+    fn activity_activate_does_not_clear_keyboard_focus() {
+        let mut s = shell();
+        s.set_activity_keyboard_focused(true);
+        s.activity_cursor = 1;
+        let _ = s.activity_activate_selected();
+        // Consumer decides whether to clear focus; AppShell must not.
+        assert!(s.activity_keyboard_focused());
+    }
+
+    #[test]
+    fn activity_activate_selected_returns_none_when_no_items() {
+        let mut s = AppShell::new(vec![], 30.0);
+        assert!(s.activity_activate_selected().is_none());
+    }
+
+    #[test]
+    fn select_next_noop_on_empty_shell() {
+        let mut s = AppShell::new(vec![], 30.0);
+        s.activity_select_next(); // must not panic
+        assert_eq!(s.activity_cursor, 0);
     }
 
     // ── Programmatic state control ──────────────────────────────────

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -12,6 +12,10 @@
 use quadraui::tui::testing::{driver_with_shell, TuiDriver};
 use quadraui::NamedKey;
 
+#[path = "../examples/common/shell_app.rs"]
+mod shell_app_ex;
+use shell_app_ex::ShellApp as ShellAppEx;
+
 #[path = "../examples/common/toolbar_app.rs"]
 mod toolbar_app;
 use toolbar_app::ToolbarApp;
@@ -739,6 +743,54 @@ fn palette_dual_mode_typing_in_input_mode_updates_query() {
     );
 }
 
+// ─── ShellApp: AppShell keyboard activity-bar nav (#386) ────────────────────
+//
+// `ShellApp` uses `AppShell` (not the raw `ActivityBar` primitive directly).
+// These tests verify that the new keyboard navigation API (`set_activity_keyboard_focused`,
+// `activity_select_next/prev`, `activity_activate_selected`) is correctly wired
+// through `AppShell::build_activity_bar()` → TUI backend → `UiEvent::ActivityBar`
+// → `ShellApp::handle()` round-trip.
+
+#[test]
+fn shell_app_initial_screen_shows_hint() {
+    let driver = TuiDriver::new(ShellAppEx::new(), 100, 30);
+    let screen = driver.screen();
+    // The default hint instructs the user to press Tab to focus the bar.
+    assert!(
+        driver.screen_contains("Tab") || driver.screen_contains("quit"),
+        "initial screen should show keyboard hint:\n{screen}"
+    );
+    // No navigation hint yet.
+    assert!(
+        !driver.screen_contains("j/k"),
+        "j/k hint must not appear before bar is focused:\n{screen}"
+    );
+}
+
+#[test]
+fn shell_app_tab_focuses_activity_bar() {
+    // Pressing Tab must focus the activity bar: the status bar switches
+    // from the default message to "Activity bar focused (…)".
+    let mut driver = TuiDriver::new(ShellAppEx::new(), 100, 30);
+    let before = driver.screen();
+
+    driver.press_named(NamedKey::Tab);
+    let after = driver.screen();
+
+    assert_ne!(before, after, "Tab should change the screen");
+    assert!(
+        driver.screen_contains("Activity bar focused"),
+        "after Tab the status should say 'Activity bar focused (…)':\n{}",
+        driver.screen()
+    );
+    // j/k hint should appear now that the bar is focused.
+    assert!(
+        driver.screen_contains("j/k"),
+        "j/k hint should appear while bar is focused:\n{}",
+        driver.screen()
+    );
+}
+
 #[test]
 fn palette_dual_mode_escape_closes_picker() {
     let mut driver = TuiDriver::new(PaletteDualModeApp::new(), 100, 30);
@@ -748,5 +800,108 @@ fn palette_dual_mode_escape_closes_picker() {
     assert!(
         !driver.screen_contains("[L]") && !driver.screen_contains("[I]"),
         "mode badge should disappear after Escape:\n{screen}"
+    );
+}
+
+#[test]
+fn shell_app_j_moves_cursor_down() {
+    // After Tab, typing 'j' moves the cursor from the first to the second
+    // top panel. The status bar echoes the new cursor position.
+    let mut driver = TuiDriver::new(ShellAppEx::new(), 100, 30);
+    driver.press_named(NamedKey::Tab); // focus bar (cursor = 0: panel:explorer)
+    let after_tab = driver.screen();
+
+    driver.type_char('j'); // cursor moves to panel:search
+    let after_j = driver.screen();
+
+    assert_ne!(after_tab, after_j, "'j' should change the screen");
+    assert!(
+        driver.screen_contains("panel:search"),
+        "after 'j' the status should mention panel:search:\n{}",
+        driver.screen()
+    );
+}
+
+#[test]
+fn shell_app_k_moves_cursor_up() {
+    // Move down twice then up once — cursor should land on the second item.
+    let mut driver = TuiDriver::new(ShellAppEx::new(), 100, 30);
+    driver.press_named(NamedKey::Tab);
+    driver.type_char('j'); // cursor → panel:search
+    driver.type_char('j'); // cursor → panel:git
+    driver.type_char('k'); // cursor → panel:search
+    assert!(
+        driver.screen_contains("panel:search"),
+        "after j j k cursor should be on panel:search:\n{}",
+        driver.screen()
+    );
+}
+
+#[test]
+fn shell_app_enter_activates_and_dismisses_focus() {
+    // Tab (focus) → j (move to panel:search) → Enter (activate).
+    // After activation: focus is cleared and the active panel is panel:search.
+    let mut driver = TuiDriver::new(ShellAppEx::new(), 100, 30);
+    driver.press_named(NamedKey::Tab);
+    driver.type_char('j'); // cursor → panel:search
+    driver.press_named(NamedKey::Enter); // activate
+
+    let screen = driver.screen();
+    // Status bar should now show the panel that was activated.
+    assert!(
+        screen.contains("panel:search"),
+        "after Enter the status should show the activated panel:\n{screen}"
+    );
+    // Navigation hint should be gone — bar is no longer focused.
+    assert!(
+        !screen.contains("j/k"),
+        "j/k hint should disappear after activation:\n{screen}"
+    );
+}
+
+#[test]
+fn shell_app_esc_dismisses_without_activating() {
+    // Tab (focus, cursor = panel:explorer already active) → Esc (dismiss).
+    // Active panel must not change; focus hint must disappear.
+    let mut driver = TuiDriver::new(ShellAppEx::new(), 100, 30);
+    driver.press_named(NamedKey::Tab);
+    driver.type_char('j'); // move so we know we'd switch if we activated
+    driver.press_named(NamedKey::Escape);
+
+    let screen = driver.screen();
+    // Focus hint gone.
+    assert!(
+        !screen.contains("j/k"),
+        "j/k hint should disappear after Esc:\n{screen}"
+    );
+    // Status bar should say focus was returned.
+    assert!(
+        screen.contains("Focus returned"),
+        "after Esc status should say 'Focus returned to editor':\n{screen}"
+    );
+}
+
+#[test]
+fn shell_app_k_saturates_at_first_item() {
+    // Pressing k at the top must not move past the first item (no panic,
+    // cursor stays on the first panel). The status message updates to
+    // mention the cursor position — still the first panel.
+    let mut driver = TuiDriver::new(ShellAppEx::new(), 100, 30);
+    driver.press_named(NamedKey::Tab); // cursor = 0 (panel:explorer)
+    driver.type_char('k'); // should saturate — cursor still at panel:explorer
+
+    // The cursor stayed on panel:explorer, not wrapped to the bottom.
+    assert!(
+        driver.screen_contains("panel:explorer"),
+        "'k' at top should keep cursor on panel:explorer (saturates, not wraps):\n{}",
+        driver.screen()
+    );
+    // Critically, we must NOT see panel:settings (the bottom item) since
+    // saturation means k at position 0 stays at 0, not wraps to last item.
+    // (This distinguishes saturate from wrap.)
+    assert!(
+        !driver.screen_contains("panel:settings"),
+        "'k' at top must NOT wrap to the bottom item:\n{}",
+        driver.screen()
     );
 }


### PR DESCRIPTION
Closes #386

Automated merge from the coordinator for assignment 653f05e49f69 on issue #386.

Worker branch: `issue-386-appshell-keyboard-selectable-activity-ba` → `develop`.