### PR TITLE
#473: Add a KeyMap/accelerator table so consumers can declare key scope instead of hand-gating every key arm

### DIFF
--- a/quadraui/src/accelerator.rs
+++ b/quadraui/src/accelerator.rs
@@ -17,6 +17,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::event::{Key, NamedKey};
 use crate::types::{Modifiers, WidgetId};
 
 /// Stable identifier for a registered accelerator. Apps match on this in the
@@ -207,6 +208,101 @@ fn normalise_key_name(s: &str) -> String {
         s.to_ascii_lowercase()
     } else {
         s.to_string()
+    }
+}
+
+// ─── Matching ───────────────────────────────────────────────────────────────
+
+/// Parse a [`KeyBinding`] (any variant) into a [`ParsedBinding`]. Returns
+/// `None` for unparseable literals — those silently miss matching, same
+/// as [`parse_key_binding`]'s contract. The universal arms map to the
+/// canonical vim-style strings [`parse_key_binding`] itself accepts, so a
+/// `KeyBinding::Save` and a `KeyBinding::Literal("<C-s>".into())` resolve
+/// identically.
+///
+/// Shared by [`crate::tui::TuiBackend`]'s native accelerator matching and
+/// [`crate::compose::key_map::KeyMap`]'s scope-aware resolution, so the
+/// universal-binding → key mapping only lives in one place.
+pub fn parse_binding(b: &KeyBinding) -> Option<ParsedBinding> {
+    match b {
+        KeyBinding::Literal(s) if s.is_empty() => None,
+        KeyBinding::Literal(s) => parse_key_binding(s),
+        KeyBinding::Save => parse_key_binding("<C-s>"),
+        KeyBinding::Open => parse_key_binding("<C-o>"),
+        KeyBinding::New => parse_key_binding("<C-n>"),
+        KeyBinding::Close => parse_key_binding("<C-w>"),
+        KeyBinding::Copy => parse_key_binding("<C-c>"),
+        KeyBinding::Cut => parse_key_binding("<C-x>"),
+        KeyBinding::Paste => parse_key_binding("<C-v>"),
+        KeyBinding::Undo => parse_key_binding("<C-z>"),
+        KeyBinding::Redo => parse_key_binding("<C-S-z>"),
+        KeyBinding::SelectAll => parse_key_binding("<C-a>"),
+        KeyBinding::Find => parse_key_binding("<C-f>"),
+        KeyBinding::Replace => parse_key_binding("<C-h>"),
+        KeyBinding::Quit => parse_key_binding("<C-q>"),
+    }
+}
+
+/// Canonical key name for a native [`Key`], in the same form
+/// [`ParsedBinding`]'s `key` field uses — lowercased single ASCII
+/// characters, named keys in their `normalise_key_name` TitleCase.
+/// Backends and resolvers match a native key press against a registered
+/// binding by comparing this name (plus modifiers) against
+/// `ParsedBinding::key`.
+pub fn key_to_binding_name(key: &Key) -> String {
+    match key {
+        Key::Char(c) => {
+            // Single ASCII letters parse as lowercase in
+            // `parse_key_binding`; mirror that so `<C-S-T>` and
+            // `Ctrl+Shift+t` both match here.
+            if c.is_ascii() {
+                c.to_ascii_lowercase().to_string()
+            } else {
+                c.to_string()
+            }
+        }
+        Key::Named(named) => named_key_to_binding_name(*named).to_string(),
+    }
+}
+
+/// Map a [`NamedKey`] to the canonical name [`parse_key_binding`]
+/// produces. Letter case follows [`normalise_key_name`]: single letters
+/// lowercase, named keys TitleCase-preserved.
+fn named_key_to_binding_name(named: NamedKey) -> &'static str {
+    use NamedKey::*;
+    match named {
+        Escape => "Escape",
+        Tab => "Tab",
+        BackTab => "BackTab",
+        Enter => "Enter",
+        Backspace => "Backspace",
+        Delete => "Delete",
+        Insert => "Insert",
+        Home => "Home",
+        End => "End",
+        PageUp => "PageUp",
+        PageDown => "PageDown",
+        Up => "Up",
+        Down => "Down",
+        Left => "Left",
+        Right => "Right",
+        F(1) => "F1",
+        F(2) => "F2",
+        F(3) => "F3",
+        F(4) => "F4",
+        F(5) => "F5",
+        F(6) => "F6",
+        F(7) => "F7",
+        F(8) => "F8",
+        F(9) => "F9",
+        F(10) => "F10",
+        F(11) => "F11",
+        F(12) => "F12",
+        F(_) => "",
+        CapsLock => "CapsLock",
+        NumLock => "NumLock",
+        ScrollLock => "ScrollLock",
+        Menu => "Menu",
     }
 }
 
