### PR TITLE
#406: No window-edge resize API for CSD titlebars (analogous to #400's begin_window_drag/toggle_window_maximize)

### DIFF
--- a/quadraui/examples/common/full_chrome_demo.rs
+++ b/quadraui/examples/common/full_chrome_demo.rs
@@ -8,12 +8,19 @@
 //! actually moves/maximizes the window; on TUI (no window to drive) both
 //! calls are a documented no-op — the demo's status line shows which
 //! happened either way.
+//!
+//! The outer window border also exercises the edge-resize escape hatch
+//! (#406): a left-`MouseDown` within `backend.line_height()` of any edge or
+//! corner calls `Backend::begin_window_resize`, and every `MouseMoved`
+//! hints the resize cursor via `Backend::set_cursor` while hovering one.
+//! Same no-op-on-TUI story as #400 — there's no window to resize, so both
+//! calls report back `false` and the status line says so.
 
 use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
 use quadraui::{
-    Backend, Color, Key, MouseButton, NamedKey, Reaction, Rect, ShellApp as ShellAppTrait,
-    ShellConfig, ShellContext, StatusBar, StatusBarAction, StatusBarInteraction, StatusBarSegment,
-    UiEvent, WidgetId,
+    Backend, Color, Key, MouseButton, NamedKey, PointerShape, Reaction, Rect,
+    ShellApp as ShellAppTrait, ShellConfig, ShellContext, StatusBar, StatusBarAction,
+    StatusBarInteraction, StatusBarSegment, UiEvent, WidgetId,
 };
 
 /// `action_id`s for the CSD title-bar button row (#402). Namespaced per
