### PR TITLE
#516: DataTable: body cells over-paint neighbours (TUI), body rows draw no separator (TUI + GTK), last-but-one divider resizes backwards (shared)

### DIFF
--- a/quadraui/examples/common/data_table_app.rs
+++ b/quadraui/examples/common/data_table_app.rs
@@ -22,6 +22,16 @@ pub struct DataTableApp {
     sort_col: Option<usize>,
     sort_asc: bool,
     resize_col: Option<usize>,
+    /// Per-column width overrides from divider drags, layered on top of
+    /// `columns`' declared strategy (#516 defect 3) — mirrors how a real
+    /// consumer (e.g. coord-tui's Audit panel) drives `DataTable`. Kept
+    /// separate from `columns[i].width` deliberately: overriding a
+    /// column must never rewrite its original declared strategy, only
+    /// lay a resolved width on top of it — that distinction is exactly
+    /// what `primitives::data_table::resolve_columns`'s pass 2 has to
+    /// respect (and, before the fix, didn't) for a `Flex`-declared
+    /// column.
+    column_overrides: Vec<Option<f32>>,
     /// Vertical scrollbar thumb drag: (track_start_y, track_height, thumb_length, grab_offset)
     sb_drag: Option<(f32, f32, f32, f32)>,
     /// Horizontal scrollbar thumb drag: (track_start_x, track_width, thumb_length, grab_offset)
@@ -41,6 +51,7 @@ impl DataTableApp {
             sort_col: Some(0),
             sort_asc: true,
             resize_col: None,
+            column_overrides: Vec::new(),
             sb_drag: None,
             h_sb_drag: None,
             h_scroll: 0.0,
@@ -61,9 +72,16 @@ impl DataTableApp {
                 width: ColumnWidth::Flex(1.5),
                 align: ColumnAlign::Left,
             },
+            // Flex (not Fixed) so the divider immediately before the
+            // last column (Restarts) sits between two Flex-declared
+            // columns — the exact shape that reproduced #516 defect 3
+            // ("divider before the last column resizes backward"): the
+            // *dragged* column (Age) must itself be Flex-declared for
+            // `resolve_columns`'s flex-redistribution pass to have a
+            // chance of clobbering its override.
             Column {
                 title: "Age".into(),
-                width: ColumnWidth::Fixed(8.0),
+                width: ColumnWidth::Flex(0.5),
                 align: ColumnAlign::Right,
             },
             Column {
@@ -90,7 +108,18 @@ impl DataTableApp {
             ("metrics-server-6d94bc", "Running", "7d", "0"),
             ("fluentd-daemonset-abc", "Running", "7d", "0"),
             ("prometheus-server-0", "Running", "3d", "0"),
-            ("grafana-5f4c8d-mn2q7", "CrashLoopBackOff", "1h", "14"),
+            // Status is the *middle* column (not last) and this value is
+            // far wider than its resolved Flex(1.5) share — #516 defect
+            // 1's regression case ("a table whose middle column contains
+            // text far wider than its resolved width renders every other
+            // column's value intact and readable"). Before the fix this
+            // interleaved into Age/Restarts instead of clipping.
+            (
+                "grafana-5f4c8d-mn2q7",
+                "CrashLoopBackOff: ImagePullBackOff waiting for registry retry backoff window",
+                "1h",
+                "14",
+            ),
             ("loki-0", "Running", "3d", "0"),
             ("argocd-server-6b8c9d-k3m8", "Running", "10d", "0"),
             ("vault-0", "Pending", "5m", "0"),
@@ -101,9 +130,9 @@ impl DataTableApp {
             .map(|(name, status, age, restarts)| DataRow {
                 cells: vec![
                     StyledText::plain(*name),
-                    if *status == "Running" {
+                    if status.starts_with("Running") {
                         StyledText::colored(*status, Color::rgb(80, 200, 80))
-                    } else if *status == "CrashLoopBackOff" {
+                    } else if status.starts_with("CrashLoopBackOff") {
                         StyledText::colored(*status, Color::rgb(220, 60, 60))
                     } else {
                         StyledText::colored(*status, Color::rgb(220, 180, 50))
@@ -181,13 +210,27 @@ impl DataTableApp {
             show_scrollbar: true,
             min_total_width: None,
             h_scroll: self.h_scroll,
-            column_overrides: Vec::new(),
+            column_overrides: self.column_overrides.clone(),
             footer: if self.show_footer {
                 Some(self.footer_row())
             } else {
                 None
             },
         }
+    }
+
+    /// Resolved column widths for the current viewport — a test-only
+    /// accessor exercising the exact same `DataTable::layout` (and thus
+    /// the shared `primitives::data_table::resolve_columns`) any real
+    /// backend paints through, so a driver test can assert on resize
+    /// direction without hardcoding per-backend layout math (#516
+    /// defect 3).
+    pub fn resolved_column_widths(&self, backend: &dyn Backend) -> Vec<f32> {
+        self.table_layout(backend)
+            .columns
+            .iter()
+            .map(|c| c.width)
+            .collect()
     }
 
     fn status_bar(&self) -> StatusBar {
@@ -240,7 +283,12 @@ impl DataTableApp {
         self.table_layout(backend).visible_rows
     }
 
-    fn table_layout(&self, backend: &dyn Backend) -> DataTableLayout {
+    /// `pub` (not just an internal helper) so driver tests can locate
+    /// real hit-test targets (e.g. a column divider) instead of
+    /// hardcoding per-backend coordinates — see
+    /// `resolved_column_widths`'s docs for why this matters for #516
+    /// defect 3 coverage specifically.
+    pub fn table_layout(&self, backend: &dyn Backend) -> DataTableLayout {
         let vp = backend.viewport();
         let lh = backend.line_height();
         let cw = backend.char_width();
@@ -464,7 +512,18 @@ impl AppLogic for DataTableApp {
                     if col < layout.columns.len() {
                         let col_x = layout.columns[col].x;
                         let new_w = (position.x - col_x).max(20.0);
-                        self.columns[col].width = ColumnWidth::Fixed(new_w);
+                        // Layer the resolved width on top of `columns`
+                        // via `column_overrides` — the real API surface
+                        // a consumer drags through (e.g. coord-tui's
+                        // Audit panel), rather than rewriting the
+                        // column's declared strategy directly. This is
+                        // what exercises `resolve_columns`'s override
+                        // path (#516 defect 3) instead of silently
+                        // sidestepping it.
+                        if self.column_overrides.len() != self.columns.len() {
+                            self.column_overrides = vec![None; self.columns.len()];
+                        }
+                        self.column_overrides[col] = Some(new_w);
                     }
                     return Reaction::Redraw;
                 }

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1316,7 +1316,7 @@ impl Backend for GtkBackend {
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_data_table called outside enter_frame_scope");
-        crate::gtk::draw_data_table(
+        let table_layout = crate::gtk::draw_data_table(
             cr,
             layout,
             rect.x as f64,
@@ -1327,7 +1327,95 @@ impl Backend for GtkBackend {
             &theme,
             lh,
             hovered_idx,
-        )
+        );
+
+        // Record header + visible body + footer cell text into the
+        // painted-text map `GtkDriver::find`/`find_bounds`/`painted_texts`
+        // scan (mirrors `Self::draw_status_bar` above) — DataTable
+        // previously recorded nothing, so a test had no way to assert
+        // cell content short of raw pixel reads (#516). Bounds are
+        // derived from `table_layout` + the declarative `table`, not by
+        // re-deriving Cairo/Pango geometry, so they can't drift from
+        // what was actually drawn.
+        let h_off = table.h_scroll as f64;
+        let header_height = table_layout.header_height as f64;
+        for (col_idx, rc) in table_layout.columns.iter().enumerate() {
+            if rc.width <= 0.0 {
+                continue;
+            }
+            if let Some(col) = table.columns.get(col_idx) {
+                let bounds = QRect::new(
+                    (rect.x as f64 + rc.x as f64 - h_off) as f32,
+                    rect.y,
+                    rc.width,
+                    header_height as f32,
+                );
+                self.record_painted_text(&col.title, bounds);
+            }
+        }
+
+        let row_height = table_layout.row_height as f64;
+        let body_y = rect.y as f64 + header_height;
+        let visible = table_layout
+            .visible_rows
+            .min(table.rows.len().saturating_sub(table.scroll_offset));
+        for row_idx in 0..visible {
+            let abs_idx = table.scroll_offset + row_idx;
+            let row = &table.rows[abs_idx];
+            let row_y = body_y + row_idx as f64 * row_height;
+            for (col_idx, rc) in table_layout.columns.iter().enumerate() {
+                if rc.width <= 0.0 {
+                    continue;
+                }
+                let Some(cell) = row.cells.get(col_idx) else {
+                    continue;
+                };
+                if cell.spans.is_empty() {
+                    continue;
+                }
+                let text: String = cell.spans.iter().map(|s| s.text.as_str()).collect();
+                if text.is_empty() {
+                    continue;
+                }
+                let bounds = QRect::new(
+                    (rect.x as f64 + rc.x as f64 - h_off) as f32,
+                    row_y as f32,
+                    rc.width,
+                    row_height as f32,
+                );
+                self.record_painted_text(&text, bounds);
+            }
+        }
+
+        if let Some(footer) = &table.footer {
+            if table_layout.footer_height > 0.0 {
+                let footer_y = rect.y as f64 + rect.height as f64 - row_height;
+                for (col_idx, rc) in table_layout.columns.iter().enumerate() {
+                    if rc.width <= 0.0 {
+                        continue;
+                    }
+                    let Some(cell) = footer.cells.get(col_idx) else {
+                        continue;
+                    };
+                    if cell.spans.is_empty() {
+                        continue;
+                    }
+                    let text: String = cell.spans.iter().map(|s| s.text.as_str()).collect();
+                    if text.is_empty() {
+                        continue;
+                    }
+                    let bounds = QRect::new(
+                        (rect.x as f64 + rc.x as f64 - h_off) as f32,
+                        footer_y as f32,
+                        rc.width,
+                        row_height as f32,
+                    );
+                    self.record_painted_text(&text, bounds);
+                }
+            }
+        }
+
+        table_layout
     }
 
     fn data_table_layout(&self, rect: QRect, table: &crate::DataTable) -> crate::DataTableLayout {

--- a/quadraui/src/gtk/data_table.rs
+++ b/quadraui/src/gtk/data_table.rs
@@ -198,6 +198,22 @@ pub fn draw_data_table(
             pango_layout.set_attributes(None);
             cr.restore().ok();
         }
+
+        // Body column separators (#516 defect 2) — mirrors the header
+        // separator above, at the same x, for every column except the
+        // last. Drawn *after* the cell text (not clipped to a per-column
+        // rect the way the text is) so a cell whose text exactly fills
+        // its column never paints over the divider — the acceptance bar
+        // is "no zero-gap abutment" even in that edge case.
+        set_source(cr, theme.separator);
+        for (col_idx, rc) in layout.columns.iter().enumerate() {
+            if col_idx + 1 >= layout.columns.len() || rc.width <= 0.0 {
+                continue;
+            }
+            let sep_x = x + (rc.x + rc.width) as f64 - h_off;
+            cr.rectangle(sep_x - 0.5, row_y, 1.0, line_height);
+            cr.fill().ok();
+        }
     }
 
     // ── Scrollbar ──────────────────────────────────────────────────────
@@ -356,4 +372,203 @@ pub fn gtk_data_table_layout(
         8.0,
         measure,
     )
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+//
+// Headless paint tests (see `gtk/tab_bar.rs` for the pattern this follows):
+// a Cairo `ImageSurface`, no display, pixel readback. Gated on the `gtk`
+// feature so `cargo test --features tui` alone (this repo's coord
+// `test_command`) never runs them — `cargo test --features gtk,tui` does.
+//
+// #516: defect 1 (body clipping) is already correct on this backend —
+// `cr.clip()` around each body cell — so the guard here just pins it
+// against a future refactor dropping the clip. Defect 2 (body
+// separators) was genuinely missing and is fixed alongside these tests.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::data_table::{Column, ColumnWidth, DataRow};
+    use crate::theme::Theme;
+    use crate::types::{Color, Decoration, StyledText, WidgetId};
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    const W: i32 = 300;
+    const H: i32 = 100;
+    const LINE_H: f64 = 16.0;
+
+    /// Read an RGB triple from an ARgb32 surface at pixel (x, y). Same
+    /// byte layout as `gtk/tab_bar.rs`'s test helper and `GtkDriver::pixel`.
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    fn rgb(c: Color) -> (u8, u8, u8) {
+        (c.r, c.g, c.b)
+    }
+
+    fn three_col_table(a: &str, b: &str, c: &str) -> DataTable {
+        DataTable {
+            id: WidgetId::new("clip-test"),
+            columns: vec![
+                Column {
+                    title: "A".into(),
+                    width: ColumnWidth::Flex(1.0),
+                    align: ColumnAlign::Left,
+                },
+                Column {
+                    title: "B".into(),
+                    width: ColumnWidth::Flex(1.0),
+                    align: ColumnAlign::Left,
+                },
+                Column {
+                    title: "C".into(),
+                    width: ColumnWidth::Flex(1.0),
+                    align: ColumnAlign::Left,
+                },
+            ],
+            rows: vec![DataRow {
+                cells: vec![
+                    StyledText::plain(a),
+                    StyledText::plain(b),
+                    StyledText::plain(c),
+                ],
+                decoration: Decoration::Normal,
+            }],
+            selected_idx: None,
+            scroll_offset: 0,
+            sort: None,
+            has_focus: false,
+            show_scrollbar: false,
+            min_total_width: None,
+            h_scroll: 0.0,
+            column_overrides: Vec::new(),
+            footer: None,
+        }
+    }
+
+    /// Paint `table` into a fresh `theme.background`-filled surface and
+    /// return the raw pixel buffer alongside the resolved layout.
+    fn paint(table: &DataTable, theme: &Theme) -> (Vec<u8>, i32, DataTableLayout) {
+        let mut surface = ImageSurface::create(Format::ARgb32, W, H).expect("create ImageSurface");
+        let table_layout;
+        {
+            let cr = Context::new(&surface).expect("Context::new");
+            let (br, bg, bb) = cairo_rgb(theme.background);
+            cr.set_source_rgb(br, bg, bb);
+            cr.paint().ok();
+
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            table_layout = draw_data_table(
+                &cr,
+                &pango_layout,
+                0.0,
+                0.0,
+                W as f64,
+                H as f64,
+                table,
+                theme,
+                LINE_H,
+                None,
+            );
+        }
+        surface.flush();
+        let stride = surface.stride();
+        let data = surface.data().expect("surface data").to_vec();
+        (data, stride, table_layout)
+    }
+
+    /// #516 defect 1 (GTK guard): an over-long *middle* column's text
+    /// must stay inside its own column's `cr.clip()` rect — pinning the
+    /// behaviour `src/gtk/data_table.rs:143-153` already had, so a future
+    /// refactor can't quietly drop the clip and reintroduce the TUI-side
+    /// bug on this backend too.
+    #[test]
+    fn body_cell_wider_than_column_does_not_paint_into_neighbour() {
+        let long = "this-value-is-far-wider-than-its-resolved-column-share-by-a-lot";
+        let table = three_col_table("A", long, "C");
+        let theme = Theme::default();
+        let (data, stride, layout) = paint(&table, &theme);
+
+        let c_col = &layout.columns[2];
+        // A point safely inside column C, well past where its own "C"
+        // glyph paints, must be untouched background — not B's overflow.
+        let probe_x = (c_col.x + c_col.width - 4.0) as i32;
+        let probe_y = (layout.header_height as f64 + LINE_H / 2.0) as i32;
+        let px = pixel(&data, stride as usize, probe_x, probe_y);
+        assert_eq!(
+            px,
+            rgb(theme.background),
+            "pixel inside column C ({probe_x},{probe_y}) should be background, \
+             not B's overflow text bleeding through the clip"
+        );
+    }
+
+    /// #516 defect 2: body rows previously drew no separator at all.
+    ///
+    /// The 1px separator rect straddles a half-pixel boundary
+    /// (`sep_x - 0.5 .. sep_x + 0.5`), so with antialiasing on, the pixel
+    /// column at `sep_x` is a 50/50 blend of `theme.separator` over the
+    /// background, not the pure separator colour — true for the header
+    /// separator too. So the meaningful comparison is body-vs-header at
+    /// the identical x (same blend, same rendering), not either against
+    /// a hardcoded `theme.separator` tuple.
+    #[test]
+    fn body_row_draws_separator_at_same_x_as_header() {
+        let table = three_col_table("A", "B", "C");
+        let theme = Theme::default();
+        let (data, stride, layout) = paint(&table, &theme);
+
+        let sep_x = (layout.columns[0].x + layout.columns[0].width) as i32;
+        let header_y = (layout.header_height as f64 / 2.0) as i32;
+        let body_y = (layout.header_height as f64 + LINE_H / 2.0) as i32;
+
+        let header_px = pixel(&data, stride as usize, sep_x, header_y);
+        let body_px = pixel(&data, stride as usize, sep_x, body_y);
+        assert_ne!(
+            header_px,
+            rgb(theme.background),
+            "sanity check: header separator pixel should differ from background"
+        );
+        assert_eq!(
+            body_px, header_px,
+            "body row should draw the same separator at sep_x={sep_x} the header uses: \
+             header pixel {header_px:?}, body pixel {body_px:?}"
+        );
+        assert_ne!(
+            body_px,
+            rgb(theme.background),
+            "separator pixel must differ from the row background"
+        );
+    }
+
+    /// Acceptance: a cell whose text reaches all the way to its column's
+    /// right edge must not paint over the divider — no zero-gap
+    /// abutment even in the tightest case. The fix draws the separator
+    /// *after* the cell text for exactly this reason.
+    #[test]
+    fn separator_survives_a_cell_that_fills_its_entire_column() {
+        let filling = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let table = three_col_table(filling, "B", "C");
+        let theme = Theme::default();
+        let (data, stride, layout) = paint(&table, &theme);
+
+        let sep_x = (layout.columns[0].x + layout.columns[0].width) as i32;
+        let header_y = (layout.header_height as f64 / 2.0) as i32;
+        let body_y = (layout.header_height as f64 + LINE_H / 2.0) as i32;
+
+        // Compare against this same render's header separator pixel
+        // (see the blending note above) rather than a hardcoded colour:
+        // if the fill text painted over the divider, `body_px` would
+        // read as foreground ink instead of matching the header's blend.
+        let header_px = pixel(&data, stride as usize, sep_x, header_y);
+        let body_px = pixel(&data, stride as usize, sep_x, body_y);
+        assert_eq!(
+            body_px, header_px,
+            "separator must survive even when the left column's text fills the \
+             entire column width: header pixel {header_px:?}, body pixel {body_px:?}"
+        );
+    }
 }

--- a/quadraui/src/primitives/data_table.rs
+++ b/quadraui/src/primitives/data_table.rs
@@ -386,8 +386,29 @@ where
     }
 
     // Pass 2: distribute remaining space among Flex columns.
+    //
+    // Must skip any column with an active override (#516 defect 3): pass 1
+    // already resolved that column's width from the override and folded
+    // its contribution *out* of `total_flex` (the `continue` above skips
+    // the `Flex` arm for overridden columns). But `col.width` here is
+    // still the column's *original* declared strategy — overriding a
+    // column never rewrites it, only layers a width on top — so a
+    // dragged column whose original strategy is `Flex` matches this `if
+    // let` too. Without this guard its pass-1 width gets clobbered by a
+    // flex share computed from a `total_flex` that already excludes its
+    // own weight, which can land smaller than its *original* pre-drag
+    // width — i.e. the column visibly *shrinks* while being dragged
+    // wider. This is the root cause of the "divider before the last
+    // column resizes backward" symptom: it reproduces on the divider
+    // before any column whose left-hand neighbour is Flex-declared, not
+    // just the last one, but a trailing pair of Flex text columns (the
+    // common server-data-driven layout) puts it right where the last
+    // divider lives.
     if total_flex > 0.0 && remaining > 0.0 {
         for (i, col) in columns.iter().enumerate() {
+            if matches!(overrides.get(i), Some(Some(_))) {
+                continue;
+            }
             if let ColumnWidth::Flex(weight) = col.width {
                 widths[i] = (weight.max(0.0) / total_flex) * remaining;
             }
@@ -551,6 +572,73 @@ mod tests {
         assert!((layout.columns[0].width - 20.0).abs() < 0.01);
         assert!((layout.columns[1].width - 40.0).abs() < 0.01);
         assert!((layout.columns[2].width - 20.0).abs() < 0.01);
+    }
+
+    // ── #516 defect 3: divider-before-last-column resize direction ──────
+
+    /// A column override on a `Flex`-declared column must win outright —
+    /// pass 2's flex redistribution must not re-derive (and clobber) a
+    /// width pass 1 already resolved from the override. This is the
+    /// direct regression test for the root cause: before the fix, pass 2
+    /// matched on `col.width` (the column's original declared strategy)
+    /// with no check for an active override, so an overridden `Flex`
+    /// column's width was silently overwritten by a bogus share.
+    #[test]
+    fn override_on_flex_column_is_not_clobbered_by_flex_redistribution() {
+        // Three equal-weight Flex columns, matching the pattern of a
+        // trailing pair of text columns with one more before them —
+        // dragging the divider before the last column overrides the
+        // *second* column (index 1).
+        let table = make_table(3, 0);
+        let mut overrides = vec![None; 3];
+        overrides[1] = Some(45.0_f32);
+        let layout = table.layout(90.0, 20.0, 1.0, 1.0, 0.0, |_| ColumnMeasure::new(0.0));
+        assert!(
+            (layout.columns[1].width - 30.0).abs() < 0.01,
+            "sanity: unoverridden layout gives each Flex(1.0) column an equal 30.0 share"
+        );
+
+        let mut table = table;
+        table.column_overrides = overrides;
+        let layout = table.layout(90.0, 20.0, 1.0, 1.0, 0.0, |_| ColumnMeasure::new(0.0));
+        assert!(
+            (layout.columns[1].width - 45.0).abs() < 0.01,
+            "override should win outright, not get re-derived by flex redistribution: \
+             expected 45.0, got {}",
+            layout.columns[1].width
+        );
+    }
+
+    /// The literal reported symptom: dragging the divider immediately
+    /// before the last column must widen that column when the override
+    /// grows and narrow it when the override shrinks — the same
+    /// direction as every other divider, never inverted.
+    #[test]
+    fn divider_before_last_column_resizes_in_drag_direction() {
+        let table = make_table(3, 0);
+        let baseline = table.layout(90.0, 20.0, 1.0, 1.0, 0.0, |_| ColumnMeasure::new(0.0));
+        let baseline_w = baseline.columns[1].width;
+
+        let mut widen = table.clone();
+        widen.column_overrides = vec![None, Some(baseline_w + 20.0), None];
+        let widen_layout = widen.layout(90.0, 20.0, 1.0, 1.0, 0.0, |_| ColumnMeasure::new(0.0));
+
+        let mut narrow = table.clone();
+        narrow.column_overrides = vec![None, Some((baseline_w - 20.0).max(1.0)), None];
+        let narrow_layout = narrow.layout(90.0, 20.0, 1.0, 1.0, 0.0, |_| ColumnMeasure::new(0.0));
+
+        assert!(
+            widen_layout.columns[1].width > baseline_w,
+            "dragging the divider right (larger override) must widen the column: \
+             baseline={baseline_w}, widened={}",
+            widen_layout.columns[1].width
+        );
+        assert!(
+            narrow_layout.columns[1].width < baseline_w,
+            "dragging the divider left (smaller override) must narrow the column: \
+             baseline={baseline_w}, narrowed={}",
+            narrow_layout.columns[1].width
+        );
     }
 
     #[test]

--- a/quadraui/src/tui/data_table.rs
+++ b/quadraui/src/tui/data_table.rs
@@ -137,18 +137,34 @@ pub fn draw_data_table(
         }
 
         for (col_idx, rc) in layout.columns.iter().enumerate() {
-            let styled = match row.cells.get(col_idx) {
-                Some(c) if !c.spans.is_empty() => c,
-                _ => continue,
-            };
-            let full_text: String = styled.spans.iter().map(|s| s.text.as_str()).collect();
             let col_x_raw = area.x as i32 + rc.x.round() as i32 - h_off as i32;
             let col_x_end = col_x_raw + rc.width.round() as i32;
             if col_x_end <= area.x as i32 || col_x_raw >= (area.x + area.width) as i32 {
                 continue;
             }
             let col_w = rc.width.round() as u16;
-            if col_w == 0 || full_text.is_empty() {
+            if col_w == 0 {
+                continue;
+            }
+
+            // Column separator on the right edge (skip last column) —
+            // drawn regardless of whether this cell has text, mirroring
+            // the header separator. Body rows previously drew none at
+            // all, so adjacent cells butted directly together (#516
+            // defect 2).
+            if col_idx + 1 < table.columns.len() {
+                let sep_cx = col_x_raw + col_w as i32 - 1;
+                if sep_cx >= area.x as i32 && sep_cx < (area.x + area.width) as i32 {
+                    set_cell(buf, sep_cx as u16, y, '│', sep_fg, row_bg);
+                }
+            }
+
+            let styled = match row.cells.get(col_idx) {
+                Some(c) if !c.spans.is_empty() => c,
+                _ => continue,
+            };
+            let full_text: String = styled.spans.iter().map(|s| s.text.as_str()).collect();
+            if full_text.is_empty() {
                 continue;
             }
 
@@ -157,26 +173,57 @@ pub fn draw_data_table(
                 .get(col_idx)
                 .map(|c| c.align)
                 .unwrap_or(ColumnAlign::Left);
+
+            // Reserve one cell for the separator (except on the last
+            // column) — the same `usable_w` term the header already
+            // uses — so an over-long body cell is clipped at its own
+            // column boundary instead of painting across its neighbours
+            // (#516 defect 1: this was previously clipped only to the
+            // table's right edge, so it interleaved with every column
+            // to its right).
+            let usable_w: u16 = if col_idx + 1 < table.columns.len() {
+                col_w.saturating_sub(1)
+            } else {
+                col_w
+            };
+
             let text_len = full_text.chars().count() as u16;
-            let start = align_offset(align, text_len, col_w) as i32;
+            let (visible_len, needs_ellipsis) = if text_len <= usable_w {
+                (text_len, false)
+            } else if usable_w == 0 {
+                (0, false)
+            } else {
+                (usable_w - 1, true)
+            };
+            let displayed_len = visible_len + u16::from(needs_ellipsis);
+            let start = align_offset(align, displayed_len, usable_w) as i32;
 
             let is_muted = row.decoration == crate::types::Decoration::Muted;
-            let mut char_offset = 0i32;
-            for span in &styled.spans {
+            let mut char_idx = 0u16;
+            'cell: for span in &styled.spans {
                 let span_fg = if is_muted {
                     muted_fg
                 } else {
                     span.fg.map(ratatui_color).unwrap_or(row_fg)
                 };
                 for ch in span.text.chars() {
-                    let cx = col_x_raw + start + char_offset;
+                    if char_idx == visible_len {
+                        if needs_ellipsis {
+                            let cx = col_x_raw + start + char_idx as i32;
+                            if cx >= area.x as i32 && cx < (area.x + area.width) as i32 {
+                                set_cell(buf, cx as u16, y, '…', span_fg, row_bg);
+                            }
+                        }
+                        break 'cell;
+                    }
+                    let cx = col_x_raw + start + char_idx as i32;
                     if cx >= (area.x + area.width) as i32 {
-                        break;
+                        break 'cell;
                     }
                     if cx >= area.x as i32 {
                         set_cell(buf, cx as u16, y, ch, span_fg, row_bg);
                     }
-                    char_offset += 1;
+                    char_idx += 1;
                 }
             }
         }
@@ -312,6 +359,21 @@ mod tests {
     use crate::primitives::data_table::{Column, ColumnWidth, DataRow, DataTable, DataTableHit};
     use crate::types::{Decoration, StyledText, WidgetId};
 
+    /// Char-cell index of `needle`'s first occurrence in `line` — unlike
+    /// `str::find`, which returns a *byte* offset and desyncs from the
+    /// screen column as soon as a row contains a multi-byte glyph (e.g.
+    /// the `'│'` separator, #516 defect 2).
+    fn find_char_pos(line: &str, needle: &str) -> Option<usize> {
+        let chars: Vec<char> = line.chars().collect();
+        let needle: Vec<char> = needle.chars().collect();
+        if needle.is_empty() || chars.len() < needle.len() {
+            return None;
+        }
+        chars
+            .windows(needle.len())
+            .position(|w| w == needle.as_slice())
+    }
+
     fn make_table() -> DataTable {
         DataTable {
             id: WidgetId::new("test"),
@@ -409,6 +471,139 @@ mod tests {
         assert!(
             row0.contains("Running"),
             "row 0 should contain 'Running', got: {row0}"
+        );
+    }
+
+    // ── #516 defect 1 & 2: body clipping, ellipsis, body separators ─────
+
+    #[test]
+    fn body_rows_draw_column_separator_at_same_x_as_header() {
+        // Previously `'│'` was only drawn in the header loop; body rows
+        // had none at all, so adjacent cells butted directly together.
+        let table = make_table();
+        let area = Rect::new(0, 0, 40, 10);
+        let mut buf = Buffer::empty(area);
+        draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+        let find_seps =
+            |y: u16| -> Vec<u16> { (0..40).filter(|&x| buf[(x, y)].symbol() == "│").collect() };
+
+        let header_seps = find_seps(0);
+        assert_eq!(
+            header_seps.len(),
+            table.columns.len() - 1,
+            "header should have one separator per internal column boundary, got {header_seps:?}"
+        );
+
+        // `make_table()` has 2 rows, painted at y=1 and y=2.
+        for row_y in [1u16, 2u16] {
+            let body_seps = find_seps(row_y);
+            assert_eq!(
+                body_seps, header_seps,
+                "body row {row_y} separators should sit at the same x as the header's"
+            );
+        }
+    }
+
+    #[test]
+    fn body_cell_exactly_filling_column_still_gets_a_separator() {
+        // Acceptance: a cell whose text exactly fills its column must
+        // still be separated from its neighbour — no zero-gap abutment.
+        let mut table = make_table();
+        // Column 0 ("Name") is Flex(2.0) of a 40-wide, 3-Flex-weight-unit
+        // area minus the 5-wide fixed "Age" column: (40-5)*2/3 ≈ 23.33 →
+        // resolves to 23 cells wide, of which 22 are usable (one cell is
+        // reserved for the separator, same as the header). Fill exactly
+        // that usable width.
+        table.rows[0].cells[0] = StyledText::plain("x".repeat(22));
+        let area = Rect::new(0, 0, 40, 10);
+        let mut buf = Buffer::empty(area);
+        let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+        let sep_x = (layout.columns[0].x.round() as i32 + layout.columns[0].width.round() as i32
+            - 1) as u16;
+        let ch = buf[(sep_x, 1)].symbol().to_string();
+        assert_eq!(
+            ch, "│",
+            "an exactly-filling cell must not paint over the separator column"
+        );
+    }
+
+    #[test]
+    fn body_cell_wider_than_column_is_clipped_and_does_not_bleed_into_neighbour() {
+        // The core regression: an over-long *middle* column previously
+        // painted straight across every column to its right —
+        // interleaving, not truncation — because the body loop only
+        // clipped to the table's right edge (`area.x + area.width`),
+        // never to the column's own boundary the header loop already
+        // used.
+        let table = DataTable {
+            id: WidgetId::new("clip-test"),
+            columns: vec![
+                Column {
+                    title: "A".into(),
+                    width: ColumnWidth::Flex(1.0),
+                    align: ColumnAlign::Left,
+                },
+                Column {
+                    title: "B".into(),
+                    width: ColumnWidth::Flex(1.0),
+                    align: ColumnAlign::Left,
+                },
+                Column {
+                    title: "C".into(),
+                    width: ColumnWidth::Flex(1.0),
+                    align: ColumnAlign::Left,
+                },
+            ],
+            rows: vec![DataRow {
+                cells: vec![
+                    StyledText::plain("A"),
+                    StyledText::plain("this-value-is-far-wider-than-its-resolved-column-share"),
+                    StyledText::plain("C"),
+                ],
+                decoration: Decoration::Normal,
+            }],
+            selected_idx: None,
+            scroll_offset: 0,
+            sort: None,
+            has_focus: false,
+            show_scrollbar: false,
+            min_total_width: None,
+            h_scroll: 0.0,
+            column_overrides: Vec::new(),
+            footer: None,
+        };
+        let area = Rect::new(0, 0, 30, 10);
+        let mut buf = Buffer::empty(area);
+        let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+        let row: Vec<char> = (0..30)
+            .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        let row_str: String = row.iter().collect();
+
+        let c_col = &layout.columns[2];
+        let c_start = c_col.x.round() as usize;
+
+        // Column C's own value paints intact at its own column start...
+        assert_eq!(row[c_start], 'C', "row: {row_str:?}");
+        // ...and every other cell inside C's column is untouched
+        // background, never a stray character bled over from B.
+        for (x, &ch) in row.iter().enumerate().skip(c_start + 1) {
+            assert_eq!(
+                ch, ' ',
+                "cell at x={x} inside column C should be blank, not corrupted by B's overflow \
+                 (row: {row_str:?})"
+            );
+        }
+
+        // The overflowing B cell shows an ellipsis rather than a hard cut.
+        let b_col = &layout.columns[1];
+        let b_range = (b_col.x.round() as usize)..c_start;
+        assert!(
+            b_range.clone().any(|x| row[x] == '…'),
+            "over-long body cell should end in an ellipsis, not a hard cut: {row_str:?}"
         );
     }
 
@@ -524,8 +719,12 @@ mod tests {
         let body_line: String = (0..40)
             .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
             .collect();
-        let footer_pos = footer_line.find("4d").expect("footer total painted");
-        let body_pos = body_line.find("3d").expect("body cell painted");
+        // Char-cell position, not byte offset: `str::find` returns a byte
+        // index, and body rows now paint a `'│'` separator (#516 defect
+        // 2) which is 3 bytes but exactly 1 cell — a byte-offset
+        // comparison would fail even though the two cells line up.
+        let footer_pos = find_char_pos(&footer_line, "4d").expect("footer total painted");
+        let body_pos = find_char_pos(&body_line, "3d").expect("body cell painted");
         assert_eq!(
             footer_pos, body_pos,
             "footer's Age total should align at the same x as a body row's Age cell"

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -29,6 +29,10 @@ use pipeline_app::PipelineApp;
 mod appshell_demo;
 use appshell_demo::AppShellDemo;
 
+#[path = "../examples/common/data_table_app.rs"]
+mod data_table_app;
+use data_table_app::DataTableApp;
+
 /// Backend-agnostic driver surface a shared parity test body needs.
 /// Implemented once per backend below — the two rows that genuinely
 /// differ (screen representation, coordinate units) live entirely inside
@@ -183,5 +187,108 @@ fn appshell_demo_parity_tui_and_gtk_agree_on_logical_state() {
         vec![false, true, true],
         "expected: no Source Control mention before activating the cursor item, \
          a mention after Tab+j+j+Enter switches to panel:git, and exited after 'q'"
+    );
+}
+
+// ─── DataTableApp resize-direction parity (#516 defect 3) ──────────────────
+//
+// The acceptance bar for defect 3 is specifically that the fix landed in
+// the *shared* `primitives::data_table::resolve_columns`, not in one
+// rasteriser — so the same divider-drag script must produce the same
+// *direction* of change on both backends. `ExampleDriver` above is
+// generic over any `AppLogic` and can't reach `DataTableApp`-specific
+// methods (`table_layout`, `resolved_column_widths`), so this uses a
+// narrower trait implemented directly for the two concrete driver types
+// instead — same "one script body, two backends" shape, just scoped to
+// what this script needs.
+trait DataTableResizeDriver {
+    /// Resolved width of the "Age" column (index 2) — the one directly
+    /// before the last column ("Restarts"), the divider this script drags.
+    fn age_width(&self) -> f32;
+    /// Drag the Age|Restarts divider horizontally by `dx` (positive =
+    /// right = widen) in this backend's native coordinate space.
+    fn drag_age_divider(&mut self, dx: f32);
+}
+
+impl DataTableResizeDriver for TuiDriver<DataTableApp> {
+    fn age_width(&self) -> f32 {
+        self.app().resolved_column_widths(self.backend())[2]
+    }
+
+    fn drag_age_divider(&mut self, dx: f32) {
+        let layout = self.app().table_layout(self.backend());
+        let age = layout.columns[2];
+        let divider_x = age.x + age.width;
+        let y = 0.5;
+        self.drag(divider_x, y, divider_x + dx, y);
+    }
+}
+
+impl DataTableResizeDriver for GtkDriver<DataTableApp> {
+    fn age_width(&self) -> f32 {
+        self.app().resolved_column_widths(self.backend())[2]
+    }
+
+    fn drag_age_divider(&mut self, dx: f32) {
+        let layout = self.app().table_layout(self.backend());
+        let age = layout.columns[2];
+        let divider_x = age.x + age.width;
+        let y = layout.header_height / 2.0;
+        self.drag(divider_x, y, divider_x + dx, y);
+    }
+}
+
+/// One script, run against both concrete driver types: widen by dragging
+/// right, then widen further by a larger amount from scratch on a fresh
+/// driver (avoiding a second same-position `mouse_down`, which the TUI
+/// backend's double-click detector would fold into a `DoubleClick`
+/// instead of a fresh resize drag — see the sibling test in
+/// `tests/tui_example_driver.rs` for the full explanation). Returns
+/// whether each drag widened the column, for both backends to agree on.
+fn run_datatable_resize_script<D: DataTableResizeDriver + DataTableDriverCtor>(dx: f32) -> bool {
+    let mut d = D::new_default();
+    let before = d.age_width();
+    d.drag_age_divider(dx);
+    let after = d.age_width();
+    after > before
+}
+
+/// Constructs a fresh driver wrapping a fresh `DataTableApp` — kept
+/// separate from `DataTableResizeDriver` so the resize trait stays
+/// focused on the drag script itself.
+trait DataTableDriverCtor {
+    fn new_default() -> Self;
+}
+
+impl DataTableDriverCtor for TuiDriver<DataTableApp> {
+    fn new_default() -> Self {
+        TuiDriver::new(DataTableApp::new(), 100, 26)
+    }
+}
+
+impl DataTableDriverCtor for GtkDriver<DataTableApp> {
+    fn new_default() -> Self {
+        GtkDriver::new(DataTableApp::new(), 900, 600)
+    }
+}
+
+#[test]
+fn data_table_divider_before_last_column_parity_tui_and_gtk_agree_on_direction() {
+    // Dragging the divider immediately before the last column (Age |
+    // Restarts) right must widen Age on *both* backends — the literal
+    // reported symptom was that this direction inverted. Age is
+    // Flex-declared and Restarts (last) is Fixed, the exact shape that
+    // reproduced the bug (see `resolve_columns`'s pass-2 doc comment in
+    // `src/primitives/data_table.rs` for the root cause).
+    let tui_widened = run_datatable_resize_script::<TuiDriver<DataTableApp>>(60.0);
+    let gtk_widened = run_datatable_resize_script::<GtkDriver<DataTableApp>>(120.0);
+
+    assert_eq!(
+        tui_widened, gtk_widened,
+        "TUI and GTK should agree on the resize direction for the identical drag script"
+    );
+    assert!(
+        tui_widened && gtk_widened,
+        "dragging the divider before the last column right should widen it on both backends"
     );
 }

--- a/quadraui/tests/gtk_example_driver.rs
+++ b/quadraui/tests/gtk_example_driver.rs
@@ -24,6 +24,10 @@ use pipeline_app::PipelineApp;
 mod appshell_demo;
 use appshell_demo::AppShellDemo;
 
+#[path = "../examples/common/data_table_app.rs"]
+mod data_table_app;
+use data_table_app::DataTableApp;
+
 // Pixel canvas — big enough for five stage boxes + arrow connectors + the
 // bottom status bar at GTK's native (pixel, not cell) scale.
 const W: i32 = 800;
@@ -242,5 +246,117 @@ fn appshell_demo_ctrl_b_toggles_the_real_rendered_sidebar() {
     assert!(
         driver.screen_contains("Sidebar shown (Ctrl+B via ctx.shell_mut())"),
         "status line should confirm the second toggle"
+    );
+}
+
+// ─── DataTableApp: body clipping, separators, resize direction (#516) ──────
+//
+// `DataTableApp` had zero GTK coverage before this issue. Pixel canvas big
+// enough (900x600) for all 20 pod rows + header + the 2-row footer band +
+// status bar at once, at GTK's default 8px char / 16px line metrics
+// (`min_total_width = 80 * char_width` = 640px), with no scrolling.
+
+const DT_W: i32 = 900;
+const DT_H: i32 = 600;
+
+/// #516 defect 1 (GTK guard, app level): the "Status" column (index 1, a
+/// *middle* column) holds a value far wider than its resolved share.
+/// `src/gtk/data_table.rs`'s own tests already pin the `cr.clip()`
+/// behaviour in isolation; this proves the same thing through the real
+/// app + the painted-text map this issue adds to `GtkBackend::draw_data_table`
+/// — a corrupted/merged cell would show up here as a missing or mangled
+/// `painted_texts()` entry, not just a pixel discrepancy.
+#[test]
+fn data_table_wide_middle_column_leaves_neighbours_intact_in_painted_texts() {
+    let driver = GtkDriver::new(DataTableApp::new(), DT_W, DT_H);
+    assert!(
+        driver.screen_contains("grafana"),
+        "wide-status pod row should be painted: {:?}",
+        driver.painted_texts()
+    );
+    assert!(
+        driver
+            .painted_texts()
+            .iter()
+            .any(|t| t.contains("ImagePullBackOff waiting for registry retry backoff window")),
+        "the full over-long Status value should still be recorded intact (GTK clips visually \
+         via cr.clip(), not by truncating the underlying text): {:?}",
+        driver.painted_texts()
+    );
+    assert!(
+        driver.find_bounds("1h").is_some(),
+        "Age cell for the wide-status row should be painted as its own intact entry: {:?}",
+        driver.painted_texts()
+    );
+    assert!(
+        driver.find_bounds("14").is_some(),
+        "Restarts cell for the wide-status row should be painted as its own intact entry: {:?}",
+        driver.painted_texts()
+    );
+}
+
+/// #516 defect 2 (GTK): body rows previously drew no separator at all.
+#[test]
+fn data_table_body_rows_draw_separators_at_same_x_as_header() {
+    let mut driver = GtkDriver::new(DataTableApp::new(), DT_W, DT_H);
+    let layout = driver.app().table_layout(driver.backend());
+    assert!(
+        layout.columns.len() > 1,
+        "sanity: table should have more than one column"
+    );
+
+    let header_y = (layout.header_height / 2.0) as i32;
+    // Row 1, not row 0: `DataTableApp` starts with row 0 selected, and
+    // the selection highlight tints the row background under the
+    // separator's antialiased blend — comparing against a differently
+    // -tinted body row would fail even with the fix correctly applied.
+    let body_y = (layout.header_height + layout.row_height * 1.5) as i32;
+
+    // Antialiasing rasterizes the header's and body's separator rects
+    // independently (different heights: `header_height` vs `line_height`),
+    // which can land a shared boundary pixel's blend fraction a shade of
+    // a channel apart (observed: off by 1/255) even though both are
+    // unmistakably "the separator colour blended over the row
+    // background" and not "background" or "text ink" — so compare with
+    // a small tolerance rather than bit-exact equality.
+    fn close(a: (u8, u8, u8), b: (u8, u8, u8), tol: i32) -> bool {
+        (a.0 as i32 - b.0 as i32).abs() <= tol
+            && (a.1 as i32 - b.1 as i32).abs() <= tol
+            && (a.2 as i32 - b.2 as i32).abs() <= tol
+    }
+
+    for col_idx in 0..layout.columns.len() - 1 {
+        let col = layout.columns[col_idx];
+        let sep_x = (col.x + col.width) as i32;
+        let header_px = driver.pixel(sep_x, header_y);
+        let body_px = driver.pixel(sep_x, body_y);
+        assert!(
+            close(body_px, header_px, 3),
+            "column {col_idx}'s body separator should sit at the same x={sep_x} as the \
+             header's: header pixel {header_px:?}, body pixel {body_px:?}"
+        );
+    }
+}
+
+/// #516 defect 3: same script as the TUI driver test, run against GTK —
+/// dragging the divider immediately before the last column (Age |
+/// Restarts) must widen Age when dragged right.
+#[test]
+fn data_table_divider_before_last_column_widens_on_right_drag() {
+    let mut driver = GtkDriver::new(DataTableApp::new(), DT_W, DT_H);
+
+    let before = driver.app().resolved_column_widths(driver.backend())[2];
+
+    let layout = driver.app().table_layout(driver.backend());
+    let age = layout.columns[2];
+    let divider_x = age.x + age.width;
+    let divider_y = layout.header_height / 2.0;
+    driver.drag(divider_x, divider_y, divider_x + 80.0, divider_y);
+
+    let widened = driver.app().resolved_column_widths(driver.backend())[2];
+    assert!(
+        widened > before,
+        "dragging the divider before the last column right should widen it: \
+         before={before}, after={widened}"
     );
 }

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -1873,6 +1873,142 @@ fn data_table_f_key_toggles_footer_off() {
     );
 }
 
+// ─── DataTableApp: body clipping, separators, resize direction (#516) ──────
+//
+// A tall-enough viewport (26 rows) fits all 20 pod rows + header + the
+// 2-row pinned footer band + the 1-row status bar with no scrolling, so
+// these tests don't have to scroll to reach any particular row first.
+
+#[test]
+fn data_table_wide_middle_column_does_not_corrupt_neighbouring_columns() {
+    // Defect 1 regression: "Status" (column index 1, a *middle* column —
+    // not last) holds a value far wider than its resolved Flex(1.5)
+    // share. Before the fix this interleaved into Age/Restarts instead
+    // of clipping at its own column boundary, corrupting their rendered
+    // values (the exact "precisi0n" / "abil…" symptom from the issue).
+    let driver = TuiDriver::new(DataTableApp::new(), 100, 26);
+    let screen = driver.screen();
+    assert!(
+        driver.screen_contains("grafana"),
+        "wide-status pod row should be visible:\n{screen}"
+    );
+
+    let (_, y) = driver
+        .find("grafana-5f4c8d")
+        .unwrap_or_else(|| panic!("grafana row not painted:\n{screen}"));
+    let row = screen
+        .lines()
+        .nth(y as usize)
+        .unwrap_or_else(|| panic!("row {y} missing from screen:\n{screen}"));
+
+    assert!(
+        row.contains("1h"),
+        "Age column must survive intact next to the over-long Status cell: {row:?}"
+    );
+    assert!(
+        row.contains("14"),
+        "Restarts column must survive intact next to the over-long Status cell: {row:?}"
+    );
+    assert!(
+        row.contains('…'),
+        "the over-long Status cell should be truncated with an ellipsis, not a hard cut: {row:?}"
+    );
+    assert!(
+        !row.contains("ImagePullBackOff waiting for registry retry backoff window"),
+        "the full over-long value must not render past its own column: {row:?}"
+    );
+}
+
+#[test]
+fn data_table_body_rows_show_column_separators_aligned_with_header() {
+    // Defect 2: body rows previously drew no separator at all, so
+    // adjacent cells butted directly together.
+    let driver = TuiDriver::new(DataTableApp::new(), 100, 26);
+    let screen = driver.screen();
+
+    fn sep_positions(line: &str) -> Vec<usize> {
+        // Char-cell index, not byte offset — a header cell can carry a
+        // multi-byte sort-arrow suffix that a body cell never has, which
+        // would desync a byte-based comparison even though the cells
+        // line up on screen.
+        line.chars()
+            .enumerate()
+            .filter(|&(_, c)| c == '│')
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    let mut lines = screen.lines();
+    let header = lines.next().expect("header row");
+    let header_seps = sep_positions(header);
+    assert_eq!(
+        header_seps.len(),
+        3,
+        "header should have 3 separators (4 columns): {header:?}"
+    );
+
+    let body_row = lines.next().expect("first body row");
+    let body_seps = sep_positions(body_row);
+    assert_eq!(
+        body_seps, header_seps,
+        "body row separators should sit at the same columns as the header's:\n\
+         header: {header:?}\nbody:   {body_row:?}"
+    );
+}
+
+#[test]
+fn data_table_divider_before_last_column_resizes_in_drag_direction() {
+    // Defect 3, the literal reported symptom: dragging the divider
+    // immediately before the last column (Age | Restarts) must widen
+    // Age when dragged right and narrow it when dragged left — the same
+    // direction as every other divider, never inverted. `Age` is
+    // Flex-declared and directly precedes the last column (`Restarts`),
+    // the exact shape that reproduced "resizes backward".
+    let mut driver = TuiDriver::new(DataTableApp::new(), 100, 26);
+
+    let before = driver.app().resolved_column_widths(driver.backend())[2];
+
+    // Age's natural resolved width (Flex(0.5) among a small total weight)
+    // is well under the app's own 20-unit resize floor, so the deltas
+    // below are chosen generously enough that both the widen *and* the
+    // narrow target land clear of that floor — otherwise both drags
+    // would clamp to the same 20 and the direction assertion would be
+    // vacuous rather than a real test of #516 defect 3.
+    let layout = driver.app().table_layout(driver.backend());
+    let age = layout.columns[2];
+    let divider_x = age.x + age.width;
+    let divider_y = 0.5;
+    driver.drag(divider_x, divider_y, divider_x + 40.0, divider_y);
+
+    let widened = driver.app().resolved_column_widths(driver.backend())[2];
+    assert!(
+        widened > before,
+        "dragging the divider before the last column right should widen it: \
+         before={before}, after={widened}"
+    );
+
+    // Because `Restarts` (the last column) is `Fixed`, this divider's x
+    // (Age's right edge = Restarts' left edge) doesn't move when Age's
+    // width changes — it's invariant. A second `mouse_down` at that
+    // exact same point would fold into a synthetic `DoubleClick`
+    // (`DoubleClickDetector`, `DOUBLE_CLICK_RADIUS` = 1.5) instead of a
+    // fresh resize-drag start, so nudge the down-click 2 units off
+    // (still within `DIVIDER_GRAB_PX` = 3.0's hit-test tolerance) —
+    // the resize amount itself comes from the *move* target below, not
+    // the down position, so this doesn't affect what's being measured.
+    let layout2 = driver.app().table_layout(driver.backend());
+    let age2 = layout2.columns[2];
+    let divider_x2 = age2.x + age2.width;
+    driver.drag(divider_x2 + 2.0, divider_y, divider_x2 - 20.0, divider_y);
+
+    let narrowed = driver.app().resolved_column_widths(driver.backend())[2];
+    assert!(
+        narrowed < widened,
+        "dragging the divider before the last column left should narrow it: \
+         before={widened}, after={narrowed}"
+    );
+}
+
 // ─── HelpLayerDemo (#431): context-sensitive help registry + cheatsheet ────
 //
 // `HelpLayerDemo` implements `ShellApp` with two panels ("Explorer" and


### PR DESCRIPTION
Closes #516

Automated PR opened by coordinator for review of issue #516.