### PR TITLE
#477: Framework docs, fixtures, and API framing are written around named consumers (coord-tui, vimcode)

### DIFF
--- a/quadraui/examples/common/appshell_demo.rs
+++ b/quadraui/examples/common/appshell_demo.rs
@@ -18,7 +18,7 @@
 //! the real `AppShell` instance quadraui's internal `ShellAdapter` actually
 //! renders, so a consumer-driven binding can call
 //! `ctx.shell_mut().toggle_sidebar()` directly instead of tracking a shadow
-//! `AppShell` that can drift from what's on screen (the vimcode `Ctrl+B`
+//! `AppShell` that can drift from what's on screen (the class of `Ctrl+B`
 //! bug this issue fixes).
 
 use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
@@ -31,7 +31,7 @@ pub struct AppShellDemo {
     last_event: String,
     /// Set by the `p` key binding below; polled once via
     /// `take_requested_panel` to exercise the programmatic panel-switch
-    /// hook (quadraui consumer coord-tui #1029 bug A) — proves an app can
+    /// hook (a bug class seen in consumer apps) — proves an app can
     /// jump straight to a panel (no ActivityBar click) and still get the
     /// ActivityBar highlight + sidebar header updated to match.
     pending_panel: Option<WidgetId>,
@@ -165,7 +165,7 @@ impl ShellApp for AppShellDemo {
             // `AppShell` `ShellAdapter` renders, so this app can call
             // `toggle_sidebar()` on it directly — no shadow `AppShell`, no
             // drift between what this app thinks is visible and what's
-            // actually painted (the vimcode bug #454 fixes).
+            // actually painted (the class of bug #454 fixes).
             UiEvent::KeyPressed {
                 key: Key::Char('b'),
                 modifiers: Modifiers { ctrl: true, .. },

--- a/quadraui/examples/common/data_table_app.rs
+++ b/quadraui/examples/common/data_table_app.rs
@@ -24,7 +24,7 @@ pub struct DataTableApp {
     resize_col: Option<usize>,
     /// Per-column width overrides from divider drags, layered on top of
     /// `columns`' declared strategy (#516 defect 3) — mirrors how a real
-    /// consumer (e.g. coord-tui's Audit panel) drives `DataTable`. Kept
+    /// consumer app drives `DataTable`. Kept
     /// separate from `columns[i].width` deliberately: overriding a
     /// column must never rewrite its original declared strategy, only
     /// lay a resolved width on top of it — that distinction is exactly
@@ -520,9 +520,8 @@ impl AppLogic for DataTableApp {
                     // width held constant, every other column frozen at
                     // its currently-resolved width. Layered on top of
                     // `columns` via `column_overrides` — the real API
-                    // surface a consumer drags through (e.g. coord-tui's
-                    // Audit panel) — rather than rewriting the columns'
-                    // declared strategies directly.
+                    // surface a consumer drags through — rather than
+                    // rewriting the columns' declared strategies directly.
                     // A small absolute floor (not the old single-column
                     // `.max(20.0)`): this table's own `Restarts` column
                     // is declared `Fixed(10.0)` — the same literal value

--- a/quadraui/examples/common/markdown_wrap_demo.rs
+++ b/quadraui/examples/common/markdown_wrap_demo.rs
@@ -1,11 +1,11 @@
 //! Demo for [`render_markdown_to_styled_wrapped`]: word-wrapped markdown rows
 //! displayed in a [`ListView`].
 //!
-//! This is the canonical consumer pattern for coord-tui's issue-body panels:
-//! call [`render_markdown_to_styled_wrapped`] with the current content width,
-//! convert each output row to a [`ListItem`], and hand the list to the
-//! backend. Long paragraphs reflow to the viewport; code blocks are
-//! intentionally never wrapped.
+//! This is the canonical consumer pattern for a host's scrollable
+//! markdown-body panels: call [`render_markdown_to_styled_wrapped`] with
+//! the current content width, convert each output row to a [`ListItem`],
+//! and hand the list to the backend. Long paragraphs reflow to the
+//! viewport; code blocks are intentionally never wrapped.
 //!
 //! Keys:
 //! - `j` / `↓`  — scroll down

--- a/quadraui/examples/common/selection_app.rs
+++ b/quadraui/examples/common/selection_app.rs
@@ -3,7 +3,7 @@
 //! [`SelectionDemo`] implements [`ShellApp`] and proves that the selection
 //! pipeline — drag to select, Ctrl-A select-all, Ctrl-C copy — works
 //! identically when an app is driven by [`quadraui::tui::shell_runner::run_with_shell`]
-//! (the path used by coord-tui) as it does with the plain `tui::run` path.
+//! (the path used by shell-driven hosts) as it does with the plain `tui::run` path.
 //!
 //! The pipeline lives in `quadraui::tui::run::dispatch_event`; both runners
 //! converge on it. This demo is the acceptance smoke-test for issue #283.

--- a/quadraui/examples/tui_selection.rs
+++ b/quadraui/examples/tui_selection.rs
@@ -1,8 +1,9 @@
 //! Mouse-drag text-selection + Ctrl-C copy — TUI example.
 //!
 //! Exercises the selection pipeline through `run_with_shell`, proving that
-//! the pipeline works for shell apps (coord-tui's entry point) just as it
-//! does for direct `tui::run` apps. This is the acceptance demo for issue #283.
+//! the pipeline works for shell apps (the entry point a host app would use)
+//! just as it does for direct `tui::run` apps. This is the acceptance demo
+//! for issue #283.
 //!
 //! ## Controls
 //!

--- a/quadraui/src/primitives/list.rs
+++ b/quadraui/src/primitives/list.rs
@@ -44,7 +44,7 @@ pub struct ListView {
     pub bordered: bool,
     /// Horizontal scroll offset in chars (number of content columns to skip
     /// from the left before rendering). Default `0` = no scroll.
-    /// The caller (e.g. coord-tui) increments / decrements this in response
+    /// The caller increments / decrements this in response
     /// to Left / Right key events.
     #[serde(default)]
     pub h_scroll: usize,

--- a/quadraui/src/primitives/message_list.rs
+++ b/quadraui/src/primitives/message_list.rs
@@ -1,14 +1,14 @@
 //! `MessageList` primitive: a scrollable list of styled lines used by
-//! chat-style panels (vimcode's AI assistant sidebar).
+//! chat-style panels (e.g. an AI assistant sidebar).
 //!
 //! Each row carries its own foreground colour and a small left-indent
 //! offset so role labels (`You:` / `AI:`) line up flush-left while
 //! content lines indent. The panel background is supplied by the
 //! caller — message bodies share one fill. Per-message bg highlighting
 //! could be added later as an optional `bg_override` field; the current
-//! shape mirrors what both vimcode rasterisers emit today.
+//! shape mirrors what both rasterisers emit today.
 //!
-//! Wrapping happens at the call site (vimcode's adapter splits message
+//! Wrapping happens at the call site (a host's adapter splits message
 //! content into wrap-width chunks before pushing rows) — the primitive
 //! is data-only.
 //!

--- a/quadraui/src/primitives/pipeline_view.rs
+++ b/quadraui/src/primitives/pipeline_view.rs
@@ -47,7 +47,7 @@ pub enum StageStatus {
     /// Intentionally bypassed — rendered with strikethrough / grey dash (─).
     Skipped,
     /// Previously completed (or failed), but an upstream stage has since been
-    /// re-dispatched — the result is against an older revision and should not
+    /// re-run — the result is against an older revision and should not
     /// be trusted. Distinct from Pending ("never run") and Done ("trustworthy").
     /// Rendered dim with an `↻` icon to suggest re-running.
     Stale,

--- a/quadraui/src/primitives/sidebar_panel.rs
+++ b/quadraui/src/primitives/sidebar_panel.rs
@@ -15,9 +15,9 @@
 //! The compose layer already exports a `SidebarEvent` enum tied to
 //! the multi-section [`crate::SidebarSystem`]. Adding a `Sidebar`
 //! primitive with its own `SidebarEvent` would collide at the lib
-//! re-export boundary. `SidebarPanel` reads correctly at the use
-//! sites in claude-coordinator + vimcode (each panel IS a sidebar
-//! panel) and keeps the names disjoint.
+//! re-export boundary. `SidebarPanel` reads correctly at consumer
+//! use sites (each panel IS a sidebar panel) and keeps the names
+//! disjoint.
 //!
 //! ## Shape
 //!
@@ -25,8 +25,8 @@
 //!   - `None`: no slot reserved. Content occupies the full rect.
 //!   - `Some(bar)`: header slot reserved at `toolbar_height`. Reserved
 //!     *even when `bar.buttons.is_empty()`*, so content below doesn't
-//!     shift as toolbar items come and go (the actual bug coord-tui
-//!     hit when toolbar appearance was state-dependent).
+//!     shift as toolbar items come and go (a bug a consumer app hit
+//!     when toolbar appearance was state-dependent).
 //! - `toolbar_height`: optional explicit height in native units. When
 //!   `None`, backends pick an idiomatic default (`1.0` cells TUI,
 //!   `line_height` GTK / macOS).
@@ -205,7 +205,7 @@ impl SidebarPanel {
             Some(bar) => {
                 // Reserve the slot even when `bar.buttons.is_empty()`
                 // so content doesn't shift as toolbar items come and
-                // go (the bug coord-tui hit twice).
+                // go (a bug a consumer app hit twice).
                 let slot_height = toolbar_height.min(bounds.height).max(0.0);
                 let toolbar_bounds = Rect::new(bounds.x, bounds.y, bounds.width, slot_height);
                 let content_y = bounds.y + slot_height;

--- a/quadraui/src/primitives/toolbar.rs
+++ b/quadraui/src/primitives/toolbar.rs
@@ -5,8 +5,7 @@
 //!
 //! ## Why this isn't `StatusBar`
 //!
-//! Two downstream apps (vimcode debug toolbar, coord-tui sidebar action bar)
-//! historically faked toolbars by stuffing clickable verbs into
+//! Downstream apps historically faked toolbars by stuffing clickable verbs into
 //! [`crate::StatusBar`] segments with `action_id` set. That works on TUI
 //! (it's just a row of cells) but breaks the abstraction the moment a
 //! backend wants to render the strip natively:

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -441,7 +441,7 @@ pub trait ShellApp {
     /// sync with a raw internal view-state write: the ActivityBar highlight
     /// and panel header would silently keep pointing at the
     /// previously-active panel until the user clicked the ActivityBar
-    /// themselves (quadraui consumer coord-tui #1029 bug A).
+    /// themselves (a bug class seen in consumer apps).
     ///
     /// Default: never requests a switch — existing consumers are
     /// unaffected. `&mut self` (not `&self`) so implementors can `.take()`

--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -74,7 +74,7 @@ use crate::types::{Color, Modifiers, WidgetId};
 /// A single captured terminal cell in the scrollback ring buffer.
 ///
 /// Uses `vt100::Color` directly to defer RGB resolution until paint time,
-/// matching the approach in vimcode's `HistCell`.
+/// matching the approach used by downstream terminal-history cell types.
 #[derive(Clone, Copy)]
 struct HistCell {
     ch: char,
@@ -125,8 +125,8 @@ fn normalize_selection(sel: &TerminalSelection) -> (u16, u16, u16, u16) {
 
 /// Map a `vt100::Color` to an RGB triple.
 ///
-/// `Default` resolves to dark-theme terminal defaults matching the
-/// vimcode OneDark baseline (`#e5e5e5` fg, `#1e1e1e` bg). Callers
+/// `Default` resolves to dark-theme terminal defaults matching a
+/// common OneDark-style baseline (`#e5e5e5` fg, `#1e1e1e` bg). Callers
 /// that want theme-aware colours should post-process cells after
 /// calling [`TerminalSession::to_terminal`].
 fn map_vt100_color(color: vt100::Color, is_bg: bool) -> (u8, u8, u8) {
@@ -495,7 +495,7 @@ impl TerminalSession {
         let mut cmd = CommandBuilder::new(shell);
         cmd.env("TERM", "xterm-256color");
         // Present the embedded terminal as a clean, top-level terminal. When
-        // the host app (e.g. coord-tui) is itself launched from inside tmux,
+        // the host app is itself launched from inside tmux,
         // the spawned shell would otherwise inherit $TMUX/$TMUX_PANE and any
         // tmux command run here would be treated as *nested* in the host's
         // outer session — e.g. `tmux attach-session` refuses ("sessions should
@@ -591,7 +591,7 @@ impl TerminalSession {
     /// Send a UTF-8 string as input to the shell.
     ///
     /// Convenience wrapper around [`write_input`](Self::write_input).
-    /// The coordinator uses this to inject prompts programmatically.
+    /// A supervising process uses this to inject prompts programmatically.
     pub fn send_str(&mut self, s: &str) {
         self.write_input(s.as_bytes());
     }
@@ -726,7 +726,7 @@ impl TerminalSession {
     ///    pollute the shell's scrollback (quadraui #335).
     /// 2. **Route the wheel** — when the child is on the alt-screen, wheel
     ///    events forward to the PTY rather than scrolling our local
-    ///    scrollback (quadraui #334, coord #446). See
+    ///    scrollback (quadraui #334). See
     ///    [`should_forward_wheel`](Self::should_forward_wheel).
     ///
     /// Backed by vt100's `Screen::alternate_screen()`.
@@ -760,7 +760,7 @@ impl TerminalSession {
     /// `less` usable: even when those programs don't request mouse reporting,
     /// scrolling our local (now-empty, alt-screen-shadowed) scrollback would
     /// be jarring — forwarding the wheel lets the inner app paginate
-    /// (quadraui #334 / coord #446).
+    /// (quadraui #334).
     pub fn should_forward_wheel(&self) -> bool {
         self.mouse_reporting_enabled() || self.on_alt_screen()
     }
@@ -852,7 +852,7 @@ impl TerminalSession {
     /// [`screen_text`](Self::screen_text) into a single string, separated
     /// by a newline when both are non-empty.
     ///
-    /// Useful for coordinator scraping: scan `full_text()` for a prompt or
+    /// Useful for programmatic scraping: scan `full_text()` for a prompt or
     /// completion marker after each `poll()` cycle.
     pub fn full_text(&self) -> String {
         let hist = self.scrollback_text();
@@ -1222,8 +1222,8 @@ impl TerminalSession {
         let hist_len = self.history.len();
 
         // Selection coordinates are always in display-row space (0 = visible
-        // top), matching the coordinate system used by coord-tui's
-        // `terminal_pixel_to_cell`.  The gate on `scroll_offset == 0` that
+        // top), matching the coordinate system expected by a host's
+        // pixel-to-cell mapping helper.  The gate on `scroll_offset == 0` that
         // previously existed here was overly conservative: the `display_r`
         // comparison below is correct at any offset.
         let sel_bounds = self.selection.as_ref().map(normalize_selection);
@@ -2301,8 +2301,7 @@ mod tests {
 
     /// `bracketed_paste_enabled()` reflects the child's DEC private mode
     /// 2004 (`ESC[?2004h` / `ESC[?2004l`) — the input-readiness signal a
-    /// programmatic driver waits on before injecting input (quadraui #343,
-    /// consumed by coord-tui #446).
+    /// programmatic driver waits on before injecting input (quadraui #343).
     #[test]
     #[cfg(unix)]
     fn bracketed_paste_enabled_tracks_mode_2004() {
@@ -2629,8 +2628,8 @@ mod tests {
     }
 
     /// Alt-screen entry alone (without explicit mouse reporting) makes the
-    /// engine forward wheel events to the child — the routing rule from
-    /// coord #446 that fixes embedded `claude` / `tmux` / `less`.
+    /// engine forward wheel events to the child — the routing rule that
+    /// fixes embedded `claude` / `tmux` / `less`.
     #[test]
     #[cfg(unix)]
     fn wheel_forwards_on_alt_screen_even_without_mouse_reporting() {
@@ -2676,7 +2675,7 @@ mod tests {
 
     /// Scrollback must NOT grow while the child is on the alternate screen,
     /// and MUST resume growing after the child returns to the primary screen
-    /// (quadraui #335 + coord #446 — without this, `claude` / `tmux` / `vim`
+    /// (quadraui #335 — without this, `claude` / `tmux` / `vim`
     /// frames leak into the shell's scrollback as cold-frame garbage).
     #[test]
     #[cfg(unix)]

--- a/quadraui/src/tui/pipeline_view.rs
+++ b/quadraui/src/tui/pipeline_view.rs
@@ -345,7 +345,7 @@ mod tests {
 
     /// A label carrying a newline renders as two centred rows inside the box —
     /// no literal newline cell on row 1, second line on its own row. Regression
-    /// guard for the off-box "black gap" glitch (coord-tui #280).
+    /// guard for the off-box "black gap" glitch.
     #[test]
     fn two_line_label_renders_on_separate_rows() {
         let area = Rect::new(0, 0, 40, 8);
@@ -353,7 +353,7 @@ mod tests {
         let view = PipelineView {
             id: WidgetId::new("pipe"),
             stages: vec![PipelineStage {
-                label: "Review T12\n3:45".into(),
+                label: "Stage One\n3:45".into(),
                 status: StageStatus::Active,
                 action: None,
             }],
@@ -374,8 +374,8 @@ mod tests {
             .map(|x| cell_char(&buf, x, first_row + 1))
             .collect();
 
-        // Line 1 holds the stage + turn count; line 2 holds the elapsed time.
-        assert!(row1.contains("Review T12"), "row1 = {row1:?}");
+        // Line 1 holds the stage name; line 2 holds the elapsed time.
+        assert!(row1.contains("Stage One"), "row1 = {row1:?}");
         assert!(row2.contains("3:45"), "row2 = {row2:?}");
         // The elapsed segment must NOT bleed onto row 1 (the old glitch).
         assert!(!row1.contains("3:45"), "elapsed leaked onto row1: {row1:?}");


### PR DESCRIPTION
Closes #477

Automated PR opened by coordinator for review of issue #477.