@@ -34,7 +41,8 @@ pub struct FullChromeDemo {
 impl FullChromeDemo {
     pub fn new() -> Self {
         Self {
-            last_event: "click icons | drag dividers | drag/double-click title bar | q=quit".into(),
+            last_event: "click icons | drag dividers | drag/double-click title bar | drag edges to resize | q=quit"
+                .into(),
             title_bar_interaction: StatusBarInteraction::new(),
         }
     }
@@ -290,6 +298,14 @@ impl ShellAppTrait for FullChromeDemo {
                     // window on a left-button press, same as native CSD
                     // chrome. `begin_window_drag` is a documented no-op
                     // (returns `false`) on backends with no window (TUI).
+                    //
+                    // Checked before #406's window-edge resize below: a
+                    // full-width title bar owns the entire top band, same
+                    // as native GTK `HeaderBar` CSD (which has no top-edge
+                    // resize handle either — the header bar IS the top
+                    // edge). Resize is still reachable from the left/right/
+                    // bottom borders and bottom corners, which the title
+                    // bar doesn't cover.
                     if *button == MouseButton::Left {
                         let dragging = backend.begin_window_drag();
                         self.last_event = if dragging {
@@ -299,6 +315,27 @@ impl ShellAppTrait for FullChromeDemo {
                         };
                     } else {
                         self.last_event = "Title bar click".into();
+                    }
+                    Reaction::Redraw
+                } else if let Some(edge) =
+                    ctx.window_edge(position.x, position.y, backend.line_height())
+                {
+                    // #406: the outer window border resizes on a left-
+                    // button press, same as native CSD chrome. Margin
+                    // derives from `line_height()` (portable across
+                    // cells/pixels per LESSONS.md) rather than a hardcoded
+                    // constant. `begin_window_resize` is a documented
+                    // no-op (returns `false`) on backends with no window
+                    // (TUI).
+                    if *button == MouseButton::Left {
+                        let resizing = backend.begin_window_resize(edge);
+                        self.last_event = if resizing {
+                            format!("Edge resize started ({edge:?})")
+                        } else {
+                            format!("Edge resize (no window) ({edge:?})")
+                        };
+                    } else {
+                        self.last_event = format!("Edge click ({edge:?})");
                     }
                     Reaction::Redraw
                 } else if ctx.in_sidebar(position.x, position.y) {
@@ -322,6 +359,28 @@ impl ShellAppTrait for FullChromeDemo {
                 } else {
                     Reaction::Continue
                 }
+            }
+            UiEvent::MouseMoved { position, .. } => {
+                // #406: hint the resize cursor while hovering the outer
+                // window border, restore the default pointer everywhere
+                // else. No repaint needed — this only changes the OS
+                // pointer glyph, not anything the app itself draws.
+                //
+                // Skip the title bar band first, same priority as the
+                // MouseDown handling above — the title bar isn't resizable
+                // (a full-width CSD header bar owns the top edge), so it
+                // must never show a resize cursor even though it's within
+                // `window_edge`'s top margin.
+                let shape = if ctx.in_title_bar(position.x, position.y) {
+                    PointerShape::Default
+                } else {
+                    match ctx.window_edge(position.x, position.y, backend.line_height()) {
+                        Some(edge) => PointerShape::Resize(edge),
+                        None => PointerShape::Default,
+                    }
+                };
+                backend.set_cursor(shape);
+                Reaction::Continue
             }
             UiEvent::DoubleClick { position, .. } => {
                 if ctx.in_title_bar(position.x, position.y) {

--- a/quadraui/examples/gtk_full_chrome_demo.rs
+++ b/quadraui/examples/gtk_full_chrome_demo.rs
@@ -1,7 +1,9 @@
 //! GTK runner for the full-chrome AppShell demo (#217 Stage 2).
 //!
 //! Drag the empty part of the title bar to move the window; double-click
-//! it to toggle maximize/restore (#400).
+//! it to toggle maximize/restore (#400). Drag any outer window edge/corner
+//! (other than the top, which the title bar owns) to resize (#406) — hover
+//! shows the OS resize cursor.
 #[path = "common/mod.rs"]
 mod common;
 

--- a/quadraui/examples/tui_full_chrome_demo.rs
+++ b/quadraui/examples/tui_full_chrome_demo.rs
@@ -2,7 +2,8 @@
 //!
 //! No window to drag/maximize here — clicking/double-clicking the title
 //! bar exercises the same code path as GTK but is a documented no-op
-//! (#400).
+//! (#400). Same story for edge-resize (#406): clicking a window border
+//! runs the same call path but reports back "no window".
 #[path = "common/mod.rs"]
 mod common;
 

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -53,6 +53,36 @@ use crate::{
     TextDisplay, TreeView,
 };
 
+/// Which edge or corner of a window a resize gesture originates from.
+/// Mirrors `gdk4::SurfaceEdge` 1:1 (see [`Backend::begin_window_resize`]) so
+/// the GTK backend's conversion is a plain match with no ambiguity, but the
+/// type itself is backend-neutral — TUI and other backends just no-op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResizeEdge {
+    North,
+    South,
+    East,
+    West,
+    NorthEast,
+    NorthWest,
+    SouthEast,
+    SouthWest,
+}
+
+/// OS mouse-pointer glyph hint (see [`Backend::set_cursor`]).
+///
+/// Deliberately named `PointerShape`, not `CursorShape` — that name is
+/// already taken by [`crate::primitives::editor::CursorShape`] (the
+/// text-editor caret shape, re-exported as `EditorCursorShape`), which is an
+/// unrelated concept (text caret vs. OS mouse pointer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointerShape {
+    /// The platform's normal arrow/default pointer.
+    Default,
+    /// A directional resize pointer for the given window edge/corner.
+    Resize(ResizeEdge),
+}
+
 /// One implementation per platform. TUI, GTK, Win-GUI, and (v1.x) macOS.
 pub trait Backend {
     // ─── Frame + viewport ──────────────────────────────────────────────
@@ -242,6 +272,44 @@ pub trait Backend {
     /// part of the titlebar band. Returns `false` on backends with no
     /// window (TUI); `true` once the toggle happened.
     fn toggle_window_maximize(&mut self) -> bool {
+        false
+    }
+
+    /// Begin an OS-native window resize gesture from the given edge, using
+    /// the raw device/button/timestamp captured from the most recent
+    /// primary-button press (same mechanism as [`Self::begin_window_drag`]).
+    ///
+    /// For apps that draw their own client-side titlebar and want to offer
+    /// edge/corner resize the way native `gtk4::WindowHandle` /
+    /// `GDK_SURFACE_EDGE_*` decorations do for free. Apps are expected to
+    /// hit-test the pointer against their own window bounds each frame
+    /// (see [`crate::shell::ShellContext::window_edge`]) and call this from
+    /// a `MouseDown` handler when the press lands within resize-margin
+    /// distance of an edge.
+    ///
+    /// Unlike [`Self::begin_window_drag`], this does not need to defer past
+    /// a movement threshold: there is no competing "double-click on an edge
+    /// means something else" gesture to protect (double-click-to-maximize
+    /// only applies to the empty titlebar band), so `GtkBackend` calls
+    /// `gdk4::Toplevel::begin_resize` directly from the stashed press
+    /// context.
+    ///
+    /// Returns `false` when the backend owns no window (TUI, and any
+    /// backend before its window is constructed) or no primed press context
+    /// is available. Callers should treat `false` as a no-op, not an error.
+    fn begin_window_resize(&mut self, _edge: ResizeEdge) -> bool {
+        false
+    }
+
+    /// Hint the OS mouse-pointer glyph, e.g. to show a resize cursor while
+    /// hovering a window edge (see [`Self::begin_window_resize`]).
+    ///
+    /// Call from `ShellApp::handle` on every `UiEvent::MouseMoved`, passing
+    /// [`PointerShape::Resize`] when [`crate::shell::ShellContext::window_edge`]
+    /// returns `Some`, else [`PointerShape::Default`] to restore the normal
+    /// pointer. Returns `false` on backends with no native pointer concept
+    /// (TUI) or no window yet; `true` once the pointer glyph was applied.
+    fn set_cursor(&mut self, _shape: PointerShape) -> bool {
         false
     }
 

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -54,6 +54,12 @@ pub enum AppShellEvent {
 /// Layout bounds returned by [`AppShell::render`] and [`AppShell::layout`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct AppShellLayout {
+    /// The full window/viewport rect this layout was computed against —
+    /// the same `area` passed to [`AppShell::layout`] / [`AppShell::render`].
+    /// Lets [`crate::shell::ShellContext::window_edge`] (#406) hit-test the
+    /// outer window border for edge-resize without the app having to
+    /// separately track `backend.viewport()`.
+    pub window_bounds: Rect,
     pub title_bar_bounds: Option<Rect>,
     pub activity_bar_bounds: Rect,
     pub sidebar_header_bounds: Option<Rect>,
@@ -777,6 +783,7 @@ impl AppShell {
             };
             let (main_bounds, bottom_panel_bounds) = carve_bottom_panel(main_bounds);
             return AppShellLayout {
+                window_bounds: area,
                 title_bar_bounds,
                 activity_bar_bounds: ab_bounds,
                 sidebar_header_bounds: None,
@@ -814,6 +821,7 @@ impl AppShell {
                 let (main_bounds, bottom_panel_bounds) = carve_bottom_panel(main_bounds);
 
                 AppShellLayout {
+                    window_bounds: area,
                     title_bar_bounds,
                     activity_bar_bounds: ab_bounds,
                     sidebar_header_bounds: Some(header_bounds),
@@ -842,6 +850,7 @@ impl AppShell {
                 let (main_bounds, bottom_panel_bounds) = carve_bottom_panel(main_bounds);
 
                 AppShellLayout {
+                    window_bounds: area,
                     title_bar_bounds,
                     activity_bar_bounds: ab_bounds,
                     sidebar_header_bounds: Some(header_bounds),

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -53,8 +53,8 @@ use crate::types::WidgetId;
 use crate::{
     parse_key_binding, Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Backend,
     CommandLine, DragState, Form, KeyBinding, ListView, MenuBar, ModalStack, Palette,
-    ParsedBinding, PlatformServices, Rect as QRect, Split, StatusBar, TabBar,
-    Terminal as TerminalPrim, TextDisplay, TreeView, UiEvent, Viewport,
+    ParsedBinding, PlatformServices, PointerShape, Rect as QRect, ResizeEdge, Split, StatusBar,
+    TabBar, Terminal as TerminalPrim, TextDisplay, TreeView, UiEvent, Viewport,
 };
 
 use super::services::GtkPlatformServices;
@@ -899,6 +899,39 @@ fn named_key_to_binding_name(named: crate::NamedKey) -> &'static str {
     }
 }
 
+/// Map a portable [`ResizeEdge`] to GDK's native `SurfaceEdge`, the
+/// argument `gdk4::Toplevel::begin_resize` requires (#406). 1:1 mapping —
+/// `ResizeEdge` was deliberately named to mirror `SurfaceEdge`'s variants.
+fn resize_edge_to_surface_edge(edge: ResizeEdge) -> gdk::SurfaceEdge {
+    match edge {
+        ResizeEdge::North => gdk::SurfaceEdge::North,
+        ResizeEdge::South => gdk::SurfaceEdge::South,
+        ResizeEdge::East => gdk::SurfaceEdge::East,
+        ResizeEdge::West => gdk::SurfaceEdge::West,
+        ResizeEdge::NorthEast => gdk::SurfaceEdge::NorthEast,
+        ResizeEdge::NorthWest => gdk::SurfaceEdge::NorthWest,
+        ResizeEdge::SouthEast => gdk::SurfaceEdge::SouthEast,
+        ResizeEdge::SouthWest => gdk::SurfaceEdge::SouthWest,
+    }
+}
+
+/// Map a [`PointerShape`] to the GTK/CSS cursor name `WidgetExt::
+/// set_cursor_from_name` expects (#406). Names are the standard CSS Basic
+/// UI cursor keywords GTK's cursor theme lookup understands.
+fn pointer_shape_cursor_name(shape: PointerShape) -> &'static str {
+    match shape {
+        PointerShape::Default => "default",
+        PointerShape::Resize(ResizeEdge::North) => "n-resize",
+        PointerShape::Resize(ResizeEdge::South) => "s-resize",
+        PointerShape::Resize(ResizeEdge::East) => "e-resize",
+        PointerShape::Resize(ResizeEdge::West) => "w-resize",
+        PointerShape::Resize(ResizeEdge::NorthEast) => "ne-resize",
+        PointerShape::Resize(ResizeEdge::NorthWest) => "nw-resize",
+        PointerShape::Resize(ResizeEdge::SouthEast) => "se-resize",
+        PointerShape::Resize(ResizeEdge::SouthWest) => "sw-resize",
+    }
+}
+
 impl Backend for GtkBackend {
     fn viewport(&self) -> Viewport {
         self.viewport
@@ -1039,6 +1072,48 @@ impl Backend for GtkBackend {
         } else {
             window.maximize();
         }
+        true
+    }
+
+    fn begin_window_resize(&mut self, edge: ResizeEdge) -> bool {
+        // #406, mirrors `begin_window_drag`'s no-window / no-pending-press
+        // guards, but calls `gdk4::Toplevel::begin_resize` directly instead
+        // of arming a deferred request: edges have no competing
+        // double-click gesture to protect against (double-click-to-
+        // maximize only applies to the empty titlebar band), so there's no
+        // need to defer past a movement threshold the way
+        // `commit_armed_window_drag` does for the move gesture.
+        let Some(window) = self.window.as_ref() else {
+            return false;
+        };
+        let Some((device, button, x, y, time)) = self.pending_window_press.take() else {
+            return false;
+        };
+        match window.surface().downcast::<gdk::Toplevel>() {
+            Ok(toplevel) => {
+                toplevel.begin_resize(
+                    resize_edge_to_surface_edge(edge),
+                    Some(&device),
+                    button,
+                    x,
+                    y,
+                    time,
+                );
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    fn set_cursor(&mut self, shape: PointerShape) -> bool {
+        // #406: GTK CSS cursor names inherit from the window down to the
+        // (cursor-less-by-default) content `DrawingArea`, so setting it on
+        // the stored top-level window is enough to change the pointer
+        // glyph anywhere over the content area.
+        let Some(window) = self.window.as_ref() else {
+            return false;
+        };
+        window.set_cursor_from_name(Some(pointer_shape_cursor_name(shape)));
         true
     }
 
@@ -2508,6 +2583,121 @@ mod tests {
     fn gtk_backend_toggle_window_maximize_false_without_window() {
         let mut backend = GtkBackend::new();
         assert!(!Backend::toggle_window_maximize(&mut backend));
+    }
+
+    /// #406: with no window set (every unit test), `begin_window_resize`
+    /// must no-op rather than panic, mirroring `begin_window_drag`'s
+    /// no-window guard.
+    #[test]
+    fn gtk_backend_begin_window_resize_false_without_window() {
+        let mut backend = GtkBackend::new();
+        assert!(!Backend::begin_window_resize(
+            &mut backend,
+            ResizeEdge::South
+        ));
+    }
+
+    /// #406: `begin_window_resize` also no-ops when a window is present but
+    /// no press was ever stashed — there's no real device/timestamp to hand
+    /// GDK, same rationale as `begin_window_drag`'s equivalent guard.
+    #[test]
+    fn gtk_backend_begin_window_resize_false_without_pending_press() {
+        let mut backend = GtkBackend::new();
+        assert!(backend.pending_window_press.is_none());
+        assert!(!Backend::begin_window_resize(
+            &mut backend,
+            ResizeEdge::SouthEast
+        ));
+    }
+
+    /// #406: with no window set, `set_cursor` must no-op rather than panic.
+    #[test]
+    fn gtk_backend_set_cursor_false_without_window() {
+        let mut backend = GtkBackend::new();
+        assert!(!Backend::set_cursor(&mut backend, PointerShape::Default));
+        assert!(!Backend::set_cursor(
+            &mut backend,
+            PointerShape::Resize(ResizeEdge::North)
+        ));
+    }
+
+    /// #406: `ResizeEdge` maps 1:1 onto `gdk4::SurfaceEdge` — exercise
+    /// every variant so an accidental swap (e.g. `NorthEast` <->
+    /// `SouthWest`) fails loudly instead of silently resizing the wrong
+    /// corner on a real compositor.
+    #[test]
+    fn resize_edge_to_surface_edge_maps_every_variant() {
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::North),
+            gdk::SurfaceEdge::North
+        );
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::South),
+            gdk::SurfaceEdge::South
+        );
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::East),
+            gdk::SurfaceEdge::East
+        );
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::West),
+            gdk::SurfaceEdge::West
+        );
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::NorthEast),
+            gdk::SurfaceEdge::NorthEast
+        );
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::NorthWest),
+            gdk::SurfaceEdge::NorthWest
+        );
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::SouthEast),
+            gdk::SurfaceEdge::SouthEast
+        );
+        assert_eq!(
+            resize_edge_to_surface_edge(ResizeEdge::SouthWest),
+            gdk::SurfaceEdge::SouthWest
+        );
+    }
+
+    /// #406: `PointerShape` -> GTK cursor-name mapping covers every
+    /// variant with the expected CSS Basic UI keyword.
+    #[test]
+    fn pointer_shape_cursor_name_maps_every_variant() {
+        assert_eq!(pointer_shape_cursor_name(PointerShape::Default), "default");
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::North)),
+            "n-resize"
+        );
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::South)),
+            "s-resize"
+        );
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::East)),
+            "e-resize"
+        );
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::West)),
+            "w-resize"
+        );
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::NorthEast)),
+            "ne-resize"
+        );
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::NorthWest)),
+            "nw-resize"
+        );
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::SouthEast)),
+            "se-resize"
+        );
+        assert_eq!(
+            pointer_shape_cursor_name(PointerShape::Resize(ResizeEdge::SouthWest)),
+            "sw-resize"
+        );
     }
 
     #[test]

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -277,7 +277,9 @@ pub use accelerator::{
     parse_key_binding, render_accelerator, render_binding, Accelerator, AcceleratorId,
     AcceleratorScope, KeyBinding, ParsedBinding, Platform,
 };
