### PR TITLE
#409: ShellApp/ShellAdapter: no hook for consumers to drive AppShell's keyboard-selectable activity bar (#386/#368)

### DIFF
--- a/quadraui/examples/common/appshell_demo.rs
+++ b/quadraui/examples/common/appshell_demo.rs
@@ -4,6 +4,15 @@
 //! `AppLogic` (~80 lines). The shell owns activity bar, sidebar header,
 //! divider drag, and panel switching. The consumer renders sidebar
 //! content + main content into the bounds the shell provides.
+//!
+//! Also demonstrates the activity-bar keyboard-cursor hook (#409):
+//! `Tab` calls [`ShellContext::request_activity_keyboard_focus`] to enter
+//! keyboard-cursor mode; from there `j`/`k` (or arrows) move the cursor,
+//! `l`/`Enter`/`Space` activates the selected panel, and `Esc`/`h`/`Left`
+//! cancels — all driven internally by the shell runner, not this app. A
+//! `ShellApp` only needs to pick its own trigger key(s) and call
+//! `request_activity_keyboard_focus()`; a different consumer could bind
+//! `Ctrl+W` instead of `Tab` with no quadraui changes.
 
 use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
 use quadraui::{
@@ -18,7 +27,7 @@ pub struct AppShellDemo {
 impl AppShellDemo {
     pub fn new() -> Self {
         Self {
-            last_event: "click icons | drag divider | q=quit".into(),
+            last_event: "Tab=focus bar | click icons | drag divider | q=quit".into(),
         }
     }
 
@@ -112,6 +121,19 @@ impl ShellApp for AppShellDemo {
                 key: Key::Char('q') | Key::Named(NamedKey::Escape),
                 ..
             } => Reaction::Exit,
+            // Tab is this demo's chosen trigger for entering activity-bar
+            // keyboard-cursor mode (#409). The shell runner (not this app)
+            // owns j/k/Enter/Esc navigation from here — see
+            // `ShellAdapter::handle`. A different `ShellApp` is free to
+            // bind a different key (e.g. `Ctrl+W`) to the same request.
+            UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::Tab),
+                ..
+            } => {
+                ctx.request_activity_keyboard_focus();
+                self.last_event = "Activity bar focused (j/k, Enter, Esc)".into();
+                Reaction::Redraw
+            }
             UiEvent::MouseDown { position, .. } => {
                 if ctx.in_sidebar(position.x, position.y) {
                     self.last_event = format!(

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -6,6 +6,8 @@
 //! window creation, event wiring, AppShell chrome rendering, and event
 //! routing — the consumer renders only its own content.
 
+use std::cell::Cell;
+
 use crate::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition, ShellPosition};
 use crate::compose::bottom_panel::{BottomPanelConfig, BottomPanelEvent};
 use crate::event::Rect;
@@ -124,9 +126,58 @@ pub struct ShellContext<'a> {
     pub sidebar_visible: bool,
     /// Layout bounds from the last render.
     pub layout: &'a AppShellLayout,
+    /// Set via [`Self::request_activity_keyboard_focus`]; consumed by
+    /// [`crate::shell_adapter::ShellAdapter::handle`] after
+    /// `ShellApp::handle` returns. `Cell` because `ShellContext` is passed
+    /// by shared reference — the consumer can request focus without a
+    /// `&mut` hook back into the shell.
+    activity_focus_requested: Cell<bool>,
 }
 
 impl<'a> ShellContext<'a> {
+    /// Construct a [`ShellContext`] for one `ShellApp::handle` dispatch.
+    /// Only called by [`crate::shell_adapter::ShellAdapter`]; downstream
+    /// consumers receive an already-built context, they don't build one.
+    pub(crate) fn new(
+        active_panel_id: Option<&'a WidgetId>,
+        sidebar_visible: bool,
+        layout: &'a AppShellLayout,
+    ) -> Self {
+        Self {
+            active_panel_id,
+            sidebar_visible,
+            layout,
+            activity_focus_requested: Cell::new(false),
+        }
+    }
+
+    /// Request that the activity bar take keyboard focus, with its cursor
+    /// reset to the top item, once the current `ShellApp::handle` call
+    /// returns.
+    ///
+    /// Call this from your own `handle()` in response to whatever key you
+    /// want to bind as the "focus the activity bar" trigger (`Tab`,
+    /// `Ctrl+W`, a command-palette action, ...) — quadraui does not
+    /// reserve a key for this itself, so different consumers can pick
+    /// different triggers. Once focused, [`crate::shell_adapter::ShellAdapter`]
+    /// owns the navigation keys (`j`/`k`/arrows to move, `Enter`/`Space` to
+    /// activate, `Esc` to cancel) by driving the same
+    /// [`crate::compose::app_shell::AppShell`] methods the raw `AppLogic`
+    /// pattern uses directly — see `examples/common/shell_app.rs`.
+    ///
+    /// A no-op if called more than once per `handle()` call (the flag is
+    /// simply set, not counted).
+    pub fn request_activity_keyboard_focus(&self) {
+        self.activity_focus_requested.set(true);
+    }
+
+    /// Consume the pending focus request, if any. `pub(crate)` — only
+    /// [`crate::shell_adapter::ShellAdapter::handle`] calls this, after
+    /// `ShellApp::handle` returns.
+    pub(crate) fn take_activity_focus_requested(&self) -> bool {
+        self.activity_focus_requested.replace(false)
+    }
+
     /// Check if a mouse position lands inside the sidebar content area.
     pub fn in_sidebar(&self, x: f32, y: f32) -> bool {
         rect_contains_opt(self.layout.sidebar_content_bounds, x, y)

--- a/quadraui/src/shell_adapter.rs
+++ b/quadraui/src/shell_adapter.rs
@@ -25,7 +25,7 @@ use crate::event::Rect;
 use crate::runner::{AppLogic, Reaction};
 use crate::shell::{ShellApp, ShellContext};
 use crate::types::WidgetId;
-use crate::{Backend, MouseButton, UiEvent};
+use crate::{ActivityBarEvent, Backend, MouseButton, UiEvent};
 
 /// Adapts a [`ShellApp`] into an [`AppLogic`] by composing it with an
 /// [`AppShell`] and an optional [`BottomPanelController`].
@@ -174,6 +174,52 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
             AppShellEvent::Ignored => {}
         }
 
+        // ── Built-in activity-bar keyboard navigation (#409) ──────────────
+        //
+        // `AppShell::build_activity_bar()` (compose/app_shell.rs) already
+        // implements the full keyboard-cursor API (select_next/prev,
+        // activate_selected, ...) and the backends already translate a
+        // `KeyPressed` into `UiEvent::ActivityBar(id, KeyPressed { key, .. })`
+        // once `activity_keyboard_focused()` is true — see
+        // `TuiBackend::apply_dispatch`. But `ShellApp` consumers had no path
+        // to reach any of it (the raw `AppLogic` pattern in
+        // `examples/common/shell_app.rs` owns `AppShell` directly and wires
+        // this itself). Mirror that pattern here, once, for every `ShellApp`
+        // consumer: intercept the synthesized `ActivityBar` event before it
+        // would otherwise reach `ShellApp::handle` (which never sees this
+        // event type — there is nothing for a consumer to opt into or
+        // conflict with) and drive `AppShell` directly. Resulting
+        // `AppShellEvent`s are reported through the existing
+        // `on_shell_event` notification, exactly like a mouse-driven panel
+        // switch.
+        if let UiEvent::ActivityBar(_, ActivityBarEvent::KeyPressed { ref key, .. }) = event {
+            return match key.as_str() {
+                "j" | "Down" => {
+                    self.shell.activity_select_next();
+                    Reaction::Redraw
+                }
+                "k" | "Up" => {
+                    self.shell.activity_select_prev();
+                    Reaction::Redraw
+                }
+                "l" | "Enter" | " " | "Space" => {
+                    if let Some(ev) = self.shell.activity_activate_selected() {
+                        self.shell.set_activity_keyboard_focused(false);
+                        if let AppShellEvent::PanelChanged { ref panel_id } = ev {
+                            self.active_panel_id = Some(panel_id.clone());
+                        }
+                        self.app.on_shell_event(&ev);
+                    }
+                    Reaction::Redraw
+                }
+                "Escape" | "h" | "Left" => {
+                    self.shell.set_activity_keyboard_focused(false);
+                    Reaction::Redraw
+                }
+                _ => Reaction::Continue,
+            };
+        }
+
         // If the shell didn't consume the event, check the bottom panel tab strip.
         if let Some(ref ctrl_cell) = self.bottom_panel {
             if let UiEvent::MouseDown {
@@ -197,12 +243,25 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         }
 
         let layout = self.shell.layout(area, backend.line_height());
-        let ctx = ShellContext {
-            active_panel_id: self.active_panel_id.as_ref(),
-            sidebar_visible: self.shell.sidebar_visible(),
-            layout: &layout,
-        };
-        self.app.handle(event, backend, &ctx)
+        let ctx = ShellContext::new(
+            self.active_panel_id.as_ref(),
+            self.shell.sidebar_visible(),
+            &layout,
+        );
+        let mut reaction = self.app.handle(event, backend, &ctx);
+
+        // The app may have called `ctx.request_activity_keyboard_focus()`
+        // (e.g. in response to its own `Tab` / `Ctrl+W` binding) to enter
+        // the keyboard-cursor mode the block above then drives.
+        if ctx.take_activity_focus_requested() {
+            self.shell.set_activity_keyboard_focused(true);
+            self.shell.activity_set_cursor(0);
+            if reaction == Reaction::Continue {
+                reaction = Reaction::Redraw;
+            }
+        }
+
+        reaction
     }
 
     fn tick(&mut self, backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -20,6 +20,8 @@ use shell_app_ex::ShellApp as ShellAppEx;
 mod toolbar_app;
 use toolbar_app::ToolbarApp;
 
+#[path = "../examples/common/appshell_demo.rs"]
+mod appshell_demo;
 #[path = "../examples/common/clipboard_demo.rs"]
 mod clipboard_demo;
 #[path = "../examples/common/demo.rs"]
@@ -43,6 +45,7 @@ mod tab_group_demo;
 #[path = "../examples/common/text_input_demo.rs"]
 mod text_input_demo;
 
+use appshell_demo::AppShellDemo;
 use clipboard_demo::ClipboardDemo;
 use demo::AppState;
 use dialog_table_demo::DialogTableDemo;
@@ -426,6 +429,115 @@ fn shell_runner_path_drag_and_ctrl_c_copies_text() {
     assert!(
         screen.contains("quick") || screen.contains("brown"),
         "copied preview should contain selected text:\n{screen}"
+    );
+}
+
+// ─── AppShellDemo (issue #409): ShellApp activity-bar keyboard focus hook ───
+//
+// `AppShellDemo` implements `ShellApp` and binds `Tab` to
+// `ShellContext::request_activity_keyboard_focus()`. Everything after that
+// — j/k navigation, Enter activation, Escape cancellation — is driven by
+// `ShellAdapter::handle` itself, intercepting the synthesized
+// `UiEvent::ActivityBar` before it would reach `AppShellDemo::handle` (which
+// has no match arm for that event at all). These tests prove the full
+// `Tab → focus → j/k → Enter` round trip works for a `ShellApp` consumer,
+// which was impossible before #409 (only the raw `AppLogic` pattern in
+// `examples/common/shell_app.rs` could reach `AppShell`'s keyboard API).
+//
+// `Reaction::Redraw` vs `Reaction::Continue` is the key signal here: `j`/`k`/
+// `Escape` have no meaning to `AppShellDemo::handle` on their own (it would
+// return `Continue` for an unmatched raw key), so a `Redraw` after pressing
+// them proves `ShellAdapter` actually intercepted and handled the
+// synthesized `ActivityBar` event rather than the key falling through.
+
+/// `Tab` focuses the activity bar, `j` `j` moves the keyboard cursor down
+/// two items (explorer → search → git), and `Enter` activates the
+/// selection — switching to the Source Control panel and notifying
+/// `AppShellDemo::on_shell_event`, which is what paints "Panel: panel:git".
+#[test]
+fn appshell_demo_tab_focus_then_jj_enter_switches_panel() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, 80, 24);
+
+    assert!(
+        driver.screen_contains("Tab=focus bar"),
+        "initial hint should mention the Tab trigger:\n{}",
+        driver.screen()
+    );
+
+    let reaction = driver.press_named(NamedKey::Tab);
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Tab should request activity-bar keyboard focus and redraw"
+    );
+    assert!(
+        driver.screen_contains("Activity bar focused"),
+        "focusing the bar should update the status hint:\n{}",
+        driver.screen()
+    );
+
+    // Cursor starts at index 0 (explorer). Two `j` presses move it to
+    // index 2 (git) — 3 top panels, cursor saturates instead of wrapping.
+    for _ in 0..2 {
+        let reaction = driver.type_char('j');
+        assert_eq!(
+            reaction,
+            Reaction::Redraw,
+            "'j' while focused must be intercepted as ActivityBar nav, not fall through:\n{}",
+            driver.screen()
+        );
+    }
+
+    let reaction = driver.press_named(NamedKey::Enter);
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Enter should activate the selected item and redraw"
+    );
+    assert!(
+        driver.screen_contains("Panel: panel:git"),
+        "activating the cursor item should switch to the git panel and notify on_shell_event:\n{}",
+        driver.screen()
+    );
+}
+
+/// `Escape` while the bar is focused cancels keyboard-cursor mode without
+/// switching panels — and, crucially, releases focus so a *subsequent* key
+/// (here `q`) reaches `AppShellDemo::handle` again instead of being
+/// swallowed as activity-bar navigation.
+#[test]
+fn appshell_demo_escape_cancels_focus_without_switching_panel() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, 80, 24);
+
+    driver.press_named(NamedKey::Tab);
+    assert!(driver.screen_contains("Activity bar focused"));
+
+    let reaction = driver.press_named(NamedKey::Escape);
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Escape while focused should cancel, not exit the app"
+    );
+    assert!(
+        !driver.exited(),
+        "Escape while focused must not quit the demo"
+    );
+    assert!(
+        !driver.screen_contains("Panel:"),
+        "cancelling must not have activated any panel switch:\n{}",
+        driver.screen()
+    );
+
+    // If focus had not actually been released, 'q' would still be routed
+    // as an (unbound) ActivityBar key and return Continue. Getting Exit
+    // proves 'q' reached `AppShellDemo::handle`'s raw KeyPressed match arm.
+    let reaction = driver.type_char('q');
+    assert_eq!(
+        reaction,
+        Reaction::Exit,
+        "'q' after Escape should quit via the app's own binding, proving focus was released"
     );
 }
 


### PR DESCRIPTION
Closes #409

Automated merge from the coordinator for assignment 372809d651f6 on issue #409.

Worker branch: `issue-409-shellapp-shelladapter-no-hook-for-consum` → `develop`.