### PR TITLE
#420: Editor rasteriser owns paint but not its hit-test inverse — EditorLayout::hit_test assumes monospace, drifts from attributed draw_editor (blocks vimcode#560)

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -23,7 +23,7 @@ use crate::primitives::data_table::{DataTable, DataTableLayout};
 use crate::primitives::dialog::{Dialog, DialogLayout};
 use crate::primitives::diff_view::{DiffView, DiffViewLayout};
 use crate::primitives::drop_zone::DropOverlay;
-use crate::primitives::editor::Editor;
+use crate::primitives::editor::{Editor, EditorLayout};
 use crate::primitives::find_replace::FindReplacePanel;
 use crate::primitives::form::FormLayout;
 use crate::primitives::menu_bar::{MenuBar, MenuBarLayout};
@@ -565,6 +565,52 @@ pub trait Backend {
     /// overlays, etc.). Asymmetric across backends: TUI populates
     /// the result; GTK paints its own caret and returns the default.
     fn draw_editor(&mut self, rect: Rect, editor: &Editor) -> EditorPaintResult;
+
+    /// Resolve a click x-coordinate to a text column on one visible row
+    /// of an [`Editor`], honouring the same glyph-advance metrics
+    /// [`Self::draw_editor`] painted that row with (bold / italic /
+    /// `font_scale` spans on GTK's Pango layout; uniform monospace
+    /// cells on TUI) — the paint↔click round-trip fix for #420.
+    ///
+    /// `layout` is the [`EditorLayout`] `editor.layout(...)` produced
+    /// for the same viewport/metrics the caller painted with.
+    /// `view_row` indexes into `editor.lines` (0 = topmost visible row
+    /// — the same row [`crate::primitives::editor::EditorLayout::hit_test`]
+    /// resolves from a y-coordinate). `x` is an absolute (surface-space)
+    /// coordinate, matching the `x` passed to `hit_test`.
+    ///
+    /// Returns the resolved character column *within the buffer line*
+    /// (already folds in `layout.scroll_left` and the row's
+    /// `segment_col_offset` for wrap-continuation rows) — callers
+    /// combine it with `hit_test`'s resolved `line` to get a full
+    /// buffer position:
+    ///
+    /// ```ignore
+    /// if let EditorHit::BufferPos { line, .. } = layout.hit_test(x, y) {
+    ///     let view_row = line - layout.scroll_top;
+    ///     let col = backend.editor_col_at_x(&layout, &editor, view_row, x);
+    ///     // (line, col) is the resolved buffer position.
+    /// }
+    /// ```
+    ///
+    /// Default implementation delegates to
+    /// [`EditorLayout::col_at_x`] (uniform monospace division) —
+    /// correct for TUI and any backend whose configured font renders
+    /// every glyph at the same advance width. `GtkBackend` overrides
+    /// this with an exact Pango `xy_to_index` resolution against the
+    /// same per-span-attributed layout `draw_editor` painted with, so
+    /// a line containing bold / italic / `font_scale` spans (e.g. a
+    /// markdown heading) resolves clicks against its *actual* painted
+    /// glyph positions instead of a uniform grid.
+    fn editor_col_at_x(
+        &self,
+        layout: &EditorLayout,
+        editor: &Editor,
+        view_row: usize,
+        x: f32,
+    ) -> usize {
+        layout.col_at_x(editor, view_row, x)
+    }
 
     /// Draw a [`MessageList`] (chat-style streaming row history).
     /// The backend pulls panel background from its current theme;

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -207,6 +207,17 @@ pub struct GtkBackend {
     /// font/size) closes that gap: "cache at paint, hit-test at
     /// click" (see `quadraui/docs/LESSONS.md`).
     last_menu_bar_pango_layout: Option<pango::Layout>,
+    /// Clone of the Pango layout `draw_editor` actually painted with,
+    /// stashed at the end of the frame's `draw_editor` call. Mirrors
+    /// [`Self::last_menu_bar_pango_layout`] (#407) for the same reason:
+    /// `editor_col_at_x` (#420) is invoked from click-time hit-testing,
+    /// which runs *outside* any frame scope — `current_frame_refs()` is
+    /// `None` there, so falling back to `pango_ctx` would resolve
+    /// against the wrong (UI, not editor) font and silently mis-place
+    /// every click. Caching the exact layout GObject the most recent
+    /// paint used (refcounted clone — cheap, always reflects the
+    /// current editor font) closes that gap.
+    last_editor_pango_layout: Option<pango::Layout>,
 }
 
 /// Active text selection state for the GTK backend. Stores the region id
@@ -250,6 +261,7 @@ impl GtkBackend {
             pending_window_press: None,
             armed_window_drag: None,
             last_menu_bar_pango_layout: None,
+            last_editor_pango_layout: None,
         }
     }
 