@@ -525,5 +621,42 @@ mod tests {
         let json = serde_json::to_string(&acc).unwrap();
         let back: Accelerator = serde_json::from_str(&json).unwrap();
         assert_eq!(acc, back);
+    }
+
+    // ── parse_binding / key_to_binding_name ─────────────────────────────
+
+    #[test]
+    fn parse_binding_universal_matches_literal_equivalent() {
+        assert_eq!(parse_binding(&KeyBinding::Save), parse_key_binding("<C-s>"));
+        assert_eq!(
+            parse_binding(&KeyBinding::Redo),
+            parse_key_binding("<C-S-z>")
+        );
+    }
+
+    #[test]
+    fn parse_binding_literal_delegates_to_parse_key_binding() {
+        assert_eq!(
+            parse_binding(&KeyBinding::Literal("Ctrl+P".into())),
+            parse_key_binding("Ctrl+P")
+        );
+    }
+
+    #[test]
+    fn parse_binding_empty_literal_is_none() {
+        assert!(parse_binding(&KeyBinding::Literal(String::new())).is_none());
+    }
+
+    #[test]
+    fn key_to_binding_name_lowercases_ascii_char() {
+        assert_eq!(key_to_binding_name(&Key::Char('P')), "p");
+        assert_eq!(key_to_binding_name(&Key::Char('p')), "p");
+    }
+
+    #[test]
+    fn key_to_binding_name_named_key_matches_parsed_binding() {
+        assert_eq!(key_to_binding_name(&Key::Named(NamedKey::F(5))), "F5");
+        let parsed = parse_key_binding("<F5>").unwrap();
+        assert_eq!(key_to_binding_name(&Key::Named(NamedKey::F(5))), parsed.key);
     }
 }

