### PR TITLE
#393: TabGroupController: add a constructor/insert API for arbitrary mixed-direction split trees

### DIFF
--- a/quadraui/examples/common/tab_group_demo.rs
+++ b/quadraui/examples/common/tab_group_demo.rs
@@ -14,11 +14,14 @@
 //!   `Left`/`Right` edges create a horizontal split;
 //!   `Top`/`Bottom` edges create a vertical split.
 //! - Tab / Shift+Tab to cycle focus between panes.
+//! - **`f`** — rebuild via `from_layout`: 3 panes in a mixed H/V tree
+//!   (`left | (top-right / bottom-right)`). Tests the new constructor.
+//! - **`r`** — reset to the default 2-pane horizontal layout.
 //! - `q` / Esc to quit.
 
 use std::cell::RefCell;
 
-use quadraui::compose::tab_group::{PaneTab, TabGroupController, TabGroupEvent};
+use quadraui::compose::tab_group::{GroupLayout, Pane, PaneTab, TabGroupController, TabGroupEvent};
 use quadraui::{
     AppLogic, Backend, Color, Key, Modifiers, NamedKey, Reaction, Rect, SplitDirection, StatusBar,
     StatusBarSegment, UiEvent, WidgetId,
@@ -65,6 +68,115 @@ fn lbl(text: &str, bg: Color) -> Box<LabelContent> {
     })
 }
 
