### PR TITLE
#467: Backend trait has no DragState/ModalStack accessor — ShellApp::handle can't drive mouse dispatch (TUI needs drag_and_modal_mut on the trait)

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -10,6 +10,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::dispatch::DragState;
 use crate::event::{Rect, UiEvent, Viewport};
 use crate::modal_stack::ModalStack;
 use crate::primitives::activity_bar::ActivityBarRowHit;
@@ -343,6 +344,30 @@ pub trait Backend {
     /// See [`ModalStack`] and [`crate::dispatch::dispatch_mouse_down`]
     /// for the routing contract.
     fn modal_stack_mut(&mut self) -> &mut ModalStack;
+
+    // ─── Drag-state tracking ─────────────────────────────────────────
+    /// Disjoint mutable borrows of the backend's drag state and modal
+    /// stack, in one call.
+    ///
+    /// `ShellApp` mouse-dispatch consumers (see
+    /// `crate::dispatch::dispatch_mouse_down` / `_drag` / `_up`) often
+    /// need `&mut DragState` and `&mut ModalStack` *at the same time* —
+    /// e.g. to read the in-progress drag target while also consulting
+    /// (or updating) the modal stack for click routing. Two separate
+    /// `&mut self` accessors can't do that through `&mut dyn Backend`:
+    /// the first call's borrow would still be live when the second is
+    /// made, which the borrow checker rejects. This method exists
+    /// purely to hand back both borrows split from a single `&mut
+    /// self` call, the same way `TuiBackend::drag_and_modal_mut`
+    /// (pre-trait, #467) split its own fields.
+    ///
+    /// Backends that don't otherwise expose drag state on the trait
+    /// (it's normally a backend implementation detail — only the
+    /// dispatch helpers in `crate::dispatch::*` need to observe it)
+    /// implement this solely so `&mut dyn Backend` consumers can reach
+    /// it. Use [`Self::modal_stack_mut`] instead when only the modal
+    /// stack is needed.
+    fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack);
 
     // ─── Platform services ─────────────────────────────────────────────
     /// Clipboard, file dialogs, notifications, URL opening, platform name.

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -1878,6 +1878,9 @@ mod tests {
         fn modal_stack_mut(&mut self) -> &mut crate::ModalStack {
             unimplemented!()
         }
+        fn drag_and_modal_mut(&mut self) -> (&mut crate::DragState, &mut crate::ModalStack) {
+            unimplemented!()
+        }
         fn services(&self) -> &dyn crate::backend::PlatformServices {
             unimplemented!()
         }

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -1364,6 +1364,9 @@ mod tests {
         fn modal_stack_mut(&mut self) -> &mut crate::ModalStack {
             unimplemented!()
         }
+        fn drag_and_modal_mut(&mut self) -> (&mut crate::DragState, &mut crate::ModalStack) {
+            unimplemented!()
+        }
         fn services(&self) -> &dyn crate::backend::PlatformServices {
             unimplemented!()
         }

--- a/quadraui/src/compose/menu_system.rs
+++ b/quadraui/src/compose/menu_system.rs
@@ -721,12 +721,14 @@ mod tests {
 
     struct MockBackend {
         modal_stack: crate::ModalStack,
+        drag_state: crate::DragState,
     }
 
     impl MockBackend {
         fn new() -> Self {
             Self {
                 modal_stack: crate::ModalStack::new(),
+                drag_state: crate::DragState::new(),
             }
         }
     }
@@ -747,6 +749,9 @@ mod tests {
         fn unregister_accelerator(&mut self, _: &crate::accelerator::AcceleratorId) {}
         fn modal_stack_mut(&mut self) -> &mut crate::ModalStack {
             &mut self.modal_stack
+        }
+        fn drag_and_modal_mut(&mut self) -> (&mut crate::DragState, &mut crate::ModalStack) {
+            (&mut self.drag_state, &mut self.modal_stack)
         }
         fn services(&self) -> &dyn crate::backend::PlatformServices {
             unimplemented!()

--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -1506,6 +1506,9 @@ mod tests {
         fn modal_stack_mut(&mut self) -> &mut crate::ModalStack {
             unimplemented!()
         }
+        fn drag_and_modal_mut(&mut self) -> (&mut crate::DragState, &mut crate::ModalStack) {
+            unimplemented!()
+        }
         fn services(&self) -> &dyn crate::backend::PlatformServices {
             unimplemented!()
         }

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1150,6 +1150,22 @@ impl Backend for GtkBackend {
         }
     }
 
+    fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack) {
+        // Same `Rc<RefCell<>>`-leak rationale as `modal_stack_mut`
+        // above, applied to both fields. `drag_state` and
+        // `modal_stack` are separate `Rc<RefCell<>>`s, so the two
+        // leaked derefs never alias — this is just two independent
+        // instances of the same escape hatch, not a new hazard.
+        //
+        // SAFETY: see `modal_stack_mut`'s SAFETY comment; the same
+        // no-reentrancy contract applies to `drag_state` here.
+        unsafe {
+            let drag_ptr = Rc::as_ptr(&self.drag_state);
+            let modal_ptr = Rc::as_ptr(&self.modal_stack);
+            (&mut *(*drag_ptr).as_ptr(), &mut *(*modal_ptr).as_ptr())
+        }
+    }
+
     fn services(&self) -> &dyn PlatformServices {
         &self.services
     }

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -36,6 +36,7 @@ use core_graphics::sys::CGContextRef;
 use core_text::font::CTFont;
 
 use crate::backend::{Backend, EditorPaintResult};
+use crate::dispatch::DragState;
 use crate::event::{Rect, UiEvent, Viewport};
 use crate::modal_stack::ModalStack;
 use crate::primitives::activity_bar::ActivityBarRowHit;
@@ -92,6 +93,7 @@ use super::services::MacPlatformServices;
 pub struct MacBackend {
     viewport: Viewport,
     modal_stack: ModalStack,
+    drag_state: DragState,
     accelerators: HashMap<AcceleratorId, Accelerator>,
     events: Rc<std::cell::RefCell<VecDeque<UiEvent>>>,
     services: MacPlatformServices,
@@ -133,6 +135,7 @@ impl MacBackend {
         Self {
             viewport: Viewport::new(0.0, 0.0, 1.0),
             modal_stack: ModalStack::new(),
+            drag_state: DragState::new(),
             accelerators: HashMap::new(),
             events: Rc::new(std::cell::RefCell::new(VecDeque::new())),
             services: MacPlatformServices::new(),
@@ -318,6 +321,10 @@ impl Backend for MacBackend {
 
     fn modal_stack_mut(&mut self) -> &mut ModalStack {
         &mut self.modal_stack
+    }
+
+    fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack) {
+        (&mut self.drag_state, &mut self.modal_stack)
     }
 
     fn services(&self) -> &dyn PlatformServices {

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -27,10 +27,11 @@
 //! works against `TuiBackend`, `GtkBackend`, the test `MockBackend`,
 //! and any future Win-GUI / macOS backend implementer.
 //!
-//! Drag-state observation is deliberately not on the trait — only
-//! `crate::dispatch::*` needs to inspect it, and the backend keeps
-//! it as a struct field accessed through
-//! [`Self::drag_and_modal_mut`].
+//! Drag-state observation is normally a backend implementation
+//! detail — only `crate::dispatch::*` needs to inspect it directly.
+//! It's still exposed via [`crate::Backend::drag_and_modal_mut`] (#467)
+//! so `&mut dyn Backend` consumers (e.g. a `ShellApp`'s mouse-dispatch
+//! logic) can reach it without downcasting to the concrete backend.
 //!
 //! Event flow goes through the trait: [`Self::wait_events`] reads
 //! crossterm events, translates them via
@@ -227,17 +228,6 @@ impl TuiBackend {
     /// `draw_*` invocations consume the stored theme.
     pub fn set_current_theme(&mut self, theme: crate::Theme) {
         self.current_theme = theme;
-    }
-
-    /// Disjoint mutable borrows of drag state and modal stack.
-    /// `mouse.rs::handle_mouse` needs both at the same time, and
-    /// borrowing each field through a separate `&mut self` accessor
-    /// would conflict — this helper splits the field borrows in one
-    /// call. The trait deliberately doesn't expose drag state (it's
-    /// a backend implementation detail; only the dispatch helpers
-    /// in `crate::dispatch::*` need to observe it).
-    pub fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack) {
-        (&mut self.drag_state, &mut self.modal_stack)
     }
 
     // ── Text selection ─────────────────────────────────────────────────────
@@ -854,6 +844,16 @@ impl Backend for TuiBackend {
 
     fn modal_stack_mut(&mut self) -> &mut ModalStack {
         &mut self.modal_stack
+    }
+
+    /// Disjoint mutable borrows of drag state and modal stack.
+    /// `mouse.rs::handle_mouse` (quadraui + downstream consumers'
+    /// `ShellApp::handle` mouse dispatch) needs both at the same
+    /// time, and borrowing each field through a separate `&mut self`
+    /// accessor would conflict — this splits the field borrows in
+    /// one call. See [`crate::Backend::drag_and_modal_mut`] (#467).
+    fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack) {
+        (&mut self.drag_state, &mut self.modal_stack)
     }
 
     fn services(&self) -> &dyn PlatformServices {
@@ -1771,6 +1771,7 @@ mod tests {
     struct MockBackend {
         calls: Vec<DrawCall>,
         modal_stack: ModalStack,
+        drag_state: DragState,
         services: MockServices,
         viewport: Viewport,
         theme: crate::Theme,
@@ -1781,6 +1782,7 @@ mod tests {
             Self {
                 calls: Vec::new(),
                 modal_stack: ModalStack::new(),
+                drag_state: DragState::new(),
                 services: MockServices::new(),
                 viewport: Viewport::new(80.0, 24.0, 1.0),
                 theme: crate::Theme::default(),
@@ -1809,6 +1811,9 @@ mod tests {
         fn unregister_accelerator(&mut self, _id: &AcceleratorId) {}
         fn modal_stack_mut(&mut self) -> &mut ModalStack {
             &mut self.modal_stack
+        }
+        fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack) {
+            (&mut self.drag_state, &mut self.modal_stack)
         }
         fn services(&self) -> &dyn PlatformServices {
             &self.services

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::backend::{Backend, EditorPaintResult, PlatformServices};
+use crate::dispatch::DragState;
 use crate::event::{Rect, UiEvent, Viewport};
 use crate::modal_stack::ModalStack;
 use crate::primitives::activity_bar::ActivityBarRowHit;
@@ -65,6 +66,7 @@ use super::services::WinPlatformServices;
 pub struct WinBackend {
     viewport: Viewport,
     modal_stack: ModalStack,
+    drag_state: DragState,
     accelerators: HashMap<AcceleratorId, Accelerator>,
     services: WinPlatformServices,
     current_line_height: f32,
@@ -80,6 +82,7 @@ impl WinBackend {
         Self {
             viewport: Viewport::new(0.0, 0.0, 1.0),
             modal_stack: ModalStack::new(),
+            drag_state: DragState::new(),
             accelerators: HashMap::new(),
             services: WinPlatformServices::new(),
             current_line_height: 16.0,
@@ -132,6 +135,10 @@ impl Backend for WinBackend {
 
     fn modal_stack_mut(&mut self) -> &mut ModalStack {
         &mut self.modal_stack
+    }
+
+    fn drag_and_modal_mut(&mut self) -> (&mut DragState, &mut ModalStack) {
+        (&mut self.drag_state, &mut self.modal_stack)
     }
 
     // ─── Platform services ────────────────────────────────────────────


### PR DESCRIPTION
Closes #467

Automated merge from the coordinator for assignment a87ad5e34394 on issue #467.

Worker branch: `issue-467-backend-trait-has-no-dragstate-modalstac` → `develop`.