### PR TITLE
#454: ShellApp consumers cannot reach the rendered AppShell — forces a shadow copy that silently drifts

### DIFF
--- a/quadraui/examples/common/appshell_demo.rs
+++ b/quadraui/examples/common/appshell_demo.rs
@@ -13,11 +13,18 @@
 //! `ShellApp` only needs to pick its own trigger key(s) and call
 //! `request_activity_keyboard_focus()`; a different consumer could bind
 //! `Ctrl+W` instead of `Tab` with no quadraui changes.
+//!
+//! `Ctrl+B` demonstrates the #454 fix: [`ShellContext::shell_mut`] reaches
+//! the real `AppShell` instance quadraui's internal `ShellAdapter` actually
+//! renders, so a consumer-driven binding can call
+//! `ctx.shell_mut().toggle_sidebar()` directly instead of tracking a shadow
+//! `AppShell` that can drift from what's on screen (the vimcode `Ctrl+B`
+//! bug this issue fixes).
 
 use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
 use quadraui::{
-    Backend, Color, Key, NamedKey, Reaction, Rect, ShellApp, ShellConfig, ShellContext, StatusBar,
-    StatusBarSegment, UiEvent, WidgetId,
+    Backend, Color, Key, Modifiers, NamedKey, Reaction, Rect, ShellApp, ShellConfig, ShellContext,
+    StatusBar, StatusBarSegment, UiEvent, WidgetId,
 };
 
 pub struct AppShellDemo {
@@ -33,9 +40,9 @@ pub struct AppShellDemo {
 impl AppShellDemo {
     pub fn new() -> Self {
         Self {
-            last_event:
-                "Tab=focus bar | click icons | drag divider | p=jump to Source Control | q=quit"
-                    .into(),
+            last_event: "Tab=focus bar | click icons | drag divider | p=jump to Source Control \
+                         | Ctrl+B=toggle sidebar | q=quit"
+                .into(),
             pending_panel: None,
         }
     }
@@ -152,6 +159,28 @@ impl ShellApp for AppShellDemo {
             } => {
                 self.pending_panel = Some(WidgetId::new("panel:git"));
                 self.last_event = "Requested programmatic switch to panel:git".into();
+                Reaction::Redraw
+            }
+            // `Ctrl+B` = the #454 fix: `ctx.shell_mut()` reaches the real
+            // `AppShell` `ShellAdapter` renders, so this app can call
+            // `toggle_sidebar()` on it directly — no shadow `AppShell`, no
+            // drift between what this app thinks is visible and what's
+            // actually painted (the vimcode bug #454 fixes).
+            UiEvent::KeyPressed {
+                key: Key::Char('b'),
+                modifiers: Modifiers { ctrl: true, .. },
+                ..
+            } => {
+                let now_visible = {
+                    let mut shell = ctx.shell_mut();
+                    shell.toggle_sidebar();
+                    shell.sidebar_visible()
+                };
+                self.last_event = if now_visible {
+                    "Sidebar shown (Ctrl+B via ctx.shell_mut())".into()
+                } else {
+                    "Sidebar hidden (Ctrl+B via ctx.shell_mut())".into()
+                };
                 Reaction::Redraw
             }
             UiEvent::MouseDown { position, .. } => {

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -6,9 +6,11 @@
 //! window creation, event wiring, AppShell chrome rendering, and event
 //! routing — the consumer renders only its own content.
 
-use std::cell::Cell;
+use std::cell::{Cell, Ref, RefCell, RefMut};
 
-use crate::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition, ShellPosition};
+use crate::compose::app_shell::{
+    AppShell, AppShellEvent, AppShellLayout, PanelDefinition, ShellPosition,
+};
 use crate::compose::bottom_panel::{BottomPanelConfig, BottomPanelEvent};
 use crate::event::Rect;
 use crate::types::WidgetId;
@@ -157,6 +159,25 @@ pub struct ShellContext<'a> {
     /// by shared reference — the consumer can request focus without a
     /// `&mut` hook back into the shell.
     activity_focus_requested: Cell<bool>,
+    /// A scoped mutable borrow of the [`AppShell`] instance
+    /// [`crate::shell_adapter::ShellAdapter`] actually renders, lent out for
+    /// the duration of one `ShellApp::handle` dispatch (#454).
+    ///
+    /// Before this existed, a `ShellApp` consumer had no way to reach the
+    /// rendered shell at all — `ShellAdapter::shell` is `pub(crate)` — so
+    /// driving shell state programmatically (e.g. a `Ctrl+B` toggle-sidebar
+    /// binding) required keeping a second, shadow `AppShell` that silently
+    /// drifted from the one actually painted (vimcode `Ctrl+B` was dead on
+    /// GTK because of exactly this: the shadow toggled, the rendered
+    /// instance never learned about it).
+    ///
+    /// `RefCell` because `ShellContext` is passed by shared reference (see
+    /// `activity_focus_requested` above) — access via [`Self::shell`] /
+    /// [`Self::shell_mut`]. `AppShell` remains solely owned and constructed
+    /// by `ShellAdapter`; this only lends a scoped borrow for one dispatch,
+    /// so the single-owner invariant that makes drift impossible is
+    /// preserved.
+    shell: RefCell<&'a mut AppShell>,
 }
 
 impl<'a> ShellContext<'a> {
@@ -167,13 +188,47 @@ impl<'a> ShellContext<'a> {
         active_panel_id: Option<&'a WidgetId>,
         sidebar_visible: bool,
         layout: &'a AppShellLayout,
+        shell: &'a mut AppShell,
     ) -> Self {
         Self {
             active_panel_id,
             sidebar_visible,
             layout,
             activity_focus_requested: Cell::new(false),
+            shell: RefCell::new(shell),
         }
+    }
+
+    /// Borrow the real, rendered [`AppShell`] read-only.
+    ///
+    /// Prefer the narrow accessors above (`in_sidebar`, `sidebar_bounds`,
+    /// ...) for layout queries — this exists for the rest of `AppShell`'s
+    /// API (e.g. `bottom_panel_visible()`, `activity_selected_id()`) that
+    /// `ShellContext` doesn't otherwise mirror.
+    ///
+    /// # Panics
+    /// Panics if [`Self::shell_mut`] is borrowed at the same time (standard
+    /// `RefCell` rules). Each borrow is meant to be short-lived — grab it,
+    /// read, drop.
+    pub fn shell(&self) -> Ref<'_, &'a mut AppShell> {
+        self.shell.borrow()
+    }
+
+    /// Borrow the real, rendered [`AppShell`] mutably.
+    ///
+    /// This is the fix for #454: call any `AppShell` mutator directly on
+    /// the instance [`crate::shell_adapter::ShellAdapter`] actually
+    /// renders — `ctx.shell_mut().toggle_sidebar()`,
+    /// `ctx.shell_mut().show_bottom_panel()`,
+    /// `ctx.shell_mut().set_sidebar_width(w)`, etc. — instead of tracking a
+    /// shadow copy that can silently drift from what's on screen.
+    ///
+    /// # Panics
+    /// Panics if [`Self::shell`] / [`Self::shell_mut`] is borrowed at the
+    /// same time (standard `RefCell` rules). Each borrow is meant to be
+    /// short-lived — grab it, mutate, drop.
+    pub fn shell_mut(&self) -> RefMut<'_, &'a mut AppShell> {
+        self.shell.borrow_mut()
     }
 
     /// Request that the activity bar take keyboard focus, with its cursor
@@ -419,7 +474,6 @@ pub trait ShellApp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compose::app_shell::AppShell;
 
     /// Build a bare (no panels, no chrome) `AppShellLayout` sized `w x h`
     /// starting at the origin — just enough to exercise `window_bounds`.
@@ -427,8 +481,8 @@ mod tests {
         AppShell::new(Vec::new(), 20.0).layout(Rect::new(0.0, 0.0, w, h), 1.0)
     }
 
-    fn ctx(layout: &AppShellLayout) -> ShellContext<'_> {
-        ShellContext::new(None, false, layout)
+    fn ctx<'a>(layout: &'a AppShellLayout, shell: &'a mut AppShell) -> ShellContext<'a> {
+        ShellContext::new(None, false, layout, shell)
     }
 
     /// #422: a fresh `ShellConfig` has no editor-font override — backends
@@ -450,13 +504,15 @@ mod tests {
     #[test]
     fn window_edge_none_in_the_middle() {
         let layout = layout_for(100.0, 40.0);
-        assert_eq!(ctx(&layout).window_edge(50.0, 20.0, 4.0), None);
+        let mut shell = AppShell::new(Vec::new(), 20.0);
+        assert_eq!(ctx(&layout, &mut shell).window_edge(50.0, 20.0, 4.0), None);
     }
 
     #[test]
     fn window_edge_detects_each_side() {
         let layout = layout_for(100.0, 40.0);
-        let c = ctx(&layout);
+        let mut shell = AppShell::new(Vec::new(), 20.0);
+        let c = ctx(&layout, &mut shell);
         assert_eq!(c.window_edge(50.0, 0.0, 4.0), Some(ResizeEdge::North));
         assert_eq!(c.window_edge(50.0, 40.0, 4.0), Some(ResizeEdge::South));
         assert_eq!(c.window_edge(0.0, 20.0, 4.0), Some(ResizeEdge::West));
@@ -466,7 +522,8 @@ mod tests {
     #[test]
     fn window_edge_detects_each_corner() {
         let layout = layout_for(100.0, 40.0);
-        let c = ctx(&layout);
+        let mut shell = AppShell::new(Vec::new(), 20.0);
+        let c = ctx(&layout, &mut shell);
         assert_eq!(c.window_edge(0.0, 0.0, 4.0), Some(ResizeEdge::NorthWest));
         assert_eq!(c.window_edge(100.0, 0.0, 4.0), Some(ResizeEdge::NorthEast));
         assert_eq!(c.window_edge(0.0, 40.0, 4.0), Some(ResizeEdge::SouthWest));
@@ -478,8 +535,9 @@ mod tests {
     #[test]
     fn window_edge_none_outside_window() {
         let layout = layout_for(100.0, 40.0);
-        assert_eq!(ctx(&layout).window_edge(-2.0, 20.0, 4.0), None);
-        assert_eq!(ctx(&layout).window_edge(50.0, 45.0, 4.0), None);
+        let mut shell = AppShell::new(Vec::new(), 20.0);
+        assert_eq!(ctx(&layout, &mut shell).window_edge(-2.0, 20.0, 4.0), None);
+        assert_eq!(ctx(&layout, &mut shell).window_edge(50.0, 45.0, 4.0), None);
     }
 
     /// A window narrower/shorter than `2 * margin` must still resolve
@@ -488,10 +546,38 @@ mod tests {
     #[test]
     fn window_edge_degenerate_tiny_window_is_deterministic() {
         let layout = layout_for(3.0, 3.0);
-        let c = ctx(&layout);
+        let mut shell = AppShell::new(Vec::new(), 20.0);
+        let c = ctx(&layout, &mut shell);
         // Every point in a 3x3 window is within margin=4.0 of every edge;
         // just assert this doesn't panic and returns a corner (checked
         // first in the priority chain).
         assert_eq!(c.window_edge(1.5, 1.5, 4.0), Some(ResizeEdge::NorthWest));
+    }
+
+    /// #454: `ctx.shell_mut()` reaches the real `AppShell` — a `ShellApp`
+    /// can drive shell state (e.g. a `Ctrl+B` toggle-sidebar binding)
+    /// directly on the instance that's actually rendered, with no shadow
+    /// copy required.
+    #[test]
+    fn shell_mut_toggles_the_real_app_shell() {
+        let layout = layout_for(100.0, 40.0);
+        let mut shell = AppShell::new(Vec::new(), 20.0);
+        assert!(shell.sidebar_visible());
+        {
+            let c = ctx(&layout, &mut shell);
+            c.shell_mut().toggle_sidebar();
+        }
+        assert!(!shell.sidebar_visible());
+    }
+
+    /// #454: `ctx.shell()` gives read access without requiring a mutable
+    /// borrow, mirroring the read-only convenience accessors above.
+    #[test]
+    fn shell_read_reflects_current_state() {
+        let layout = layout_for(100.0, 40.0);
+        let mut shell = AppShell::new(Vec::new(), 20.0);
+        shell.hide_sidebar();
+        let c = ctx(&layout, &mut shell);
+        assert!(!c.shell().sidebar_visible());
     }
 }

--- a/quadraui/src/shell_adapter.rs
+++ b/quadraui/src/shell_adapter.rs
@@ -183,10 +183,12 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         if let Some(position) = mouse_event_position(&event) {
             if backend.modal_stack_mut().hit_test(position).is_some() {
                 let layout = self.shell.layout(area, backend.line_height());
+                let sidebar_visible = self.shell.sidebar_visible();
                 let ctx = ShellContext::new(
                     self.active_panel_id.as_ref(),
-                    self.shell.sidebar_visible(),
+                    sidebar_visible,
                     &layout,
+                    &mut self.shell,
                 );
                 return self.app.handle(event, backend, &ctx);
             }
@@ -301,10 +303,12 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         }
 
         let layout = self.shell.layout(area, backend.line_height());
+        let sidebar_visible = self.shell.sidebar_visible();
         let ctx = ShellContext::new(
             self.active_panel_id.as_ref(),
-            self.shell.sidebar_visible(),
+            sidebar_visible,
             &layout,
+            &mut self.shell,
         );
         let mut reaction = self.app.handle(event, backend, &ctx);
 

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -655,6 +655,66 @@ fn appshell_demo_programmatic_panel_switch_updates_chrome() {
     );
 }
 
+/// #454: `ctx.shell_mut()` reaches the real `AppShell` instance
+/// `ShellAdapter` renders — `AppShellDemo` binds `Ctrl+B` to
+/// `ctx.shell_mut().toggle_sidebar()`, exactly the call a consumer like
+/// vimcode needs for a toggle-sidebar keybinding. Before #454 a `ShellApp`
+/// had no way to reach the rendered `AppShell` at all, so this had to be
+/// faked with a second, shadow `AppShell` that silently drifted from the
+/// one actually painted (vimcode's `Ctrl+B` was dead on GTK because of
+/// exactly this). Driving this through `driver_with_shell` — the same
+/// `ShellApp` → `ShellAdapter` → `AppShell` dispatch `run_with_shell` uses
+/// in production — proves the fix on the real path, not a synthetic
+/// `ShellContext` built by hand.
+#[test]
+fn appshell_demo_ctrl_b_toggles_the_real_rendered_sidebar() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, 100, 30);
+
+    // Sidebar starts visible: the demo paints its sidebar-content
+    // placeholder text into `layout.sidebar_content_bounds`, which is
+    // `Some` only while the sidebar is shown.
+    assert!(
+        driver.screen_contains("(sidebar content"),
+        "sidebar should be visible on the initial screen:\n{}",
+        driver.screen()
+    );
+
+    let reaction = driver.ctrl_char('b');
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Ctrl+B toggling the real AppShell must redraw"
+    );
+    assert!(
+        !driver.screen_contains("(sidebar content"),
+        "Ctrl+B must hide the sidebar that ShellAdapter actually renders, \
+         not a shadow copy:\n{}",
+        driver.screen()
+    );
+    assert!(
+        driver.screen_contains("Sidebar hidden (Ctrl+B via ctx.shell_mut())"),
+        "status line should confirm the toggle went through ctx.shell_mut():\n{}",
+        driver.screen()
+    );
+
+    // Toggling again brings it back — proves `ctx.shell_mut()` mutates the
+    // same live instance `render_content` reads from on the next frame,
+    // round-tripping the real state rather than a one-way flag.
+    let reaction = driver.ctrl_char('b');
+    assert_eq!(reaction, Reaction::Redraw);
+    assert!(
+        driver.screen_contains("(sidebar content"),
+        "a second Ctrl+B should show the sidebar again:\n{}",
+        driver.screen()
+    );
+    assert!(
+        driver.screen_contains("Sidebar shown (Ctrl+B via ctx.shell_mut())"),
+        "status line should confirm the second toggle:\n{}",
+        driver.screen()
+    );
+}
+
 // ─── DialogTableDemo (issue #225): table layout in dialog ───────────────────
 
 /// Initial screen renders dialog title and table headers.


### PR DESCRIPTION
Closes #454

Automated merge from the coordinator for assignment 5631d8d0db51 on issue #454.

Worker branch: `issue-454-shellapp-consumers-cannot-reach-the-rend` → `develop`.