### PR TITLE
#439: gtk_terminal: CJK/emoji (wide) characters render with clipped/half glyphs

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -18,7 +18,9 @@ terminal = ["dep:portable-pty", "dep:vt100"]
 tui = ["dep:ratatui", "dep:arboard", "dep:unicode-width"]
 
 # Public GTK rasterisers in `quadraui::gtk`. Pulls in gtk4 + pangocairo.
-gtk = ["dep:gtk4", "dep:pangocairo", "dep:arboard"]
+# `unicode-width` is needed for wide-char (CJK/emoji) cell-width detection
+# in the terminal rasteriser (#439).
+gtk = ["dep:gtk4", "dep:pangocairo", "dep:arboard", "dep:unicode-width"]
 
 # Public Win-GUI rasterisers in `quadraui::win`. No deps yet — the
 # feature gate exists so the module compiles and the Backend impl is
@@ -51,6 +53,8 @@ gtk4 = { version = "0.7", features = ["v4_10"], optional = true }
 pangocairo = { version = "0.18", optional = true }
 # Optional — pulled in by the `tui` feature.
 ratatui = { version = "0.30", optional = true }
+# Optional — pulled in by the `tui` and `gtk` features for wide-char
+# (CJK/emoji) cell-width detection.
 unicode-width = { version = "0.2.2", optional = true }
 # Optional — pulled in by `tui` and `gtk` for system clipboard access.
 arboard = { version = "3", optional = true }

