### PR TITLE
#391: Add Backend::set_nerd_fonts() to trait so ShellApp::render_content can sync icon-font flag

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -78,6 +78,18 @@ pub trait Backend {
     /// `draw_*` calls consume the updated palette.
     fn set_theme(&mut self, _theme: crate::Theme) {}
 
+    /// Sync the nerd-fonts flag so icon-bearing surfaces (`draw_tree`,
+    /// `draw_multi_section_view`, etc.) render `Icon::glyph` when `true`
+    /// and `Icon::fallback` when `false`.
+    ///
+    /// Call at the start of `render_content()` (or once from `setup()` if
+    /// the setting is static) so that the runner-owned backend picks up the
+    /// app's preference before any draw calls are made.
+    ///
+    /// Default: no-op. Backends that always use one icon form (e.g. a
+    /// headless test backend) can accept this default.
+    fn set_nerd_fonts(&mut self, _enabled: bool) {}
+
     // ─── Text selection ────────────────────────────────────────────────
     /// Register a selectable text region for the current frame.
     ///

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -200,13 +200,6 @@ impl GtkBackend {
         }
     }
 
-    /// Update the cached nerd-font flag. Call from the app's settings
-    /// or per-frame sync (vimcode does this in
-    /// `App::update::CacheFontMetrics`).
-    pub fn set_nerd_fonts(&mut self, enabled: bool) {
-        self.nerd_fonts_enabled = enabled;
-    }
-
     /// Update the cached UI font description string (Pango format,
     /// e.g. `"Cantarell 11"`). Call from the app's settings sync.
     pub fn set_ui_font(&mut self, ui_font: impl Into<String>) {
@@ -806,6 +799,10 @@ impl Backend for GtkBackend {
 
     fn set_theme(&mut self, theme: crate::Theme) {
         self.set_current_theme(theme);
+    }
+
+    fn set_nerd_fonts(&mut self, enabled: bool) {
+        self.nerd_fonts_enabled = enabled;
     }
 
     fn poll_events(&mut self) -> Vec<UiEvent> {

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -229,14 +229,6 @@ impl TuiBackend {
         self.current_theme = theme;
     }
 
-    /// Toggle Nerd Font glyph rendering for primitives that vary
-    /// based on font availability. Apps wire this from their own
-    /// settings (vimcode reads `engine.settings.use_nerd_fonts`;
-    /// kubeui has its own setting).
-    pub fn set_nerd_fonts(&mut self, enabled: bool) {
-        self.nerd_fonts_enabled = enabled;
-    }
-
     /// Disjoint mutable borrows of drag state and modal stack.
     /// `mouse.rs::handle_mouse` needs both at the same time, and
     /// borrowing each field through a separate `&mut self` accessor
@@ -787,6 +779,10 @@ impl Backend for TuiBackend {
 
     fn set_theme(&mut self, theme: crate::Theme) {
         self.set_current_theme(theme);
+    }
+
+    fn set_nerd_fonts(&mut self, enabled: bool) {
+        self.nerd_fonts_enabled = enabled;
     }
 
     fn poll_events(&mut self) -> Vec<UiEvent> {


### PR DESCRIPTION
Closes #391

Automated merge from the coordinator for assignment 7810ac2afca8 on issue #391.

Worker branch: `issue-391-add-backend-set-nerd-fonts-to-trait-so-s` → `develop`.