### PR TITLE
#466: TUI ShellApp: no consumer applies Backend::draw_editor's EditorPaintResult::cursor_position

### DIFF
--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -143,6 +143,22 @@ pub struct TuiBackend {
     /// `KeyPressed` events to `UiEvent::ActivityBar(id, KeyPressed { … })`
     /// so app logic receives activity-bar keys through a typed channel.
     focused_activity_bar: Option<WidgetId>,
+    /// Screen-space `(x, y)` for `Frame::set_cursor_position`, cached from
+    /// the most recent [`Backend::draw_editor`] call this frame (quadraui#466).
+    ///
+    /// `draw_editor` only has access to the ratatui buffer, not the `Frame`
+    /// itself (see [`Self::current_frame_mut`]'s note on why trait methods
+    /// can't reach `Frame::set_cursor_position` directly), so it stashes
+    /// the position here. [`super::run::render_frame`] takes it via
+    /// [`Self::take_last_cursor_position`] after the render closure returns
+    /// and applies it to the real `Frame`, mirroring how
+    /// `apply_selection_highlight` bridges buffer-only paint to a
+    /// frame-level side effect.
+    ///
+    /// Cleared at the start of every frame by [`Self::begin_frame`] (same
+    /// lifecycle as `text_regions`) so a frame that doesn't paint an editor
+    /// doesn't inherit a stale cursor position from the previous one.
+    last_cursor_position: Option<(u16, u16)>,
 }
 
 impl TuiBackend {
@@ -169,6 +185,7 @@ impl TuiBackend {
             cached_selection_text: String::new(),
             last_text_region_id: None,
             focused_activity_bar: None,
+            last_cursor_position: None,
         }
     }
 
