### PR TITLE
#518: gtk::testing has no driver_with_shell — ShellApp consumers cannot GtkDriver-test at all

### DIFF
--- a/quadraui/src/gtk/shell_runner.rs
+++ b/quadraui/src/gtk/shell_runner.rs
@@ -12,8 +12,20 @@ use crate::compose::bottom_panel::BottomPanelController;
 use crate::shell::{ShellApp, ShellConfig};
 use crate::shell_adapter::ShellAdapter;
 
-/// Run a [`ShellApp`] with AppShell chrome on the GTK backend.
-pub fn run_with_shell<A: ShellApp + 'static>(app: A, config: ShellConfig) {
+/// Assemble the [`AppShell`] + [`ShellAdapter`] stack for a [`ShellApp`].
+///
+/// This is the single source of truth for shell construction — both the
+/// live runner ([`run_with_shell`]) and the headless test driver
+/// ([`crate::gtk::testing::driver_with_shell`]) call this so they cannot
+/// drift apart as [`ShellConfig`] grows. Mirrors
+/// [`crate::tui::shell_runner::build_shell_adapter`] line for line; GTK has
+/// no backend-specific wiring beyond what [`ShellAdapter`] already
+/// encapsulates (editor font, bottom-panel init), so the two are identical
+/// today.
+pub(crate) fn build_shell_adapter<A: ShellApp + 'static>(
+    app: A,
+    config: ShellConfig,
+) -> ShellAdapter<A> {
     let editor_font = config.editor_font.clone();
     let mut shell = AppShell::new(config.panels, config.default_sidebar_width)
         .with_bottom_items(config.bottom_items)
@@ -43,6 +55,8 @@ pub fn run_with_shell<A: ShellApp + 'static>(app: A, config: ShellConfig) {
     // and create the controller. Initial height is set in setup() once we
     // have the backend's viewport + line_height.
     let bottom_panel = if let Some(bp_config) = config.bottom_panel {
+        // Enable the panel with a generous initial height; setup() will
+        // recalculate from height_fraction once the backend is ready.
         shell = shell
             .with_bottom_panel(10.0)
             .with_bottom_panel_limits(3.0, 40.0);
@@ -53,7 +67,11 @@ pub fn run_with_shell<A: ShellApp + 'static>(app: A, config: ShellConfig) {
 
     let active_panel_id = shell.active_panel_id().cloned();
 
-    let adapter = ShellAdapter::new(app, shell, active_panel_id, bottom_panel, editor_font);
+    ShellAdapter::new(app, shell, active_panel_id, bottom_panel, editor_font)
+}
 
+/// Run a [`ShellApp`] with AppShell chrome on the GTK backend.
+pub fn run_with_shell<A: ShellApp + 'static>(app: A, config: ShellConfig) {
+    let adapter = build_shell_adapter(app, config);
     super::run::run(adapter);
 }

--- a/quadraui/src/gtk/testing.rs
+++ b/quadraui/src/gtk/testing.rs
@@ -49,10 +49,53 @@ use pangocairo::cairo::{Context, Format, ImageSurface};
 use crate::backend::Backend;
 use crate::dispatch::{dispatch_click, dispatch_mouse_drag, dispatch_mouse_up};
 use crate::runner::{AppLogic, Reaction};
+use crate::shell::{ShellApp, ShellConfig};
 use crate::{ButtonMask, Key, Modifiers, MouseButton, NamedKey, Point, UiEvent};
 
 use super::backend::GtkBackend;
 use super::run::{dispatch_event, render_frame, EventOutcome};