--- a/quadraui/src/compose/key_map.rs
+++ b/quadraui/src/compose/key_map.rs
@@ -1,0 +1,436 @@
+//! Ordered, scope-aware key binding table (#473).
+//!
+//! [`Backend::register_accelerator`][crate::Backend::register_accelerator]
+//! only resolves `AcceleratorScope::Global` bindings — the backend doesn't
+//! know which widget has focus or which app-defined mode is active, so
+//! [`TuiBackend::apply_accelerators`](crate::tui::TuiBackend) explicitly
+//! skips `Widget`/`Mode`-scoped entries and leaves them as raw
+//! `KeyPressed` events. Consumers that want those scopes have
+//! historically hand-rolled the guard themselves — repeating a predicate
+//! like `!pty_active && !any_blocking_modal_active() && …` across every
+//! `Key::Char` match arm instead of declaring the scope once.
+//!
+//! [`KeyMap`] is that missing resolver. Apps declare an ordered table of
+//! `(scope, binding, action id)` once; at each `KeyPressed` event they
+//! call [`KeyMap::resolve`] with a [`KeyContext`] describing *this
+//! frame's* focus/mode/blocked state, and get back the one
+//! [`AcceleratorId`] (if any) that should fire — no per-arm guard
+//! clauses, no scope logic duplicated at every call site.
+//!
+//! # Ordering = priority
+//!
+//! Entries are tried in registration order; the first entry whose key +
+//! modifiers match **and** whose scope is currently active wins. This is
+//! the "fallthrough" the table provides: register the narrow, specific
+//! binding first (e.g. `Widget(palette_id)` → `"palette.close"` for
+//! `Escape`) and the broad fallback after (e.g. `Global` → `"app.blur"`
+//! for the same `Escape`). When the palette has focus the first entry's
+//! scope is active and wins; otherwise resolution falls through to the
+//! next entry that matches the key.
+//!
+//! # Relationship to `Accelerator` / `Backend::register_accelerator`
+//!
+//! `KeyMap` is backend-agnostic and doesn't require registering anything
+//! with a `Backend` — it resolves directly against raw `Key` +
+//! `Modifiers`, so it works identically whether the native `KeyPressed`
+//! event came through unmodified or already had `Global` accelerators
+//! peeled off upstream by the backend. [`KeyMap::bind_accelerator`] lets
+//! apps build the table straight from the same [`Accelerator`] values they
+//! already declare for `register_accelerator`, so the two paths share one
+//! source of truth instead of two.
+
+use crate::accelerator::{key_to_binding_name, parse_binding};
+use crate::event::Key;
+use crate::types::{Modifiers, WidgetId};
+use crate::{Accelerator, AcceleratorId, AcceleratorScope, KeyBinding, ParsedBinding};
+
+/// One resolved row of the table: a scope, its parsed key binding, and
+/// the action it fires. Kept private — apps interact with the table
+/// through [`KeyMap::bind`] / [`KeyMap::resolve`], never this struct
+/// directly.
+#[derive(Debug, Clone)]
+struct KeyMapEntry {
+    scope: AcceleratorScope,
+    binding: ParsedBinding,
+    action: AcceleratorId,
+}
+
+/// An ordered `(AcceleratorScope, ParsedBinding, AcceleratorId)` table.
+/// See the module docs for the resolution model.
+#[derive(Debug, Clone, Default)]
+pub struct KeyMap {
+    entries: Vec<KeyMapEntry>,
+}
+
+impl KeyMap {
+    /// An empty table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `binding` at `scope` for `action`. Later calls are lower
+    /// priority — see the module docs' "Ordering = priority" section.
+    ///
+    /// Silently skips unparseable `KeyBinding::Literal` strings, mirroring
+    /// [`Backend::register_accelerator`][crate::Backend::register_accelerator]'s
+    /// contract (an unparseable binding never matches rather than
+    /// panicking or erroring).
+    pub fn bind(
+        &mut self,
+        scope: AcceleratorScope,
+        binding: KeyBinding,
+        action: impl Into<AcceleratorId>,
+    ) -> &mut Self {
+        if let Some(parsed) = parse_binding(&binding) {
+            self.entries.push(KeyMapEntry {
+                scope,
+                binding: parsed,
+                action: action.into(),
+            });
+        }
+        self
+    }
+
+    /// Register an already-declared [`Accelerator`] — the same value an
+    /// app hands to `Backend::register_accelerator`, so a `Global`-scoped
+    /// accelerator and its `KeyMap` entry never drift apart. See the
+    /// module docs' "Relationship to `Accelerator`" section.
+    pub fn bind_accelerator(&mut self, acc: &Accelerator) -> &mut Self {
+        if let Some(parsed) = parse_binding(&acc.binding) {
+            self.entries.push(KeyMapEntry {
+                scope: acc.scope.clone(),
+                binding: parsed,
+                action: acc.id.clone(),
+            });
+        }
+        self
+    }
+
+    /// Remove every entry bound to `action`, regardless of scope/binding.
+    pub fn unbind(&mut self, action: &AcceleratorId) {
+        self.entries.retain(|e| &e.action != action);
+    }
+
+    /// Number of registered entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the table has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Resolve a native key press to the highest-priority matching action
+    /// whose scope is active in `ctx`, or `None` if nothing matches.
+    ///
+    /// Apps typically call this from their `UiEvent::KeyPressed` arm
+    /// before falling back to widget-local handling — a `Some` result
+    /// means "dispatch this one action id"; a `None` result means "no
+    /// declared binding claims this key, handle it (or ignore it) as
+    /// before".
+    pub fn resolve(
+        &self,
+        key: &Key,
+        modifiers: Modifiers,
+        ctx: &KeyContext,
+    ) -> Option<AcceleratorId> {
+        let key_name = key_to_binding_name(key);
+        self.entries
+            .iter()
+            .find(|e| {
+                e.binding.modifiers == modifiers
+                    && e.binding.key == key_name
+                    && ctx.scope_active(&e.scope)
+            })
+            .map(|e| e.action.clone())
+    }
+}
+
+/// Per-frame state [`KeyMap::resolve`] evaluates a candidate entry's
+/// [`AcceleratorScope`] against.
+///
+/// Cheap to construct fresh on every `KeyPressed` event — it borrows the
+/// caller's own focus/mode bookkeeping rather than owning a copy.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct KeyContext<'a> {
+    /// Every [`WidgetId`] that currently "has focus" for the purpose of
+    /// `AcceleratorScope::Widget` matching — the focused widget itself
+    /// plus any ancestors that should also claim its widget-scoped
+    /// bindings (e.g. a modal's own id, so its `Escape` binding fires
+    /// no matter which child control inside it is focused). An
+    /// `AcceleratorScope::Widget(id)` entry is active whenever `id`
+    /// appears anywhere in this slice — order doesn't matter.
+    pub focus_chain: &'a [WidgetId],
+    /// The app-defined mode string (vim-like apps: `"n"`, `"i"`, `"v"`,
+    /// …). `AcceleratorScope::Mode(m)` is active when this equals
+    /// `Some(m)`.
+    pub mode: Option<&'a str>,
+    /// When `true`, `AcceleratorScope::Global` entries never match —
+    /// the single flag that replaces the hand-repeated
+    /// `!pty_active && !any_blocking_modal_active() && …` guard chain
+    /// this type was filed to eliminate. Set it whenever *anything*
+    /// should suppress global shortcuts (a blocking modal is open, a
+    /// PTY has raw input focus, …); `Widget`/`Mode`-scoped entries are
+    /// unaffected since their own scope already gates them precisely.
+    pub global_blocked: bool,
+}
+
+impl<'a> KeyContext<'a> {
+    /// A context with no focus chain, no mode, and `Global` unblocked.
+    pub fn new() -> Self {
+        Self {
+            focus_chain: &[],
+            mode: None,
+            global_blocked: false,
+        }
+    }
+
+    /// Set the focus chain (see [`Self::focus_chain`]).
+    pub fn with_focus_chain(mut self, chain: &'a [WidgetId]) -> Self {
+        self.focus_chain = chain;
+        self
+    }
+
+    /// Set the active mode string (see [`Self::mode`]).
+    pub fn with_mode(mut self, mode: &'a str) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Mark `Global`-scope entries as blocked for this resolution (see
+    /// [`Self::global_blocked`]).
+    pub fn blocked(mut self) -> Self {
+        self.global_blocked = true;
+        self
+    }
+
+    fn scope_active(&self, scope: &AcceleratorScope) -> bool {
+        match scope {
+            AcceleratorScope::Global => !self.global_blocked,
+            AcceleratorScope::Widget(id) => self.focus_chain.contains(id),
+            AcceleratorScope::Mode(m) => self.mode == Some(m.as_str()),
+        }
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mods_none() -> Modifiers {
+        Modifiers::default()
+    }
+
+    fn ctrl() -> Modifiers {
+        Modifiers {
+            ctrl: true,
+            ..Modifiers::default()
+        }
+    }
+
+    #[test]
+    fn empty_map_resolves_nothing() {
+        let map = KeyMap::new();
+        assert!(map.is_empty());
+        assert_eq!(
+            map.resolve(&Key::Char('p'), ctrl(), &KeyContext::new()),
+            None
+        );
+    }
+
+    #[test]
+    fn global_scope_matches_by_default() {
+        let mut map = KeyMap::new();
+        map.bind(
+            AcceleratorScope::Global,
+            KeyBinding::Literal("Ctrl+P".into()),
+            "palette.open",
+        );
+        assert_eq!(map.len(), 1);
+        let id = map
+            .resolve(&Key::Char('p'), ctrl(), &KeyContext::new())
+            .unwrap();
+        assert_eq!(id.as_str(), "palette.open");
+    }
+
+    #[test]
+    fn global_scope_blocked_does_not_match() {
+        let mut map = KeyMap::new();
+        map.bind(
+            AcceleratorScope::Global,
+            KeyBinding::Literal("Ctrl+P".into()),
+            "palette.open",
+        );
+        let ctx = KeyContext::new().blocked();
+        assert_eq!(map.resolve(&Key::Char('p'), ctrl(), &ctx), None);
+    }
+
+    #[test]
+    fn widget_scope_matches_when_in_focus_chain() {
+        let mut map = KeyMap::new();
+        let modal_id = WidgetId::new("modal:confirm");
+        map.bind(
+            AcceleratorScope::Widget(modal_id.clone()),
+            KeyBinding::Literal("Escape".into()),
+            "modal.close",
+        );
+        let chain = [WidgetId::new("modal:confirm:input"), modal_id.clone()];
+        let ctx = KeyContext::new().with_focus_chain(&chain);
+        let id = map
+            .resolve(&Key::Named(crate::NamedKey::Escape), mods_none(), &ctx)
+            .unwrap();
+        assert_eq!(id.as_str(), "modal.close");
+    }
+
+    #[test]
+    fn widget_scope_does_not_match_when_absent_from_focus_chain() {
+        let mut map = KeyMap::new();
+        map.bind(
+            AcceleratorScope::Widget(WidgetId::new("modal:confirm")),
+            KeyBinding::Literal("Escape".into()),
+            "modal.close",
+        );
+        let chain = [WidgetId::new("editor:main")];
+        let ctx = KeyContext::new().with_focus_chain(&chain);
+        assert_eq!(
+            map.resolve(&Key::Named(crate::NamedKey::Escape), mods_none(), &ctx),
+            None
+        );
+    }
+
+    #[test]
+    fn mode_scope_matches_active_mode_only() {
+        let mut map = KeyMap::new();
+        map.bind(
+            AcceleratorScope::Mode("n".into()),
+            KeyBinding::Literal("d".into()),
+            "vim.delete_line",
+        );
+        let ctx_normal = KeyContext::new().with_mode("n");
+        assert_eq!(
+            map.resolve(&Key::Char('d'), mods_none(), &ctx_normal)
+                .as_ref()
+                .map(AcceleratorId::as_str),
+            Some("vim.delete_line")
+        );
+
+        let ctx_insert = KeyContext::new().with_mode("i");
+        assert_eq!(map.resolve(&Key::Char('d'), mods_none(), &ctx_insert), None);
+    }
+
+    #[test]
+    fn earlier_binding_wins_when_both_scopes_active() {
+        let mut map = KeyMap::new();
+        let palette_id = WidgetId::new("palette");
+        map.bind(
+            AcceleratorScope::Widget(palette_id.clone()),
+            KeyBinding::Literal("Escape".into()),
+            "palette.close",
+        );
+        map.bind(
+            AcceleratorScope::Global,
+            KeyBinding::Literal("Escape".into()),
+            "app.blur",
+        );
+
+        let chain = [palette_id.clone()];
+        let ctx_focused = KeyContext::new().with_focus_chain(&chain);
+        assert_eq!(
+            map.resolve(
+                &Key::Named(crate::NamedKey::Escape),
+                mods_none(),
+                &ctx_focused
+            )
+            .as_ref()
+            .map(AcceleratorId::as_str),
+            Some("palette.close")
+        );
+    }
+
+    #[test]
+    fn falls_through_to_next_entry_when_first_scope_inactive() {
+        let mut map = KeyMap::new();
+        let palette_id = WidgetId::new("palette");
+        map.bind(
+            AcceleratorScope::Widget(palette_id),
+            KeyBinding::Literal("Escape".into()),
+            "palette.close",
+        );
+        map.bind(
+            AcceleratorScope::Global,
+            KeyBinding::Literal("Escape".into()),
+            "app.blur",
+        );
+
+        // Palette not focused — falls through to the Global fallback.
+        let ctx = KeyContext::new();
+        assert_eq!(
+            map.resolve(&Key::Named(crate::NamedKey::Escape), mods_none(), &ctx)
+                .as_ref()
+                .map(AcceleratorId::as_str),
+            Some("app.blur")
+        );
+    }
+
+    #[test]
+    fn bind_accelerator_shares_scope_and_id() {
+        let mut map = KeyMap::new();
+        let acc = Accelerator {
+            id: AcceleratorId::new("editor.save"),
+            binding: KeyBinding::Save,
+            scope: AcceleratorScope::Global,
+            label: None,
+        };
+        map.bind_accelerator(&acc);
+        let id = map
+            .resolve(&Key::Char('s'), ctrl(), &KeyContext::new())
+            .unwrap();
+        assert_eq!(id, acc.id);
+    }
+
+    #[test]
+    fn unparseable_literal_is_skipped_silently() {
+        let mut map = KeyMap::new();
+        map.bind(
+            AcceleratorScope::Global,
+            KeyBinding::Literal("".into()),
+            "noop",
+        );
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn unbind_removes_all_entries_for_action() {
+        let mut map = KeyMap::new();
+        map.bind(
+            AcceleratorScope::Global,
+            KeyBinding::Literal("Ctrl+P".into()),
+            "palette.open",
+        );
+        map.bind(
+            AcceleratorScope::Mode("n".into()),
+            KeyBinding::Literal("Ctrl+P".into()),
+            "palette.open",
+        );
+        assert_eq!(map.len(), 2);
+        map.unbind(&AcceleratorId::new("palette.open"));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn modifier_mismatch_does_not_match() {
+        let mut map = KeyMap::new();
+        map.bind(
+            AcceleratorScope::Global,
+            KeyBinding::Literal("Ctrl+P".into()),
+            "palette.open",
+        );
+        assert_eq!(
+            map.resolve(&Key::Char('p'), mods_none(), &KeyContext::new()),
+            None
+        );
+    }
+}

--- a/quadraui/src/compose/mod.rs
+++ b/quadraui/src/compose/mod.rs
@@ -24,6 +24,9 @@
 //! - [`HelpRegistry`] / [`HelpOverlayController`] — per-view help registry +
 //!   `?`-triggered cheatsheet overlay, plus helpers to feed registered
 //!   actions into the command palette.
+//! - [`KeyMap`] — ordered, scope-aware key binding table so consumers
+//!   declare `AcceleratorScope` once instead of hand-gating every key
+//!   match arm (#473).
 
 pub mod app_shell;
 pub mod bottom_panel;
@@ -34,6 +37,7 @@ pub mod focus_ring;
 pub mod folder_picker;
 pub mod form_controller;
 pub mod help_layer;
+pub mod key_map;
 pub mod markdown;
 pub mod menu_system;
 pub mod sidebar_system;
@@ -57,6 +61,7 @@ pub use help_layer::{
     filter_help_actions, help_actions_to_palette_items, HelpAction, HelpNote,
     HelpOverlayController, HelpOverlayEvent, HelpRegistry, ViewHelp,
 };
+pub use key_map::{KeyContext, KeyMap};
 pub use markdown::{render_markdown_to_styled_wrapped, CodeBlockRange, RenderedMarkdown};
 pub use menu_system::{MenuDef, MenuEvent, MenuSystem};
 pub use sidebar_system::{

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -301,11 +301,11 @@ pub use compose::{
     BottomPanelTab, ChatController, ChatControllerEvent, ChatRole, ChatTurn,
     DualModePaletteController, DualModePaletteEvent, FocusGroup, FocusRing, FolderPickerController,
     FolderPickerEvent, FormController, FormControllerEvent, GroupLayout, HelpAction, HelpNote,
-    HelpOverlayController, HelpOverlayEvent, HelpRegistry, MenuDef, MenuEvent, MenuSystem,
-    NavigationMode, Pane, PaneDragRect, PaneTab, PanelDefinition, SectionKind, ShellPosition,
-    SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBarAction, StatusBarInteraction,
-    TabGroupController, TabGroupEvent, TabGroupLayout, ToolbarHoverTracker, TreeController,
-    TreeControllerEvent, ViewHelp, PALETTE_CHROME_ROWS,
+    HelpOverlayController, HelpOverlayEvent, HelpRegistry, KeyContext, KeyMap, MenuDef, MenuEvent,
+    MenuSystem, NavigationMode, Pane, PaneDragRect, PaneTab, PanelDefinition, SectionKind,
+    ShellPosition, SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBarAction,
+    StatusBarInteraction, TabGroupController, TabGroupEvent, TabGroupLayout, ToolbarHoverTracker,
+    TreeController, TreeControllerEvent, ViewHelp, PALETTE_CHROME_ROWS,
 };
 pub use dispatch::{
     dispatch_click, dispatch_mouse_down, dispatch_mouse_drag, dispatch_mouse_up, dispatch_scroll,

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -45,14 +45,20 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::time::Duration;
 
+use crate::accelerator::{key_to_binding_name, parse_binding};
 use crate::backend::{activity_bar_hits, tab_bar_layout_to_hits};
 use crate::dispatch::TextRegion;
 use crate::{
-    parse_key_binding, Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Backend,
-    CommandLine, DragState, DragTarget, Form, KeyBinding, ListView, MenuBar, ModalStack, Palette,
-    ParsedBinding, PlatformServices, Point, Rect as QRect, Split, StatusBar, TabBar,
-    Terminal as TerminalPrim, TextDisplay, TreeView, UiEvent, Viewport, WidgetId,
+    Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Backend, CommandLine, DragState,
+    DragTarget, Form, ListView, MenuBar, ModalStack, Palette, ParsedBinding, PlatformServices,
+    Point, Rect as QRect, Split, StatusBar, TabBar, Terminal as TerminalPrim, TextDisplay,
+    TreeView, UiEvent, Viewport, WidgetId,
 };
+// `KeyBinding` is only referenced by `#[cfg(test)]` code below (the rest of
+// this file matches already-parsed `Accelerator`s) — gate the import the
+// same way so a non-test build doesn't flag it as unused.
+#[cfg(test)]
+use crate::KeyBinding;
 use ratatui::layout::Rect;
 use ratatui::Frame;
 
@@ -619,19 +625,7 @@ impl TuiBackend {
         key: &crate::Key,
         modifiers: crate::Modifiers,
     ) -> Option<AcceleratorId> {
-        let key_name = match key {
-            crate::Key::Char(c) => {
-                // Single ASCII letters parse as lowercase in
-                // `parse_key_binding`; mirror that so `<C-S-T>` and
-                // `Ctrl+Shift+t` both match here.
-                if c.is_ascii() {
-                    c.to_ascii_lowercase().to_string()
-                } else {
-                    c.to_string()
-                }
-            }
-            crate::Key::Named(named) => named_key_to_binding_name(*named).to_string(),
-        };
+        let key_name = key_to_binding_name(key);
         for (parsed, id) in &self.parsed_accelerators {
             if parsed.modifiers == modifiers && parsed.key == key_name {
                 // Skip non-Global-scope entries — the backend doesn't
@@ -644,71 +638,6 @@ impl TuiBackend {
             }
         }
         None
-    }
-}
-
-/// Parse a `KeyBinding` (any variant) into a `ParsedBinding`. Returns
-/// `None` for unparseable literals — those silently miss matching, same
-/// as the engine-side B.2 path. The universal arms map to the canonical
-/// vim-style strings the rest of vimcode already uses.
-fn parse_binding(b: &KeyBinding) -> Option<ParsedBinding> {
-    match b {
-        KeyBinding::Literal(s) if s.is_empty() => None,
-        KeyBinding::Literal(s) => parse_key_binding(s),
-        KeyBinding::Save => parse_key_binding("<C-s>"),
-        KeyBinding::Open => parse_key_binding("<C-o>"),
-        KeyBinding::New => parse_key_binding("<C-n>"),
-        KeyBinding::Close => parse_key_binding("<C-w>"),
-        KeyBinding::Copy => parse_key_binding("<C-c>"),
-        KeyBinding::Cut => parse_key_binding("<C-x>"),
-        KeyBinding::Paste => parse_key_binding("<C-v>"),
-        KeyBinding::Undo => parse_key_binding("<C-z>"),
-        KeyBinding::Redo => parse_key_binding("<C-S-z>"),
-        KeyBinding::SelectAll => parse_key_binding("<C-a>"),
-        KeyBinding::Find => parse_key_binding("<C-f>"),
-        KeyBinding::Replace => parse_key_binding("<C-h>"),
-        KeyBinding::Quit => parse_key_binding("<C-q>"),
-    }
-}
-
-/// Map a `crate::NamedKey` to the canonical name `parse_key_binding`
-/// produces. Letter case follows `accelerator::normalise_key_name`:
-/// single letters lowercase, named keys TitleCase-preserved.
-fn named_key_to_binding_name(named: crate::NamedKey) -> &'static str {
-    use crate::NamedKey::*;
-    match named {
-        Escape => "Escape",
-        Tab => "Tab",
-        BackTab => "BackTab",
-        Enter => "Enter",
-        Backspace => "Backspace",
-        Delete => "Delete",
-        Insert => "Insert",
-        Home => "Home",
-        End => "End",
-        PageUp => "PageUp",
-        PageDown => "PageDown",
-        Up => "Up",
-        Down => "Down",
-        Left => "Left",
-        Right => "Right",
-        F(1) => "F1",
-        F(2) => "F2",
-        F(3) => "F3",
-        F(4) => "F4",
-        F(5) => "F5",
-        F(6) => "F6",
-        F(7) => "F7",
-        F(8) => "F8",
-        F(9) => "F9",
-        F(10) => "F10",
-        F(11) => "F11",
-        F(12) => "F12",
-        F(_) => "",
-        CapsLock => "CapsLock",
-        NumLock => "NumLock",
-        ScrollLock => "ScrollLock",
-        Menu => "Menu",
     }
 }
 


### PR DESCRIPTION
Closes #473

Automated PR opened by coordinator for review of issue #473.