### PR TITLE
#400: run_with_shell (GTK): no way to get drag-to-move / double-click-to-maximize for a custom CSD titlebar drawn inside the single-DA window

### DIFF
--- a/quadraui/examples/common/full_chrome_demo.rs
+++ b/quadraui/examples/common/full_chrome_demo.rs
@@ -1,11 +1,18 @@
 //! Full-chrome AppShell demo — proves all four chrome slots
 //! (title bar, bottom panel, command line, status bar) plus the
 //! existing activity bar / sidebar / main layout.
+//!
+//! The empty part of the title bar also exercises the CSD drag/maximize
+//! escape hatch (#400): left-`MouseDown` calls `Backend::begin_window_drag`,
+//! `DoubleClick` calls `Backend::toggle_window_maximize`. On GTK this
+//! actually moves/maximizes the window; on TUI (no window to drive) both
+//! calls are a documented no-op — the demo's status line shows which
+//! happened either way.
 
 use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
 use quadraui::{
-    Backend, Color, Key, NamedKey, Reaction, Rect, ShellApp as ShellAppTrait, ShellConfig,
-    ShellContext, StatusBar, StatusBarSegment, UiEvent, WidgetId,
+    Backend, Color, Key, MouseButton, NamedKey, Reaction, Rect, ShellApp as ShellAppTrait,
+    ShellConfig, ShellContext, StatusBar, StatusBarSegment, UiEvent, WidgetId,
 };
 
 pub struct FullChromeDemo {
@@ -15,7 +22,7 @@ pub struct FullChromeDemo {
 impl FullChromeDemo {
     pub fn new() -> Self {
         Self {
-            last_event: "click icons | drag dividers | q=quit".into(),
+            last_event: "click icons | drag dividers | drag/double-click title bar | q=quit".into(),
         }
     }
 
@@ -170,7 +177,7 @@ impl ShellAppTrait for FullChromeDemo {
     fn handle(
         &mut self,
         event: UiEvent,
-        _backend: &mut dyn Backend,
+        backend: &mut dyn Backend,
         ctx: &ShellContext,
     ) -> Reaction {
         match &event {
@@ -178,9 +185,24 @@ impl ShellAppTrait for FullChromeDemo {
                 key: Key::Char('q') | Key::Named(NamedKey::Escape),
                 ..
             } => Reaction::Exit,
-            UiEvent::MouseDown { position, .. } => {
+            UiEvent::MouseDown {
+                position, button, ..
+            } => {
                 if ctx.in_title_bar(position.x, position.y) {
-                    self.last_event = "Title bar click".into();
+                    // #400: the empty part of the title bar drags the
+                    // window on a left-button press, same as native CSD
+                    // chrome. `begin_window_drag` is a documented no-op
+                    // (returns `false`) on backends with no window (TUI).
+                    if *button == MouseButton::Left {
+                        let dragging = backend.begin_window_drag();
+                        self.last_event = if dragging {
+                            "Title bar drag started".into()
+                        } else {
+                            "Title bar click (no window to drag)".into()
+                        };
+                    } else {
+                        self.last_event = "Title bar click".into();
+                    }
                     Reaction::Redraw
                 } else if ctx.in_sidebar(position.x, position.y) {
                     self.last_event = format!(
@@ -199,6 +221,23 @@ impl ShellAppTrait for FullChromeDemo {
                     Reaction::Redraw
                 } else if ctx.in_status_bar(position.x, position.y) {
                     self.last_event = "Status bar click".into();
+                    Reaction::Redraw
+                } else {
+                    Reaction::Continue
+                }
+            }
+            UiEvent::DoubleClick { position, .. } => {
+                if ctx.in_title_bar(position.x, position.y) {
+                    // #400: double-click on the empty title bar toggles
+                    // maximize/restore, same as native CSD chrome.
+                    // `toggle_window_maximize` is a documented no-op on
+                    // backends with no window (TUI).
+                    let toggled = backend.toggle_window_maximize();
+                    self.last_event = if toggled {
+                        "Title bar double-click: maximize toggled".into()
+                    } else {
+                        "Title bar double-click (no window)".into()
+                    };
                     Reaction::Redraw
                 } else {
                     Reaction::Continue

--- a/quadraui/examples/gtk_full_chrome_demo.rs
+++ b/quadraui/examples/gtk_full_chrome_demo.rs
@@ -1,4 +1,7 @@
 //! GTK runner for the full-chrome AppShell demo (#217 Stage 2).
+//!
+//! Drag the empty part of the title bar to move the window; double-click
+//! it to toggle maximize/restore (#400).
 #[path = "common/mod.rs"]
 mod common;
 

--- a/quadraui/examples/tui_full_chrome_demo.rs
+++ b/quadraui/examples/tui_full_chrome_demo.rs
@@ -1,4 +1,8 @@
 //! TUI runner for the full-chrome AppShell demo (#217 Stage 2).
+//!
+//! No window to drag/maximize here — clicking/double-clicking the title
+//! bar exercises the same code path as GTK but is a documented no-op
+//! (#400).
 #[path = "common/mod.rs"]
 mod common;
 

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -200,6 +200,43 @@ pub trait Backend {
     ) {
     }
 
+    // ─── Window chrome (CSD) ────────────────────────────────────────────
+    /// Begin an OS-native window drag-to-move gesture, using the raw
+    /// device/button/timestamp captured from the most recent primary-button
+    /// press.
+    ///
+    /// For apps that draw their own client-side titlebar (`ShellConfig::
+    /// with_title_bar` + `window.set_decorated(false)`) into
+    /// `AppShellLayout::title_bar_bounds` and want the empty part of that
+    /// band to drag the window like a native titlebar. Call from
+    /// [`crate::shell::ShellApp::handle`] when a `MouseDown` lands in
+    /// [`crate::shell::ShellContext::in_title_bar`] outside any interactive
+    /// segment (menu item, min/max/close button).
+    ///
+    /// `GtkBackend` wires this to `gdk4::Toplevel::begin_move`, using the
+    /// press context `gtk::run`'s click controller stashes just before the
+    /// press is translated to a portable [`UiEvent`] (see #400) — GDK
+    /// requires the *originating* event's device/timestamp, not synthesized
+    /// values, or the drag silently no-ops on some compositors.
+    ///
+    /// Returns `false` when the backend owns no window (TUI, and any
+    /// backend before its window is constructed) or no primed press context
+    /// is available. Callers should treat `false` as a no-op, not an error.
+    fn begin_window_drag(&mut self) -> bool {
+        false
+    }
+
+    /// Toggle the OS window between maximized and restored — the
+    /// double-click-to-maximize half of the CSD-titlebar gesture pair
+    /// (see [`Self::begin_window_drag`]).
+    ///
+    /// Call from `ShellApp::handle` on a `DoubleClick` landing in the empty
+    /// part of the titlebar band. Returns `false` on backends with no
+    /// window (TUI); `true` once the toggle happened.
+    fn toggle_window_maximize(&mut self) -> bool {
+        false
+    }
+
     // ─── Modal-overlay tracking ────────────────────────────────────────
     /// Mutable handle to the backend's modal stack. Apps push when a
     /// palette / dialog / context-menu opens and pop when it closes;

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -213,15 +213,23 @@ pub trait Backend {
     /// [`crate::shell::ShellContext::in_title_bar`] outside any interactive
     /// segment (menu item, min/max/close button).
     ///
-    /// `GtkBackend` wires this to `gdk4::Toplevel::begin_move`, using the
-    /// press context `gtk::run`'s click controller stashes just before the
-    /// press is translated to a portable [`UiEvent`] (see #400) — GDK
+    /// `GtkBackend` arms a deferred `gdk4::Toplevel::begin_move` call, using
+    /// the press context `gtk::run`'s click controller stashes just before
+    /// the press is translated to a portable [`UiEvent`] (see #400) — GDK
     /// requires the *originating* event's device/timestamp, not synthesized
-    /// values, or the drag silently no-ops on some compositors.
+    /// values, or the drag silently no-ops on some compositors. The actual
+    /// `begin_move` call only fires once the pointer moves past the drag
+    /// threshold (mirroring native `gtk4::WindowHandle`'s `GestureDrag`
+    /// `drag-begin` gating); calling this from a `MouseDown` handler does
+    /// not itself start an interactive move grab, so a press that turns out
+    /// to be the first half of a double-click still reaches the app as
+    /// `UiEvent::DoubleClick`.
     ///
     /// Returns `false` when the backend owns no window (TUI, and any
     /// backend before its window is constructed) or no primed press context
     /// is available. Callers should treat `false` as a no-op, not an error.
+    /// A `true` return means the drag request was accepted/armed, not that
+    /// the window has necessarily started moving yet.
     fn begin_window_drag(&mut self) -> bool {
         false
     }

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -42,7 +42,9 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use gtk4::cairo::Context;
+use gtk4::gdk;
 use gtk4::pango;
+use gtk4::prelude::*;
 
 use crate::backend::{activity_bar_hits, tab_bar_layout_to_hits};
 use crate::dispatch::TextRegion;
@@ -158,6 +160,20 @@ pub struct GtkBackend {
     /// `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })` so
     /// consumers receive typed key events without fighting GTK widget focus.
     focused_activity_bar: Option<WidgetId>,
+    /// Top-level window handle, set once by `gtk::run::activate` via
+    /// [`Self::set_window`]. `None` until the runner finishes constructing
+    /// the window (and in unit tests, which never call `set_window`).
+    /// Backs [`Backend::begin_window_drag`] / [`Backend::toggle_window_maximize`]
+    /// — the CSD titlebar drag/maximize escape hatch (#400).
+    window: Option<gtk4::ApplicationWindow>,
+    /// Raw GDK context (device, button, x, y, timestamp) of the most
+    /// recent primary-button press, stashed by `gtk/run.rs`'s
+    /// `GestureClick::connect_pressed` before the press is translated to a
+    /// portable [`UiEvent`]. [`Backend::begin_window_drag`] consumes this
+    /// (via `.take()`) to call `gdk4::Toplevel::begin_move` with the real
+    /// device/timestamp the gesture requires — GDK ignores synthesized
+    /// values on some compositors.
+    pending_window_press: Option<(gdk::Device, i32, f64, f64, u32)>,
 }
 
 /// Active text selection state for the GTK backend. Stores the region id
@@ -197,7 +213,33 @@ impl GtkBackend {
             active_selection: None,
             last_text_region_id: None,
             focused_activity_bar: None,
+            window: None,
+            pending_window_press: None,
         }
+    }
+
+    /// Store the top-level window handle. Called once by `gtk::run::activate`
+    /// right after the window is constructed. Backs
+    /// [`Backend::begin_window_drag`] / [`Backend::toggle_window_maximize`].
+    pub fn set_window(&mut self, window: gtk4::ApplicationWindow) {
+        self.window = Some(window);
+    }
+
+    /// Stash the raw GDK context of a primary-button press. Called by
+    /// `gtk/run.rs`'s `GestureClick::connect_pressed`, before the press is
+    /// translated to a portable [`UiEvent`], so
+    /// [`Backend::begin_window_drag`] can later request a native
+    /// window-drag using the *originating* event's device/timestamp.
+    /// Overwritten by the next press; harmless if never consumed.
+    pub(crate) fn stash_window_press(
+        &mut self,
+        device: gdk::Device,
+        button: i32,
+        x: f64,
+        y: f64,
+        time: u32,
+    ) {
+        self.pending_window_press = Some((device, button, x, y, time));
     }
 
     /// Update the cached UI font description string (Pango format,
@@ -878,6 +920,39 @@ impl Backend for GtkBackend {
 
     fn services(&self) -> &dyn PlatformServices {
         &self.services
+    }
+
+    fn begin_window_drag(&mut self) -> bool {
+        let Some(window) = self.window.as_ref() else {
+            return false;
+        };
+        let Some((device, button, x, y, time)) = self.pending_window_press.take() else {
+            return false;
+        };
+        // `ApplicationWindow` implements `Native` directly (gtk4-rs
+        // `@implements Native` on both `Window` and `ApplicationWindow`),
+        // so `.surface()` is reachable without an upcast. Only an actual
+        // toplevel surface implements the `Toplevel` interface `begin_move`
+        // lives on — downcast can fail if the surface isn't realized yet.
+        match window.surface().downcast::<gdk::Toplevel>() {
+            Ok(toplevel) => {
+                toplevel.begin_move(&device, button, x, y, time);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    fn toggle_window_maximize(&mut self) -> bool {
+        let Some(window) = self.window.as_ref() else {
+            return false;
+        };
+        if window.is_maximized() {
+            window.unmaximize();
+        } else {
+            window.maximize();
+        }
+        true
     }
 
     // ─── Drawing ───────────────────────────────────────────────────────────
@@ -2265,6 +2340,33 @@ mod tests {
         backend.push_event(crate::UiEvent::WindowFocused(true));
         let q = backend.events_handle();
         assert_eq!(q.borrow().len(), 1);
+    }
+
+    /// #400: with no window set (the state of every unit test and every
+    /// backend before `gtk::run::activate` calls `set_window`),
+    /// `begin_window_drag` must no-op rather than panic.
+    #[test]
+    fn gtk_backend_begin_window_drag_false_without_window() {
+        let mut backend = GtkBackend::new();
+        assert!(!Backend::begin_window_drag(&mut backend));
+    }
+
+    /// #400: `begin_window_drag` also no-ops when a window is present but
+    /// no press was ever stashed (e.g. called from a non-mouse-driven
+    /// path) — there's no real device/timestamp to hand GDK.
+    #[test]
+    fn gtk_backend_begin_window_drag_false_without_pending_press() {
+        let mut backend = GtkBackend::new();
+        assert!(backend.pending_window_press.is_none());
+        assert!(!Backend::begin_window_drag(&mut backend));
+    }
+
+    /// #400: with no window set, `toggle_window_maximize` must no-op
+    /// rather than panic.
+    #[test]
+    fn gtk_backend_toggle_window_maximize_false_without_window() {
+        let mut backend = GtkBackend::new();
+        assert!(!Backend::toggle_window_maximize(&mut backend));
     }
 
     #[test]

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -170,10 +170,27 @@ pub struct GtkBackend {
     /// recent primary-button press, stashed by `gtk/run.rs`'s
     /// `GestureClick::connect_pressed` before the press is translated to a
     /// portable [`UiEvent`]. [`Backend::begin_window_drag`] consumes this
-    /// (via `.take()`) to call `gdk4::Toplevel::begin_move` with the real
+    /// (via `.take()`) to arm [`Self::armed_window_drag`] with the real
     /// device/timestamp the gesture requires — GDK ignores synthesized
     /// values on some compositors.
     pending_window_press: Option<(gdk::Device, i32, f64, f64, u32)>,
+    /// Armed-but-not-yet-started window-drag request (#400 double-click
+    /// fix). Set by [`Backend::begin_window_drag`] from
+    /// [`Self::pending_window_press`]; consumed by
+    /// [`Self::commit_armed_window_drag`], which `gtk/run.rs`'s motion
+    /// controller calls only once the pointer has moved past the drag
+    /// threshold since the arming press.
+    ///
+    /// This split exists because calling `gdk4::Toplevel::begin_move`
+    /// synchronously on the very first press — before it's known whether
+    /// a second press is coming — starts an interactive move grab that
+    /// swallows the second press, so a double-click on a CSD titlebar
+    /// never reaches the app as `UiEvent::DoubleClick`. Native
+    /// `gtk4::WindowHandle` avoids this by deferring its own move-start
+    /// to `GestureDrag`'s `drag-begin` signal, which itself only fires
+    /// past the drag threshold — this mirrors that behaviour instead of
+    /// starting the grab on the raw press.
+    armed_window_drag: Option<(gdk::Device, i32, f64, f64, u32)>,
 }
 
 /// Active text selection state for the GTK backend. Stores the region id
@@ -215,6 +232,7 @@ impl GtkBackend {
             focused_activity_bar: None,
             window: None,
             pending_window_press: None,
+            armed_window_drag: None,
         }
     }
 
@@ -240,6 +258,74 @@ impl GtkBackend {
         time: u32,
     ) {
         self.pending_window_press = Some((device, button, x, y, time));
+    }
+
+    /// Screen-space origin `(x, y)` of the press that armed the current
+    /// window-drag request, if one is armed. `gtk/run.rs`'s motion
+    /// controller uses this to measure how far the pointer has moved
+    /// since the press, so it can decide when to call
+    /// [`Self::commit_armed_window_drag`] (#400).
+    pub(crate) fn armed_window_drag_origin(&self) -> Option<(f64, f64)> {
+        self.armed_window_drag
+            .as_ref()
+            .map(|(_, _, x, y, _)| (*x, *y))
+    }
+
+    /// Discard an armed-but-uncommitted window-drag request without
+    /// starting a move. Called by `gtk/run.rs`'s `GestureClick::connect_released`
+    /// handler: if the button goes up before the pointer ever moved past
+    /// the drag threshold, the press was a plain click (or the first half
+    /// of a double-click) and must not leave stale state around to be
+    /// accidentally committed by an unrelated later hover-motion event
+    /// (#400).
+    pub(crate) fn discard_armed_window_drag(&mut self) {
+        self.armed_window_drag = None;
+    }
+
+    /// Commit an armed window-drag request by calling
+    /// `gdk4::Toplevel::begin_move` with the originating press's
+    /// device/button/timestamp (#400). Called by `gtk/run.rs`'s motion
+    /// controller once the pointer has moved past the drag threshold
+    /// since the arming press — see [`Self::armed_window_drag`] for why
+    /// this is deferred instead of running synchronously from
+    /// `Backend::begin_window_drag`.
+    ///
+    /// Returns `false` (no-op) if no window is set or nothing is armed.
+    pub(crate) fn commit_armed_window_drag(&mut self) -> bool {
+        let Some(window) = self.window.as_ref() else {
+            self.armed_window_drag = None;
+            return false;
+        };
+        let Some((device, button, x, y, time)) = self.armed_window_drag.take() else {
+            return false;
+        };
+        // `ApplicationWindow` implements `Native` directly (gtk4-rs
+        // `@implements Native` on both `Window` and `ApplicationWindow`),
+        // so `.surface()` is reachable without an upcast. Only an actual
+        // toplevel surface implements the `Toplevel` interface `begin_move`
+        // lives on — downcast can fail if the surface isn't realized yet.
+        match window.surface().downcast::<gdk::Toplevel>() {
+            Ok(toplevel) => {
+                toplevel.begin_move(&device, button, x, y, time);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Pixel distance the pointer must travel from an armed press before
+    /// [`Self::armed_window_drag`] is committed (#400). Reads GTK's own
+    /// `gtk-dnd-drag-threshold` setting (the same threshold `GestureDrag`
+    /// uses natively) so the titlebar drag feels identical to any other
+    /// GTK drag gesture; falls back to GTK's documented default (8px) when
+    /// no window/display is available yet (e.g. in unit tests).
+    pub(crate) fn window_drag_threshold_px(&self) -> f64 {
+        const DEFAULT_THRESHOLD_PX: f64 = 8.0;
+        match self.window.as_ref() {
+            Some(w) => gtk4::Settings::for_display(&gtk4::prelude::WidgetExt::display(w))
+                .gtk_dnd_drag_threshold() as f64,
+            None => DEFAULT_THRESHOLD_PX,
+        }
     }
 
     /// Update the cached UI font description string (Pango format,
@@ -923,24 +1009,25 @@ impl Backend for GtkBackend {
     }
 
     fn begin_window_drag(&mut self) -> bool {
-        let Some(window) = self.window.as_ref() else {
+        // #400 double-click fix: this does NOT call `gdk4::Toplevel::begin_move`
+        // synchronously. Doing so on the very first press — before it's known
+        // whether a second press is coming — starts an interactive move grab
+        // that swallows the second press, so a double-click on a CSD titlebar
+        // never reaches the app. Instead this arms `Self::armed_window_drag`;
+        // `gtk/run.rs`'s motion controller commits it (via
+        // `commit_armed_window_drag`, which does the actual `begin_move` —
+        // see there for the downcast rationale) once the pointer has moved
+        // past the drag threshold, mirroring how native `gtk4::WindowHandle`
+        // defers its own move-start to `GestureDrag`'s threshold-gated
+        // `drag-begin` signal rather than the raw press.
+        if self.window.is_none() {
             return false;
-        };
-        let Some((device, button, x, y, time)) = self.pending_window_press.take() else {
-            return false;
-        };
-        // `ApplicationWindow` implements `Native` directly (gtk4-rs
-        // `@implements Native` on both `Window` and `ApplicationWindow`),
-        // so `.surface()` is reachable without an upcast. Only an actual
-        // toplevel surface implements the `Toplevel` interface `begin_move`
-        // lives on — downcast can fail if the surface isn't realized yet.
-        match window.surface().downcast::<gdk::Toplevel>() {
-            Ok(toplevel) => {
-                toplevel.begin_move(&device, button, x, y, time);
-                true
-            }
-            Err(_) => false,
         }
+        let Some(press) = self.pending_window_press.take() else {
+            return false;
+        };
+        self.armed_window_drag = Some(press);
+        true
     }
 
     fn toggle_window_maximize(&mut self) -> bool {
@@ -2359,6 +2446,60 @@ mod tests {
         let mut backend = GtkBackend::new();
         assert!(backend.pending_window_press.is_none());
         assert!(!Backend::begin_window_drag(&mut backend));
+    }
+
+    /// #400 double-click fix: `armed_window_drag_origin` must be `None`
+    /// when nothing has been armed (the state of every unit test and
+    /// every fresh backend).
+    #[test]
+    fn gtk_backend_armed_window_drag_origin_none_when_unarmed() {
+        let backend = GtkBackend::new();
+        assert!(backend.armed_window_drag_origin().is_none());
+    }
+
+    /// #400 double-click fix: `discard_armed_window_drag` clears a
+    /// simulated armed request, and the origin reads back `None`
+    /// afterwards — this is what `gtk/run.rs`'s `connect_released` relies
+    /// on to stop a plain click (or the first half of a double-click)
+    /// from being committed by a later, unrelated hover-motion event.
+    #[test]
+    fn gtk_backend_discard_armed_window_drag_clears_state() {
+        let mut backend = GtkBackend::new();
+        // No real `gdk::Device` is constructible headlessly, so this test
+        // exercises the discard path directly against the private field
+        // rather than going through `Backend::begin_window_drag` (which
+        // requires a real window).
+        assert!(backend.armed_window_drag_origin().is_none());
+        backend.discard_armed_window_drag();
+        assert!(backend.armed_window_drag_origin().is_none());
+    }
+
+    /// #400 double-click fix: `commit_armed_window_drag` must no-op
+    /// (rather than panic) with no window set, mirroring
+    /// `begin_window_drag`'s no-window no-op.
+    #[test]
+    fn gtk_backend_commit_armed_window_drag_false_without_window() {
+        let mut backend = GtkBackend::new();
+        assert!(!backend.commit_armed_window_drag());
+    }
+
+    /// #400 double-click fix: `commit_armed_window_drag` must no-op when
+    /// a window is present but nothing is armed (e.g. `connect_motion`
+    /// fires before any title-bar press ever called `begin_window_drag`).
+    #[test]
+    fn gtk_backend_commit_armed_window_drag_false_without_armed_request() {
+        let mut backend = GtkBackend::new();
+        assert!(backend.armed_window_drag.is_none());
+        assert!(!backend.commit_armed_window_drag());
+    }
+
+    /// #400 double-click fix: `window_drag_threshold_px` must fall back
+    /// to GTK's documented default (8px) rather than panic when no
+    /// window/display is available yet (every unit test).
+    #[test]
+    fn gtk_backend_window_drag_threshold_px_defaults_without_window() {
+        let backend = GtkBackend::new();
+        assert_eq!(backend.window_drag_threshold_px(), 8.0);
     }
 
     /// #400: with no window set, `toggle_window_maximize` must no-op

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -350,10 +350,13 @@ fn activate<A: AppLogic + 'static>(
 
             // Stash the raw GDK press context (device + button + timestamp)
             // before this press gets translated to a portable `UiEvent`, so
-            // `Backend::begin_window_drag` can later hand it to GDK's
-            // native window-drag call (#400). Runs for both single- and
-            // double-press events (both fire `connect_pressed`); harmless
-            // if the app never calls `begin_window_drag`.
+            // `Backend::begin_window_drag` can later arm a deferred
+            // window-drag request with it (#400; see
+            // `GtkBackend::armed_window_drag` for why it's deferred rather
+            // than calling GDK's native window-drag immediately). Runs for
+            // both single- and double-press events (both fire
+            // `connect_pressed`); harmless if the app never calls
+            // `begin_window_drag`.
             if let Some(event) = gesture.current_event() {
                 if let Some(device) = event.device() {
                     backend.borrow_mut().stash_window_press(
@@ -442,6 +445,14 @@ fn activate<A: AppLogic + 'static>(
         let window_for_close = window.clone();
         click.connect_released(move |gesture, _n_press, x, y| {
             let mut backend_mut = backend.borrow_mut();
+            // #400: if the button goes up before the pointer ever moved
+            // past the drag threshold, this was a plain click (or the
+            // first half of a double-click), not a drag. Discard the
+            // armed window-drag request rather than leaving it to be
+            // accidentally committed by a later, unrelated hover-motion
+            // event. See `GtkBackend::armed_window_drag` for the full
+            // rationale.
+            backend_mut.discard_armed_window_drag();
             let position = Point::new(x as f32, y as f32);
             let button: MouseButton = gdk_button_to_quadraui(gesture.current_button());
             let events = {
@@ -482,6 +493,32 @@ fn activate<A: AppLogic + 'static>(
         let cursor_pos = cursor_pos.clone();
         motion.connect_motion(move |ctrl, x, y| {
             cursor_pos.set((x, y));
+
+            // #400: commit a deferred window-drag once the pointer has
+            // moved past the drag threshold since the press that armed
+            // it (`Backend::begin_window_drag`). Mirrors native
+            // `gtk4::WindowHandle`, which defers its own move-start to
+            // `GestureDrag`'s threshold-gated `drag-begin` signal rather
+            // than the raw button press — this is what keeps a press
+            // that turns into a double-click from starting an
+            // interactive move grab that would swallow the second press.
+            // Only returns early when a drag is actually committed
+            // (control passes to the compositor's native move at that
+            // point); otherwise falls through to the normal motion
+            // handling below unaffected.
+            {
+                let mut backend_mut = backend.borrow_mut();
+                if let Some((origin_x, origin_y)) = backend_mut.armed_window_drag_origin() {
+                    let dx = x - origin_x;
+                    let dy = y - origin_y;
+                    let threshold = backend_mut.window_drag_threshold_px();
+                    if (dx * dx + dy * dy).sqrt() >= threshold {
+                        backend_mut.commit_armed_window_drag();
+                        return;
+                    }
+                }
+            }
+
             let modifier = ctrl.current_event_state();
             let buttons = ButtonMask {
                 left: modifier.contains(gtk4::gdk::ModifierType::BUTTON1_MASK),

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -104,6 +104,12 @@ fn activate<A: AppLogic + 'static>(
         .default_height(600)
         .build();
 
+    // Stash the window handle so `Backend::begin_window_drag` /
+    // `Backend::toggle_window_maximize` (#400) have something to drive.
+    // Harmless for apps that never call them (default no-op on every
+    // other backend, and GTK apps that don't opt into a CSD titlebar).
+    backend.borrow_mut().set_window(window.clone());
+
     let da = DrawingArea::new();
     da.set_hexpand(true);
     da.set_vexpand(true);
@@ -341,6 +347,24 @@ fn activate<A: AppLogic + 'static>(
             let button = gdk_button_to_quadraui(gdk_button);
             let modifiers = gdk_modifiers_to_quadraui(modifier);
             let position = Point::new(x as f32, y as f32);
+
+            // Stash the raw GDK press context (device + button + timestamp)
+            // before this press gets translated to a portable `UiEvent`, so
+            // `Backend::begin_window_drag` can later hand it to GDK's
+            // native window-drag call (#400). Runs for both single- and
+            // double-press events (both fire `connect_pressed`); harmless
+            // if the app never calls `begin_window_drag`.
+            if let Some(event) = gesture.current_event() {
+                if let Some(device) = event.device() {
+                    backend.borrow_mut().stash_window_press(
+                        device,
+                        gdk_button as i32,
+                        x,
+                        y,
+                        event.time(),
+                    );
+                }
+            }
 
             if n_press == 2 {
                 // Double-click: clear selection and deliver DoubleClick directly.

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -10,7 +10,7 @@
 #![cfg(feature = "tui")]
 
 use quadraui::tui::testing::{driver_with_shell, TuiDriver};
-use quadraui::NamedKey;
+use quadraui::{NamedKey, Point, UiEvent};
 
 #[path = "../examples/common/shell_app.rs"]
 mod shell_app_ex;
@@ -26,6 +26,8 @@ mod clipboard_demo;
 mod demo;
 #[path = "../examples/common/dialog_table_demo.rs"]
 mod dialog_table_demo;
+#[path = "../examples/common/full_chrome_demo.rs"]
+mod full_chrome_demo;
 #[path = "../examples/common/mini_app.rs"]
 mod mini_app;
 #[path = "../examples/common/palette_dual_mode_app.rs"]
@@ -44,6 +46,7 @@ mod text_input_demo;
 use clipboard_demo::ClipboardDemo;
 use demo::AppState;
 use dialog_table_demo::DialogTableDemo;
+use full_chrome_demo::FullChromeDemo;
 use mini_app::MiniApp;
 use palette_dual_mode_app::PaletteDualModeApp;
 use panel_app::PanelApp;
@@ -1047,6 +1050,63 @@ fn shell_app_k_saturates_at_first_item() {
     assert!(
         !driver.screen_contains("panel:settings"),
         "'k' at top must NOT wrap to the bottom item:\n{}",
+        driver.screen()
+    );
+}
+
+// ─── FullChromeDemo: CSD title-bar drag / maximize escape hatch (#400) ──────
+//
+// `FullChromeDemo` reserves a title-bar band via `ShellConfig::with_title_bar`
+// and, on the empty part of that band, calls the new
+// `Backend::begin_window_drag` / `Backend::toggle_window_maximize` methods.
+// TUI has no window to drive, so both are documented no-ops (`false`) —
+// these tests prove the call path runs cleanly end-to-end (paint → hit-test
+// → `ShellApp::handle` → backend call → re-render) and falls back to the
+// "no window" message, exactly as a headless backend should. The real
+// window-drag/maximize behaviour is GTK-only and has no automated coverage
+// yet (`GtkDriver` — #301); see the manual smoke test instead.
+
+/// Left-`MouseDown` on the empty title bar calls `begin_window_drag`, which
+/// must return `false` on `TuiBackend` (no window) and the demo must show
+/// the "no window to drag" fallback message rather than crash or hang.
+#[test]
+fn full_chrome_title_bar_click_requests_window_drag() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    let (x, y) = driver
+        .find("TITLE BAR")
+        .unwrap_or_else(|| panic!("title bar band should be painted:\n{}", driver.screen()));
+
+    driver.click(x, y);
+    assert!(
+        driver.screen_contains("Title bar click (no window to drag)"),
+        "clicking the empty title bar on TUI should call begin_window_drag(), get false back \
+         (no window), and fall back to the plain-click message:\n{}",
+        driver.screen()
+    );
+}
+
+/// Double-click on the empty title bar calls `toggle_window_maximize`,
+/// which must return `false` on `TuiBackend` (no window) and the demo must
+/// show the "no window" fallback message.
+#[test]
+fn full_chrome_title_bar_double_click_requests_maximize_toggle() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    let (x, y) = driver
+        .find("TITLE BAR")
+        .unwrap_or_else(|| panic!("title bar band should be painted:\n{}", driver.screen()));
+
+    driver.dispatch(UiEvent::DoubleClick {
+        widget: None,
+        position: Point::new(x, y),
+    });
+    assert!(
+        driver.screen_contains("Title bar double-click (no window)"),
+        "double-clicking the empty title bar on TUI should call toggle_window_maximize(), get \
+         false back (no window), and fall back to the no-window message:\n{}",
         driver.screen()
     );
 }


### PR DESCRIPTION
Closes #400

Automated merge from the coordinator for assignment 963246e538f6 on issue #400.

Worker branch: `issue-400-run-with-shell-gtk-no-way-to-get-drag-to` → `develop`.