@@ -1878,8 +1890,32 @@ impl Backend for GtkBackend {
             char_width,
             line_height,
         );
+        // Stash the exact layout just painted with — see the field doc
+        // on `last_editor_pango_layout` for why this is necessary
+        // rather than relying on `current_frame_refs()` alone.
+        self.last_editor_pango_layout = Some(pango_layout.clone());
         let _ = rect;
         crate::backend::EditorPaintResult::default()
+    }
+
+    fn editor_col_at_x(
+        &self,
+        layout: &crate::primitives::editor::EditorLayout,
+        editor: &crate::primitives::editor::Editor,
+        view_row: usize,
+        x: f32,
+    ) -> usize {
+        let Some(line) = editor.lines.get(view_row) else {
+            return layout.col_at_x(editor, view_row, x);
+        };
+        let frame_layout = self.current_frame_refs().map(|(_, l)| l.clone());
+        let pango_layout = frame_layout
+            .or_else(|| self.last_editor_pango_layout.clone())
+            .or_else(|| self.pango_ctx.as_ref().map(pango::Layout::new));
+        let Some(pango_layout) = pango_layout else {
+            return layout.col_at_x(editor, view_row, x);
+        };
+        crate::gtk::editor_col_at_x(&pango_layout, line, layout, x)
     }
 
     fn draw_message_list(

--- a/quadraui/src/gtk/editor.rs
+++ b/quadraui/src/gtk/editor.rs
@@ -37,8 +37,8 @@
 //! `draw_editor` does not paint scrollbars on GTK.
 
 use crate::primitives::editor::{
-    CursorShape, DiagnosticSeverity, DiffLine, Editor, EditorLine, EditorSelection, GitLineStatus,
-    SelectionKind, StyledSpan,
+    CursorShape, DiagnosticSeverity, DiffLine, Editor, EditorLayout, EditorLine, EditorSelection,
+    GitLineStatus, SelectionKind, StyledSpan,
 };
 use crate::theme::Theme;
 use crate::types::Color;
@@ -620,6 +620,45 @@ fn build_pango_attrs(spans: &[StyledSpan]) -> AttrList {
     attrs
 }
 
+/// Resolve `x` (absolute/surface-space) to a character column within
+/// `line.raw_text`, inverting the **exact** glyph geometry
+/// [`draw_editor`] painted the line with — the paint↔click round-trip
+/// fix for #420 (`GtkBackend::editor_col_at_x`).
+///
+/// `pango_layout`'s text and attributes are overwritten by this call
+/// (`set_text` + [`build_pango_attrs`], mirroring `draw_editor`'s own
+/// per-line setup) — pass a layout carrying the same font family/size
+/// `draw_editor` painted with (the frame-scoped layout while still
+/// inside `enter_frame_scope`, or the cached last-painted clone when
+/// called at click-time outside any frame scope — see
+/// `GtkBackend::last_editor_pango_layout`).
+///
+/// `editor_layout` supplies `text_bounds.x`, `scroll_left`, and
+/// `cell_width` — the same values `draw_editor` used to compute
+/// `text_x_offset`. Horizontal scroll is resolved in the *layout's*
+/// local coordinate space (the Pango layout holds the line's full,
+/// unscrolled `raw_text`; scrolling only changes where `draw_editor`
+/// positions that layout on screen), so the returned column already
+/// reflects `scroll_left` — do not add it again.
+pub fn editor_col_at_x(
+    pango_layout: &pango::Layout,
+    line: &EditorLine,
+    editor_layout: &EditorLayout,
+    x: f32,
+) -> usize {
+    pango_layout.set_text(&line.raw_text);
+    let attrs = build_pango_attrs(&line.spans);
+    pango_layout.set_attributes(Some(&attrs));
+
+    let cell_width = editor_layout.cell_width as f64;
+    let local_x = (x as f64 - editor_layout.text_bounds.x as f64)
+        + editor_layout.scroll_left as f64 * cell_width;
+    let x_pango = (local_x.max(0.0) * pango::SCALE as f64).round() as i32;
+    let (_inside, byte_index, _trailing) = pango_layout.xy_to_index(x_pango, 0);
+    let clamped = (byte_index.max(0) as usize).min(line.raw_text.len());
+    line.raw_text[..clamped].chars().count() + line.segment_col_offset
+}
+
 /// Paint a visual selection range (Char / Line / Block) onto `cr`.
 /// Handles wrap-continuation skipping (chooses the LAST non-skippable
 /// view row per buffer line). Mirrors
@@ -761,5 +800,227 @@ fn draw_visual_selection(
             }
             cr.fill().ok();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::Rect;
+    use crate::primitives::editor::{Editor, Style};
+    use crate::types::Color;
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+    use std::collections::{HashMap, HashSet};
+
+    /// A line with three differently-styled spans (bold / italic /
+    /// `font_scale`) so its painted glyph advances are *not* uniform —
+    /// the exact case where the monospace `EditorLayout::col_at_x`
+    /// fallback drifts from what `draw_editor` actually painted (#420).
+    fn styled_line() -> EditorLine {
+        let plain = Style {
+            fg: Color::rgb(220, 220, 220),
+            bg: None,
+            bold: false,
+            italic: false,
+            font_scale: 1.0,
+        };
+        EditorLine {
+            raw_text: "let x = width; // note".into(),
+            gutter_text: "  1".into(),
+            spans: vec![
+                StyledSpan {
+                    start_byte: 0,
+                    end_byte: 3,
+                    style: Style {
+                        bold: true,
+                        ..plain
+                    },
+                }, // "let"
+                StyledSpan {
+                    start_byte: 8,
+                    end_byte: 13,
+                    style: Style {
+                        italic: true,
+                        ..plain
+                    },
+                }, // "width"
+                StyledSpan {
+                    start_byte: 15,
+                    end_byte: 22,
+                    style: Style {
+                        font_scale: 1.8,
+                        ..plain
+                    },
+                }, // "// note"
+            ],
+            line_idx: 0,
+            is_current_line: false,
+            is_fold_header: false,
+            folded_line_count: 0,
+            git_diff: None,
+            diff_status: None,
+            diagnostics: Vec::new(),
+            spell_errors: Vec::new(),
+            is_breakpoint: false,
+            is_conditional_bp: false,
+            is_dap_current: false,
+            is_wrap_continuation: false,
+            segment_col_offset: 0,
+            annotation: None,
+            ghost_suffix: None,
+            is_ghost_continuation: false,
+            indent_guides: Vec::new(),
+            colorcolumns: Vec::new(),
+        }
+    }
+
+    fn headless_pango_layout() -> pango::Layout {
+        let surface = ImageSurface::create(Format::ARgb32, 900, 60).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let ctx = pangocairo::functions::create_context(&cr);
+        ctx.set_font_description(Some(&pango::FontDescription::from_string("Monospace 12")));
+        pango::Layout::new(&ctx)
+    }
+
+    /// Coordinate-drift round-trip (`quadraui/docs/TESTING.md` taxonomy
+    /// row 1): paint a styled, horizontally-scrolled line, then assert
+    /// `editor_col_at_x` resolves every visible glyph's own painted x
+    /// position back to its own column. A naive uniform-monospace
+    /// resolver (the bug #420 fixes) fails this for any glyph painted
+    /// after the bold/italic/`font_scale` spans, since their advances
+    /// differ from a plain-glyph cell width.
+    #[test]
+    fn editor_col_at_x_round_trips_styled_line_with_scroll() {
+        // Two independent `pango::Layout`s from the same font context —
+        // mirrors production, where the "ground truth" paint layout
+        // (`draw_editor`'s frame-scoped layout) and the click-time probe
+        // layout (`editor_col_at_x`'s argument, possibly the cached
+        // clone) are distinct GObjects. Using one shared, mutable layout
+        // for both would let `editor_col_at_x`'s internal `set_text` /
+        // `set_attributes` calls silently overwrite the "ground truth"
+        // measurements taken later in the loop — which is exactly what
+        // happened when this test was first written with one shared
+        // layout: it kept passing even with `set_attributes(None)`
+        // hard-coded into `editor_col_at_x`, because the corrupted
+        // shared state made "expected" and "actual" agree for the wrong
+        // reason. Two layouts closes that hole.
+        let truth_layout = headless_pango_layout();
+        let probe_layout = headless_pango_layout();
+        let line = styled_line();
+        let editor = Editor {
+            id: "ed".into(),
+            rect: Rect::new(0.0, 0.0, 900.0, 60.0),
+            lines: vec![line.clone()],
+            cursor: None,
+            extra_cursors: Vec::new(),
+            selection: None,
+            extra_selections: Vec::new(),
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: 3,
+            total_lines: 1,
+            max_col: 30,
+            gutter_char_width: 4,
+            is_active: true,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: HashMap::new(),
+            code_action_lines: HashSet::new(),
+            bracket_match_positions: Vec::new(),
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: true,
+            lightbulb_glyph: '!',
+        };
+
+        let cell_width = 9.0_f32;
+        let line_height = 18.0_f32;
+        let viewport = Rect::new(0.0, 0.0, 900.0, 60.0);
+        let editor_layout = editor.layout(viewport, cell_width, line_height);
+
+        // Pass 1 — paint with attrs (identical setup to `draw_editor`'s
+        // per-line loop) into `truth_layout` and record every glyph's
+        // real painted x position *before* touching `probe_layout` at
+        // all, so nothing later can contaminate these measurements.
+        truth_layout.set_text(&line.raw_text);
+        let attrs = build_pango_attrs(&line.spans);
+        truth_layout.set_attributes(Some(&attrs));
+
+        let text_x_offset =
+            editor_layout.text_bounds.x as f64 - editor.scroll_left as f64 * cell_width as f64;
+
+        let glyph_click_xs: Vec<(usize, char, f64)> = line
+            .raw_text
+            .char_indices()
+            .enumerate()
+            .map(|(char_idx, (byte_idx, ch))| {
+                let pos = truth_layout.index_to_pos(byte_idx as i32);
+                let glyph_left_x = text_x_offset + pos.x() as f64 / pango::SCALE as f64;
+                let glyph_width = (pos.width() as f64 / pango::SCALE as f64).max(2.0);
+                // Click a quarter-glyph past the leading edge — solidly
+                // inside the glyph, clear of boundary-rounding ambiguity.
+                (char_idx, ch, glyph_left_x + glyph_width * 0.25)
+            })
+            .collect();
+
+        // Pass 2 — resolve each recorded click through the function
+        // under test, which owns (and mutates) `probe_layout`.
+        for (char_idx, ch, click_x) in glyph_click_xs {
+            let resolved = editor_col_at_x(&probe_layout, &line, &editor_layout, click_x as f32);
+            assert_eq!(
+                resolved, char_idx,
+                "glyph '{ch}' (char {char_idx}) at x={click_x} resolved to col {resolved}"
+            );
+        }
+    }
+
+    #[test]
+    fn editor_col_at_x_adds_segment_col_offset_for_wrap_continuation() {
+        let pango_layout = headless_pango_layout();
+        let mut line = styled_line();
+        line.is_wrap_continuation = true;
+        line.segment_col_offset = 12;
+
+        let editor = Editor {
+            id: "ed".into(),
+            rect: Rect::new(0.0, 0.0, 900.0, 60.0),
+            lines: vec![line.clone()],
+            cursor: None,
+            extra_cursors: Vec::new(),
+            selection: None,
+            extra_selections: Vec::new(),
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: 0,
+            total_lines: 1,
+            max_col: 30,
+            gutter_char_width: 4,
+            is_active: true,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: HashMap::new(),
+            code_action_lines: HashSet::new(),
+            bracket_match_positions: Vec::new(),
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: true,
+            lightbulb_glyph: '!',
+        };
+
+        let cell_width = 9.0_f32;
+        let viewport = Rect::new(0.0, 0.0, 900.0, 60.0);
+        let editor_layout = editor.layout(viewport, cell_width, 18.0);
+
+        // Click exactly at the text origin (col 0 of the visual segment)
+        // — the resolved buffer column must be the segment offset.
+        let resolved = editor_col_at_x(
+            &pango_layout,
+            &line,
+            &editor_layout,
+            editor_layout.text_bounds.x,
+        );
+        assert_eq!(resolved, 12);
     }
 }

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -79,7 +79,7 @@ pub use data_table::{draw_data_table, gtk_data_table_layout};
 pub use dialog::draw_dialog;
 pub use diff_view::draw_diff_view;
 pub use drop_overlay::draw_drop_overlay;