+
+/// Build a [`GtkDriver`] that wraps `app` in the full
+/// [`crate::shell_adapter::ShellAdapter`] stack, mirroring exactly what
+/// [`crate::gtk::shell_runner::run_with_shell`] does at runtime — but
+/// returning a testable driver instead of entering the live event loop.
+/// The GTK twin of [`crate::tui::testing::driver_with_shell`]; the two share
+/// the same [`crate::shell::ShellApp`] + [`ShellConfig`] input, differing
+/// only in the native units their respective drivers take (TUI cells vs
+/// GTK pixels, per [`GtkDriver::new`]).
+///
+/// Use this constructor in tests that need to verify the full
+/// `ShellApp → ShellAdapter → dispatch_event` integration path on the GTK
+/// backend — e.g. confirming that shell chrome (activity bar, sidebar
+/// panel) renders and that panel switches reach the real [`AppShell`]
+/// instance [`crate::shell_adapter::ShellAdapter`] paints, not a shadow
+/// copy.
+///
+/// [`AppShell`]: crate::compose::app_shell::AppShell
+///
+/// # Example
+///
+/// ```no_run
+/// # use quadraui::gtk::testing::driver_with_shell;
+/// # use quadraui::{ShellApp, ShellConfig, Backend, ShellContext, Reaction, UiEvent};
+/// # struct MyApp;
+/// # impl ShellApp for MyApp {
+/// #     fn render_content(&self, _: &mut dyn Backend, _: &quadraui::compose::app_shell::AppShellLayout) {}
+/// #     fn handle(&mut self, _: UiEvent, _: &mut dyn Backend, _: &ShellContext) -> Reaction { Reaction::Continue }
+/// # }
+/// let config = ShellConfig::new("Demo", vec![]);
+/// let mut driver = driver_with_shell(MyApp, config, 800, 480);
+/// let _ = driver.pixel(0, 0);
+/// ```
+pub fn driver_with_shell<A: ShellApp + 'static>(
+    app: A,
+    config: ShellConfig,
+    width: i32,
+    height: i32,
+) -> GtkDriver<impl AppLogic> {
+    let adapter = super::shell_runner::build_shell_adapter(app, config);
+    GtkDriver::new(adapter, width, height)
+}
 
 /// Drives an [`AppLogic`] impl headlessly against the GTK backend for
 /// tests. Construct with [`Self::new`] (runs `setup` + paints the first

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -17,13 +17,17 @@
 //! `--features tui,gtk` (the CI `gtk` job builds/tests with both).
 #![cfg(all(feature = "tui", feature = "gtk"))]
 
-use quadraui::gtk::testing::GtkDriver;
-use quadraui::tui::testing::TuiDriver;
+use quadraui::gtk::testing::{driver_with_shell as gtk_driver_with_shell, GtkDriver};
+use quadraui::tui::testing::{driver_with_shell as tui_driver_with_shell, TuiDriver};
 use quadraui::{AppLogic, NamedKey};
 
 #[path = "../examples/common/pipeline_app.rs"]
 mod pipeline_app;
 use pipeline_app::PipelineApp;
+
+#[path = "../examples/common/appshell_demo.rs"]
+mod appshell_demo;
+use appshell_demo::AppShellDemo;
 
 /// Backend-agnostic driver surface a shared parity test body needs.
 /// Implemented once per backend below — the two rows that genuinely
@@ -126,5 +130,58 @@ fn pipeline_parity_tui_and_gtk_agree_on_logical_state() {
         vec![false, true, true],
         "expected: no stage-3 mention before the click, a mention after \
          clicking Go, and exited after 'q'"
+    );
+}
+
+// ─── Shell-level parity (quadraui#518): a ShellApp, not just an AppLogic ───
+//
+// `pipeline_parity_*` above proves parity for the `AppLogic`-level harness
+// (#448/GD-3). But every *real* quadraui consumer (coord-tui included)
+// implements `ShellApp` and is driven by `{tui,gtk}::testing::driver_with_shell`,
+// not `AppLogic` directly — so this lifts the same claim to the shell level:
+// one `ShellApp` (`AppShellDemo`), one script, both `driver_with_shell`
+// entry points, same logical outcome. `ExampleDriver` is reused unchanged —
+// both `driver_with_shell` functions return a driver generic over
+// `impl AppLogic` (the `ShellAdapter` wrapping the `ShellApp`), which the
+// existing blanket `impl<A: AppLogic> ExampleDriver for {Tui,Gtk}Driver<A>`
+// already covers.
+
+/// Script: focus the activity bar, move the keyboard cursor down two items
+/// (explorer → search → git), activate the selection, then quit. Returns
+/// the observations a test wants to compare across backends: whether the
+/// sidebar-header text for the *destination* panel appears before the
+/// switch, after it, and whether 'q' exits.
+fn run_appshell_script<D: ExampleDriver>(d: &mut D) -> Vec<bool> {
+    let before = d.screen_has("SOURCE CONTROL");
+    d.press_named(NamedKey::Tab);
+    d.type_char('j');
+    d.type_char('j');
+    d.press_named(NamedKey::Enter);
+    let after_activate = d.screen_has("SOURCE CONTROL");
+    d.type_char('q');
+    vec![before, after_activate, d.exited()]
+}
+
+#[test]
+fn appshell_demo_parity_tui_and_gtk_agree_on_logical_state() {
+    // Same native-unit split as the `AppLogic`-level test: TUI cells vs
+    // GTK pixels for the identical logical shell chrome.
+    let mut tui = tui_driver_with_shell(AppShellDemo::new(), AppShellDemo::config(), 100, 30);
+    let mut gtk = gtk_driver_with_shell(AppShellDemo::new(), AppShellDemo::config(), 800, 480);
+
+    let tui_observations = run_appshell_script(&mut tui);
+    let gtk_observations = run_appshell_script(&mut gtk);
+
+    assert_eq!(
+        tui_observations, gtk_observations,
+        "TUI and GTK should reach the same logical state \
+         (mentions-SOURCE-CONTROL before activation, after activation, exited-on-q) \
+         for the identical AppShellDemo (ShellApp) event script"
+    );
+    assert_eq!(
+        tui_observations,
+        vec![false, true, true],
+        "expected: no Source Control mention before activating the cursor item, \
+         a mention after Tab+j+j+Enter switches to panel:git, and exited after 'q'"
     );
 }