-pub use backend::{Backend, Clipboard, FileDialogOptions, Notification, PlatformServices};
+pub use backend::{
+    Backend, Clipboard, FileDialogOptions, Notification, PlatformServices, PointerShape, ResizeEdge,
+};
 pub use event::{
     BackendNativeEvent, ButtonMask, Key, MouseButton, NamedKey, Point, Rect, ScrollDelta, UiEvent,
     Viewport,

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -10,7 +10,7 @@ use crate::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition, 
 use crate::compose::bottom_panel::{BottomPanelConfig, BottomPanelEvent};
 use crate::event::Rect;
 use crate::types::WidgetId;
-use crate::{Backend, Reaction, UiEvent};
+use crate::{Backend, Reaction, ResizeEdge, UiEvent};
 
 /// Configuration for creating an AppShell.
 pub struct ShellConfig {
@@ -177,6 +177,75 @@ impl<'a> ShellContext<'a> {
         self.layout.title_bar_bounds
     }
 
+    /// The full window/viewport bounds this layout was computed against.
+    pub fn window_bounds(&self) -> Rect {
+        self.layout.window_bounds
+    }
+
+    /// Which edge or corner of the window `(x, y)` is within `margin` of,
+    /// or `None` if the position isn't near any outer border (#406).
+    ///
+    /// Mirrors [`Self::in_title_bar`]'s pattern: the app hit-tests the
+    /// pointer against a stored bounds field every frame rather than the
+    /// backend owning edge detection. Callers should derive `margin` from a
+    /// portable backend unit (e.g. `backend.line_height()`) rather than a
+    /// hardcoded pixel/cell constant — see `quadraui/docs/LESSONS.md`
+    /// "Shared AppLogic code must not hardcode backend-native units".
+    ///
+    /// Call from a `MouseDown` handler (pass the result to
+    /// [`Backend::begin_window_resize`]) and from a `MouseMoved` handler
+    /// (pass `PointerShape::Resize(edge)` / `PointerShape::Default` to
+    /// [`Backend::set_cursor`]).
+    pub fn window_edge(&self, x: f32, y: f32, margin: f32) -> Option<ResizeEdge> {
+        let r = self.layout.window_bounds;
+        // Points outside the window entirely (shouldn't normally happen —
+        // mouse events are clipped to the window — but defend anyway) never
+        // resolve to an edge.
+        if x < r.x || x > r.x + r.width || y < r.y || y > r.y + r.height {
+            return None;
+        }
+        // `near_right`/`near_bottom` use `>=` (not `>`) so the last valid
+        // cell index is included on TUI, mirroring `rect_contains`'s own
+        // `x < r.x + r.width` upper bound (which treats column
+        // `r.width - 1` as inside). With continuous GTK pixel coordinates
+        // the `=` case is a single point of measure zero and doesn't
+        // change behaviour; on TUI's discrete cell grid it's the
+        // difference between the bottom-right corner being reachable at
+        // all and a permanently-dead corner (margin == 1 cell exactly
+        // covers the last row/column, so a strict `>` would never fire).
+        let margin = margin.max(0.0);
+        let near_left = x < r.x + margin;
+        let near_right = x >= r.x + r.width - margin;
+        let near_top = y < r.y + margin;
+        let near_bottom = y >= r.y + r.height - margin;
+
+        // Corners first, then single edges. An if-chain (rather than an
+        // exhaustive match on all four bools) reads clearer and handles the
+        // degenerate case of a window smaller than `2 * margin` in one
+        // dimension (both `near_top` and `near_bottom` true, no left/right)
+        // by falling through to a deterministic single-edge pick instead of
+        // requiring a meaningless tie-break arm.
+        if near_top && near_left {
+            Some(ResizeEdge::NorthWest)
+        } else if near_top && near_right {
+            Some(ResizeEdge::NorthEast)
+        } else if near_bottom && near_left {
+            Some(ResizeEdge::SouthWest)
+        } else if near_bottom && near_right {
+            Some(ResizeEdge::SouthEast)
+        } else if near_top {
+            Some(ResizeEdge::North)
+        } else if near_bottom {
+            Some(ResizeEdge::South)
+        } else if near_left {
+            Some(ResizeEdge::West)
+        } else if near_right {
+            Some(ResizeEdge::East)
+        } else {
+            None
+        }
+    }
+
     /// Status bar bounds.
     pub fn status_bar_bounds(&self) -> Option<Rect> {
         self.layout.status_bar_bounds
@@ -239,5 +308,73 @@ pub trait ShellApp {
     /// that must happen without a user input event. Default is no-op.
     fn tick(&mut self, _backend: &mut dyn Backend) -> Reaction {
         Reaction::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compose::app_shell::AppShell;
+
+    /// Build a bare (no panels, no chrome) `AppShellLayout` sized `w x h`
+    /// starting at the origin — just enough to exercise `window_bounds`.
+    fn layout_for(w: f32, h: f32) -> AppShellLayout {
+        AppShell::new(Vec::new(), 20.0).layout(Rect::new(0.0, 0.0, w, h), 1.0)
+    }
+
+    fn ctx(layout: &AppShellLayout) -> ShellContext<'_> {
+        ShellContext {
+            active_panel_id: None,
+            sidebar_visible: false,
+            layout,
+        }
+    }
+
+    #[test]
+    fn window_edge_none_in_the_middle() {
+        let layout = layout_for(100.0, 40.0);
+        assert_eq!(ctx(&layout).window_edge(50.0, 20.0, 4.0), None);
+    }
+
+    #[test]
+    fn window_edge_detects_each_side() {
+        let layout = layout_for(100.0, 40.0);
+        let c = ctx(&layout);
+        assert_eq!(c.window_edge(50.0, 0.0, 4.0), Some(ResizeEdge::North));
+        assert_eq!(c.window_edge(50.0, 40.0, 4.0), Some(ResizeEdge::South));
+        assert_eq!(c.window_edge(0.0, 20.0, 4.0), Some(ResizeEdge::West));
+        assert_eq!(c.window_edge(100.0, 20.0, 4.0), Some(ResizeEdge::East));
+    }
+
+    #[test]
+    fn window_edge_detects_each_corner() {
+        let layout = layout_for(100.0, 40.0);
+        let c = ctx(&layout);
+        assert_eq!(c.window_edge(0.0, 0.0, 4.0), Some(ResizeEdge::NorthWest));
+        assert_eq!(c.window_edge(100.0, 0.0, 4.0), Some(ResizeEdge::NorthEast));
+        assert_eq!(c.window_edge(0.0, 40.0, 4.0), Some(ResizeEdge::SouthWest));
+        assert_eq!(c.window_edge(100.0, 40.0, 4.0), Some(ResizeEdge::SouthEast));
+    }
+
+    /// A point outside the window bounds entirely never resolves to an
+    /// edge, even if it would be "within margin" of one in absolute terms.
+    #[test]
+    fn window_edge_none_outside_window() {
+        let layout = layout_for(100.0, 40.0);
+        assert_eq!(ctx(&layout).window_edge(-2.0, 20.0, 4.0), None);
+        assert_eq!(ctx(&layout).window_edge(50.0, 45.0, 4.0), None);
+    }
+
+    /// A window narrower/shorter than `2 * margin` must still resolve
+    /// deterministically (no panic) rather than requiring an ambiguous
+    /// top-vs-bottom / left-vs-right tie-break.
+    #[test]
+    fn window_edge_degenerate_tiny_window_is_deterministic() {
+        let layout = layout_for(3.0, 3.0);
+        let c = ctx(&layout);
+        // Every point in a 3x3 window is within margin=4.0 of every edge;
+        // just assert this doesn't panic and returns a corner (checked
+        // first in the priority chain).
+        assert_eq!(c.window_edge(1.5, 1.5, 4.0), Some(ResizeEdge::NorthWest));
     }
 }

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -10,7 +10,7 @@
 #![cfg(feature = "tui")]
 
 use quadraui::tui::testing::{driver_with_shell, TuiDriver};
-use quadraui::{NamedKey, Point, Reaction, UiEvent};
+use quadraui::{ButtonMask, NamedKey, Point, Reaction, UiEvent};
 
 #[path = "../examples/common/shell_app.rs"]
 mod shell_app_ex;
@@ -1189,5 +1189,135 @@ fn full_chrome_title_bar_close_button_exits() {
     assert!(
         driver.exited(),
         "driver should latch `exited` after the close button is clicked"
+    );
+}
+
+// ─── FullChromeDemo: window-edge resize escape hatch (#406) ────────────────
+//
+// `FullChromeDemo` hit-tests `ShellContext::window_edge` on `MouseDown` and
+// calls `Backend::begin_window_resize`, mirroring #400's drag/maximize
+// pattern. TUI has no window to resize, so this must return `false` and the
+// demo must show the "no window" fallback message rather than crash or
+// hang — same story as the #400 tests above. `MouseMoved` hints the resize
+// cursor via `Backend::set_cursor`, which is also a documented no-op on
+// TUI; those tests just prove the call path runs cleanly (no automated way
+// to observe the OS pointer glyph headlessly).
+
+/// Left-`MouseDown` on the window's right border (away from the title bar
+/// and any corner) calls `begin_window_resize(East)`, which must return
+/// `false` on `TuiBackend` (no window) and the demo must show the
+/// no-window fallback.
+///
+/// The *left* border isn't a usable equivalent here: `FullChromeDemo`'s
+/// activity bar sits flush against column 0 and spans the full band
+/// height, and `AppShell::handle` already claims the whole
+/// `activity_bar_bounds` rect for panel-switching before `ShellApp::handle`
+/// (and thus `window_edge`) ever sees the event — so West/NorthWest/
+/// SouthWest resize is unreachable in this particular demo layout. That's
+/// a property of an icon column starting at the literal window edge with
+/// no reserved margin, not a bug in `window_edge` itself; East/South/
+/// SouthEast (checked here and below) aren't shadowed by any shell-owned
+/// region and exercise the same mechanism.
+#[test]
+fn full_chrome_right_edge_click_requests_window_resize() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    // x=99 is the last column (the right border); y=15 sits well below the
+    // 2-row title bar and above the bottom-panel resize grip.
+    driver.click(99.0, 15.0);
+    assert!(
+        driver.screen_contains("Edge resize (no window) (East)"),
+        "clicking the right border should call begin_window_resize(East), \
+         get false back (no window), and show the edge-resize fallback \
+         message:\n{}",
+        driver.screen()
+    );
+}
+
+/// Left-`MouseDown` on the bottom-right corner calls
+/// `begin_window_resize(SouthEast)`, same no-window fallback as above.
+#[test]
+fn full_chrome_bottom_right_corner_click_requests_window_resize() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    // (99, 29) is the last valid cell in a 100x30 grid — the bottom-right
+    // corner, nowhere near the title bar.
+    driver.click(99.0, 29.0);
+    assert!(
+        driver.screen_contains("Edge resize (no window) (SouthEast)"),
+        "clicking the bottom-right corner should call \
+         begin_window_resize(SouthEast), get false back (no window), and \
+         show the edge-resize fallback message:\n{}",
+        driver.screen()
+    );
+}
+
+/// Regression guard for the priority decision documented in
+/// `FullChromeDemo::handle`: the title bar band owns the *entire* top edge
+/// (including its corners), same as native GTK `HeaderBar` CSD having no
+/// top-edge resize handle. A click at the top-left corner — which falls
+/// within both `in_title_bar` and `window_edge`'s margin — must still
+/// resolve to the title-bar-drag gesture (#400), not edge-resize (#406).
+#[test]
+fn full_chrome_title_bar_wins_over_window_edge_at_top_corner() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    driver.click(0.0, 0.0);
+    assert!(
+        driver.screen_contains("Title bar click (no window to drag)"),
+        "a MouseDown at the top-left corner overlaps both the title bar \
+         and the window-edge margin; the title bar must win:\n{}",
+        driver.screen()
+    );
+    assert!(
+        !driver.screen_contains("Edge resize"),
+        "the top corner must not be reported as an edge-resize request \
+         while a title bar owns that band:\n{}",
+        driver.screen()
+    );
+}
+
+/// `MouseMoved` over a window edge calls `Backend::set_cursor` with a
+/// resize hint. `TuiBackend` has no OS pointer to change, so this just
+/// proves the call path runs end-to-end without crashing or hanging —
+/// there's no headless way to observe the (nonexistent) TUI cursor glyph.
+#[test]
+fn full_chrome_mouse_moved_over_edge_does_not_crash() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    // Hover with no button held (a plain move, not a drag) over the right
+    // border, then back over plain main-content — both must return
+    // `Continue` (a cursor hint never triggers a repaint) and leave the
+    // rest of the screen exactly as it was.
+    let reaction = driver.dispatch(UiEvent::MouseMoved {
+        position: Point::new(99.0, 15.0),
+        buttons: ButtonMask::default(),
+    });
+    assert_eq!(
+        reaction,
+        Reaction::Continue,
+        "hovering a window edge should only hint the cursor, never redraw"
+    );
+    // The full initial status line is longer than the visible
+    // main-content width and gets clipped — check a prefix that's
+    // guaranteed to survive the clip rather than the full string.
+    assert!(
+        driver.screen_contains("drag edges"),
+        "the status line should be unaffected by a hover-only cursor hint:\n{}",
+        driver.screen()
+    );
+
+    let reaction = driver.dispatch(UiEvent::MouseMoved {
+        position: Point::new(50.0, 15.0),
+        buttons: ButtonMask::default(),
+    });
+    assert_eq!(
+        reaction,
+        Reaction::Continue,
+        "hovering plain main content (not an edge) should also just return Continue"
     );
 }


### PR DESCRIPTION
Closes #406

Automated merge from the coordinator for assignment 73770e4f2de3 on issue #406.

Worker branch: `issue-406-no-window-edge-resize-api-for-csd-titleb` → `develop`.