### PR TITLE
#533: Backend::draw_terminal_divider trait method — split-terminal divider is a free-function holdout

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -541,6 +541,20 @@ pub trait Backend {
     /// terminal selection is driven by mouse drag against cell
     /// dimensions, which the app already tracks.
     fn draw_terminal(&mut self, rect: Rect, term: &Terminal);
+    /// Draw a vertical divider between two split terminal panes.
+    /// `rect.x` is the divider's column, `rect.y` its top row, and
+    /// `rect.height` its length; `rect.width` is ignored — the
+    /// divider is always a single cell (TUI) or 1px (GTK/macOS) wide.
+    /// See `tui::draw_terminal_divider` / `gtk::draw_terminal_divider`
+    /// for the exact glyph/fill painted.
+    ///
+    /// No default impl — every backend implementer sees this as a
+    /// compile error and fills in a real rasteriser
+    /// (`BACKEND_TRAIT_PROPOSAL.md` §4, `PRIMITIVE_RULES.md` rule 7).
+    /// Do not add a no-op default here; see
+    /// `docs/SMELL_AUDIT_2026-07.md` PORT-01 for why that pattern is a
+    /// portability risk, not a precedent to follow.
+    fn draw_terminal_divider(&mut self, rect: Rect);
     /// Draw a `TextDisplay` (streaming-text panel — log viewer, output
     /// pane, YAML view, etc). No hit-region data is returned;
     /// `TextDisplay` itself is non-interactive (selection / scroll

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -2062,6 +2062,7 @@ mod tests {
             Vec::new()
         }
         fn draw_terminal(&mut self, _r: Rect, _t: &crate::Terminal) {}
+        fn draw_terminal_divider(&mut self, _r: Rect) {}
         fn draw_text_display(&mut self, _r: Rect, _t: &crate::TextDisplay) {}
         fn draw_command_line(&mut self, _r: Rect, _c: &crate::CommandLine) {}
         fn status_bar_layout(&self, _r: Rect, _b: &crate::StatusBar) -> crate::StatusBarLayout {

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -1425,6 +1425,7 @@ mod tests {
             unimplemented!()
         }
         fn draw_terminal(&mut self, _r: Rect, _t: &crate::Terminal) {}
+        fn draw_terminal_divider(&mut self, _r: Rect) {}
         fn draw_text_display(&mut self, _r: Rect, _t: &crate::TextDisplay) {}
         fn draw_command_line(&mut self, _r: Rect, _c: &crate::CommandLine) {}
         fn status_bar_layout(&self, _r: Rect, _b: &crate::StatusBar) -> crate::StatusBarLayout {

--- a/quadraui/src/compose/menu_system.rs
+++ b/quadraui/src/compose/menu_system.rs
@@ -824,6 +824,7 @@ mod tests {
             unimplemented!()
         }
         fn draw_terminal(&mut self, _r: Rect, _t: &crate::Terminal) {}
+        fn draw_terminal_divider(&mut self, _r: Rect) {}
         fn draw_text_display(&mut self, _r: Rect, _t: &crate::TextDisplay) {}
         fn draw_command_line(&mut self, _r: Rect, _c: &crate::CommandLine) {}
         fn status_bar_layout(&self, _r: Rect, _b: &crate::StatusBar) -> crate::StatusBarLayout {

--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -1574,6 +1574,7 @@ mod tests {
             unimplemented!()
         }
         fn draw_terminal(&mut self, _r: Rect, _t: &crate::Terminal) {}
+        fn draw_terminal_divider(&mut self, _r: Rect) {}
         fn draw_text_display(&mut self, _r: Rect, _t: &crate::TextDisplay) {}
         fn draw_command_line(&mut self, _r: Rect, _c: &crate::CommandLine) {}
         fn status_bar_layout(&self, _r: Rect, _b: &crate::StatusBar) -> crate::StatusBarLayout {

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1836,6 +1836,20 @@ impl Backend for GtkBackend {
         }
     }
 
+    fn draw_terminal_divider(&mut self, rect: QRect) {
+        let theme = self.current_theme;
+        let (cr, _layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_terminal_divider called outside enter_frame_scope");
+        crate::gtk::draw_terminal_divider(
+            cr,
+            rect.x as f64,
+            rect.y as f64,
+            rect.height as f64,
+            &theme,
+        );
+    }
+
     fn draw_text_display(&mut self, rect: QRect, td: &TextDisplay) {
         let (cr, layout) = self
             .current_frame_refs()

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -688,6 +688,24 @@ impl Backend for MacBackend {
             unsafe { super::scrollbar::draw_scrollbar(ctx, &sb, &theme) }
         }
     }
+    fn draw_terminal_divider(&mut self, rect: Rect) {
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_terminal_divider called outside enter_frame_scope",
+        );
+        let theme = self.current_theme;
+        // SAFETY: ctx is non-null inside the frame scope.
+        unsafe {
+            super::terminal::draw_terminal_divider(
+                ctx,
+                rect.x as f64,
+                rect.y as f64,
+                rect.height as f64,
+                &theme,
+            );
+        }
+    }
     fn draw_text_display(&mut self, rect: Rect, td: &TextDisplay) {
         let ctx = self.current_cg();
         debug_assert!(

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1145,6 +1145,15 @@ impl Backend for TuiBackend {
         crate::tui::draw_terminal(frame.buffer_mut(), area, term, &theme);
     }
 
+    fn draw_terminal_divider(&mut self, rect: QRect) {
+        let area = q_rect_to_ratatui(rect);
+        let theme = self.current_theme;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_terminal_divider called outside enter_frame_scope");
+        crate::tui::draw_terminal_divider(frame.buffer_mut(), area.x, area.y, area.height, &theme);
+    }
+
     fn draw_text_display(&mut self, rect: QRect, td: &TextDisplay) {
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
@@ -1915,6 +1924,7 @@ mod tests {
             Vec::new()
         }
         fn draw_terminal(&mut self, _r: QRect, _t: &TerminalPrim) {}
+        fn draw_terminal_divider(&mut self, _r: QRect) {}
         fn draw_text_display(&mut self, _r: QRect, _t: &TextDisplay) {}
         fn draw_command_line(&mut self, _r: QRect, _c: &CommandLine) {}
         fn status_bar_layout(&self, _r: QRect, _b: &StatusBar) -> crate::StatusBarLayout {

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -251,6 +251,10 @@ impl Backend for WinBackend {
         todo!("Direct2D terminal cell grid rasteriser")
     }
 
+    fn draw_terminal_divider(&mut self, _rect: Rect) {
+        todo!("Direct2D terminal split divider rasteriser")
+    }
+
     fn draw_text_display(&mut self, _rect: Rect, _td: &TextDisplay) {
         todo!("Direct2D text display rasteriser")
     }


### PR DESCRIPTION
Closes #533

Adds `Backend::draw_terminal_divider` — the last free-function holdout in the
terminal-panel primitive set — as a required trait method, backed by the
existing per-backend rasterisers. Signature is geometry-neutral (`rect: Rect`),
matching the shape #531's `draw_settings_chrome` settled on.

## Downstream impact

**No consumer hits.** Both downstream consumers (`coord-tui`, `vimcode`) use
`Backend` only through `&mut dyn Backend`; neither carries its own
`impl Backend`, so adding a required method cannot break their unpinned
`develop`-tip builds.

Verified by grep across both checkouts:

```
$ grep -rn "impl Backend\|impl quadraui::Backend\|impl crate::Backend" \
    ~/src/claude-coordinator/tui/src ~/src/vimcode/src
(no matches)
```

All 9 in-repo implementation sites are updated — 4 real backends
(`tui/backend.rs`, `gtk/backend.rs`, `macos/backend.rs`, `win/backend.rs`) plus
5 `#[cfg(test)]` `MockBackend`s (`app_shell.rs`, `chat_controller.rs`,
`menu_system.rs`, `tree_controller.rs`, `tui/backend.rs` mod tests). Because the
method has no default body, any missed site would be a compile error rather than
a silent gap.

**Unblocks downstream:** JDonaghy/vimcode#634 (#595 Stage 6) needs the terminal
panel to paint through `render_content`, which only has `&mut dyn Backend` — no
raw `Buffer`. Without this trait entry, `render_terminal_panel_content` clears
the panel and leaves it blank rather than misrepresenting a split as undivided.
This is the last of the three upstream blockers (#531, #532, #533) on that
cutover.
