### PR TITLE
#532: AppShell: runtime toggle for title-bar row reservation (set_title_bar_visible)

### DIFF
--- a/quadraui/examples/common/full_chrome_demo.rs
+++ b/quadraui/examples/common/full_chrome_demo.rs
@@ -15,10 +15,21 @@
 //! hints the resize cursor via `Backend::set_cursor` while hovering one.
 //! Same no-op-on-TUI story as #400 — there's no window to resize, so both
 //! calls report back `false` and the status line says so.
+//!
+//! `Ctrl+T` demonstrates the #532 runtime toggle:
+//! `ctx.shell_mut().set_title_bar_visible(!visible)` shows/hides the title
+//! bar band without rebuilding the shell, the same `ctx.shell_mut()` path
+//! `Ctrl+B` uses for the sidebar in `appshell_demo.rs` (#454). This is the
+//! shape vimcode's runtime-toggleable menu bar (vimcode#605) needs: the
+//! activity bar and main content must re-derive their top origin from
+//! `AppShell::layout()` on the very next frame, not from a cached offset —
+//! toggle title bar off and the "TITLE BAR" label disappears while the
+//! activity bar/content shift up to reclaim the row; toggle it back on and
+//! they shift back down without losing the configured height.
 
 use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
 use quadraui::{
-    Backend, Color, Key, MouseButton, NamedKey, PointerShape, Reaction, Rect,
+    Backend, Color, Key, Modifiers, MouseButton, NamedKey, PointerShape, Reaction, Rect,
     ShellApp as ShellAppTrait, ShellConfig, ShellContext, StatusBar, StatusBarAction,
     StatusBarInteraction, StatusBarSegment, UiEvent, WidgetId,
 };
