### PR TITLE
#545: char_cell_width hardcodes width 2 for U+F0000-F9999 only, so nerd glyphs in the BMP PUA measure 1 and SPUA-A measure 2 — misaligns every consumer's status line (#472 regression)

### DIFF
--- a/quadraui/src/tui/text.rs
+++ b/quadraui/src/tui/text.rs
@@ -2,12 +2,11 @@
 //!
 //! Every TUI consumer measuring or truncating text needs to reckon in
 //! terminal display columns, not bytes or `char`s: CJK and wide-emoji
-//! glyphs occupy two columns, Nerd Font Private-Use-Area glyphs render
-//! double-width in terminals regardless of what `unicode-width` reports
-//! for them, and a byte-indexed slice (`&s[..n]`) can land mid-codepoint
-//! and panic. Before this module existed, every consumer re-rolled this
-//! by hand (coord-tui alone had ~24 inline `s.chars().take(n).collect()`
-//! sites, none of which accounted for display width). See issue #472.
+//! glyphs occupy two columns, and a byte-indexed slice (`&s[..n]`) can
+//! land mid-codepoint and panic. Before this module existed, every
+//! consumer re-rolled this by hand (coord-tui alone had ~24 inline
+//! `s.chars().take(n).collect()` sites, none of which accounted for
+//! display width). See issue #472.
 //!
 //! [`char_cell_width`] and [`display_width`] measure; [`truncate_to_width`]
 //! and [`truncate_to_width_ellipsis`] clip a string to a column budget
@@ -18,17 +17,17 @@ use std::borrow::Cow;
 
 /// Terminal cell width of a single character (0, 1, or 2).
 ///
-/// Uses the `unicode-width` crate's UAX#11 tables, with a range-based
-/// override for the Nerd Font Supplement PUA range (`U+F0000`–`U+F9999`),
-/// which terminals render as double-width. This is checked *before*
-/// falling through to `unicode-width` rather than only as a fallback for
-/// `None`: some `unicode-width` releases report `Some(1)` rather than
-/// `None` for this range, which would otherwise silently undersize
-/// Nerd Font glyphs depending on the exact dependency version resolved.
+/// Uses the `unicode-width` crate's UAX#11 tables directly, with no
+/// codepoint-range overrides. Private-Use-Area codepoints — including
+/// both Nerd Font PUA blocks (BMP `U+E000`–`U+F8FF` and Supplementary-A
+/// `U+F0000`–`U+FFFFD`) — measure as width 1, matching `unicode-width`
+/// and `Nerd Font Mono` (the terminal-recommended, single-cell variant).
+/// Non-Mono Nerd Font variants are genuinely double-width, but that is a
+/// font/theme property, not something derivable from the codepoint
+/// alone; if double-width PUA glyphs ever need supporting, it must come
+/// in as an explicit input (theme/config/probe), not a range guess here.
+/// See issue #545.
 pub fn char_cell_width(c: char) -> u16 {
-    if ('\u{F0000}'..='\u{F9999}').contains(&c) {
-        return 2;
-    }
     unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) as u16
 }
 
@@ -99,12 +98,17 @@ mod tests {
     }
 
     #[test]
-    fn char_cell_width_nerd_font_pua_override_is_two() {
-        // Always 2, regardless of what unicode-width reports for these
-        // codepoints (it varies by release — Some(1) or None).
-        assert_eq!(char_cell_width('\u{F0000}'), 2);
-        assert_eq!(char_cell_width('\u{F0001}'), 2);
-        assert_eq!(char_cell_width('\u{F9999}'), 2);
+    fn char_cell_width_pua_glyphs_are_width_one_and_consistent_across_blocks() {
+        // No codepoint-range special cases: both Nerd Font PUA blocks
+        // measure the same width (1), per unicode-width / Nerd Font Mono.
+        // BMP PUA, e.g. nf-fa-github (U+F09B).
+        let bmp_pua = char_cell_width('\u{F09B}');
+        // Supplementary PUA-A, U+F0000 — inside the range this override
+        // used to hardcode to width 2.
+        let spua_a = char_cell_width('\u{F0000}');
+        assert_eq!(bmp_pua, 1);
+        assert_eq!(spua_a, 1);
+        assert_eq!(bmp_pua, spua_a);
     }
 
     #[test]


### PR DESCRIPTION
Closes #545

Removes the `#472`-introduced range override in `char_cell_width` and lets
`unicode-width` decide, restoring pre-#472 behaviour.

## The bug

`quadraui/src/tui/text.rs` returned `2` for `U+F0000..=U+F9999` and fell through to
`unicode-width` (which returns `1` for private-use) everywhere else. Nerd Font glyphs
live in **two** PUA blocks, so the same icon set measured inconsistently depending on
which block a codepoint happened to sit in:

| block | icons in vimcode's `src/icons.rs` | old width |
|---|---|---|
| BMP PUA `U+E000–F8FF` | 50 | 1 |
| SPUA-A `U+F0000–F9999` | 12 | **2** |

`F9999` is not a Unicode boundary either — SPUA-A runs to `U+FFFFD` — so the range was
arbitrary as well as inconsistent. There is no font in which that split is correct.

The override is **removed**, not flipped to `1`: Nerd Font Mono is single-width while the
non-Mono variants genuinely are double-width, so any hardcoded constant is the same
mistake pointed a different way. Double-width support, if ever needed, belongs as an
explicit font/theme input rather than a codepoint-range guess.

## Downstream impact

**`vimcode` — fixes a live rendering regression.** The renderer budgeted two columns for
a glyph the terminal draws in one, so the status line rendered `󰘖utf-8` instead of
`󰘖 utf-8` and everything to the right of an icon was misaligned by one cell.

The regression test is vimcode's six `tui_main::render_impl::tests::snapshot_*` tests,
run **unmodified** (no `cargo insta review`, no `.snap` edits — they were correct all
along, and re-recording them would bake the regression in):

```
quadraui 799a19f (develop tip, pre-fix)   →  test result: FAILED. 0 passed; 6 failed
quadraui d3825c0 (this PR)                →  test result: ok.     6 passed; 0 failed
```

Independently reproduced by the reviewer as well as the author.

This unblocks deleting the seven-entry `--skip` list from vimcode's `ci.yml`
(JDonaghy/vimcode#625), which in turn unblocks claude-coordinator#1963 — the coord Test
stage currently fails on *every* vimcode issue because it runs the unfiltered command
that CI had to relax for these tests.

**`coord-tui` — no direct hits.** `grep -rn 'char_cell_width\|display_width\|truncate_to_width'`
over `~/src/claude-coordinator/tui/src` returns nothing; impact reaches both consumers
only through quadraui's own `status_bar.rs` / `tab_bar.rs` rasterisers, which derive their
wide/narrow paint decision from `char_cell_width` directly. Any tab/status width that
shifted since #472 shifts back to pre-#472 behaviour, which is the intended correction.

**Public API unchanged.** `char_cell_width` / `display_width` / `truncate_to_width` keep
their signatures; only the returned width for PUA codepoints changes.

## Tests

New unit test covers one glyph from each PUA block returning the same width, so the
block-dependent split cannot silently return.