--- a/quadraui/tests/gtk_example_driver.rs
+++ b/quadraui/tests/gtk_example_driver.rs
@@ -13,12 +13,16 @@
 //! `tests/cross_backend_parity.rs`.
 #![cfg(feature = "gtk")]
 
-use quadraui::gtk::testing::GtkDriver;
+use quadraui::gtk::testing::{driver_with_shell, GtkDriver};
 use quadraui::{NamedKey, Reaction};
 
 #[path = "../examples/common/pipeline_app.rs"]
 mod pipeline_app;
 use pipeline_app::PipelineApp;
+
+#[path = "../examples/common/appshell_demo.rs"]
+mod appshell_demo;
+use appshell_demo::AppShellDemo;
 
 // Pixel canvas — big enough for five stage boxes + arrow connectors + the
 // bottom status bar at GTK's native (pixel, not cell) scale.
@@ -86,5 +90,157 @@ fn pipeline_clicking_a_stage_action_routes_the_click() {
     assert!(
         driver.screen_contains("stage 3"),
         "clicking the Deploy action should update the status to mention stage 3"
+    );
+}
+
+// ─── AppShellDemo: `driver_with_shell` (ShellApp) coverage (quadraui#518) ───
+//
+// `AppShellDemo` implements `ShellApp` (not `AppLogic` directly) and is
+// driven by `gtk::shell_runner::run_with_shell` in production.
+// `driver_with_shell` builds the identical `ShellAdapter` stack — through
+// the same `gtk::shell_runner::build_shell_adapter` factory `run_with_shell`
+// calls — then scripts events through it headlessly. Before quadraui#518
+// there was no way for a `ShellApp` consumer to reach `GtkDriver` at all;
+// these are the GTK twins of `tests/tui_example_driver.rs`'s
+// `appshell_demo_*` tests.
+
+// Pixel canvas sized for the shell chrome (activity bar + sidebar + main
+// content), distinct from the pipeline canvas above.
+const SHELL_W: i32 = 800;
+const SHELL_H: i32 = 480;
+
+/// The initial frame paints real shell chrome — the sidebar header for the
+/// default-active panel and the app's own content — asserted via
+/// `find_bounds`/`painted_texts` (real painted geometry), not just "it did
+/// not panic".
+#[test]
+fn appshell_demo_renders_shell_chrome_via_driver_with_shell() {
+    let config = AppShellDemo::config();
+    let driver = driver_with_shell(AppShellDemo::new(), config, SHELL_W, SHELL_H);
+
+    let bounds = driver
+        .find_bounds("EXPLORER")
+        .expect("sidebar header for the default-active panel should be painted");
+    assert!(
+        bounds.width > 0.0 && bounds.height > 0.0,
+        "sidebar header bounds should be non-empty: {bounds:?}"
+    );
+    assert!(
+        driver
+            .painted_texts()
+            .iter()
+            .any(|t| t.contains("Tab=focus bar")),
+        "main content hint should be painted: {:?}",
+        driver.painted_texts()
+    );
+}
+
+/// `Tab` focuses the activity bar, `j` `j` moves the keyboard cursor down
+/// two items (explorer → search → git), and `Enter` activates the
+/// selection — switching the *real* `AppShell` panel, visible as the
+/// sidebar header flipping from "EXPLORER" to "SOURCE CONTROL".
+///
+/// This is the acceptance criterion that the GTK test path and the live
+/// `gtk::run` path build the adapter through the same function: the
+/// ActivityBar keyboard-focus intercept lives in `gtk::run::dispatch_event`
+/// (shared by `GtkDriver::dispatch`) and reads `ShellAdapter` state built by
+/// `build_shell_adapter` — if `driver_with_shell` constructed that adapter
+/// differently than `run_with_shell` does, this round trip would desync
+/// exactly the way vimcode's Ctrl+B bug (#454) did for the sidebar toggle.
+#[test]
+fn appshell_demo_tab_focus_then_jj_enter_switches_panel() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, SHELL_W, SHELL_H);
+
+    assert!(
+        driver.find_bounds("EXPLORER").is_some(),
+        "starts on the default (index 0) Explorer panel"
+    );
+
+    let reaction = driver.press_named(NamedKey::Tab);
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Tab should request activity-bar keyboard focus and redraw"
+    );
+    assert!(
+        driver.screen_contains("Activity bar focused"),
+        "focusing the bar should update the status hint: {:?}",
+        driver.painted_texts()
+    );
+
+    // Cursor starts at index 0 (explorer). Two `j` presses move it to
+    // index 2 (git) — 3 top panels, cursor saturates instead of wrapping.
+    for _ in 0..2 {
+        let reaction = driver.type_char('j');
+        assert_eq!(
+            reaction,
+            Reaction::Redraw,
+            "'j' while focused must be intercepted as ActivityBar nav, not fall through"
+        );
+    }
+
+    let reaction = driver.press_named(NamedKey::Enter);
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Enter should activate the selected item and redraw"
+    );
+
+    let bounds = driver
+        .find_bounds("SOURCE CONTROL")
+        .expect("sidebar header must switch to the git panel's real title");
+    assert!(bounds.width > 0.0 && bounds.height > 0.0);
+    assert!(
+        driver.find_bounds("EXPLORER").is_none(),
+        "the stale Explorer header must not still be painted"
+    );
+    assert!(
+        driver.screen_contains("Panel: panel:git"),
+        "on_shell_event(PanelChanged) must fire for a keyboard-driven switch, \
+         mirroring the TUI path: {:?}",
+        driver.painted_texts()
+    );
+}
+
+/// #454's fix, proven on GTK: `ctx.shell_mut()` reaches the real `AppShell`
+/// instance `ShellAdapter` renders, so `Ctrl+B` hides/shows the sidebar
+/// `driver_with_shell` actually painted — not a shadow copy. Mirrors
+/// `tests/tui_example_driver.rs`'s
+/// `appshell_demo_ctrl_b_toggles_the_real_rendered_sidebar`.
+#[test]
+fn appshell_demo_ctrl_b_toggles_the_real_rendered_sidebar() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, SHELL_W, SHELL_H);
+
+    assert!(
+        driver.find_bounds("(sidebar content here)").is_some(),
+        "sidebar should be visible on the initial screen"
+    );
+
+    let reaction = driver.ctrl_char('b');
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Ctrl+B toggling the real AppShell must redraw"
+    );
+    assert!(
+        driver.find_bounds("(sidebar content here)").is_none(),
+        "Ctrl+B must hide the sidebar that ShellAdapter actually renders, not a shadow copy"
+    );
+    assert!(
+        driver.screen_contains("Sidebar hidden (Ctrl+B via ctx.shell_mut())"),
+        "status line should confirm the toggle went through ctx.shell_mut()"
+    );
+
+    let reaction = driver.ctrl_char('b');
+    assert_eq!(reaction, Reaction::Redraw);
+    assert!(
+        driver.find_bounds("(sidebar content here)").is_some(),
+        "a second Ctrl+B should show the sidebar again"
+    );
+    assert!(
+        driver.screen_contains("Sidebar shown (Ctrl+B via ctx.shell_mut())"),
+        "status line should confirm the second toggle"
     );
 }


### PR DESCRIPTION
Closes #518

Automated PR opened by coordinator for review of issue #518.