-pub use editor::draw_editor;
+pub use editor::{draw_editor, editor_col_at_x};
 pub use events::wire_da_events;
 pub use find_replace::draw_find_replace;
 pub use form::{draw_form, draw_settings_chrome};

--- a/quadraui/src/primitives/editor.rs
+++ b/quadraui/src/primitives/editor.rs
@@ -369,9 +369,19 @@ fn default_lightbulb_glyph() -> char {
 /// Classification of a hit-test result within an editor viewport.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EditorHit {
-    /// Click landed on a text position. `line` is the buffer line index,
-    /// `col` is the character column (accounting for scroll_left and
-    /// tab expansion).
+    /// Click landed on a text position. `line` is the buffer line index
+    /// (always accurate — row height is uniform on every backend).
+    ///
+    /// `col` is a **uniform-monospace approximation** of the character
+    /// column (`(x - text_bounds.x) / cell_width`, plus `scroll_left`;
+    /// no tab expansion). It matches the painted glyph exactly on TUI's
+    /// fixed-cell grid, but can drift from the actual glyph on
+    /// proportional-font or per-span-attributed backends (bold /
+    /// italic / `font_scale` spans paint at a different advance than
+    /// `cell_width` — see #420). Callers that need the exact column on
+    /// those backends should discard this field and resolve via
+    /// [`crate::Backend::editor_col_at_x`] instead (falls back to this
+    /// same approximation on TUI).
     BufferPos { line: usize, col: usize },
     /// Click landed in the gutter region.
     Gutter { line_idx: usize, gutter_col: usize },
@@ -412,8 +422,14 @@ pub struct EditorLayout {
 
 impl EditorLayout {
     /// Resolve an absolute point to an editor zone with buffer-relative
-    /// positions. Assumes monospace text (character width uniform across
-    /// the viewport — true for code editors).
+    /// positions.
+    ///
+    /// Zone classification (gutter / scrollbar / text-area) and the
+    /// resolved `line` are always accurate. The `col` on the returned
+    /// [`EditorHit::BufferPos`] is a uniform-monospace approximation —
+    /// see that variant's doc and [`Self::col_at_x`] /
+    /// [`crate::Backend::editor_col_at_x`] for the text-engine-accurate
+    /// resolution proportional/attributed backends need (#420).
     pub fn hit_test(&self, x: f32, y: f32) -> EditorHit {
         if x < self.bounds.x
             || x >= self.bounds.x + self.bounds.width
@@ -460,6 +476,40 @@ impl EditorLayout {
         }
 
         EditorHit::Empty
+    }
+
+    /// Resolve `x` to a character column within `editor.lines[view_row]`
+    /// using uniform monospace division (`self.cell_width`).
+    ///
+    /// This is the default [`crate::Backend::editor_col_at_x`]
+    /// implementation — correct for TUI's fixed-cell grid and any
+    /// backend whose configured font renders every glyph at the same
+    /// advance width. Backends that paint editor text with a real
+    /// text-shaping engine and per-span attributes (bold / italic /
+    /// `font_scale`) override `Backend::editor_col_at_x` with an exact
+    /// glyph-position inverse of their `draw_editor` instead of relying
+    /// on this approximation (GTK's Pango `xy_to_index` — see #420).
+    ///
+    /// The returned column already folds in `self.scroll_left` and the
+    /// row's `segment_col_offset` (0 for non-wrapped lines and the
+    /// first visual segment of a wrapped line), so it's directly usable
+    /// as the buffer-line-relative column. Falls back to
+    /// `self.scroll_left` alone (no segment offset) when `view_row` is
+    /// out of range for `editor.lines`.
+    pub fn col_at_x(&self, editor: &Editor, view_row: usize, x: f32) -> usize {
+        let segment_col_offset = editor
+            .lines
+            .get(view_row)
+            .map(|line| line.segment_col_offset)
+            .unwrap_or(0);
+        let col_offset = if self.cell_width > 0.0 {
+            ((x - self.text_bounds.x) / self.cell_width)
+                .floor()
+                .max(0.0) as usize
+        } else {
+            0
+        };
+        self.scroll_left + col_offset + segment_col_offset
     }
 }
 
@@ -800,5 +850,80 @@ mod tests {
         assert_eq!(l.visible_cols, 95);
         // visible_lines with h_scrollbar: (600 - 16) / 16 = 36
         assert_eq!(l.visible_lines, 36);
+    }
+
+    // ── EditorLayout::col_at_x (#420) ───────────────────────────────
+
+    fn line_with_segment_offset(segment_col_offset: usize) -> EditorLine {
+        EditorLine {
+            raw_text: "wrapped segment text".into(),
+            gutter_text: String::new(),
+            spans: Vec::new(),
+            line_idx: 0,
+            is_current_line: false,
+            is_fold_header: false,
+            folded_line_count: 0,
+            git_diff: None,
+            diff_status: None,
+            diagnostics: Vec::new(),
+            spell_errors: Vec::new(),
+            is_breakpoint: false,
+            is_conditional_bp: false,
+            is_dap_current: false,
+            is_wrap_continuation: segment_col_offset > 0,
+            segment_col_offset,
+            annotation: None,
+            ghost_suffix: None,
+            is_ghost_continuation: false,
+            indent_guides: Vec::new(),
+            colorcolumns: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn editor_col_at_x_matches_hit_test_in_monospace_case() {
+        // Non-wrapped row (segment_col_offset == 0): col_at_x must agree
+        // with hit_test's BufferPos.col exactly, since both use the same
+        // uniform cell-division formula.
+        let mut ed = make_editor(4, 100, 40);
+        ed.scroll_top = 10;
+        ed.scroll_left = 5;
+        ed.lines = vec![line_with_segment_offset(0)];
+        let vp = Rect::new(0.0, 0.0, 80.0, 24.0);
+        let l = ed.layout(vp, 1.0, 1.0);
+
+        match l.hit_test(7.0, 2.0) {
+            EditorHit::BufferPos { col, .. } => {
+                assert_eq!(l.col_at_x(&ed, 2, 7.0), col);
+            }
+            other => panic!("expected BufferPos, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn editor_col_at_x_adds_segment_col_offset_for_wrapped_rows() {
+        // A wrap-continuation row's resolved column must be shifted by
+        // its segment_col_offset so it lands at the right buffer column,
+        // not the visual column within the wrapped segment.
+        let mut ed = make_editor(4, 100, 40);
+        ed.lines = vec![line_with_segment_offset(20)];
+        let vp = Rect::new(0.0, 0.0, 80.0, 24.0);
+        let l = ed.layout(vp, 1.0, 1.0);
+
+        // Click at text_bounds origin (col_offset == 0, scroll_left == 0):
+        // resolved column should be exactly the segment offset.
+        assert_eq!(l.col_at_x(&ed, 0, l.text_bounds.x), 20);
+        // 3 cells further right adds 3.
+        assert_eq!(l.col_at_x(&ed, 0, l.text_bounds.x + 3.0), 23);
+    }
+
+    #[test]
+    fn editor_col_at_x_out_of_range_row_falls_back_to_scroll_left() {
+        let mut ed = make_editor(4, 100, 40);
+        ed.scroll_left = 7;
+        ed.lines = Vec::new();
+        let vp = Rect::new(0.0, 0.0, 80.0, 24.0);
+        let l = ed.layout(vp, 1.0, 1.0);
+        assert_eq!(l.col_at_x(&ed, 0, l.text_bounds.x), 7);
     }
 }


### PR DESCRIPTION
Closes #420

Automated merge from the coordinator for assignment cedb7f8b5be7 on issue #420.

Worker branch: `issue-420-editor-rasteriser-owns-paint-but-not-its` → `develop`.