@@ -355,6 +372,20 @@ impl TuiBackend {
     /// the cache persists until the selection is cleared.
     pub(crate) fn cached_selection_text(&self) -> String {
         self.cached_selection_text.clone()
+    }
+
+    /// Take the editor cursor position cached by the most recent
+    /// [`Backend::draw_editor`] call this frame, leaving `None` behind.
+    ///
+    /// Called by [`super::run::render_frame`] once per frame, after the
+    /// render closure returns but still inside `terminal.draw(|frame| …)`,
+    /// so it can apply `frame.set_cursor_position(pos)` — the only place
+    /// with access to the real `Frame` (quadraui#466). "Take" (not a plain
+    /// getter) because the value is frame-scoped: [`Self::begin_frame`]
+    /// clears it again before the next `draw_editor` call, so nothing relies
+    /// on the value surviving past this one read.
+    pub(crate) fn take_last_cursor_position(&mut self) -> Option<(u16, u16)> {
+        self.last_cursor_position.take()
     }
 
     /// Set the active selection to cover the entire visible content of the
@@ -751,6 +782,11 @@ impl Backend for TuiBackend {
         // Clear the focused activity bar — re-set by draw_activity_bar
         // during the render pass if still focused.
         self.focused_activity_bar = None;
+        // Clear the cached editor cursor position — re-set by draw_editor
+        // during the render pass if an editor paints this frame. Without
+        // this a frame that stops painting an editor (e.g. it's hidden)
+        // would keep showing the terminal cursor at the last-known spot.
+        self.last_cursor_position = None;
     }
 
     fn register_text_region(&mut self, region: TextRegion) {
@@ -1313,6 +1349,11 @@ impl Backend for TuiBackend {
             .current_frame_mut()
             .expect("TuiBackend::draw_editor called outside enter_frame_scope");
         let tui_result = crate::tui::draw_editor(frame.buffer_mut(), area, editor, &theme);
+        // Cache for `render_frame` (quadraui#466) — `draw_editor` only sees
+        // the buffer, not the `Frame`, so it can't call
+        // `Frame::set_cursor_position` itself. See
+        // `last_cursor_position`'s field doc for the full handoff.
+        self.last_cursor_position = tui_result.cursor_position;
         crate::backend::EditorPaintResult {
             cursor_position: tui_result.cursor_position,
         }

--- a/quadraui/src/tui/run.rs
+++ b/quadraui/src/tui/run.rs
@@ -221,9 +221,10 @@ fn run_inner<A: AppLogic>(
 ///
 /// Syncs the viewport from the terminal size, runs `app.render` inside
 /// the backend's frame scope, overlays the active text-selection
-/// highlight, and finalises the frame. Generic over the ratatui backend
-/// `B` so the live runner (`CrosstermBackend`) and the headless test
-/// driver (`TestBackend`) share one paint path.
+/// highlight, applies any editor cursor position painted this frame, and
+/// finalises the frame. Generic over the ratatui backend `B` so the live
+/// runner (`CrosstermBackend`) and the headless test driver
+/// (`TestBackend`) share one paint path.
 pub(crate) fn render_frame<A, B>(
     terminal: &mut Terminal<B>,
     backend: &mut TuiBackend,
@@ -253,6 +254,16 @@ where
             // buffer. Done outside enter_frame_scope so the closure lifetime
             // doesn't conflict with the frame borrow.
             backend.apply_selection_highlight(frame.buffer_mut());
+            // Apply the editor cursor position cached by `draw_editor`
+            // (quadraui#466). `Backend::draw_editor` only has the buffer,
+            // not the `Frame`, so it stashes the position on `TuiBackend`
+            // for us to apply here — the one place per frame with access
+            // to the real `Frame::set_cursor_position`. `run_with_shell`
+            // and `TuiDriver` both go through this same `render_frame`, so
+            // they pick up the behavior for free.
+            if let Some(pos) = backend.take_last_cursor_position() {
+                frame.set_cursor_position(pos);
+            }
         })
         .map_err(|e| io::Error::other(e.to_string()))?;
     backend.end_frame();
@@ -618,6 +629,142 @@ mod tests {
         assert!(
             backend.active_text_selection().is_some(),
             "cancel_text_selection_drag must NOT clear the active selection display"
+        );
+    }
+
+    // ── Editor cursor-position pipeline (quadraui#466) ─────────────────────────
+    //
+    // `Backend::draw_editor`'s `EditorPaintResult::cursor_position` used to have
+    // no consumer downstream of `AppLogic::render` — the runner never applied it
+    // to the real ratatui `Frame`. These tests exercise the fix: `render_frame`
+    // takes `TuiBackend`'s cached position (set by the `draw_editor` trait impl)
+    // and calls `Frame::set_cursor_position`, observable via `TestBackend`'s own
+    // cursor state.
+
+    /// Minimal app that paints a single-line `Editor` with a `Bar`-shaped
+    /// cursor at a configurable column. `Bar`/`Underline` cursors are the
+    /// shapes `tui::draw_editor` reports via `EditorPaintResult::cursor_position`
+    /// (a `Block` cursor is drawn as an inverted cell instead — see
+    /// `tui/editor.rs`'s cursor-paint match).
+    struct EditorCursorApp {
+        cursor_col: usize,
+        /// When false, `render` paints no editor at all — used to verify the
+        /// cursor position doesn't linger from a previous frame.
+        show_editor: bool,
+    }
+
+    impl EditorCursorApp {
+        fn new(cursor_col: usize) -> Self {
+            Self {
+                cursor_col,
+                show_editor: true,
+            }
+        }
+
+        fn build_editor(&self) -> crate::Editor {
+            crate::Editor {
+                id: WidgetId::new("editor"),
+                rect: Rect::new(0.0, 0.0, 20.0, 5.0),
+                lines: vec![crate::EditorLine {
+                    raw_text: "hello world".into(),
+                    gutter_text: String::new(),
+                    spans: vec![],
+                    line_idx: 0,
+                    is_current_line: true,
+                    is_fold_header: false,
+                    folded_line_count: 0,
+                    git_diff: None,
+                    diff_status: None,
+                    diagnostics: vec![],
+                    spell_errors: vec![],
+                    is_breakpoint: false,
+                    is_conditional_bp: false,
+                    is_dap_current: false,
+                    is_wrap_continuation: false,
+                    segment_col_offset: 0,
+                    annotation: None,
+                    ghost_suffix: None,
+                    is_ghost_continuation: false,
+                    indent_guides: vec![],
+                    colorcolumns: vec![],
+                }],
+                cursor: Some(crate::EditorCursor {
+                    pos: crate::EditorCursorPos {
+                        view_line: 0,
+                        col: self.cursor_col,
+                    },
+                    shape: crate::EditorCursorShape::Bar,
+                }),
+                extra_cursors: vec![],
+                selection: None,
+                extra_selections: vec![],
+                yank_highlight: None,
+                scroll_top: 0,
+                scroll_left: 0,
+                total_lines: 1,
+                max_col: 11,
+                gutter_char_width: 0,
+                is_active: true,
+                show_active_bg: false,
+                has_git_diff: false,
+                has_breakpoints: false,
+                diagnostic_gutter: Default::default(),
+                code_action_lines: Default::default(),
+                bracket_match_positions: vec![],
+                active_indent_col: None,
+                tabstop: 4,
+                cursorline: false,
+                lightbulb_glyph: '\0',
+            }
+        }
+    }
+
+    impl AppLogic for EditorCursorApp {
+        type AreaId = ();
+
+        fn render(&self, backend: &mut dyn Backend, _area: ()) {
+            if self.show_editor {
+                let editor = self.build_editor();
+                backend.draw_editor(editor.rect, &editor);
+            }
+        }
+
+        fn handle(&mut self, _event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
+            Reaction::Continue
+        }
+    }
+
+    /// A `Bar`-cursor `Editor` paints its `cursor_position` onto the real
+    /// `Frame` — `render_frame` must apply it via `Frame::set_cursor_position`,
+    /// observable through `TestBackend`'s own cursor state.
+    #[test]
+    fn editor_bar_cursor_position_reaches_the_terminal_frame() {
+        let mut driver = TuiDriver::new(EditorCursorApp::new(3), 40, 10);
+
+        // Gutter width 0, scroll_left 0 → screen x == cursor_col, screen y ==
+        // the editor rect's origin row (0).
+        assert_eq!(
+            driver.terminal_cursor_position(),
+            Some((3, 0)),
+            "draw_editor's cursor_position must reach Frame::set_cursor_position"
+        );
+    }
+
+    /// Moving the cursor and re-rendering updates the applied terminal
+    /// position — confirms the handoff isn't a one-shot artifact of the
+    /// first frame.
+    #[test]
+    fn editor_bar_cursor_position_updates_across_frames() {
+        let mut driver = TuiDriver::new(EditorCursorApp::new(3), 40, 10);
+        assert_eq!(driver.terminal_cursor_position(), Some((3, 0)));
+
+        driver.app_mut().cursor_col = 7;
+        driver.render();
+
+        assert_eq!(
+            driver.terminal_cursor_position(),
+            Some((7, 0)),
+            "a later frame's draw_editor call must overwrite the previous cursor position"
         );
     }
 }

--- a/quadraui/src/tui/testing.rs
+++ b/quadraui/src/tui/testing.rs
@@ -281,10 +281,33 @@ impl<A: AppLogic> TuiDriver<A> {
         &self.app
     }
 
+    /// Mutable access to the app state for tests that need to poke state
+    /// directly rather than through a scripted [`UiEvent`] — e.g. asserting
+    /// a render-time invariant (like editor cursor placement) across a
+    /// state change with no dedicated event/handler of its own.
+    pub fn app_mut(&mut self) -> &mut A {
+        &mut self.app
+    }
+
     /// Access the backend for test assertions (e.g. active selection state,
     /// drag state).
     pub fn backend(&self) -> &TuiBackend {
         &self.backend
+    }
+
+    /// The `(x, y)` position `Terminal::draw` last applied to the
+    /// underlying `TestBackend` via `Frame::set_cursor_position` —
+    /// reflecting [`super::run::render_frame`]'s `take_last_cursor_position`
+    /// handoff from `TuiBackend::draw_editor` (quadraui#466).
+    ///
+    /// Note `TestBackend` tracks only the last-set position, not whether
+    /// the cursor is currently hidden — so this always returns the most
+    /// recent position ever applied, even on a later frame that painted no
+    /// editor and would hide the real terminal cursor. Fine for asserting
+    /// "the editor's cursor position reached the Frame", not for asserting
+    /// hide/show transitions.
+    pub fn terminal_cursor_position(&mut self) -> Option<(u16, u16)> {
+        self.terminal.get_cursor_position().ok().map(|p| (p.x, p.y))
     }
 
     /// Cell-centre coordinates of the first row containing `needle`, at


### PR DESCRIPTION
Closes #466

Automated merge from the coordinator for assignment d5ff8ab61329 on issue #466.

Worker branch: `issue-466-tui-shellapp-no-consumer-applies-backend` → `develop`.