### PR TITLE
#447: GtkDriver GD-2: fixtures + assertion API (find/pixel/geometry/text)

### DIFF
--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -59,6 +59,16 @@ use crate::{
 
 use super::services::GtkPlatformServices;
 
+/// One piece of text painted this frame, with its on-surface bounds in
+/// backend (pixel) coordinates. Recorded via
+/// [`GtkBackend::record_painted_text`] into [`GtkBackend::painted_text`] —
+/// the map [`super::testing::GtkDriver::find`] scans (quadraui#447, GD-2).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PaintedText {
+    pub(crate) text: String,
+    pub(crate) bounds: QRect,
+}
+
 /// GTK backend implementing [`quadraui::Backend`].
 ///
 /// Field roles:
@@ -149,6 +159,15 @@ pub struct GtkBackend {
     /// [`Backend::register_text_region`]. Cleared at the start of each
     /// frame by [`Self::begin_frame`]. Parallels `TuiBackend::text_regions`.
     pub(crate) text_regions: Vec<TextRegion>,
+    /// The `(text, bounds)` map painted this frame — recorded by trait
+    /// methods that already compute a label's on-surface rect (e.g.
+    /// [`Self::draw_status_bar`]) so [`super::testing::GtkDriver::find`]
+    /// can locate a control without hardcoded coordinates (quadraui#447,
+    /// GD-2). Cleared at the start of each frame by [`Self::begin_frame`];
+    /// mirrors `text_regions`' lifecycle. Coverage is incremental — only
+    /// widgets whose trait method has been updated to call
+    /// [`Self::record_painted_text`] appear here; see that method's docs.
+    pub(crate) painted_text: Vec<PaintedText>,
     /// Active text selection (persists after mouse-up until a new click
     /// clears it). Set by [`Self::set_active_text_selection`], cleared by
     /// [`Self::clear_text_selection`] or [`Self::clear_selection_display`].
@@ -267,6 +286,7 @@ impl GtkBackend {
             editor_font_family: "Monospace".to_string(),
             editor_font_size_pt: 11.0,
             text_regions: Vec::new(),
+            painted_text: Vec::new(),
             active_selection: None,
             last_text_region_id: None,
             focused_activity_bar: None,
@@ -652,6 +672,26 @@ impl GtkBackend {
         self.last_text_region_id = Some(id);
     }
 
+    /// Record one painted label into [`Self::painted_text`] — the
+    /// `(text, bounds)` map [`super::testing::GtkDriver::find`] scans.
+    ///
+    /// `bounds` is in backend (pixel) coordinates, matching what
+    /// [`super::testing::GtkDriver::click`] expects. Called by trait
+    /// methods that already compute a label's rect for hit-testing (e.g.
+    /// [`Backend::draw_status_bar`]) — coverage grows as more `draw_*`
+    /// methods adopt it; see `painted_text`'s docs for the current state.
+    /// Skips empty `text` so blank/placeholder segments don't pollute
+    /// `find` matches.
+    pub(crate) fn record_painted_text(&mut self, text: &str, bounds: QRect) {
+        if text.is_empty() {
+            return;
+        }
+        self.painted_text.push(PaintedText {
+            text: text.to_string(),
+            bounds,
+        });
+    }
+
     /// Paint the active text selection highlight onto `cr`. Must be called
     /// after `app.render` (so the highlight sits on top of the rendered
     /// content). Converts the pixel-based anchor/focus into cell-index space
@@ -1008,6 +1048,8 @@ impl Backend for GtkBackend {
         // Clear per-frame text regions so stale registrations from the
         // previous frame don't linger. Mirrors TuiBackend::begin_frame.
         self.text_regions.clear();
+        // Clear last frame's painted-text map — see `painted_text`'s docs.
+        self.painted_text.clear();
         // Clear the focused activity bar — re-set by draw_activity_bar
         // during the render pass if still focused. Same lifecycle as
         // text_regions.
@@ -1393,7 +1435,7 @@ impl Backend for GtkBackend {
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_status_bar called outside enter_frame_scope");
-        crate::gtk::draw_status_bar(
+        let bar_layout = crate::gtk::draw_status_bar(
             cr,
             layout,
             rect.x as f64,
@@ -1404,7 +1446,26 @@ impl Backend for GtkBackend {
             &self.current_theme,
             hovered_id,
             pressed_id,
-        )
+        );
+        // Record each visible segment's label into the painted-text map
+        // GtkDriver::find scans (quadraui#447, GD-2) — resolve the text
+        // from `bar` via the segment's side + index, since
+        // `VisibleStatusSegment` carries the resolved bounds but not the
+        // label itself.
+        for seg in &bar_layout.visible_segments {
+            let text = match seg.side {
+                crate::primitives::status_bar::StatusSegmentSide::Left => {
+                    bar.left_segments.get(seg.segment_idx).map(|s| &s.text)
+                }
+                crate::primitives::status_bar::StatusSegmentSide::Right => {
+                    bar.right_segments.get(seg.segment_idx).map(|s| &s.text)
+                }
+            };
+            if let Some(text) = text {
+                self.record_painted_text(text, seg.bounds);
+            }
+        }
+        bar_layout
     }
 
     fn draw_tab_bar(

--- a/quadraui/src/gtk/testing.rs
+++ b/quadraui/src/gtk/testing.rs
@@ -273,6 +273,70 @@ impl<A: AppLogic> GtkDriver<A> {
         let off = y as usize * stride + x as usize * 4;
         (data[off + 2], data[off + 1], data[off])
     }
+
+    /// Raw `ARgb32` pixel buffer of the last [`Self::render`] — the
+    /// `screen()`-equivalent GD-2 raw-buffer accessor. Four bytes per
+    /// pixel, `[B, G, R, A]` (see [`Self::pixel`]); row stride is
+    /// [`Self::stride`], not necessarily `width * 4`. Copies out of the
+    /// surface (Cairo's borrow guard can't outlive this call) — prefer
+    /// [`Self::pixel`] / [`Self::find`] / [`Self::screen_contains`] for
+    /// assertions; this is the escape hatch for tests that need the whole
+    /// buffer (e.g. diffing two frames).
+    pub fn screen(&mut self) -> Vec<u8> {
+        self.surface.flush();
+        self.surface.data().expect("surface data").to_vec()
+    }
+
+    /// Row stride (bytes per row) of the surface [`Self::screen`] reads
+    /// back from. Cairo pads rows for alignment, so this can exceed
+    /// `width * 4`.
+    pub fn stride(&self) -> i32 {
+        self.surface.stride()
+    }
+
+    /// All text painted during the last [`Self::render`], as recorded by
+    /// [`super::backend::GtkBackend::record_painted_text`] — the
+    /// `(text, bounds)` map [`Self::find`] / [`Self::find_bounds`] /
+    /// [`Self::screen_contains`] query. See `GtkBackend::painted_text`'s
+    /// docs for which widgets currently report into it.
+    pub fn painted_texts(&self) -> Vec<&str> {
+        self.backend
+            .painted_text
+            .iter()
+            .map(|p| p.text.as_str())
+            .collect()
+    }
+
+    /// True if any painted label contains `needle` — the GTK analogue of
+    /// [`crate::tui::testing::TuiDriver::screen_contains`].
+    pub fn screen_contains(&self, needle: &str) -> bool {
+        self.backend
+            .painted_text
+            .iter()
+            .any(|p| p.text.contains(needle))
+    }
+
+    /// Pixel bounds (backend coordinates) of the first painted label
+    /// containing `needle`, via the `(text, bounds)` map recorded at
+    /// paint time (quadraui#447, GD-2) — mirrors the `TuiDriver::find`
+    /// rule (*locate targets with `find`, never hardcode coords*), but
+    /// resolved from Pango-measured layout geometry rather than a
+    /// character grid.
+    pub fn find_bounds(&self, needle: &str) -> Option<crate::Rect> {
+        self.backend
+            .painted_text
+            .iter()
+            .find(|p| p.text.contains(needle))
+            .map(|p| p.bounds)
+    }
+
+    /// Center coordinates (pixels) of the first painted label containing
+    /// `needle` — pass straight to [`Self::click`]. `None` if nothing
+    /// painted this frame matched.
+    pub fn find(&self, needle: &str) -> Option<(f32, f32)> {
+        self.find_bounds(needle)
+            .map(|b| (b.x + b.width / 2.0, b.y + b.height / 2.0))
+    }
 }
 
 #[cfg(test)]
@@ -333,6 +397,195 @@ mod tests {
             (r, g, b),
             (KNOWN_BG.r, KNOWN_BG.g, KNOWN_BG.b),
             "expected the status bar segment's known background colour, got ({r}, {g}, {b})"
+        );
+    }
+
+    /// `find`/`find_bounds` locate the segment's label via the
+    /// `(text, bounds)` map [`GtkBackend::draw_status_bar`] records — the
+    /// coordinate-free counterpart to
+    /// [`renders_offscreen_and_reads_back_known_pixel`]'s hardcoded
+    /// `pixel(4, H / 2)` (quadraui#447, GD-2).
+    #[test]
+    fn find_locates_status_bar_segment_by_text() {
+        let mut driver = GtkDriver::new(StatusBarApp, W, H);
+
+        let bounds = driver
+            .find_bounds("known-pixel")
+            .expect("find_bounds should locate the painted segment");
+        assert_eq!(
+            (bounds.x, bounds.y),
+            (0.0, 0.0),
+            "the only segment should start at the bar's origin"
+        );
+
+        let (x, y) = driver
+            .find("known-pixel")
+            .expect("find should locate the painted segment label");
+        assert!(
+            x >= bounds.x && x <= bounds.x + bounds.width,
+            "find()'s x should fall within the segment's own bounds"
+        );
+        assert!(
+            y >= bounds.y && y <= bounds.y + bounds.height,
+            "find()'s y should fall within the segment's own bounds"
+        );
+
+        // Sample the whole segment bounds and take the most common
+        // colour — the background fill, since it covers far more area
+        // than the label's thin anti-aliased glyph strokes — rather than
+        // guessing a coordinate known to dodge the text.
+        let (r, g, b) = dominant_pixel(&mut driver, bounds);
+        assert_eq!(
+            (r, g, b),
+            (KNOWN_BG.r, KNOWN_BG.g, KNOWN_BG.b),
+            "dominant colour within find_bounds() should be the segment's bg, got ({r}, {g}, {b})"
+        );
+
+        assert!(driver.screen_contains("known-pixel"));
+        assert!(!driver.screen_contains("no such label"));
+    }
+
+    /// Most common `(r, g, b)` pixel within `bounds` — the background
+    /// colour, since it covers far more area than a label's thin
+    /// anti-aliased glyph strokes. Used to assert on a text-tight
+    /// segment's fill colour without hardcoding a coordinate known (by
+    /// construction) to dodge the text.
+    fn dominant_pixel<A: AppLogic>(driver: &mut GtkDriver<A>, bounds: Rect) -> (u8, u8, u8) {
+        use std::collections::HashMap;
+
+        let mut counts: HashMap<(u8, u8, u8), u32> = HashMap::new();
+        for py in bounds.y as i32..(bounds.y + bounds.height) as i32 {
+            for px in bounds.x as i32..(bounds.x + bounds.width) as i32 {
+                *counts.entry(driver.pixel(px, py)).or_insert(0) += 1;
+            }
+        }
+        counts
+            .into_iter()
+            .max_by_key(|(_, count)| *count)
+            .map(|(color, _)| color)
+            .expect("bounds should contain at least one pixel")
+    }
+
+    /// Fixture analogous to the issue's `make_test_app(BoardData)`: a
+    /// full GTK view built purely from in-memory state — one clickable
+    /// `StatusBar` segment that flips its background colour on click.
+    /// No live app, no example wiring — just an `AppLogic` a test can
+    /// hand straight to [`GtkDriver::new`].
+    struct ToggleStatusBarApp {
+        on: bool,
+    }
+
+    impl ToggleStatusBarApp {
+        const OFF_BG: Color = Color::rgb(40, 40, 40);
+        const ON_BG: Color = Color::rgb(0, 200, 0);
+
+        fn bar(&self) -> StatusBar {
+            StatusBar {
+                id: WidgetId::new("status"),
+                left_segments: vec![StatusBarSegment {
+                    text: "Toggle".to_string(),
+                    fg: Color::rgb(255, 255, 255),
+                    bg: if self.on { Self::ON_BG } else { Self::OFF_BG },
+                    bold: false,
+                    action_id: Some(WidgetId::new("toggle")),
+                }],
+                right_segments: vec![],
+            }
+        }
+    }
+
+    impl AppLogic for ToggleStatusBarApp {
+        type AreaId = ();
+
+        fn render(&self, backend: &mut dyn Backend, _area: ()) {
+            backend.draw_status_bar(
+                Rect::new(0.0, 0.0, W as f32, H as f32),
+                &self.bar(),
+                None,
+                None,
+            );
+        }
+
+        fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+            // Hit-test via the non-painting `status_bar_layout` query
+            // (mirrors CLAUDE.md's "cached layout hit-test pattern" —
+            // recompute the layout from state, don't repaint to hit-test).
+            if let UiEvent::MouseDown { position, .. } = event {
+                let layout =
+                    backend.status_bar_layout(Rect::new(0.0, 0.0, W as f32, H as f32), &self.bar());
+                if layout.hit_test(position.x, position.y)
+                    == crate::primitives::status_bar::StatusBarHit::Segment(WidgetId::new("toggle"))
+                {
+                    self.on = !self.on;
+                    return Reaction::Redraw;
+                }
+            }
+            Reaction::Continue
+        }
+    }
+
+    /// GD-2 acceptance test: `find` locates the control (no hardcoded
+    /// coords), `click` activates it, and both a pixel-colour probe and a
+    /// geometry (bounds) assertion observe the resulting change.
+    #[test]
+    fn find_click_asserts_pixel_and_geometry_change() {
+        let mut driver = GtkDriver::new(ToggleStatusBarApp { on: false }, W, H);
+
+        let (x, y) = driver
+            .find("Toggle")
+            .expect("find should locate the toggle segment before any click");
+        let bounds_before = driver.find_bounds("Toggle").expect("bounds before click");
+        // The segment's bounds are text-tight (clickable segments aren't
+        // padded out to fill the bar, unlike the trailing non-clickable
+        // segment `renders_offscreen_and_reads_back_known_pixel` reads
+        // from), so no single fixed pixel is guaranteed to dodge the
+        // label's anti-aliased glyphs. Sample the whole bounds rect and
+        // take the most common colour — the background, since it covers
+        // far more area than the thin glyph strokes.
+        let pixel_before = dominant_pixel(&mut driver, bounds_before);
+        assert_eq!(
+            pixel_before,
+            (
+                ToggleStatusBarApp::OFF_BG.r,
+                ToggleStatusBarApp::OFF_BG.g,
+                ToggleStatusBarApp::OFF_BG.b
+            ),
+            "segment should start OFF-coloured"
+        );
+
+        let reaction = driver.click(x, y);
+        assert_eq!(reaction, Reaction::Redraw, "click should trigger a redraw");
+        assert!(
+            driver.app().on,
+            "click should have flipped the toggle state"
+        );
+
+        // Pixel assertion: same bounds (segment didn't move — the bar
+        // layout is unchanged), different dominant colour.
+        let pixel_after = dominant_pixel(&mut driver, bounds_before);
+        assert_eq!(
+            pixel_after,
+            (
+                ToggleStatusBarApp::ON_BG.r,
+                ToggleStatusBarApp::ON_BG.g,
+                ToggleStatusBarApp::ON_BG.b
+            ),
+            "segment should be ON-coloured after the click toggled state"
+        );
+        assert_ne!(
+            pixel_before, pixel_after,
+            "click should change the painted pixel"
+        );
+
+        // Geometry assertion: re-`find` after the click (the label text
+        // is unchanged, so this proves the API works post-redraw too) and
+        // confirm the bounds are stable across the repaint.
+        let bounds_after = driver
+            .find_bounds("Toggle")
+            .expect("bounds after click should still resolve");
+        assert_eq!(
+            bounds_before, bounds_after,
+            "segment geometry should be unchanged by a colour-only redraw"
         );
     }
 


### PR DESCRIPTION
Closes #447

Automated merge from the coordinator for assignment cf6841cd9ed4 on issue #447.

Worker branch: `issue-447-gtkdriver-gd-2-fixtures-assertion-api-fi` → `develop`.