### PR TITLE
#514: CI never runs on any worker PR: ci.yml triggers only on PRs to main, but the default branch is develop — so the merge gate blocks every quadraui PR with 'no checks reported'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #514

Automated PR opened by coordinator for review of issue #514.