+// ── Layout builders ───────────────────────────────────────────────────────────
+
+/// Default layout: two panes side-by-side (horizontal), built via the
+/// incremental `with_pane` / `add_pane_with_tab` API.
+fn make_default_group() -> TabGroupController {
+    let mut group = TabGroupController::with_pane(
+        "pane:0",
+        vec![
+            PaneTab {
+                id: "p0:t0".into(),
+                label: " main.rs ".into(),
+                closable: true,
+                content: lbl("main.rs content", Color::rgb(30, 40, 60)),
+            },
+            PaneTab {
+                id: "p0:t1".into(),
+                label: " lib.rs ".into(),
+                closable: true,
+                content: lbl("lib.rs content", Color::rgb(40, 30, 60)),
+            },
+        ],
+        "p0:t0",
+        SplitDirection::Horizontal,
+    );
+    group.add_pane_with_tab(
+        "pane:1",
+        PaneTab {
+            id: "p1:t0".into(),
+            label: " Cargo.toml ".into(),
+            closable: true,
+            content: lbl("Cargo.toml content", Color::rgb(30, 60, 40)),
+        },
+    );
+    group.focus_pane(0);
+    group
+}
+
+/// Mixed-direction layout built via `from_layout`:
+///
+/// ```text
+///  ┌──────────┬──────────┐
+///  │          │  top.rs  │
+///  │  left.rs ├──────────┤
+///  │          │bottom.rs │
+///  └──────────┴──────────┘
+/// ```
+///
+/// Root split is Horizontal (left | right); the right sub-tree is Vertical
+/// (top-right / bottom-right).  This is the layout that was impossible to
+/// express before `from_layout` was added.
+fn make_from_layout_group() -> TabGroupController {
+    let layout = GroupLayout::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(GroupLayout::Leaf(0)),
+        second: Box::new(GroupLayout::Split {
+            direction: SplitDirection::Vertical,
+            ratio: 0.5,
+            first: Box::new(GroupLayout::Leaf(1)),
+            second: Box::new(GroupLayout::Leaf(2)),
+        }),
+    };
+    TabGroupController::from_layout(
+        vec![
+            Pane::new(
+                "pane:left",
+                vec![
+                    PaneTab {
+                        id: "left:t0".into(),
+                        label: " left.rs ".into(),
+                        closable: true,
+                        content: lbl("left pane (pane 0)", Color::rgb(30, 40, 60)),
+                    },
+                    PaneTab {
+                        id: "left:t1".into(),
+                        label: " app.rs ".into(),
+                        closable: true,
+                        content: lbl("app.rs — left pane tab 2", Color::rgb(20, 50, 70)),
+                    },
+                ],
+                "left:t0",
+            ),
+            Pane::new(
+                "pane:top-right",
+                vec![PaneTab {
+                    id: "tr:t0".into(),
+                    label: " top.rs ".into(),
+                    closable: true,
+                    content: lbl("top-right pane (pane 1)", Color::rgb(60, 30, 40)),
+                }],
+                "tr:t0",
+            ),
+            Pane::new(
+                "pane:bottom-right",
+                vec![PaneTab {
+                    id: "br:t0".into(),
+                    label: " bottom.rs ".into(),
+                    closable: true,
+                    content: lbl("bottom-right pane (pane 2)", Color::rgb(30, 60, 30)),
+                }],
+                "br:t0",
+            ),
+        ],
+        layout,
+        SplitDirection::Horizontal,
+    )
+    .expect("from_layout: layout is structurally valid")
+}
+
 // ── App ───────────────────────────────────────────────────────────────────────
 
 pub struct TabGroupDemo {
@@ -87,41 +199,10 @@ pub struct TabGroupDemo {
 
 impl TabGroupDemo {
     pub fn new() -> Self {
-        let mut group = TabGroupController::with_pane(
-            "pane:0",
-            vec![
-                PaneTab {
-                    id: "p0:t0".into(),
-                    label: " main.rs ".into(),
-                    closable: true,
-                    content: lbl("main.rs content", Color::rgb(30, 40, 60)),
-                },
-                PaneTab {
-                    id: "p0:t1".into(),
-                    label: " lib.rs ".into(),
-                    closable: true,
-                    content: lbl("lib.rs content", Color::rgb(40, 30, 60)),
-                },
-            ],
-            "p0:t0",
-            SplitDirection::Horizontal,
-        );
-
-        group.add_pane_with_tab(
-            "pane:1",
-            PaneTab {
-                id: "p1:t0".into(),
-                label: " Cargo.toml ".into(),
-                closable: true,
-                content: lbl("Cargo.toml content", Color::rgb(30, 60, 40)),
-            },
-        );
-        group.focus_pane(0);
-
         Self {
-            group: RefCell::new(group),
+            group: RefCell::new(make_default_group()),
             last_event: RefCell::new(
-                "click tabs | drag divider | drag tab to edge/pane | Tab=focus | q=quit".into(),
+                "click tabs · drag divider · drag tab to edge/pane · Tab=focus · f=from_layout · r=reset · q=quit".into(),
             ),
             last_bounds: RefCell::new(Rect::new(0.0, 0.0, 100.0, 20.0)),
             divider_dragging: RefCell::new(false),
@@ -199,6 +280,39 @@ impl AppLogic for TabGroupDemo {
                 *self.tab_dragging.borrow_mut() = false;
                 *self.tab_drag_pending_pos.borrow_mut() = None;
                 Reaction::Exit
+            }
+
+            // ── from_layout demo (f) / reset (r) ──────────────────
+            UiEvent::KeyPressed {
+                key: Key::Char('f'),
+                ..
+            } => {
+                // Rebuild the controller from an explicit mixed-direction tree:
+                //   left pane | (top-right pane / bottom-right pane)
+                // The root split is Horizontal; the right sub-tree is Vertical.
+                // This layout was impossible to construct before from_layout.
+                *self.group.borrow_mut() = make_from_layout_group();
+                *self.last_event.borrow_mut() =
+                    "from_layout: left | (top-right / bottom-right) — drag/click/Tab to verify"
+                        .into();
+                *self.divider_dragging.borrow_mut() = false;
+                *self.tab_dragging.borrow_mut() = false;
+                *self.tab_drag_pending_pos.borrow_mut() = None;
+                Reaction::Redraw
+            }
+
+            UiEvent::KeyPressed {
+                key: Key::Char('r'),
+                ..
+            } => {
+                // Reset to the default 2-pane horizontal layout (with_pane API).
+                *self.group.borrow_mut() = make_default_group();
+                *self.last_event.borrow_mut() =
+                    "reset to default 2-pane layout (with_pane API)".into();
+                *self.divider_dragging.borrow_mut() = false;
+                *self.tab_dragging.borrow_mut() = false;
+                *self.tab_drag_pending_pos.borrow_mut() = None;
+                Reaction::Redraw
             }
 
             // ── Focus cycling ──────────────────────────────────────

--- a/quadraui/examples/tui_tabgroup.rs
+++ b/quadraui/examples/tui_tabgroup.rs
@@ -1,7 +1,8 @@
 //! `TabGroupController` demo (TUI backend).
 //!
 //! Two split panes, each with its own tab bar. Demonstrates tab
-//! switching, closing, new-tab, pane focus, and divider dragging.
+//! switching, closing, new-tab, pane focus, divider dragging, and
+//! the `from_layout` constructor for mixed-direction split trees.
 //!
 //! ```sh
 //! cargo run --example tui_tabgroup --features tui
@@ -17,6 +18,9 @@
 //! - drag tab to a pane's edge   — split off a new adjacent pane
 //! - drag tab within its strip   — reorder tabs in the same pane
 //! - Tab / Shift+Tab             — cycle focus
+//! - f                           — rebuild via `from_layout`: 3 panes,
+//!                                 mixed H/V tree (left | top-right/bottom-right)
+//! - r                           — reset to the default 2-pane layout
 //! - q / Esc                     — quit
 
 #[path = "common/mod.rs"]

--- a/quadraui/src/compose/mod.rs
+++ b/quadraui/src/compose/mod.rs
@@ -55,6 +55,8 @@ pub use sidebar_system::{
     NavigationMode, SectionKind, SidebarEvent, SidebarSectionDef, SidebarSystem,
 };
 pub use status_bar_interaction::{StatusBarAction, StatusBarInteraction};
-pub use tab_group::{GroupLayout, PaneTab, TabGroupController, TabGroupEvent, TabGroupLayout};
+pub use tab_group::{
+    GroupLayout, Pane, PaneTab, TabGroupController, TabGroupEvent, TabGroupLayout,
+};
 pub use toolbar_hover_tracker::ToolbarHoverTracker;
 pub use tree_controller::{TreeController, TreeControllerEvent};

--- a/quadraui/src/compose/tab_group.rs
+++ b/quadraui/src/compose/tab_group.rs
@@ -39,7 +39,44 @@
 //! }
 //! ```
 //!
-//! # Adding panes
+//! # Building multi-pane layouts
+//!
+//! For simple cases, [`TabGroupController::add_pane_with_tab`] opens a new
+//! pane splitting the focused pane in the controller's default direction.
+//!
+//! When your app already knows the full layout — especially when it mixes
+//! horizontal and vertical splits — use
+//! [`TabGroupController::from_layout`] to hand the tree over directly:
+//!
+//! ```ignore
+//! use quadraui::compose::tab_group::{Pane, PaneTab, TabGroupController, GroupLayout};
+//! use quadraui::SplitDirection;
+//!
+//! // Three panes: left | (top-right / bottom-right)
+//! //   Pane 0 on the left, pane 1 top-right, pane 2 bottom-right.
+//! let layout = GroupLayout::Split {
+//!     direction: SplitDirection::Horizontal,
+//!     ratio: 0.5,
+//!     first: Box::new(GroupLayout::Leaf(0)),
+//!     second: Box::new(GroupLayout::Split {
+//!         direction: SplitDirection::Vertical,
+//!         ratio: 0.5,
+//!         first: Box::new(GroupLayout::Leaf(1)),
+//!         second: Box::new(GroupLayout::Leaf(2)),
+//!     }),
+//! };
+//! let ctrl = TabGroupController::from_layout(
+//!     vec![
+//!         Pane::new("pane:0", vec![/* tabs */], "t0"),
+//!         Pane::new("pane:1", vec![/* tabs */], "t1"),
+//!         Pane::new("pane:2", vec![/* tabs */], "t2"),
+//!     ],
+//!     layout,
+//!     SplitDirection::Horizontal,
+//! ).expect("layout must cover every pane index exactly once");
+//! ```
+//!
+//! # Adding panes incrementally
 //!
 //! [`TabGroupController::add_pane_with_tab`] opens a new pane, splitting the
 //! focused pane evenly. Panes are separated by draggable
@@ -192,6 +229,51 @@ impl GroupLayout {
         }
     }
 
+    /// Collect all leaf values into `out` (in-order traversal).
+    fn collect_leaves(&self, out: &mut Vec<usize>) {
+        match self {
+            GroupLayout::Leaf(k) => out.push(*k),
+            GroupLayout::Split { first, second, .. } => {
+                first.collect_leaves(out);
+                second.collect_leaves(out);
+            }
+        }
+    }
+
+    /// Validate that the tree is a bijection onto `0..n`.
+    ///
+    /// Returns `Ok(())` when every index in `0..n` appears exactly once as a
+    /// leaf. Returns `Err` with a descriptive message otherwise.
+    fn validate_for_pane_count(&self, n: usize) -> Result<(), String> {
+        let mut leaves = Vec::with_capacity(n);
+        self.collect_leaves(&mut leaves);
+
+        if leaves.len() != n {
+            return Err(format!(
+                "layout has {} leaf nodes but {} panes were provided",
+                leaves.len(),
+                n
+            ));
+        }
+
+        let mut seen = vec![false; n];
+        for &idx in &leaves {
+            if idx >= n {
+                return Err(format!(
+                    "leaf index {idx} is out of range for {n} panes (indices must be 0..{n})"
+                ));
+            }
+            if seen[idx] {
+                return Err(format!(
+                    "leaf index {idx} appears more than once in the layout"
+                ));
+            }
+            seen[idx] = true;
+        }
+
+        Ok(())
+    }
+
     /// Shift all leaf indices >= `threshold` up by one.
     ///
     /// Use before inserting a new pane into the middle of the vec.
@@ -306,7 +388,18 @@ pub struct Pane {
 }
 
 impl Pane {
-    fn new(id: impl Into<String>, tabs: Vec<PaneTab>, active_tab_id: impl Into<String>) -> Self {
+    /// Construct a new pane.
+    ///
+    /// `active_tab_id` is resolved against `tabs`; when the named tab is absent
+    /// the first tab's id is used as the fallback.
+    ///
+    /// Primarily used with [`TabGroupController::from_layout`] to build a
+    /// controller from an explicit split tree.
+    pub fn new(
+        id: impl Into<String>,
+        tabs: Vec<PaneTab>,
+        active_tab_id: impl Into<String>,
+    ) -> Self {
         let active_tab_id = active_tab_id.into();
         // Fallback to first tab when the named one is absent.
         let resolved = if tabs.iter().any(|t| t.id == active_tab_id) {
@@ -602,6 +695,83 @@ impl TabGroupController {
             dragging_divider: None,
             dragging_tab: None,
         }
+    }
+
+    /// Construct a controller from an explicit pane list and layout tree.
+    ///
+    /// This is the primary constructor when the caller already owns an
+    /// arbitrary mixed-direction split tree — for example, when reconstructing
+    /// a saved session that mixes horizontal and vertical splits.
+    ///
+    /// # Arguments
+    ///
+    /// * `panes` — the ordered pane vec; use [`Pane::new`] to build each entry.
+    ///   Must be non-empty.
+    /// * `layout` — the binary split tree. Every index `0..panes.len()` must
+    ///   appear **exactly once** as a `Leaf`; the tree must contain no other
+    ///   indices.
+    /// * `default_split_direction` — the direction used by future
+    ///   [`add_pane_with_tab`](Self::add_pane_with_tab) calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(message)` when:
+    ///
+    /// * `panes` is empty.
+    /// * The layout contains a leaf index ≥ `panes.len()`.
+    /// * A leaf index appears more than once.
+    /// * The number of leaves ≠ `panes.len()`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Three panes: left | (top-right / bottom-right)
+    /// let layout = GroupLayout::Split {
+    ///     direction: SplitDirection::Horizontal,
+    ///     ratio: 0.5,
+    ///     first: Box::new(GroupLayout::Leaf(0)),
+    ///     second: Box::new(GroupLayout::Split {
+    ///         direction: SplitDirection::Vertical,
+    ///         ratio: 0.5,
+    ///         first:  Box::new(GroupLayout::Leaf(1)),
+    ///         second: Box::new(GroupLayout::Leaf(2)),
+    ///     }),
+    /// };
+    /// let ctrl = TabGroupController::from_layout(
+    ///     vec![
+    ///         Pane::new("pane:0", left_tabs,        "t0"),
+    ///         Pane::new("pane:1", top_right_tabs,   "t1"),
+    ///         Pane::new("pane:2", bottom_right_tabs,"t2"),
+    ///     ],
+    ///     layout,
+    ///     SplitDirection::Horizontal,
+    /// )?;
+    /// ```
+    pub fn from_layout(
+        panes: Vec<Pane>,
+        layout: GroupLayout,
+        default_split_direction: SplitDirection,
+    ) -> Result<Self, String> {
+        let n = panes.len();
+        if n == 0 {
+            return Err("panes must be non-empty".into());
+        }
+        layout.validate_for_pane_count(n)?;
+        Ok(Self {
+            panes,
+            focus: FocusGroup::new(n),
+            layout,
+            default_split_direction,
+            // Start auto-generated drag-split IDs above n so names like
+            // "pane:0", "pane:1", … (that the consumer may have used) are
+            // not repeated by the first handle_tab_drop split.
+            next_pane_counter: n,
+            last_bounds: None,
+            last_pane_hits: (0..n).map(|_| None).collect(),
+            last_dividers: vec![],
+            dragging_divider: None,
+            dragging_tab: None,
+        })
     }
 
     // ── Accessors ───────────────────────────────────────────────────
@@ -1632,6 +1802,213 @@ mod tests {
         assert_eq!(ctrl.panes[0].tabs().len(), 2);
         assert_eq!(ctrl.panes[0].active_tab_id(), "t0");
         assert_eq!(ctrl.focused_pane(), None); // starts unfocused
+    }
+
+    // ── from_layout ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn from_layout_single_pane() {
+        let pane = Pane::new("p0", vec![tab("t0", "main.rs", true)], "t0");
+        let layout = GroupLayout::Leaf(0);
+        let ctrl = TabGroupController::from_layout(vec![pane], layout, SplitDirection::Horizontal)
+            .expect("valid single-pane layout");
+        assert_eq!(ctrl.pane_count(), 1);
+        assert_eq!(ctrl.layout, GroupLayout::Leaf(0));
+        assert_eq!(ctrl.focused_pane(), None); // starts unfocused
+        assert_eq!(ctrl.panes[0].active_tab_id(), "t0");
+    }
+
+    #[test]
+    fn from_layout_two_pane_horizontal() {
+        let panes = vec![
+            Pane::new("p0", vec![tab("t0", "a.rs", true)], "t0"),
+            Pane::new("p1", vec![tab("t1", "b.rs", true)], "t1"),
+        ];
+        let layout = GroupLayout::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.4,
+            first: Box::new(GroupLayout::Leaf(0)),
+            second: Box::new(GroupLayout::Leaf(1)),
+        };
+        let ctrl = TabGroupController::from_layout(panes, layout.clone(), SplitDirection::Vertical)
+            .expect("valid two-pane layout");
+        assert_eq!(ctrl.pane_count(), 2);
+        assert_eq!(ctrl.layout, layout);
+        // Spot-check pane ids.
+        assert_eq!(ctrl.panes[0].id, "p0");
+        assert_eq!(ctrl.panes[1].id, "p1");
+    }
+
+    #[test]
+    fn from_layout_three_pane_mixed_direction() {
+        // Left pane | (top-right pane / bottom-right pane)
+        // Root split is Horizontal; the right sub-tree is Vertical.
+        // This is the canonical mixed-direction case the issue targets.
+        let panes = vec![
+            Pane::new("left", vec![tab("tl", "left.rs", true)], "tl"),
+            Pane::new("top-right", vec![tab("tr", "top.rs", true)], "tr"),
+            Pane::new("bottom-right", vec![tab("tb", "bottom.rs", true)], "tb"),
+        ];
+        let layout = GroupLayout::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(GroupLayout::Leaf(0)),
+            second: Box::new(GroupLayout::Split {
+                direction: SplitDirection::Vertical,
+                ratio: 0.5,
+                first: Box::new(GroupLayout::Leaf(1)),
+                second: Box::new(GroupLayout::Leaf(2)),
+            }),
+        };
+        let ctrl = TabGroupController::from_layout(panes, layout, SplitDirection::Horizontal)
+            .expect("valid mixed-direction layout");
+
+        assert_eq!(ctrl.pane_count(), 3);
+        assert_eq!(ctrl.layout.leaf_count(), 3);
+        assert!(ctrl.layout.contains_leaf(0));
+        assert!(ctrl.layout.contains_leaf(1));
+        assert!(ctrl.layout.contains_leaf(2));
+
+        // Confirm the root split is Horizontal and the nested split is Vertical.
+        match &ctrl.layout {
+            GroupLayout::Split {
+                direction: SplitDirection::Horizontal,
+                second,
+                ..
+            } => match second.as_ref() {
+                GroupLayout::Split {
+                    direction: SplitDirection::Vertical,
+                    ..
+                } => {}
+                other => panic!("expected Vertical nested split, got {other:?}"),
+            },
+            other => panic!("expected Horizontal root split, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_layout_custom_ratio_preserved() {
+        // Verify that the exact ratio provided is stored as-is.
+        let panes = vec![
+            Pane::new("p0", vec![tab("t0", "a.rs", false)], "t0"),
+            Pane::new("p1", vec![tab("t1", "b.rs", false)], "t1"),
+        ];
+        let layout = GroupLayout::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.3,
+            first: Box::new(GroupLayout::Leaf(0)),
+            second: Box::new(GroupLayout::Leaf(1)),
+        };
+        let ctrl = TabGroupController::from_layout(panes, layout, SplitDirection::Horizontal)
+            .expect("valid");
+        let ratio = match &ctrl.layout {
+            GroupLayout::Split { ratio, .. } => *ratio,
+            _ => panic!("expected Split"),
+        };
+        assert!((ratio - 0.3).abs() < 1e-6, "ratio={ratio}");
+    }
+
+    #[test]
+    fn from_layout_add_pane_after_construction() {
+        // A from_layout controller should behave correctly with subsequent
+        // add_pane_with_tab calls (important: next_pane_counter must not
+        // collide with pre-existing pane ids).
+        let panes = vec![
+            Pane::new("p0", vec![tab("t0", "a.rs", true)], "t0"),
+            Pane::new("p1", vec![tab("t1", "b.rs", true)], "t1"),
+        ];
+        let layout = GroupLayout::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(GroupLayout::Leaf(0)),
+            second: Box::new(GroupLayout::Leaf(1)),
+        };
+        let mut ctrl = TabGroupController::from_layout(panes, layout, SplitDirection::Horizontal)
+            .expect("valid");
+        assert_eq!(ctrl.pane_count(), 2);
+
+        // Add a third pane via the regular incremental API.
+        let new_idx = ctrl.add_pane_with_tab("extra", tab("te", "extra.rs", false));
+        assert_eq!(ctrl.pane_count(), 3);
+        assert_eq!(ctrl.layout.leaf_count(), 3);
+        assert_eq!(ctrl.panes[new_idx].id, "extra");
+    }
+
+    // ── from_layout: error cases ──────────────────────────────────────────────
+
+    #[test]
+    fn from_layout_error_empty_panes() {
+        let result = TabGroupController::from_layout(
+            vec![],
+            GroupLayout::Leaf(0),
+            SplitDirection::Horizontal,
+        );
+        assert!(result.is_err(), "expected Err for empty panes");
+        let msg = result.err().unwrap();
+        assert!(msg.contains("non-empty"), "unexpected message: {msg}");
+    }
+
+    #[test]
+    fn from_layout_error_leaf_count_mismatch() {
+        let panes = vec![Pane::new("p0", vec![tab("t0", "a.rs", false)], "t0")];
+        // Tree has 2 leaves but only 1 pane provided.
+        let layout = GroupLayout::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(GroupLayout::Leaf(0)),
+            second: Box::new(GroupLayout::Leaf(1)),
+        };
+        let result = TabGroupController::from_layout(panes, layout, SplitDirection::Horizontal);
+        assert!(result.is_err(), "expected Err for count mismatch");
+        let msg = result.err().unwrap();
+        assert!(
+            msg.contains("2") && msg.contains("1"),
+            "error should mention counts, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_layout_error_duplicate_leaf_index() {
+        let panes = vec![
+            Pane::new("p0", vec![tab("t0", "a.rs", false)], "t0"),
+            Pane::new("p1", vec![tab("t1", "b.rs", false)], "t1"),
+        ];
+        // Both leaves reference index 0.
+        let layout = GroupLayout::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(GroupLayout::Leaf(0)),
+            second: Box::new(GroupLayout::Leaf(0)), // duplicate!
+        };
+        let result = TabGroupController::from_layout(panes, layout, SplitDirection::Horizontal);
+        assert!(result.is_err(), "expected Err for duplicate leaf");
+        let msg = result.err().unwrap();
+        assert!(
+            msg.contains("more than once") || msg.contains("duplicate"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_layout_error_out_of_range_leaf_index() {
+        let panes = vec![
+            Pane::new("p0", vec![tab("t0", "a.rs", false)], "t0"),
+            Pane::new("p1", vec![tab("t1", "b.rs", false)], "t1"),
+        ];
+        // Leaf index 2 is out of range for 2 panes (valid range: 0..2).
+        let layout = GroupLayout::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(GroupLayout::Leaf(0)),
+            second: Box::new(GroupLayout::Leaf(2)), // out of range!
+        };
+        let result = TabGroupController::from_layout(panes, layout, SplitDirection::Horizontal);
+        assert!(result.is_err(), "expected Err for out-of-range leaf");
+        let msg = result.err().unwrap();
+        assert!(
+            msg.contains("out of range") || msg.contains("range"),
+            "unexpected error message: {msg}"
+        );
     }
 
     // ── Tab switching ─────────────────────────────────────────────────────────

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -294,10 +294,10 @@ pub use compose::{
     BottomPanelController, BottomPanelEvent, BottomPanelLayout, BottomPanelTab, ChatController,
     ChatControllerEvent, ChatRole, ChatTurn, DualModePaletteController, DualModePaletteEvent,
     FocusGroup, FocusRing, FolderPickerController, FolderPickerEvent, FormController,
-    FormControllerEvent, GroupLayout, MenuDef, MenuEvent, MenuSystem, NavigationMode, PaneTab,
-    PanelDefinition, SectionKind, ShellPosition, SidebarEvent, SidebarSectionDef, SidebarSystem,
-    StatusBarAction, StatusBarInteraction, TabGroupController, TabGroupEvent, TabGroupLayout,
-    ToolbarHoverTracker, TreeController, TreeControllerEvent, PALETTE_CHROME_ROWS,
+    FormControllerEvent, GroupLayout, MenuDef, MenuEvent, MenuSystem, NavigationMode, Pane,
+    PaneTab, PanelDefinition, SectionKind, ShellPosition, SidebarEvent, SidebarSectionDef,
+    SidebarSystem, StatusBarAction, StatusBarInteraction, TabGroupController, TabGroupEvent,
+    TabGroupLayout, ToolbarHoverTracker, TreeController, TreeControllerEvent, PALETTE_CHROME_ROWS,
 };
 pub use dispatch::{
     dispatch_click, dispatch_mouse_down, dispatch_mouse_drag, dispatch_mouse_up, dispatch_scroll,

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -680,6 +680,92 @@ fn toolbar_q_exits() {
     assert!(driver.exited(), "'q' should exit the toolbar demo");
 }
 
+/// Pressing `f` rebuilds the controller via `from_layout`, producing a
+/// 3-pane mixed H/V tree (left | top-right / bottom-right).
+///
+/// Verifies that after pressing 'f':
+/// - All three pane tab labels are visible on screen.
+/// - The pane count shown in the status bar reflects 3 panes.
+///
+/// This is the primary smoke-test for `TabGroupController::from_layout` (#393).
+#[test]
+fn tab_group_f_key_switches_to_from_layout_3_pane() {
+    let mut driver = TuiDriver::new(TabGroupDemo::new(), 120, 30);
+
+    // Press 'f' to rebuild via from_layout.
+    driver.type_char('f');
+
+    let screen = driver.screen();
+
+    // Pane 0 (left): active tab is "left.rs".
+    assert!(
+        screen.contains("left.rs"),
+        "after 'f' the left pane tab 'left.rs' must be visible:\n{screen}"
+    );
+    // Pane 1 (top-right): active tab is "top.rs".
+    assert!(
+        screen.contains("top.rs"),
+        "after 'f' the top-right pane tab 'top.rs' must be visible:\n{screen}"
+    );
+    // Pane 2 (bottom-right): active tab is "bottom.rs".
+    assert!(
+        screen.contains("bottom.rs"),
+        "after 'f' the bottom-right pane tab 'bottom.rs' must be visible:\n{screen}"
+    );
+    // Status bar right segment shows "panes: 3" for the from_layout 3-pane tree.
+    assert!(
+        screen.contains("panes: 3"),
+        "after 'f' the status bar should report 'panes: 3':\n{screen}"
+    );
+}
+
+/// Pressing `f` then `r` resets the layout back to the default 2-pane split.
+///
+/// Verifies that after pressing 'f' followed by 'r':
+/// - The original main.rs and Cargo.toml tabs are restored.
+/// - The 3-pane from_layout tabs (left.rs, top.rs, bottom.rs) are gone.
+/// - The pane count is back to 2.
+///
+/// This exercises the full from_layout → reset round-trip (#393).
+#[test]
+fn tab_group_f_then_r_resets_to_default_layout() {
+    let mut driver = TuiDriver::new(TabGroupDemo::new(), 120, 30);
+
+    // Switch to the from_layout 3-pane tree.
+    driver.type_char('f');
+    assert!(
+        driver.screen_contains("left.rs"),
+        "prerequisite: 'f' must produce the from_layout layout:\n{}",
+        driver.screen()
+    );
+
+    // Reset back to default.
+    driver.type_char('r');
+
+    let screen = driver.screen();
+
+    // Default pane 0 tabs must be back.
+    assert!(
+        screen.contains("main.rs"),
+        "after 'r' the default tab 'main.rs' must be visible:\n{screen}"
+    );
+    // Default pane 1 tab must be back.
+    assert!(
+        screen.contains("Cargo.toml"),
+        "after 'r' the default tab 'Cargo.toml' must be visible:\n{screen}"
+    );
+    // The from_layout tabs should no longer be present.
+    assert!(
+        !screen.contains("left.rs"),
+        "after 'r' the from_layout 'left.rs' tab must not be visible:\n{screen}"
+    );
+    // Pane count is back to 2.
+    assert!(
+        screen.contains("panes: 2"),
+        "after 'r' the status bar should report 'panes: 2':\n{screen}"
+    );
+}
+
 /// Regression test for #375.
 ///
 /// Before the fix, crossing `TAB_DRAG_THRESHOLD` during a `MouseMoved` event


### PR DESCRIPTION
Closes #393

Automated merge from the coordinator for assignment 61bfc725593e on issue #393.

Worker branch: `issue-393-tabgroupcontroller-add-a-constructor-ins` → `develop`.