--- a/quadraui/examples/common/terminal_app.rs
+++ b/quadraui/examples/common/terminal_app.rs
@@ -74,21 +74,33 @@ impl TerminalApp {
 
     /// Return the PTY dimensions (cols, rows) from a viewport,
     /// reserving `FOOTER_ROWS` at the bottom for the hint bar.
-    fn viewport_to_pty(vp: Viewport) -> (u16, u16) {
-        // TUI backend: viewport units are cells (f32 but always integral).
-        let cols = vp.width.max(10.0) as u16;
-        let rows = (vp.height - FOOTER_ROWS as f32).max(3.0) as u16;
+    ///
+    /// `char_w`/`line_h` are `Backend::char_width()` /
+    /// `Backend::line_height()` — `1.0` on TUI (viewport units already
+    /// are cells, so this is a no-op division) and real Pango-resolved
+    /// pixel metrics on GTK, where `Viewport` is in pixels, not cells
+    /// (quadraui#437 — this used to treat GTK's pixel viewport as a
+    /// cell count directly, spawning wildly wrong PTY sizes).
+    fn viewport_to_pty(vp: Viewport, char_w: f32, line_h: f32) -> (u16, u16) {
+        let char_w = char_w.max(1.0);
+        let line_h = line_h.max(1.0);
+        let cols = (vp.width / char_w).max(10.0) as u16;
+        let rows = (Self::term_height(vp, line_h) / line_h).max(3.0) as u16;
         (cols, rows)
     }
 
-    /// Height of the terminal grid area (viewport height minus footer).
-    fn term_height(vp: Viewport) -> f32 {
-        (vp.height - FOOTER_ROWS as f32).max(0.0)
+    /// Height of the terminal grid area (viewport height minus footer),
+    /// in the same native units as `vp` (cells on TUI, pixels on GTK).
+    fn term_height(vp: Viewport, line_h: f32) -> f32 {
+        let line_h = line_h.max(1.0);
+        (vp.height - FOOTER_ROWS as f32 * line_h).max(0.0)
     }
 
-    /// X column of the scrollbar (rightmost column of the viewport).
-    fn scrollbar_col(vp: Viewport) -> f32 {
-        (vp.width - 1.0).max(0.0)
+    /// X position of the scrollbar (rightmost character column of the
+    /// viewport), in the same native units as `vp`.
+    fn scrollbar_col(vp: Viewport, char_w: f32) -> f32 {
+        let char_w = char_w.max(1.0);
+        (vp.width - char_w).max(0.0)
     }
 
     // ── Footer rendering ──────────────────────────────────────────────────────
@@ -98,8 +110,9 @@ impl TerminalApp {
     /// - Normal operation: shows keyboard shortcuts.
     /// - Process exited: shows the exit code and prompts the user to quit.
     fn render_footer(&self, backend: &mut dyn Backend, vp: Viewport) {
-        let y = vp.height - FOOTER_ROWS as f32;
-        let footer_rect = Rect::new(0.0, y, vp.width, FOOTER_ROWS as f32);
+        let footer_h = FOOTER_ROWS as f32 * backend.line_height().max(1.0);
+        let y = vp.height - footer_h;
+        let footer_rect = Rect::new(0.0, y, vp.width, footer_h);
 
         let (text, fg, bg) = if let Some(ref sess) = self.session {
             if sess.is_exited() {
@@ -187,7 +200,7 @@ impl AppLogic for TerminalApp {
     fn setup(&mut self, backend: &mut dyn Backend) {
         let vp = backend.viewport();
         self.last_viewport = vp;
-        let (cols, rows) = Self::viewport_to_pty(vp);
+        let (cols, rows) = Self::viewport_to_pty(vp, backend.char_width(), backend.line_height());
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
         let shell = default_shell();
         match TerminalSession::spawn(cols, rows, &shell, &cwd, 10_000) {
@@ -198,7 +211,7 @@ impl AppLogic for TerminalApp {
 
     fn render(&self, backend: &mut dyn Backend, _area: ()) {
         let vp = backend.viewport();
-        let term_h = Self::term_height(vp);
+        let term_h = Self::term_height(vp, backend.line_height());
         let rect = Rect::new(0.0, 0.0, vp.width, term_h);
 
         if let Some(ref sess) = self.session {
@@ -228,7 +241,8 @@ impl AppLogic for TerminalApp {
                 }],
                 right_segments: vec![],
             };
-            let bar_rect = Rect::new(0.0, rect.height - 1.0, rect.width, 1.0);
+            let line_h = backend.line_height().max(1.0);
+            let bar_rect = Rect::new(0.0, (rect.height - line_h).max(0.0), rect.width, line_h);
             backend.draw_status_bar(bar_rect, &bar, None, None);
         }
 
@@ -248,7 +262,11 @@ impl AppLogic for TerminalApp {
             UiEvent::WindowResized { viewport } => {
                 self.last_viewport = viewport;
                 if let Some(ref mut sess) = self.session {
-                    let (cols, rows) = Self::viewport_to_pty(viewport);
+                    let (cols, rows) = Self::viewport_to_pty(
+                        viewport,
+                        backend.char_width(),
+                        backend.line_height(),
+                    );
                     sess.resize(cols, rows);
                 }
                 return Reaction::Redraw;
@@ -260,7 +278,7 @@ impl AppLogic for TerminalApp {
             } => {
                 if let Some(ref mut sess) = self.session {
                     let vp = self.last_viewport;
-                    let term_h = Self::term_height(vp);
+                    let term_h = Self::term_height(vp, backend.line_height());
                     let in_term = position.y >= 0.0 && position.y < term_h;
 
                     // Try to forward the wheel to the PTY first.
@@ -305,8 +323,8 @@ impl AppLogic for TerminalApp {
                 ..
             } => {
                 let vp = self.last_viewport;
-                let term_h = Self::term_height(vp);
-                let sb_col = Self::scrollbar_col(vp);
+                let term_h = Self::term_height(vp, backend.line_height());
+                let sb_col = Self::scrollbar_col(vp, backend.char_width());
 
                 // Left-button click on the scrollbar column → start a drag.
                 let in_scrollbar = button == MouseButton::Left
@@ -368,7 +386,7 @@ impl AppLogic for TerminalApp {
                 }
                 // Forward button release to the PTY when mouse reporting is on.
                 let vp = self.last_viewport;
-                let term_h = Self::term_height(vp);
+                let term_h = Self::term_height(vp, backend.line_height());
                 let in_term = position.y >= 0.0 && position.y < term_h;
                 if in_term {
                     if let Some(ref mut sess) = self.session {
@@ -1098,11 +1116,15 @@ mod tests {
     }
 
     // ── viewport_to_pty reserves footer row ───────────────────────────────────
+    //
+    // char_w = line_h = 1.0 exercises the TUI path (viewport units
+    // already are cells, so the conversion is a no-op) — mirrors what
+    // `TuiBackend::char_width()`/`line_height()` actually return.
 
     #[test]
     fn viewport_to_pty_reserves_footer() {
         let vp = Viewport::new(80.0, 24.0, 1.0);
-        let (cols, rows) = TerminalApp::viewport_to_pty(vp);
+        let (cols, rows) = TerminalApp::viewport_to_pty(vp, 1.0, 1.0);
         assert_eq!(cols, 80);
         // height 24 minus FOOTER_ROWS 1 = 23
         assert_eq!(rows, 23);
@@ -1112,7 +1134,58 @@ mod tests {
     fn viewport_to_pty_minimum_rows() {
         // Very small terminal — rows must not go below 3.
         let vp = Viewport::new(80.0, 3.0, 1.0);
-        let (_cols, rows) = TerminalApp::viewport_to_pty(vp);
+        let (_cols, rows) = TerminalApp::viewport_to_pty(vp, 1.0, 1.0);
         assert_eq!(rows, 3); // max(3.0 - 1.0 = 2.0, 3.0) = 3
+    }
+
+    // ── viewport_to_pty converts pixels → cells (GTK path) ────────────────────
+    //
+    // quadraui#437: GTK's `Viewport` is in pixels, not cells. These pin
+    // the conversion so a future edit can't silently regress back to
+    // treating pixel dimensions as cell counts.
+
+    #[test]
+    fn viewport_to_pty_converts_gtk_pixels_to_cells() {
+        // 800×600px window, 8px chars, 16px lines (GtkBackend's defaults
+        // before the first real Pango measurement) → 100 cols; 600/16 =
+        // 37.5 total rows minus the 1-row footer = 36.5, truncated to 36.
+        let vp = Viewport::new(800.0, 600.0, 1.0);
+        let (cols, rows) = TerminalApp::viewport_to_pty(vp, 8.0, 16.0);
+        assert_eq!(cols, 100);
+        assert_eq!(rows, 36);
+    }
+
+    #[test]
+    fn viewport_to_pty_gtk_minimum_rows() {
+        // A tiny GTK window still clamps to the same 10-col/3-row floor
+        // as TUI, once converted through the char metrics.
+        let vp = Viewport::new(40.0, 20.0, 1.0);
+        let (cols, rows) = TerminalApp::viewport_to_pty(vp, 8.0, 16.0);
+        assert_eq!(cols, 10); // (40/8=5) clamped up to the 10-col floor
+        assert_eq!(rows, 3); // (20/16=1.25 → term_height 4px/16=0) clamped up to 3
+    }
+
+    // ── term_height / scrollbar_col unit conversion ────────────────────────────
+
+    #[test]
+    fn term_height_tui_units_unchanged() {
+        // line_h = 1.0 (TUI): behaves exactly like the old hardcoded
+        // `vp.height - FOOTER_ROWS` formula.
+        let vp = Viewport::new(80.0, 24.0, 1.0);
+        assert_eq!(TerminalApp::term_height(vp, 1.0), 23.0);
+    }
+
+    #[test]
+    fn term_height_gtk_subtracts_pixel_footer() {
+        // line_h = 16px (GTK): footer is FOOTER_ROWS * line_h pixels,
+        // not a flat 1px sliver.
+        let vp = Viewport::new(800.0, 600.0, 1.0);
+        assert_eq!(TerminalApp::term_height(vp, 16.0), 584.0);
+    }
+
+    #[test]
+    fn scrollbar_col_gtk_uses_char_width() {
+        let vp = Viewport::new(800.0, 600.0, 1.0);
+        assert_eq!(TerminalApp::scrollbar_col(vp, 8.0), 792.0);
     }
 }

--- a/quadraui/src/gtk/events.rs
+++ b/quadraui/src/gtk/events.rs
@@ -109,12 +109,14 @@ pub fn gdk_scroll_to_uievent(dx: f64, dy: f64, x: f64, y: f64) -> UiEvent {
 /// `scale` is the surface scale factor (HiDPI multiplier) — typically
 /// `widget.scale_factor() as f32`.
 ///
-/// Currently unused — GTK doesn't surface resize through this queue
-/// because `Backend::begin_frame(viewport)` already updates the
-/// viewport from the active DrawingArea each frame. Kept here as a
-/// reference translator for the day a non-DrawingArea-driven resize
-/// path needs to push into the queue.
-#[allow(dead_code)]
+/// `Backend::begin_frame(viewport)` keeps `Backend::viewport()` in sync
+/// with the DrawingArea's allocated size every frame, so pure `render`
+/// logic never needed this. But apps with *side effects* on resize
+/// (e.g. `TerminalApp` resizing its PTY — quadraui#437) need an actual
+/// event, not just an updated viewport the next time they happen to
+/// render. `src/gtk/run.rs` wires `DrawingArea::connect_resize` to this
+/// translator so GTK delivers `WindowResized` the same way TUI does via
+/// crossterm's `Resize` event.
 pub fn gdk_resize_to_uievent(width: i32, height: i32, scale: f32) -> UiEvent {
     UiEvent::WindowResized {
         viewport: crate::Viewport::new(width as f32, height as f32, scale),

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -43,12 +43,25 @@ use pangocairo::functions as pcfn;
 
 use super::backend::GtkBackend;
 use super::events::{
-    gdk_button_to_quadraui, gdk_key_to_uievent, gdk_modifiers_to_quadraui, gdk_scroll_to_uievent,
+    gdk_button_to_quadraui, gdk_key_to_uievent, gdk_modifiers_to_quadraui, gdk_resize_to_uievent,
+    gdk_scroll_to_uievent,
 };
 use crate::backend::Backend;
 use crate::dispatch::{dispatch_click, dispatch_mouse_drag, dispatch_mouse_up};
 use crate::runner::{AppLogic, Reaction};
 use crate::{ButtonMask, Key, Modifiers, MouseButton, Point, UiEvent};
+
+/// Default window size, in DIPs. Matches the `ApplicationWindow`
+/// builder's `default_width`/`default_height` below. Also used to seed
+/// `GtkBackend`'s viewport *before* `app.setup()` runs, so
+/// `Backend::viewport()` returns a sane, non-zero size to apps that read
+/// it during setup (e.g. to size an embedded PTY — quadraui#437) instead
+/// of `GtkBackend::new()`'s zeroed default. `DrawingArea::connect_resize`
+/// (wired below) corrects this to the widget's *actual* allocated size
+/// as soon as it's realized, so this seed only matters for the brief
+/// window between `setup()` and the first resize signal.
+const DEFAULT_WINDOW_WIDTH: i32 = 800;
+const DEFAULT_WINDOW_HEIGHT: i32 = 600;
 
 /// Drive `app` to completion in a basic single-`DrawingArea` GTK
 /// environment.
@@ -100,8 +113,8 @@ fn activate<A: AppLogic + 'static>(
     let window = ApplicationWindow::builder()
         .application(gapp)
         .title("quadraui app")
-        .default_width(800)
-        .default_height(600)
+        .default_width(DEFAULT_WINDOW_WIDTH)
+        .default_height(DEFAULT_WINDOW_HEIGHT)
         .build();
 
     // Stash the window handle so `Backend::begin_window_drag` /
@@ -139,8 +152,20 @@ fn activate<A: AppLogic + 'static>(
     }
 
     // App setup hook (one-time).
+    //
+    // Seed the viewport with the window's default size first (see
+    // `DEFAULT_WINDOW_WIDTH`/`HEIGHT` above) — the `DrawingArea` has no
+    // allocation yet at this point, so without this `backend.viewport()`
+    // would return `GtkBackend::new()`'s zeroed default and any app that
+    // sizes something (e.g. a PTY) from the setup-time viewport would
+    // size it to ~zero (quadraui#437).
     {
         let mut backend_mut = backend.borrow_mut();
+        backend_mut.begin_frame(crate::Viewport::new(
+            DEFAULT_WINDOW_WIDTH as f32,
+            DEFAULT_WINDOW_HEIGHT as f32,
+            1.0,
+        ));
         let mut app_mut = app.borrow_mut();
         app_mut.setup(&mut *backend_mut);
     }
@@ -290,6 +315,42 @@ fn activate<A: AppLogic + 'static>(
                     // Suppress original Ctrl-C from reaching the app.
                     return glib::Propagation::Stop;
                 }
+            }
+
+            // ── Ctrl-V interception (paste) ──────────────────────────
+            //
+            // GTK has no native paste signal on a bespoke `DrawingArea`
+            // canvas the way a real `gtk4::Entry`/`TextView` would —
+            // unlike TUI, which gets bracketed paste from crossterm for
+            // free. Without this, `UiEvent::ClipboardPaste` was never
+            // constructed on GTK at all, so paste silently did nothing
+            // for every text-accepting primitive, including the
+            // embedded terminal (quadraui#437). Reads the system
+            // clipboard via the same `Clipboard` service used for the
+            // Ctrl-C copy path above and delivers `ClipboardPaste` —
+            // routing to the focused input is the app's job, same as
+            // TUI's bracketed paste.
+            if let UiEvent::KeyPressed {
+                key: Key::Char('v') | Key::Char('V'),
+                modifiers:
+                    Modifiers {
+                        ctrl: true,
+                        shift: false,
+                        alt: false,
+                        cmd: false,
+                    },
+                ..
+            } = &ev
+            {
+                let mut backend_mut = backend.borrow_mut();
+                if let Some(text) = backend_mut.services().clipboard().read_text() {
+                    let paste_ev = UiEvent::ClipboardPaste(text);
+                    let mut app_mut = app.borrow_mut();
+                    let reaction = app_mut.handle(paste_ev, &mut *backend_mut);
+                    drop(backend_mut);
+                    apply_reaction(reaction, &da_for_redraw, &window_for_close);
+                }
+                return glib::Propagation::Stop;
             }
 
             // ── Ctrl-A interception (select-all for text regions) ────
@@ -646,6 +707,40 @@ fn activate<A: AppLogic + 'static>(
         });
     }
     da.add_controller(scroll);
+
+    // ── Resize ─────────────────────────────────────────────────────
+    //
+    // `Backend::begin_frame(viewport)` (in `set_draw_func` above) keeps
+    // `backend.viewport()` in sync with the DA's allocated size on every
+    // *render*, but apps with side effects on resize — not just
+    // re-painting — never learned about it: GTK didn't deliver
+    // `UiEvent::WindowResized` at all (quadraui#437; see
+    // `gdk_resize_to_uievent`'s doc comment). `DrawingArea::connect_resize`
+    // fires with the widget's real allocated pixel size both on first
+    // realization (correcting the `DEFAULT_WINDOW_WIDTH`/`HEIGHT` seed
+    // above) and on every subsequent resize, mirroring how the TUI
+    // runner delivers `WindowResized` from crossterm's `Resize` event.
+    {
+        let backend = backend.clone();
+        let app = app.clone();
+        let da_for_redraw = da.clone();
+        let window_for_close = window.clone();
+        let pump_depth = pump_depth.clone();
+        da.connect_resize(move |da, width, height| {
+            // #427 re-entrancy guard — see the key-press handler above.
+            if pump_depth.get() > 0 {
+                return;
+            }
+            let scale = da.scale_factor() as f32;
+            let ev = gdk_resize_to_uievent(width, height, scale);
+            let reaction = {
+                let mut backend_mut = backend.borrow_mut();
+                let mut app_mut = app.borrow_mut();
+                app_mut.handle(ev, &mut *backend_mut)
+            };
+            apply_reaction(reaction, &da_for_redraw, &window_for_close);
+        });
+    }
 
     // ── Backend event-queue drain (low-rate idle) ─────────────────
     //

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -720,25 +720,77 @@ fn activate<A: AppLogic + 'static>(
     // realization (correcting the `DEFAULT_WINDOW_WIDTH`/`HEIGHT` seed
     // above) and on every subsequent resize, mirroring how the TUI
     // runner delivers `WindowResized` from crossterm's `Resize` event.
+    //
+    // The dispatch of `UiEvent::WindowResized` itself is **debounced**
+    // (quadraui#437 follow-up): a live edge-drag fires `connect_resize`
+    // dozens of times per second, and apps with PTY-backed side effects
+    // (`TerminalApp::handle` → `TerminalSession::resize` → SIGWINCH) were
+    // resizing the child shell on every single intermediate frame. A
+    // shell's line-editor (readline/zle) redraws its prompt on SIGWINCH;
+    // firing another SIGWINCH before that redraw finishes interleaves two
+    // half-written escape sequences and leaves the display permanently
+    // garbled — no amount of further resizing, scrolling, or typing
+    // recovers it, because the line-editor's internal notion of the
+    // screen is now out of sync with what's actually on screen. Real
+    // terminal emulators avoid this by resizing the PTY only once the
+    // drag settles, not on every intermediate frame; `resize_timer` below
+    // does the same via a short trailing-edge debounce. Painting itself
+    // is unaffected and stays perfectly live — `set_draw_func` re-reads
+    // the DA's actual allocated size every frame regardless of whether
+    // the debounced event has fired yet.
+    let resize_timer: Rc<Cell<Option<glib::SourceId>>> = Rc::new(Cell::new(None));
     {
         let backend = backend.clone();
         let app = app.clone();
         let da_for_redraw = da.clone();
         let window_for_close = window.clone();
         let pump_depth = pump_depth.clone();
-        da.connect_resize(move |da, width, height| {
+        let resize_timer = resize_timer.clone();
+        da.connect_resize(move |_da, _width, _height| {
             // #427 re-entrancy guard — see the key-press handler above.
             if pump_depth.get() > 0 {
                 return;
             }
-            let scale = da.scale_factor() as f32;
-            let ev = gdk_resize_to_uievent(width, height, scale);
-            let reaction = {
-                let mut backend_mut = backend.borrow_mut();
-                let mut app_mut = app.borrow_mut();
-                app_mut.handle(ev, &mut *backend_mut)
-            };
-            apply_reaction(reaction, &da_for_redraw, &window_for_close);
+            // Cancel any pending debounced dispatch — this signal
+            // supersedes it. `remove()` is a no-op-safe consume; the
+            // source may have already fired (Cell held `None`).
+            if let Some(id) = resize_timer.take() {
+                id.remove();
+            }
+            let backend = backend.clone();
+            let app = app.clone();
+            let da_for_redraw = da_for_redraw.clone();
+            let window_for_close = window_for_close.clone();
+            let pump_depth = pump_depth.clone();
+            let resize_timer_inner = resize_timer.clone();
+            let id = glib::source::timeout_add_local_once(Duration::from_millis(120), move || {
+                // The fired timer is no longer "pending" — clear so a
+                // future resize doesn't try to cancel a dead source.
+                resize_timer_inner.set(None);
+                // #427 re-entrancy guard, re-checked at fire time —
+                // a dialog pump may have started after this timer was
+                // scheduled.
+                if pump_depth.get() > 0 {
+                    return;
+                }
+                // Query the DA's *current* (settled) allocated size
+                // rather than replaying the size captured when this
+                // timer was scheduled — later `connect_resize` calls
+                // during the same drag reschedule (see above), so by
+                // the time this fires the widget has already reached
+                // its final size.
+                let width = da_for_redraw.width();
+                let height = da_for_redraw.height();
+                let scale = da_for_redraw.scale_factor() as f32;
+                let ev = gdk_resize_to_uievent(width, height, scale);
+                let reaction = {
+                    let mut backend_mut = backend.borrow_mut();
+                    let mut app_mut = app.borrow_mut();
+                    app_mut.handle(ev, &mut *backend_mut)
+                };
+                apply_reaction(reaction, &da_for_redraw, &window_for_close);
+            });
+            resize_timer.set(Some(id));
         });
     }
 

--- a/quadraui/src/gtk/terminal.rs
+++ b/quadraui/src/gtk/terminal.rs
@@ -6,10 +6,26 @@
 //! override the cell's `bg`/`fg` to match the legacy bespoke
 //! renderer's behaviour. Bold / italic / underline applied via Pango
 //! `AttrList` per cell.
+//!
+//! # Wide characters (#439)
+//!
+//! [`crate::terminal_engine::TerminalSession::to_terminal`] builds its
+//! cell grid straight from vt100's model: a double-width character
+//! (CJK, emoji, ...) occupies its *own* column plus one trailing
+//! "continuation" column that vt100 reports as an empty cell (`ch =
+//! ' '`). Before #439, this rasteriser advanced by exactly
+//! `char_width` per grid column regardless of glyph width, so a
+//! double-width glyph — which Pango draws at roughly double the
+//! advance width — got its right half painted over by the
+//! continuation column's background fill. [`draw_terminal_cells`] now
+//! detects wide glyphs with `unicode-width`, paints their background
+//! across two columns, and skips the continuation column so it's
+//! never independently painted on top of the glyph.
 
 use gtk4::cairo::Context;
 use gtk4::pango;
 use gtk4::pango::AttrList;
+use unicode_width::UnicodeWidthChar;
 
 use crate::primitives::terminal::Terminal;
 use crate::theme::Theme;
@@ -38,8 +54,22 @@ pub fn draw_terminal_cells(
     for (row_idx, row) in term.cells.iter().enumerate() {
         let row_y = content_y + row_idx as f64 * line_height;
         let mut cell_x = x;
-        for cell in row {
-            if cell_x + char_width > x + cell_area_w {
+        let mut col = 0usize;
+        while col < row.len() {
+            let cell = &row[col];
+            // Double-width glyphs (CJK, emoji, ...) get a two-column cell:
+            // the vt100 grid already reserves the following column as an
+            // empty continuation placeholder, so claim it here rather
+            // than letting it paint its own (mismatched) background over
+            // the glyph's right half.
+            let is_wide = matches!(UnicodeWidthChar::width(cell.ch), Some(2));
+            let cell_w = if is_wide {
+                char_width * 2.0
+            } else {
+                char_width
+            };
+
+            if cell_x + cell_w > x + cell_area_w {
                 break;
             }
             let (br, bg, bb) = (cell.bg.r, cell.bg.g, cell.bg.b);
@@ -64,7 +94,7 @@ pub fn draw_terminal_cells(
                 draw_bg as f64 / 255.0,
                 draw_bb as f64 / 255.0,
             );
-            cr.rectangle(cell_x, row_y, char_width, line_height);
+            cr.rectangle(cell_x, row_y, cell_w, line_height);
             cr.fill().ok();
 
             if cell.ch != ' ' && cell.ch != '\0' {
@@ -99,7 +129,8 @@ pub fn draw_terminal_cells(
                 layout.set_attributes(None);
             }
 
-            cell_x += char_width;
+            cell_x += cell_w;
+            col += if is_wide { 2 } else { 1 };
         }
     }
 }
@@ -116,4 +147,134 @@ pub fn draw_terminal_divider(cr: &Context, x: f64, y: f64, height: f64, theme: &
     cr.set_source_rgb(r, g, b);
     cr.rectangle(x, y, 1.0, height);
     cr.fill().ok();
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+//
+// Headless paint tests: verify `draw_terminal_cells` background-fill
+// behaviour for wide (double-width) vs narrow cells without a display.
+// Uses a Cairo `ImageSurface` and reads back pixel data directly, mirroring
+// the pattern in `gtk::tab_bar` / `gtk::multi_section_view`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::terminal::TerminalCell;
+    use crate::types::{Color, WidgetId};
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    const W: i32 = 200;
+    const H: i32 = 40;
+    const CHAR_W: f64 = 10.0;
+    const LINE_H: f64 = 20.0;
+
+    /// Read an RGB triple from an ARgb32 surface at pixel (x, y).
+    /// ARgb32 stores each pixel as [B, G, R, A] in native (little-endian)
+    /// byte order; `stride` is in bytes and may include padding.
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    fn cell(ch: char, fg: Color, bg: Color) -> TerminalCell {
+        TerminalCell {
+            ch,
+            fg,
+            bg,
+            bold: false,
+            italic: false,
+            underline: false,
+            selected: false,
+            is_cursor: false,
+            is_find_match: false,
+            is_find_active: false,
+        }
+    }
+
+    fn paint(term: &Terminal) -> ImageSurface {
+        let surface = ImageSurface::create(Format::ARgb32, W, H).expect("create ImageSurface");
+        {
+            let cr = Context::new(&surface).expect("Context::new");
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            let theme = Theme::default();
+            draw_terminal_cells(
+                &cr,
+                &pango_layout,
+                term,
+                0.0,
+                0.0,
+                W as f64,
+                LINE_H,
+                CHAR_W,
+                &theme,
+            );
+        }
+        surface
+    }
+
+    /// #439 regression: a double-width glyph (CJK) followed by vt100's
+    /// blank continuation cell must have its background span both
+    /// columns — the continuation cell's own (different) background must
+    /// NOT paint over the second half of the wide glyph's cell.
+    #[test]
+    fn wide_cell_background_spans_two_columns() {
+        let magenta = Color::rgb(200, 30, 200);
+        let cyan = Color::rgb(30, 200, 200);
+        let white = Color::rgb(255, 255, 255);
+        // '日' is a double-width CJK character. Its vt100-derived
+        // continuation cell carries a *different* background (cyan) to
+        // prove the rasteriser doesn't just get lucky on matching colours.
+        let row = vec![cell('日', white, magenta), cell(' ', white, cyan)];
+        let term = Terminal {
+            id: WidgetId::new("term"),
+            cells: vec![row],
+            scrollbar: None,
+        };
+        let mut s = paint(&term);
+        s.flush();
+        let stride = s.stride() as usize;
+        let data = s.data().expect("surface data");
+
+        // Probe just past the first single-cell-width boundary, still
+        // within the wide glyph's two-column span: must be magenta, not
+        // cyan.
+        let probe_x = (CHAR_W * 1.5) as i32;
+        let (r, g, b) = pixel(&data, stride, probe_x, 5);
+        assert_eq!(
+            (r, g, b),
+            (magenta.r, magenta.g, magenta.b),
+            "wide cell's background should span both columns, not be \
+             overpainted by the continuation cell's background"
+        );
+    }
+
+    /// Companion regression: ordinary narrow (single-width) cells must
+    /// still advance by exactly `char_width` — the wide-cell fix must not
+    /// widen unrelated cells.
+    #[test]
+    fn narrow_cells_advance_by_single_char_width() {
+        let magenta = Color::rgb(200, 30, 200);
+        let cyan = Color::rgb(30, 200, 200);
+        let white = Color::rgb(255, 255, 255);
+        let row = vec![cell('A', white, magenta), cell('B', white, cyan)];
+        let term = Terminal {
+            id: WidgetId::new("term"),
+            cells: vec![row],
+            scrollbar: None,
+        };
+        let mut s = paint(&term);
+        s.flush();
+        let stride = s.stride() as usize;
+        let data = s.data().expect("surface data");
+
+        // Just past the single-cell-width boundary: second cell's own
+        // background (cyan) should already be showing.
+        let probe_x = (CHAR_W * 1.5) as i32;
+        let (r, g, b) = pixel(&data, stride, probe_x, 5);
+        assert_eq!(
+            (r, g, b),
+            (cyan.r, cyan.g, cyan.b),
+            "narrow cells must still advance by exactly char_width"
+        );
+    }
 }

--- a/quadraui/src/gtk/terminal.rs
+++ b/quadraui/src/gtk/terminal.rs
@@ -277,11 +277,23 @@ mod tests {
     fn wide_cell_background_spans_two_columns() {
         let magenta = Color::rgb(200, 30, 200);
         let cyan = Color::rgb(30, 200, 200);
-        let white = Color::rgb(255, 255, 255);
         // '日' is a double-width CJK character. Its vt100-derived
         // continuation cell carries a *different* background (cyan) to
         // prove the rasteriser doesn't just get lucky on matching colours.
-        let row = vec![cell('日', white, magenta), cell(' ', white, cyan)];
+        //
+        // The wide glyph's foreground is set equal to its background
+        // (magenta on magenta) so the glyph is invisible. This isolates the
+        // thing under test — the two-column *background* fill — from the
+        // glyph raster itself: with wide glyphs now scaled to fill the full
+        // two-cell box (`wide_glyph_x_scale`), antialiased glyph ink reaches
+        // deep into the second column and its exact colour depends on which
+        // fallback font Pango picks, which varies by machine. A white glyph
+        // here made the probe read a magenta/white blend on some hosts and
+        // fail spuriously. Painting the glyph in the background colour keeps
+        // the probe a pure, deterministic background read on every host,
+        // while the glyph-scaling maths stays covered by the dedicated
+        // `wide_glyph_x_scale` unit tests below.
+        let row = vec![cell('日', magenta, magenta), cell(' ', magenta, cyan)];
         let term = Terminal {
             id: WidgetId::new("term"),
             cells: vec![row],
@@ -313,7 +325,13 @@ mod tests {
         let magenta = Color::rgb(200, 30, 200);
         let cyan = Color::rgb(30, 200, 200);
         let white = Color::rgb(255, 255, 255);
-        let row = vec![cell('A', white, magenta), cell('B', white, cyan)];
+        // 'B' (the probed cell) paints its glyph in its own background
+        // colour so antialiased glyph ink can't corrupt the background
+        // probe; 'A' keeps a visible (white) glyph as it isn't probed.
+        // This tests the *advance* logic — that 'A' occupies exactly one
+        // char_width and doesn't bleed into 'B''s column — independent of
+        // glyph rendering.
+        let row = vec![cell('A', white, magenta), cell('B', cyan, cyan)];
         let term = Terminal {
             id: WidgetId::new("term"),
             cells: vec![row],

--- a/quadraui/src/gtk/terminal.rs
+++ b/quadraui/src/gtk/terminal.rs
@@ -21,6 +21,15 @@
 //! detects wide glyphs with `unicode-width`, paints their background
 //! across two columns, and skips the continuation column so it's
 //! never independently painted on top of the glyph.
+//!
+//! The two-column cell is the *box*; the glyph inside it still needs to
+//! fill that box. The font Pango falls back to for CJK / emoji typically
+//! lays a glyph out at its own natural advance — often narrower than two
+//! terminal cells (a CJK glyph measuring 15px inside an 18px box), which
+//! left a ragged gap before the next wide glyph. [`draw_terminal_cells`]
+//! therefore scales each wide glyph horizontally (see
+//! [`wide_glyph_x_scale`]) so it spans exactly `cell_w`, giving the tight,
+//! even two-cell packing a normal terminal produces.
 
 use gtk4::cairo::Context;
 use gtk4::pango;
@@ -124,14 +133,62 @@ pub fn draw_terminal_cells(
                 layout.set_attributes(Some(&attrs));
                 let s = cell.ch.to_string();
                 layout.set_text(&s);
-                cr.move_to(cell_x, row_y);
-                pangocairo::functions::show_layout(cr, layout);
+
+                if is_wide {
+                    // A double-width glyph occupies a two-column (`cell_w`)
+                    // box, but the font Pango falls back to for CJK / emoji
+                    // usually lays the glyph out at its *own* natural advance
+                    // — narrower than two terminal cells (e.g. a CJK glyph
+                    // measuring 15px inside an 18px box) or, for some emoji
+                    // fonts, wider. Drawn left-aligned at the cell origin,
+                    // that leaves a ragged gap before the next wide glyph:
+                    // the #439 follow-up defect where consecutive CJK/emoji
+                    // looked abnormally spread out. Scale the glyph
+                    // horizontally so it fills exactly `cell_w`, giving the
+                    // tight, even two-cell packing a normal terminal
+                    // produces. Narrow cells already match `char_width`
+                    // (measured from the same monospace font), so only wide
+                    // cells need this.
+                    let (natural_w, _) = layout.pixel_size();
+                    let scale_x = wide_glyph_x_scale(natural_w, cell_w);
+                    if (scale_x - 1.0).abs() > f64::EPSILON {
+                        cr.save().ok();
+                        cr.translate(cell_x, row_y);
+                        cr.scale(scale_x, 1.0);
+                        cr.move_to(0.0, 0.0);
+                        pangocairo::functions::show_layout(cr, layout);
+                        cr.restore().ok();
+                    } else {
+                        cr.move_to(cell_x, row_y);
+                        pangocairo::functions::show_layout(cr, layout);
+                    }
+                } else {
+                    cr.move_to(cell_x, row_y);
+                    pangocairo::functions::show_layout(cr, layout);
+                }
                 layout.set_attributes(None);
             }
 
             cell_x += cell_w;
             col += if is_wide { 2 } else { 1 };
         }
+    }
+}
+
+/// Horizontal scale factor to draw a double-width glyph so it fills its
+/// two-column (`cell_w`) box exactly.
+///
+/// `natural_w` is the glyph's laid-out pixel width as reported by Pango.
+/// Returns `cell_w / natural_w` so the rendered glyph spans exactly two
+/// cells — stretching a narrow CJK glyph out to the full box and shrinking
+/// an over-wide emoji back into it. Returns `1.0` (no scaling) when
+/// `natural_w` is non-positive (empty / zero-advance layout) so we never
+/// divide by zero or blow a degenerate glyph up to infinity.
+fn wide_glyph_x_scale(natural_w: i32, cell_w: f64) -> f64 {
+    if natural_w <= 0 {
+        1.0
+    } else {
+        cell_w / natural_w as f64
     }
 }
 
@@ -276,5 +333,48 @@ mod tests {
             (cyan.r, cyan.g, cyan.b),
             "narrow cells must still advance by exactly char_width"
         );
+    }
+
+    /// #439 follow-up: a wide glyph whose natural Pango advance is *narrower*
+    /// than its two-cell box must be stretched to fill it exactly, so
+    /// consecutive CJK/emoji pack tightly with no ragged inter-glyph gap.
+    /// A CJK glyph measuring 15px inside an 18px (2 × 9px) box → 1.2×.
+    #[test]
+    fn narrow_wide_glyph_is_stretched_to_fill_two_cells() {
+        let cell_w = 18.0;
+        let scale = wide_glyph_x_scale(15, cell_w);
+        assert!(
+            (scale - 1.2).abs() < 1e-9,
+            "15px glyph in an 18px box should scale 1.2×, got {scale}"
+        );
+        // And the rendered advance is exactly the two-cell box width.
+        assert!((15.0 * scale - cell_w).abs() < 1e-9);
+    }
+
+    /// A wide glyph that already fills its box (emoji measuring exactly two
+    /// cells) is left untouched — scale factor 1.0.
+    #[test]
+    fn exact_fit_wide_glyph_is_not_scaled() {
+        assert_eq!(wide_glyph_x_scale(18, 18.0), 1.0);
+    }
+
+    /// A wide glyph *wider* than two cells (some colour-emoji fonts) is
+    /// shrunk back into the box so it can't overlap the next glyph.
+    #[test]
+    fn over_wide_glyph_is_shrunk_into_box() {
+        let scale = wide_glyph_x_scale(24, 18.0);
+        assert!(
+            scale < 1.0,
+            "24px glyph in 18px box should shrink, got {scale}"
+        );
+        assert!((24.0 * scale - 18.0).abs() < 1e-9);
+    }
+
+    /// A zero / negative advance (empty or degenerate layout) must not
+    /// divide by zero or explode — it falls back to no scaling.
+    #[test]
+    fn degenerate_glyph_width_falls_back_to_no_scale() {
+        assert_eq!(wide_glyph_x_scale(0, 18.0), 1.0);
+        assert_eq!(wide_glyph_x_scale(-3, 18.0), 1.0);
     }
 }


### PR DESCRIPTION
Closes #439

Automated merge from the coordinator for assignment 7539763587a9 on issue #439.

Worker branch: `issue-439-gtk-terminal-cjk-emoji-wide-characters-r` → `develop`.