@@ -41,7 +52,7 @@ pub struct FullChromeDemo {
 impl FullChromeDemo {
     pub fn new() -> Self {
         Self {
-            last_event: "click icons | drag dividers | drag/double-click title bar | drag edges to resize | q=quit"
+            last_event: "click icons | drag dividers | drag/double-click title bar | drag edges to resize | Ctrl+T=toggle title bar | q=quit"
                 .into(),
             title_bar_interaction: StatusBarInteraction::new(),
         }
@@ -290,6 +301,32 @@ impl ShellAppTrait for FullChromeDemo {
                 key: Key::Char('q') | Key::Named(NamedKey::Escape),
                 ..
             } => Reaction::Exit,
+            // `Ctrl+T` = the #532 runtime toggle: `ctx.shell_mut()` reaches
+            // the same real `AppShell` `ShellAdapter` renders (the #454
+            // pattern `Ctrl+B` uses for the sidebar in `appshell_demo.rs`),
+            // so this app can show/hide the title-bar row without
+            // rebuilding the shell. `compute_layout` re-derives the
+            // activity bar and main content origins from `has_title_bar`
+            // on the very next `layout()` call, so no other state needs to
+            // change in lockstep.
+            UiEvent::KeyPressed {
+                key: Key::Char('t'),
+                modifiers: Modifiers { ctrl: true, .. },
+                ..
+            } => {
+                let now_visible = {
+                    let mut shell = ctx.shell_mut();
+                    let visible = !shell.title_bar_visible();
+                    shell.set_title_bar_visible(visible);
+                    visible
+                };
+                self.last_event = if now_visible {
+                    "Title bar shown (Ctrl+T via ctx.shell_mut())".into()
+                } else {
+                    "Title bar hidden (Ctrl+T via ctx.shell_mut())".into()
+                };
+                Reaction::Redraw
+            }
             UiEvent::MouseDown {
                 position, button, ..
             } => {

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -181,6 +181,9 @@ impl AppShell {
         self
     }
 
+    /// Reserve a title-bar row at construction time. See
+    /// [`Self::set_title_bar_visible`] to show/hide the row at runtime
+    /// (e.g. a toggleable menu bar) without rebuilding the `AppShell`.
     pub fn with_title_bar(mut self, height_lh: f32) -> Self {
         self.has_title_bar = true;
         self.title_bar_height_lh = height_lh;
@@ -229,6 +232,13 @@ impl AppShell {
 
     pub fn position(&self) -> ShellPosition {
         self.position
+    }
+
+    /// Whether the title-bar row is currently reserved. See
+    /// [`Self::set_title_bar_visible`] for the runtime toggle and
+    /// [`Self::with_title_bar`] for the construction-time builder.
+    pub fn title_bar_visible(&self) -> bool {
+        self.has_title_bar
     }
 
     pub fn hovered_activity_idx(&self) -> Option<usize> {
@@ -332,6 +342,36 @@ impl AppShell {
 
     pub fn toggle_sidebar(&mut self) {
         self.sidebar_visible = !self.sidebar_visible;
+    }
+
+    /// Runtime toggle for whether the title-bar row is reserved (#532).
+    ///
+    /// Unlike [`Self::with_title_bar`] — a construction-time builder that
+    /// permanently commits to reserving the row for the lifetime of the
+    /// `AppShell` — this can be flipped at any point after construction
+    /// without rebuilding the shell. `compute_layout` re-derives every
+    /// downstream bound (activity bar, sidebar, main content, bottom
+    /// panel, ...) from `area` and current state on every
+    /// `render`/`layout`/`handle` call, so toggling this and calling any
+    /// of those next is sufficient — no other field needs to change in
+    /// lockstep, and no fixed offset is cached anywhere that would go
+    /// stale.
+    ///
+    /// Motivating case (vimcode#605, issue #532): a menu bar painted into
+    /// the title-bar row that the user can show/hide at runtime
+    /// (`engine.menu_bar_visible`). Always reserving the row would cost
+    /// the editor a row even while the menu is hidden; never reserving it
+    /// would make a shown menu overwrite the activity bar's first row
+    /// (which starts at `y = 0` when `has_title_bar` is `false`).
+    /// Toggling this from the app's own visibility state avoids both.
+    ///
+    /// If [`Self::with_title_bar`] was never called, toggling visible for
+    /// the first time reserves the default height (`title_bar_height_lh`,
+    /// 1.5 line-heights). The configured height is otherwise preserved
+    /// across visible → hidden → visible round-trips — hiding does not
+    /// forget it.
+    pub fn set_title_bar_visible(&mut self, visible: bool) {
+        self.has_title_bar = visible;
     }
 
     pub fn set_sidebar_width(&mut self, width: f32) {
@@ -1851,6 +1891,76 @@ mod tests {
             area(),
         );
         assert!(matches!(ev, AppShellEvent::BottomPanelResized { .. }));
+    }
+
+    // ── Runtime title-bar toggle (#532) ─────────────────────────────
+
+    #[test]
+    fn title_bar_visible_reflects_construction_state() {
+        assert!(!shell().title_bar_visible());
+        assert!(full_chrome_shell().title_bar_visible());
+    }
+
+    #[test]
+    fn set_title_bar_visible_toggles_at_runtime_without_with_title_bar() {
+        let mut s = shell(); // never called with_title_bar()
+        assert!(s.layout(area(), 1.0).title_bar_bounds.is_none());
+
+        s.set_title_bar_visible(true);
+        assert!(s.title_bar_visible());
+        let tb = s
+            .layout(area(), 1.0)
+            .title_bar_bounds
+            .expect("row now reserved");
+        // Falls back to the default height (1.5 line-heights) since
+        // `with_title_bar` was never called: (1.5 * lh=1.0).round() == 2.0.
+        assert_eq!(tb.height, 2.0);
+
+        s.set_title_bar_visible(false);
+        assert!(!s.title_bar_visible());
+        assert!(s.layout(area(), 1.0).title_bar_bounds.is_none());
+    }
+
+    /// The operator's explicit ask on #532: confirm the activity bar and
+    /// main content re-derive their origins from scratch in both states
+    /// rather than assuming a fixed offset cached from construction.
+    #[test]
+    fn set_title_bar_visible_shifts_activity_bar_and_main_origin_both_ways() {
+        let mut s = full_chrome_shell(); // with_title_bar(1.5)
+        let l = s.layout(area(), 1.0);
+        let tb = l.title_bar_bounds.unwrap();
+        assert_eq!(l.activity_bar_bounds.y, tb.y + tb.height);
+        assert_eq!(l.main_content_bounds.y, tb.y + tb.height);
+
+        s.set_title_bar_visible(false);
+        let l = s.layout(area(), 1.0);
+        assert!(l.title_bar_bounds.is_none());
+        assert_eq!(l.activity_bar_bounds.y, area().y);
+        assert_eq!(l.main_content_bounds.y, area().y);
+
+        // Toggle back on: restores the height configured via
+        // `with_title_bar` (2.0, from 1.5 lh) — hiding does not forget it
+        // and fall back to some other default.
+        s.set_title_bar_visible(true);
+        let l = s.layout(area(), 1.0);
+        let tb = l.title_bar_bounds.unwrap();
+        assert_eq!(tb.height, 2.0);
+        assert_eq!(l.activity_bar_bounds.y, tb.y + tb.height);
+    }
+
+    #[test]
+    fn set_title_bar_visible_false_reclaims_the_row_for_content() {
+        let mut s = full_chrome_shell();
+        let visible_main_h = s.layout(area(), 1.0).main_content_bounds.height;
+
+        s.set_title_bar_visible(false);
+        let hidden_main_h = s.layout(area(), 1.0).main_content_bounds.height;
+
+        assert!(
+            hidden_main_h > visible_main_h,
+            "hiding the title bar should hand its row back to content: \
+             hidden={hidden_main_h}, visible={visible_main_h}"
+        );
     }
 
     // ── Mock backend for handle() tests ─────────────────────────────

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -1478,6 +1478,105 @@ fn full_chrome_title_bar_close_button_exits() {
     );
 }
 
+// ─── FullChromeDemo: runtime title-bar visibility toggle (#532) ────────────
+//
+// `AppShell::set_title_bar_visible` (#532) is the runtime counterpart to the
+// construction-time `ShellConfig::with_title_bar` builder — see its doc
+// comment in `compose/app_shell.rs` for the motivating vimcode case (a menu
+// bar painted into the title-bar row that the app shows/hides at runtime).
+// Unit tests alongside `AppShell::layout()` already prove the layout math
+// directly; these tests prove the `ctx.shell_mut()` integration point a
+// `ShellApp` actually uses works end-to-end through the real
+// `ShellAdapter`-rendered `AppShell` — the same precedent
+// `appshell_demo_ctrl_b_toggles_the_real_rendered_sidebar` set for
+// `toggle_sidebar()` (#454).
+
+/// `Ctrl+T` on `FullChromeDemo` (which reserves a title bar via
+/// `with_title_bar` in `config()`) hides the real rendered title-bar band
+/// and shows it again, round-tripping through
+/// `ctx.shell_mut().set_title_bar_visible`.
+#[test]
+fn full_chrome_ctrl_t_hides_and_shows_the_real_rendered_title_bar() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    // Title bar starts visible: `with_title_bar(1.5)` in `config()` reserves
+    // the row, so the "TITLE BAR" label painted into `title_bar_bounds`
+    // should be on the initial screen.
+    assert!(
+        driver.screen_contains("TITLE BAR"),
+        "title bar should be visible on the initial screen:\n{}",
+        driver.screen()
+    );
+
+    let reaction = driver.ctrl_char('t');
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Ctrl+T toggling the real AppShell must redraw"
+    );
+    assert!(
+        !driver.screen_contains("TITLE BAR"),
+        "Ctrl+T must hide the title bar that ShellAdapter actually renders, \
+         not a shadow copy:\n{}",
+        driver.screen()
+    );
+    assert!(
+        driver.screen_contains("Title bar hidden (Ctrl+T via ctx.shell_mut())"),
+        "status line should confirm the toggle went through ctx.shell_mut():\n{}",
+        driver.screen()
+    );
+
+    // Toggling again brings it back — proves `ctx.shell_mut()` mutates the
+    // same live instance `render_content` reads from on the next frame,
+    // round-tripping the real state rather than a one-way flag, and that
+    // the configured height (1.5 line-heights) survives the round trip.
+    let reaction = driver.ctrl_char('t');
+    assert_eq!(reaction, Reaction::Redraw);
+    assert!(
+        driver.screen_contains("TITLE BAR"),
+        "a second Ctrl+T should show the title bar again:\n{}",
+        driver.screen()
+    );
+    assert!(
+        driver.screen_contains("Title bar shown (Ctrl+T via ctx.shell_mut())"),
+        "status line should confirm the second toggle:\n{}",
+        driver.screen()
+    );
+}
+
+/// The operator's pinned ask on #532: confirm the activity bar reclaims the
+/// title bar's row rather than leaving it blank, through the *real*
+/// rendered path (not `AppShell::layout()` called directly, which the
+/// `compose/app_shell.rs` unit tests already cover). Row 0 must switch from
+/// the title bar's label to the activity bar's top icon once the title bar
+/// is hidden — proving `ShellAdapter` re-paints from the freshly toggled
+/// `has_title_bar`, not a stale cached offset.
+#[test]
+fn full_chrome_ctrl_t_hands_the_title_bar_row_to_the_activity_bar() {
+    let config = FullChromeDemo::config();
+    let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+
+    let visible_top_row = driver.screen().lines().next().unwrap().to_string();
+    assert!(
+        visible_top_row.contains("TITLE BAR"),
+        "row 0 should be the title bar band while it's reserved:\n{visible_top_row}"
+    );
+
+    driver.ctrl_char('t');
+    let hidden_top_row = driver.screen().lines().next().unwrap().to_string();
+    assert!(
+        !hidden_top_row.contains("TITLE BAR"),
+        "row 0 should no longer show the title bar label once it's hidden:\n{hidden_top_row}"
+    );
+    assert!(
+        hidden_top_row.contains('E'),
+        "row 0 should now be the activity bar's top row (Explorer icon 'E'), \
+         proving the activity bar reclaimed the row rather than it going \
+         blank:\n{hidden_top_row}"
+    );
+}
+
 // ─── FullChromeDemo: window-edge resize escape hatch (#406) ────────────────
 //
 // `FullChromeDemo` hit-tests `ShellContext::window_edge` on `MouseDown` and


### PR DESCRIPTION
Closes #532

Automated PR opened by coordinator for review of issue #532.