### PR TITLE
#550: [retry] DataTableLayout::hit_test ignores h_scroll — a horizontally-scrolled table routes clicks to the wrong column, so h_scroll is paint-only

### DIFF
--- a/quadraui/examples/common/data_table_app.rs
+++ b/quadraui/examples/common/data_table_app.rs
@@ -6,7 +6,14 @@
 //! - `s` — cycle sort column (Name → Status → Age → Restarts → none)
 //! - `d` — toggle sort direction
 //! - `f` — toggle the pinned footer/summary row (#432)
+//! - `H` / `←`, `L` / `→` — scroll horizontally by 5 units (#550)
 //! - `q` / `Esc` — quit
+//!
+//! Horizontal scrolling only has anywhere to go when the terminal is
+//! narrower than the table's `min_total_width` (80 cells) — run this at
+//! ~50 columns to exercise it. Clicks stay routed to the column painted
+//! under the cursor at any `h_scroll`: `DataTableLayout::hit_test`
+//! undoes the same offset the rasteriser applies (#550).
 
 use quadraui::primitives::scrollbar::fit_thumb;
 use quadraui::{

--- a/quadraui/src/primitives/data_table.rs
+++ b/quadraui/src/primitives/data_table.rs
@@ -22,6 +22,22 @@
 //! `DataTableLayout::footer_height`, which is `row_height * 2.0` — a
 //! divider row plus the content row), and is not hit-testable as a
 //! row (`DataTableHit::Footer`, not `Row`).
+//!
+//! # Coordinate spaces (`h_scroll`)
+//!
+//! [`ResolvedColumn::x`] lives in **content space**: it always starts at
+//! `0.0` for the first column and runs to `content_width`, which may be
+//! wider than the viewport when `min_total_width` is set. Backends paint
+//! a column at `rc.x - h_scroll` (see `tui::data_table::draw_data_table`
+//! and its GTK/macOS peers), so **viewport space** — the space every
+//! click arrives in — is content space shifted left by `h_scroll`.
+//!
+//! Everything on [`DataTableLayout`] that takes an `x` from a pointer
+//! ([`DataTableLayout::hit_test`], [`DataTableLayout::column_hit`],
+//! [`DataTableLayout::drag_divider`]) therefore takes it in **viewport
+//! space** and adds [`DataTableLayout::h_scroll`] back before comparing
+//! against `columns`. At `h_scroll == 0.0` the two spaces coincide and
+//! the conversion is a no-op (#550).
 
 use crate::types::{Decoration, Modifiers, StyledText, WidgetId};
 use serde::{Deserialize, Serialize};
@@ -161,6 +177,10 @@ impl ColumnMeasure {
 }
 
 /// Resolved column position after layout.
+///
+/// `x` is in **content space** — measured from the left edge of the
+/// first column, *not* from the left edge of the viewport. When
+/// `h_scroll` is non-zero the two differ; see the module header.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ResolvedColumn {
     pub x: f32,
@@ -207,12 +227,69 @@ pub struct DataTableLayout {
     /// never overwrites the last body row in cell-granular backends
     /// (TUI) and stays visually breathing-room'd in pixel backends.
     pub footer_height: f32,
+    /// The horizontal scroll offset this layout was painted at — a copy
+    /// of [`DataTable::h_scroll`], carried here so hit-testing can undo
+    /// the same shift the renderer applied (#550).
+    ///
+    /// Backends paint column `i` at `columns[i].x - h_scroll`, so a
+    /// pointer `x` in viewport space maps to `x + h_scroll` in the
+    /// content space `columns` is expressed in. `0.0` (the overwhelmingly
+    /// common case) makes every conversion an identity.
+    pub h_scroll: f32,
 }
 
 /// Grab zone half-width for column divider detection (surface units).
 const DIVIDER_GRAB_PX: f32 = 3.0;
 
 impl DataTableLayout {
+    /// Convert a pointer `x` in **viewport space** into the **content
+    /// space** [`ResolvedColumn::x`] is expressed in, undoing the same
+    /// `- h_scroll` shift the renderer applies when painting (#550).
+    ///
+    /// Identity when `h_scroll == 0.0`.
+    ///
+    /// Cell-granular backends (TUI) round `h_scroll` to whole cells when
+    /// painting; this deliberately does not, because a click inside cell
+    /// `v` arrives as `v + 0.5` and `floor(v + 0.5 + h)` equals
+    /// `v + round(h)` for every `h >= 0` — the un-rounded add already
+    /// agrees with the rounded paint, and staying in `f32` keeps pixel
+    /// backends exact.
+    #[inline]
+    fn content_x(&self, x: f32) -> f32 {
+        x + self.h_scroll
+    }
+
+    /// Is viewport-space `x` inside the vertical scrollbar's track, on a
+    /// table whose columns only reach there *because* of `h_scroll`?
+    ///
+    /// The strip is the rightmost `scrollbar_width` of the viewport —
+    /// painted over by the scrollbar itself, so nothing under it is
+    /// clickable column geometry. Adding `h_scroll` back would otherwise
+    /// slide a real column beneath the track and let a track click sort
+    /// the wrong header.
+    ///
+    /// Deliberately inert at `h_scroll == 0.0`. A `min_total_width`
+    /// table's columns already extend past the strip's left edge at zero
+    /// scroll, so an unconditional exclusion would change what such a
+    /// table's *unscrolled* clicks resolve to — and acceptance bullet 3
+    /// of #550 requires zero-scroll routing to stay bit-identical for
+    /// the many callers that pin `h_scroll` at 0. Pre-existing
+    /// strip-fall-through at zero scroll is the callers' to intercept
+    /// (coord-tui already does, via `audit_scrollbar_hit`); this fix's
+    /// job is only to avoid *introducing* a new one.
+    #[inline]
+    fn in_v_scrollbar_strip(&self, x: f32) -> bool {
+        self.h_scroll != 0.0
+            && self.scrollbar_width > 0.0
+            && x >= (self.viewport_width - self.scrollbar_width).max(0.0)
+    }
+
+    /// Resolve a click to a header / divider / row / footer.
+    ///
+    /// `x` and `y` are **viewport-relative** (see the module header):
+    /// `x` is measured from the table's left edge, *before* `h_scroll`
+    /// is added back, so callers pass the raw pointer position exactly
+    /// as they did before #550.
     pub fn hit_test(
         &self,
         x: f32,
@@ -224,17 +301,26 @@ impl DataTableLayout {
             return DataTableHit::Empty;
         }
         if y < self.header_height {
+            // The vertical scrollbar owns its strip outright — never let
+            // horizontally-scrolled column geometry leak underneath it.
+            if self.in_v_scrollbar_strip(x) {
+                return DataTableHit::Empty;
+            }
+            let cx = self.content_x(x);
             // Check dividers first (higher priority than header body).
             for (i, rc) in self.columns.iter().enumerate() {
                 let right_edge = rc.x + rc.width;
-                if (x - right_edge).abs() <= DIVIDER_GRAB_PX && i + 1 < self.columns.len() {
+                if (cx - right_edge).abs() <= DIVIDER_GRAB_PX && i + 1 < self.columns.len() {
                     return DataTableHit::HeaderDivider { col: i };
                 }
             }
+            // No clamping: a `cx` before the first column's left edge or
+            // past the last column's right edge is genuinely *no* column,
+            // not column 0 and not the last column.
             let col = self
                 .columns
                 .iter()
-                .position(|c| x >= c.x && x < c.x + c.width);
+                .position(|c| cx >= c.x && cx < c.x + c.width);
             return match col {
                 Some(col) => DataTableHit::Header { col },
                 None => DataTableHit::Empty,
@@ -256,18 +342,30 @@ impl DataTableLayout {
         DataTableHit::Empty
     }
 
+    /// Which column is painted under viewport-space `x`, if any.
+    ///
+    /// This is the cell-resolution counterpart to [`Self::hit_test`]
+    /// (which reports rows, not cells) and takes `x` in the same
+    /// **viewport space**: `h_scroll` is added back before the lookup,
+    /// and the vertical scrollbar strip resolves to `None` (#550).
     pub fn column_hit(&self, x: f32) -> Option<usize> {
+        if self.in_v_scrollbar_strip(x) {
+            return None;
+        }
+        let cx = self.content_x(x);
         self.columns
             .iter()
-            .position(|c| x >= c.x && x < c.x + c.width)
+            .position(|c| cx >= c.x && cx < c.x + c.width)
     }
 
     /// Compute the `column_overrides` for a divider drag (#521 defect 1).
     ///
     /// `col` is the column to the LEFT of the dragged divider, as
     /// returned by [`DataTableHit::HeaderDivider`]. `pointer_x` is the
-    /// drag pointer's current position, in this layout's coordinate
-    /// space. `min_width` clamps both halves of the dragged pair.
+    /// drag pointer's current position in **viewport space** — the same
+    /// space [`Self::hit_test`] took to produce `col`, so a caller keeps
+    /// forwarding the raw pointer `x` and this converts once, internally
+    /// (#550). `min_width` clamps both halves of the dragged pair.
     ///
     /// A divider is the boundary between column `col` and `col + 1`, so
     /// a drag must only ever move width between *those two* columns,
@@ -316,7 +414,7 @@ impl DataTableLayout {
         let lo = min_width.min(pair_total);
         let hi = (pair_total - min_width).max(lo);
         let col_x = self.columns[col].x;
-        let new_left = (pointer_x - col_x).clamp(lo, hi);
+        let new_left = (self.content_x(pointer_x) - col_x).clamp(lo, hi);
         next[col] = Some(new_left);
         next[col + 1] = Some(pair_total - new_left);
         next
@@ -394,6 +492,7 @@ impl DataTable {
             content_width,
             h_scrollbar_height: h_sb_h,
             footer_height,
+            h_scroll: self.h_scroll,
         }
     }
 }
@@ -1021,6 +1120,308 @@ mod tests {
         let json = serde_json::to_string(&table).unwrap();
         let back: DataTable = serde_json::from_str(&json).unwrap();
         assert_eq!(table, back);
+    }
+
+    // ── #550: `hit_test` must undo the renderer's `h_scroll` shift ──────
+    //
+    // Geometry shared by the tests below: 4 × `Fixed(30.0)` columns laid
+    // out at `min_total_width = 120` inside a 60-wide viewport, so
+    // content space is exactly twice the viewport and every column
+    // boundary lands on a round number.
+    //
+    //   content x:  0───30───60───90───120
+    //   column:      c0 │ c1 │ c2 │ c3
+    //
+    // A backend paints column `i` at `columns[i].x - h_scroll`, so at
+    // `h_scroll = 45` the operator sees c1's right half, all of c2, and
+    // c3's left half — and c0 not at all.
+    fn make_wide_table(nrows: usize) -> DataTable {
+        let mut table = make_table(4, nrows);
+        for c in &mut table.columns {
+            c.width = ColumnWidth::Fixed(30.0);
+        }
+        table.min_total_width = Some(120.0);
+        table
+    }
+
+    fn wide_layout(h_scroll: f32, nrows: usize) -> DataTableLayout {
+        let mut table = make_wide_table(nrows);
+        table.h_scroll = h_scroll;
+        table.layout(60.0, 20.0, 1.0, 1.0, 1.0, |_| ColumnMeasure::new(0.0))
+    }
+
+    /// The pre-#550 algorithm, verbatim, as the oracle for the
+    /// "`h_scroll == 0.0` is bit-identical" acceptance bullet.
+    fn legacy_hit_test(
+        l: &DataTableLayout,
+        x: f32,
+        y: f32,
+        scroll_offset: usize,
+        total_rows: usize,
+    ) -> DataTableHit {
+        if x < 0.0 || y < 0.0 || x >= l.viewport_width || y >= l.viewport_height {
+            return DataTableHit::Empty;
+        }
+        if y < l.header_height {
+            for (i, rc) in l.columns.iter().enumerate() {
+                let right_edge = rc.x + rc.width;
+                if (x - right_edge).abs() <= DIVIDER_GRAB_PX && i + 1 < l.columns.len() {
+                    return DataTableHit::HeaderDivider { col: i };
+                }
+            }
+            return match l.columns.iter().position(|c| x >= c.x && x < c.x + c.width) {
+                Some(col) => DataTableHit::Header { col },
+                None => DataTableHit::Empty,
+            };
+        }
+        let body_bottom = l.header_height + l.visible_rows as f32 * l.row_height;
+        if y < body_bottom {
+            let row_in_viewport = ((y - l.header_height) / l.row_height).floor() as usize;
+            let abs_idx = scroll_offset + row_in_viewport;
+            return if abs_idx < total_rows {
+                DataTableHit::Row { idx: abs_idx }
+            } else {
+                DataTableHit::Empty
+            };
+        }
+        if l.footer_height > 0.0 && y < body_bottom + l.footer_height {
+            return DataTableHit::Footer;
+        }
+        DataTableHit::Empty
+    }
+
+    #[test]
+    fn layout_carries_h_scroll_through_to_the_layout() {
+        assert_eq!(wide_layout(0.0, 10).h_scroll, 0.0);
+        assert_eq!(wide_layout(45.0, 10).h_scroll, 45.0);
+    }
+
+    #[test]
+    fn hit_test_header_resolves_to_the_painted_column_at_every_h_scroll() {
+        // For each offset, walk every viewport cell centre and check the
+        // hit against the column the renderer paints there — derived
+        // from the same `rc.x - h_scroll` the rasterisers use, not from
+        // a hardcoded table.
+        for h_scroll in [0.0_f32, 10.0, 30.0, 45.0, 62.0] {
+            let layout = wide_layout(h_scroll, 10);
+            for cell in 0..60u32 {
+                let x = cell as f32 + 0.5;
+                let content_x = x + h_scroll;
+                // Skip the divider grab zones — they take priority and
+                // are covered by their own test below.
+                let near_divider = layout.columns[..layout.columns.len() - 1]
+                    .iter()
+                    .any(|rc| (content_x - (rc.x + rc.width)).abs() <= DIVIDER_GRAB_PX);
+                if near_divider {
+                    continue;
+                }
+                let painted = layout
+                    .columns
+                    .iter()
+                    .position(|rc| content_x >= rc.x && content_x < rc.x + rc.width);
+                let expected = match painted {
+                    Some(col) => DataTableHit::Header { col },
+                    None => DataTableHit::Empty,
+                };
+                assert_eq!(
+                    layout.hit_test(x, 0.5, 0, 10),
+                    expected,
+                    "h_scroll={h_scroll}, viewport x={x} (content x={content_x})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hit_test_header_at_scroll_that_pushes_the_first_column_off_screen() {
+        // `h_scroll = 45` puts content x 45 at viewport x 0 — c0 (content
+        // 0..30) is entirely off-screen to the left, so *nothing* in the
+        // viewport may resolve to column 0 any more.
+        let layout = wide_layout(45.0, 10);
+        assert_eq!(
+            layout.hit_test(5.0, 0.5, 0, 10),
+            DataTableHit::Header { col: 1 },
+            "viewport x=5 sits over c1's painted right half"
+        );
+        assert_eq!(
+            layout.hit_test(25.0, 0.5, 0, 10),
+            DataTableHit::Header { col: 2 }
+        );
+        assert_eq!(
+            layout.hit_test(50.0, 0.5, 0, 10),
+            DataTableHit::Header { col: 3 }
+        );
+        for cell in 0..60u32 {
+            assert_ne!(
+                layout.hit_test(cell as f32 + 0.5, 0.5, 0, 10),
+                DataTableHit::Header { col: 0 },
+                "column 0 is scrolled fully off-screen; no viewport x may resolve to it \
+                 (viewport x={cell})"
+            );
+        }
+    }
+
+    #[test]
+    fn hit_test_header_past_the_last_column_is_no_column() {
+        // Over-scrolled to the very end: content x 90..120 fills the left
+        // half of the viewport, and the right half is past the last
+        // column's right edge — no column, not a clamp to the last one.
+        let layout = wide_layout(90.0, 10);
+        assert_eq!(
+            layout.hit_test(10.0, 0.5, 0, 10),
+            DataTableHit::Header { col: 3 }
+        );
+        assert_eq!(
+            layout.hit_test(45.0, 0.5, 0, 10),
+            DataTableHit::Empty,
+            "content x=135 is past the 120-wide content — no column lives there"
+        );
+    }
+
+    #[test]
+    fn hit_test_header_divider_follows_h_scroll() {
+        // Divider between c1 and c2 sits at content x 60 → viewport 15
+        // when h_scroll is 45; the one between c2 and c3 (content 90)
+        // lands at viewport 45.
+        let layout = wide_layout(45.0, 10);
+        assert_eq!(
+            layout.hit_test(15.0, 0.5, 0, 10),
+            DataTableHit::HeaderDivider { col: 1 }
+        );
+        assert_eq!(
+            layout.hit_test(45.0, 0.5, 0, 10),
+            DataTableHit::HeaderDivider { col: 2 }
+        );
+        // The *unscrolled* positions of those dividers must no longer
+        // grab: viewport 60 is off-viewport, and viewport 30 is now the
+        // middle of c2.
+        assert_eq!(
+            layout.hit_test(30.0, 0.5, 0, 10),
+            DataTableHit::Header { col: 2 }
+        );
+    }
+
+    #[test]
+    fn column_hit_follows_h_scroll() {
+        let unscrolled = wide_layout(0.0, 10);
+        assert_eq!(unscrolled.column_hit(5.0), Some(0));
+        assert_eq!(unscrolled.column_hit(35.0), Some(1));
+
+        let scrolled = wide_layout(45.0, 10);
+        assert_eq!(scrolled.column_hit(5.0), Some(1));
+        assert_eq!(scrolled.column_hit(25.0), Some(2));
+        assert_eq!(scrolled.column_hit(50.0), Some(3));
+    }
+
+    #[test]
+    fn hit_test_row_index_is_unaffected_by_h_scroll() {
+        // Vertical routing is orthogonal — the same body click resolves
+        // to the same absolute row at every horizontal offset.
+        for h_scroll in [0.0_f32, 30.0, 45.0, 90.0] {
+            let layout = wide_layout(h_scroll, 40);
+            assert_eq!(
+                layout.hit_test(10.0, 3.5, 5, 40),
+                DataTableHit::Row { idx: 7 },
+                "h_scroll={h_scroll} must not shift row resolution"
+            );
+        }
+    }
+
+    #[test]
+    fn scrollbar_strips_keep_priority_when_horizontally_scrolled() {
+        let mut table = make_wide_table(200);
+        table.show_scrollbar = true;
+        table.h_scroll = 45.0;
+        let layout = table.layout(60.0, 20.0, 1.0, 1.0, 1.0, |_| ColumnMeasure::new(0.0));
+        assert!(layout.scrollbar_width > 0.0);
+        assert!(layout.h_scrollbar_height > 0.0);
+
+        // Vertical track: the rightmost `scrollbar_width` columns. Under
+        // h_scroll a naive offset would land this on a real column and
+        // sort it — the track must stay inert instead.
+        let sb_x = layout.viewport_width - layout.scrollbar_width;
+        assert_eq!(
+            layout.hit_test(sb_x + 0.5, 0.5, 0, 200),
+            DataTableHit::Empty,
+            "a vertical-scrollbar track click must not fall through to a header"
+        );
+        assert_eq!(layout.column_hit(sb_x + 0.5), None);
+
+        // Horizontal track: the band below the last body row. It is not
+        // a header and not a row.
+        let body_bottom = layout.header_height + layout.visible_rows as f32 * layout.row_height;
+        let hit = layout.hit_test(10.0, body_bottom + 0.5, 0, 200);
+        assert!(
+            !matches!(hit, DataTableHit::Row { .. } | DataTableHit::Header { .. }),
+            "a horizontal-scrollbar track click must not fall through to a header or a row, \
+             got {hit:?}"
+        );
+    }
+
+    #[test]
+    fn drag_divider_reads_pointer_x_in_viewport_space() {
+        // A divider drag started from a `HeaderDivider` hit keeps passing
+        // the raw viewport pointer x, so the resolved widths must come
+        // out the same whether or not the table is scrolled.
+        let unscrolled = wide_layout(0.0, 10);
+        let baseline = unscrolled.drag_divider(&[], 1, 70.0, 4.0);
+
+        let scrolled = wide_layout(45.0, 10);
+        // Same content-space pointer (70), expressed in viewport space.
+        let dragged = scrolled.drag_divider(&[], 1, 70.0 - 45.0, 4.0);
+        assert_eq!(
+            baseline, dragged,
+            "the same physical divider position must resize identically at any h_scroll"
+        );
+        assert_eq!(dragged[1], Some(40.0), "c1 grows from 30 to 70 - 30 = 40");
+        assert_eq!(dragged[2], Some(20.0), "the pair's 60 total is conserved");
+    }
+
+    #[test]
+    fn h_scroll_zero_hit_testing_is_bit_identical_to_the_pre_change_algorithm() {
+        // Acceptance bullet 3. Swept exhaustively over half-cell
+        // positions across the whole viewport for four table shapes —
+        // with and without a vertical scrollbar, with and without a
+        // footer, narrow and `min_total_width`-wide.
+        let mut shapes: Vec<DataTable> = Vec::new();
+        shapes.push(make_table(4, 40));
+        let mut with_sb = make_table(4, 40);
+        with_sb.show_scrollbar = true;
+        shapes.push(with_sb);
+        let mut with_footer = make_table(3, 40);
+        with_footer.show_scrollbar = true;
+        with_footer.footer = Some(footer_row(3));
+        shapes.push(with_footer);
+        let mut wide = make_wide_table(40);
+        wide.show_scrollbar = true;
+        shapes.push(wide);
+
+        for (i, table) in shapes.iter().enumerate() {
+            assert_eq!(table.h_scroll, 0.0, "shape {i} must pin h_scroll at zero");
+            let layout = table.layout(60.0, 20.0, 1.0, 1.0, 1.0, |_| ColumnMeasure::new(0.0));
+            for cell_x in 0..62u32 {
+                for cell_y in 0..22u32 {
+                    let x = cell_x as f32 + 0.5;
+                    let y = cell_y as f32 + 0.5;
+                    for scroll_offset in [0usize, 7] {
+                        assert_eq!(
+                            layout.hit_test(x, y, scroll_offset, 40),
+                            legacy_hit_test(&layout, x, y, scroll_offset, 40),
+                            "shape {i}: hit_test({x}, {y}, {scroll_offset}, 40) must match the \
+                             pre-#550 algorithm exactly"
+                        );
+                    }
+                    assert_eq!(
+                        layout.column_hit(x),
+                        layout
+                            .columns
+                            .iter()
+                            .position(|c| x >= c.x && x < c.x + c.width),
+                        "shape {i}: column_hit({x}) must match the pre-#550 algorithm exactly"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/quadraui/src/primitives/data_table.rs
+++ b/quadraui/src/primitives/data_table.rs
@@ -38,6 +38,28 @@
 //! space** and adds [`DataTableLayout::h_scroll`] back before comparing
 //! against `columns`. At `h_scroll == 0.0` the two spaces coincide and
 //! the conversion is a no-op (#550).
+//!
+//! ## `h_scroll` must already agree with what was painted
+//!
+//! Pointer positions are **raw pixel/cell coordinates** — for the TUI
+//! backend, `Point::new(event.column as f32, event.row as f32)`
+//! (`tui::events`), an integer cell index, *not* a cell-centre `+ 0.5`.
+//! `DataTableLayout::h_scroll` therefore has to be exactly the value the
+//! renderer subtracted when it painted, not merely "close" to it — any
+//! rounding a backend applies at paint time must already be baked into
+//! the `h_scroll` carried on the layout `hit_test` runs against, because
+//! `hit_test` does no rounding of its own (#550 round 2).
+//!
+//! Pixel backends (GTK/macOS) paint at the exact fractional `h_scroll`,
+//! so the layout's `h_scroll` — copied verbatim from `DataTable::h_scroll`
+//! in [`DataTable::layout`] — already matches. The TUI backend is
+//! cell-granular: it paints at `h_scroll.round()` (`tui::data_table`'s
+//! `h_off`), so `tui::data_table::draw_data_table` overwrites the
+//! returned layout's `h_scroll` with that same rounded value before
+//! returning it, keeping every `hit_test`/`column_hit` call downstream
+//! in agreement with the paint. A caller that hand-builds a
+//! `DataTableLayout` for a cell-granular surface without going through
+//! that backend function must apply the same rounding itself.
 
 use crate::types::{Decoration, Modifiers, StyledText, WidgetId};
 use serde::{Deserialize, Serialize};
@@ -204,7 +226,15 @@ pub enum DataTableHit {
 }
 
 /// Fully-resolved DataTable layout.
+///
+/// `#[non_exhaustive]`: per PRIMITIVE_RULES rule 8, this keeps future
+/// field additions non-breaking regardless of what downstream ends up
+/// doing with the struct. Today (#550) no downstream crate constructs or
+/// pattern-matches this type directly — both `coord-tui` and `vimcode`
+/// only ever receive it from `.layout()` — but there's no reason to
+/// leave that door open for free.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct DataTableLayout {
     pub header_height: f32,
     pub row_height: f32,
@@ -227,14 +257,23 @@ pub struct DataTableLayout {
     /// never overwrites the last body row in cell-granular backends
     /// (TUI) and stays visually breathing-room'd in pixel backends.
     pub footer_height: f32,
-    /// The horizontal scroll offset this layout was painted at — a copy
-    /// of [`DataTable::h_scroll`], carried here so hit-testing can undo
-    /// the same shift the renderer applied (#550).
+    /// The horizontal scroll offset this layout was **painted** at — not
+    /// necessarily a bit-for-bit copy of [`DataTable::h_scroll`], carried
+    /// here so hit-testing can undo the same shift the renderer applied
+    /// (#550).
     ///
     /// Backends paint column `i` at `columns[i].x - h_scroll`, so a
     /// pointer `x` in viewport space maps to `x + h_scroll` in the
     /// content space `columns` is expressed in. `0.0` (the overwhelmingly
     /// common case) makes every conversion an identity.
+    ///
+    /// For pixel backends this is exactly `DataTable::h_scroll`. For
+    /// cell-granular backends (TUI) it is `DataTable::h_scroll.round()`
+    /// — the same rounding the renderer applies before subtracting it
+    /// from each column's `x` — because `hit_test`/`column_hit` add this
+    /// field back with no rounding of their own; a mismatch here
+    /// misroutes clicks whenever `DataTable::h_scroll`'s fractional part
+    /// crosses 0.5 (#550 round 2). See `tui::data_table::draw_data_table`.
     pub h_scroll: f32,
 }
 
@@ -248,12 +287,14 @@ impl DataTableLayout {
     ///
     /// Identity when `h_scroll == 0.0`.
     ///
-    /// Cell-granular backends (TUI) round `h_scroll` to whole cells when
-    /// painting; this deliberately does not, because a click inside cell
-    /// `v` arrives as `v + 0.5` and `floor(v + 0.5 + h)` equals
-    /// `v + round(h)` for every `h >= 0` — the un-rounded add already
-    /// agrees with the rounded paint, and staying in `f32` keeps pixel
-    /// backends exact.
+    /// This performs no rounding of its own — it trusts `self.h_scroll`
+    /// to already be exactly the value the renderer subtracted at paint
+    /// time (see the module-level "`h_scroll` must already agree with
+    /// what was painted" section). Pointer coordinates are raw pixel/cell
+    /// positions, not cell-centres, so there is no `+ 0.5` to lean on:
+    /// a cell-granular backend that fed this an un-rounded `h_scroll`
+    /// while painting at a rounded offset would misroute clicks whenever
+    /// `h_scroll`'s fractional part crosses 0.5 (#550 round 2).
     #[inline]
     fn content_x(&self, x: f32) -> f32 {
         x + self.h_scroll
@@ -326,6 +367,18 @@ impl DataTableLayout {
                 None => DataTableHit::Empty,
             };
         }
+        // Row resolution is intentionally purely `y`-based and does NOT
+        // consult `in_v_scrollbar_strip` — a v-scrollbar-track click here
+        // already fell through to `Row { .. }` before #550 (row
+        // resolution never looked at `x` at all), so this fix does not
+        // regress it. It is, however, still uncovered by this layer: the
+        // issue's acceptance bullet ("a track click must not fall
+        // through to a header or a row") is only satisfied for rows by a
+        // caller intercepting the strip itself before calling
+        // `hit_test` — e.g. coord-tui's `audit_scrollbar_hit`. See
+        // `scrollbar_strips_keep_priority_when_horizontally_scrolled`
+        // (header case) and `v_scrollbar_strip_row_click_is_a_caller_concern`
+        // (documents this row-branch gap) in the tests below.
         let body_bottom = self.header_height + self.visible_rows as f32 * self.row_height;
         if y < body_bottom {
             let row_in_viewport = ((y - self.header_height) / self.row_height).floor() as usize;
@@ -1355,6 +1408,35 @@ mod tests {
             !matches!(hit, DataTableHit::Row { .. } | DataTableHit::Header { .. }),
             "a horizontal-scrollbar track click must not fall through to a header or a row, \
              got {hit:?}"
+        );
+    }
+
+    #[test]
+    fn v_scrollbar_strip_row_click_is_a_caller_concern() {
+        // Documents the non-blocking #550-review gap: unlike the header
+        // branch, `hit_test`'s row branch never consults `x` at all (row
+        // resolution is purely `y`-based, both before and after #550),
+        // so a click over the vertical-scrollbar track on a body row
+        // falls through to `Row { .. }` here rather than `Empty`. This
+        // is pre-existing behaviour, not a #550 regression — asserted
+        // against explicitly so a future change can't silently start
+        // relying on `hit_test` filtering this out. Callers that own a
+        // vertical scrollbar (e.g. coord-tui's `audit_scrollbar_hit`)
+        // are expected to intercept the strip themselves before forwarding
+        // to `hit_test`.
+        let mut table = make_wide_table(200);
+        table.show_scrollbar = true;
+        table.h_scroll = 45.0;
+        let layout = table.layout(60.0, 20.0, 1.0, 1.0, 1.0, |_| ColumnMeasure::new(0.0));
+        assert!(layout.scrollbar_width > 0.0);
+
+        let sb_x = layout.viewport_width - layout.scrollbar_width;
+        let y_in_body = layout.header_height + 0.5;
+        assert_eq!(
+            layout.hit_test(sb_x + 0.5, y_in_body, 0, 200),
+            DataTableHit::Row { idx: 0 },
+            "row branch does not filter the v-scrollbar strip — intentional, see comment on \
+             the row branch in `hit_test`"
         );
     }
 

--- a/quadraui/src/primitives/data_table.rs
+++ b/quadraui/src/primitives/data_table.rs
@@ -52,14 +52,30 @@
 //!
 //! Pixel backends (GTK/macOS) paint at the exact fractional `h_scroll`,
 //! so the layout's `h_scroll` — copied verbatim from `DataTable::h_scroll`
-//! in [`DataTable::layout`] — already matches. The TUI backend is
-//! cell-granular: it paints at `h_scroll.round()` (`tui::data_table`'s
-//! `h_off`), so `tui::data_table::draw_data_table` overwrites the
-//! returned layout's `h_scroll` with that same rounded value before
-//! returning it, keeping every `hit_test`/`column_hit` call downstream
-//! in agreement with the paint. A caller that hand-builds a
-//! `DataTableLayout` for a cell-granular surface without going through
-//! that backend function must apply the same rounding itself.
+//! in [`DataTable::layout`] — already matches, and both their
+//! `draw_data_table` and their `Backend::data_table_layout` are
+//! self-consistent for free.
+//!
+//! The TUI backend is cell-granular: it paints at `h_scroll.round()`
+//! (`tui::data_table`'s `h_off`), so it must overwrite the returned
+//! layout's `h_scroll` with that same rounded value. It does that in one
+//! place — [`tui::data_table_layout`](crate::tui::data_table_layout) —
+//! which **both** `tui::data_table::draw_data_table` and
+//! `Backend::data_table_layout` route through, so the layout-on-demand
+//! hit-test path (no repaint) agrees with the paint path bit-for-bit.
+//! Adding a third TUI entry point that calls [`DataTable::layout`]
+//! directly would reopen #550; go through `tui::data_table_layout`
+//! instead. The same applies to any caller that hand-builds a
+//! `DataTableLayout` for a cell-granular surface: it must apply the
+//! rounding itself.
+//!
+//! One residual, pre-existing and unrelated to `h_scroll`: the TUI paint
+//! loop rounds each column's `rc.x` and the scroll offset independently
+//! (`rc.x.round() - h_off`), while `hit_test` compares against the
+//! continuous `rc.x`. For columns whose resolved boundaries aren't
+//! integers (`Flex`/`Content` widths that don't divide evenly) the two
+//! can disagree by up to one cell. That predates #550 and is not
+//! addressed here.
 
 use crate::types::{Decoration, Modifiers, StyledText, WidgetId};
 use serde::{Deserialize, Serialize};
@@ -273,7 +289,10 @@ pub struct DataTableLayout {
     /// from each column's `x` — because `hit_test`/`column_hit` add this
     /// field back with no rounding of their own; a mismatch here
     /// misroutes clicks whenever `DataTable::h_scroll`'s fractional part
-    /// crosses 0.5 (#550 round 2). See `tui::data_table::draw_data_table`.
+    /// crosses 0.5 (#550 round 2). Both TUI entry points that produce a
+    /// layout — `tui::data_table::draw_data_table` and
+    /// `Backend::data_table_layout` — apply it via
+    /// [`tui::data_table_layout`](crate::tui::data_table_layout).
     pub h_scroll: f32,
 }
 

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -876,15 +876,14 @@ impl Backend for TuiBackend {
     }
 
     fn data_table_layout(&self, rect: QRect, table: &crate::DataTable) -> crate::DataTableLayout {
+        // Must go through the *same* resolver `draw_data_table` uses —
+        // in particular the cell-granular `h_scroll.round()`. This is the
+        // cache-free, layout-on-demand path real apps hit-test through
+        // (see `examples/common/data_table_app.rs`), so resolving the
+        // geometry independently here reopened #550 for every fractional
+        // `h_scroll` (round 3).
         let area = q_rect_to_ratatui(rect);
-        table.layout(
-            area.width as f32,
-            area.height as f32,
-            1.0,
-            1.0,
-            1.0,
-            |col| crate::ColumnMeasure::new(col.title.chars().count() as f32),
-        )
+        crate::tui::data_table_layout(area, table)
     }
 
     fn list_hscrollbar(&self, rect: QRect, list: &ListView) -> Option<crate::Scrollbar> {
@@ -2531,6 +2530,102 @@ mod tests {
             binding: KeyBinding::Literal(binding.to_string()),
             scope: AcceleratorScope::Global,
             label: None,
+        }
+    }
+
+    /// Four `Fixed(30.0)` columns (content boundaries 0/30/60/90/120)
+    /// in a 60-wide viewport — the #550 repro geometry.
+    fn wide_hscroll_table() -> crate::DataTable {
+        crate::DataTable {
+            id: WidgetId::new("wide-hscroll"),
+            columns: ["a", "b", "c", "d"]
+                .iter()
+                .map(|t| crate::Column {
+                    title: (*t).into(),
+                    width: crate::ColumnWidth::Fixed(30.0),
+                    align: crate::ColumnAlign::Left,
+                })
+                .collect(),
+            rows: vec![crate::DataRow {
+                cells: vec![
+                    StyledText::plain("a-one"),
+                    StyledText::plain("b-two"),
+                    StyledText::plain("c-three"),
+                    StyledText::plain("d-four"),
+                ],
+                decoration: crate::Decoration::Normal,
+            }],
+            selected_idx: None,
+            scroll_offset: 0,
+            sort: None,
+            has_focus: false,
+            show_scrollbar: false,
+            min_total_width: Some(120.0),
+            h_scroll: 0.0,
+            column_overrides: Vec::new(),
+            footer: None,
+        }
+    }
+
+    /// #550 round 3: `Backend::data_table_layout` is the *cache-free,
+    /// layout-on-demand* hit-test path (see
+    /// `examples/common/data_table_app.rs`, which calls it from every
+    /// mouse handler without repainting). It resolved geometry with its
+    /// own `table.layout(..)` call and so returned the raw fractional
+    /// `h_scroll`, while `draw_data_table` painted at the rounded one —
+    /// reopening the original defect through a second entry point.
+    #[test]
+    fn data_table_layout_rounds_h_scroll_like_the_renderer() {
+        let backend = TuiBackend::new();
+        let rect = QRect::new(0.0, 0.0, 60.0, 3.0);
+        let mut table = wide_hscroll_table();
+
+        // A trackpad/wheel h-scroll lands on an arbitrary fraction; the
+        // example's `UiEvent::Scroll` handler does no rounding at all.
+        table.h_scroll = 23.7;
+        let layout = backend.data_table_layout(rect, &table);
+        assert_eq!(
+            layout.h_scroll, 24.0,
+            "layout-on-demand must carry the same rounded offset the renderer paints at"
+        );
+
+        // The review's exact repro value, and the click it misroutes.
+        table.h_scroll = 15.6;
+        let layout = backend.data_table_layout(rect, &table);
+        assert_eq!(layout.h_scroll, 16.0);
+        assert_eq!(
+            layout.column_hit(14.0),
+            Some(1),
+            "integer click x=14 sits on c1 as painted at h_scroll=15.6"
+        );
+        assert_ne!(
+            layout.column_hit(14.0),
+            Some(0),
+            "un-rounded 15.6 would put this at content x=29.6, inside c0"
+        );
+    }
+
+    /// The two TUI entry points must be interchangeable: a consumer that
+    /// hit-tests against a repaint-free layout has to land on exactly
+    /// what the last `draw_data_table` put on screen.
+    #[test]
+    fn data_table_layout_matches_draw_data_table_at_every_fractional_offset() {
+        let backend = TuiBackend::new();
+        let rect = QRect::new(0.0, 0.0, 60.0, 3.0);
+        let area = q_rect_to_ratatui(rect);
+        let mut table = wide_hscroll_table();
+
+        for tenths in 0..=600u32 {
+            table.h_scroll = tenths as f32 / 10.0;
+            let on_demand = backend.data_table_layout(rect, &table);
+            let mut buf = ratatui::buffer::Buffer::empty(area);
+            let painted =
+                crate::tui::draw_data_table(&mut buf, area, &table, &backend.current_theme, None);
+            assert_eq!(
+                on_demand, painted,
+                "layouts diverged at h_scroll = {}",
+                table.h_scroll
+            );
         }
     }
 

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1846,6 +1846,7 @@ mod tests {
                 content_width: 0.0,
                 h_scrollbar_height: 0.0,
                 footer_height: 0.0,
+                h_scroll: 0.0,
             }
         }
         fn data_table_layout(
@@ -1864,6 +1865,7 @@ mod tests {
                 content_width: 0.0,
                 h_scrollbar_height: 0.0,
                 footer_height: 0.0,
+                h_scroll: 0.0,
             }
         }
         fn list_hscrollbar(&self, _rect: QRect, _list: &ListView) -> Option<crate::Scrollbar> {

--- a/quadraui/src/tui/data_table.rs
+++ b/quadraui/src/tui/data_table.rs
@@ -15,6 +15,40 @@ use crate::primitives::data_table::{
 };
 use crate::theme::Theme;
 
+/// Resolve the layout `draw_data_table` paints `table` at, without
+/// touching a buffer.
+///
+/// This is the **single** definition of TUI DataTable geometry: both
+/// [`draw_data_table`] and `Backend::data_table_layout` go through it,
+/// so the layout a cache-free, layout-on-demand hit-test runs against is
+/// bit-for-bit the layout that was painted. Resolving the geometry in
+/// two places instead let them drift on the `h_scroll` rounding below
+/// (#550 round 3) — don't reintroduce a second `table.layout(..)` call
+/// site for the TUI.
+pub fn data_table_layout(area: Rect, table: &DataTable) -> DataTableLayout {
+    let mut layout = table.layout(
+        area.width as f32,
+        area.height as f32,
+        1.0,
+        1.0,
+        1.0,
+        |col| ColumnMeasure::new(col.title.chars().count() as f32),
+    );
+
+    // TUI is cell-granular: every column paints at a *rounded* offset
+    // (`draw_data_table`'s `h_off`), not the raw fractional `h_scroll`.
+    // `hit_test` / `column_hit` do no rounding of their own — they trust
+    // `DataTableLayout::h_scroll` to already equal what was painted — so
+    // this must be rounded here, once, before the layout is handed back
+    // to callers for hit-testing. Skipping this left a gap whenever
+    // `h_scroll`'s fractional part crossed 0.5: painting rounded up a
+    // full cell while hit-testing added the un-rounded value back,
+    // misrouting clicks on the leftmost visible cell of whichever column
+    // scrolled into view (#550 round 2).
+    layout.h_scroll = table.h_scroll.round();
+    layout
+}
+
 /// Draw a `DataTable` into `area`. `hovered_idx` carries per-frame
 /// hover state so the rasteriser can tint the hovered row. Returns
 /// the layout used for painting so callers can hit-test at the same
@@ -26,26 +60,7 @@ pub fn draw_data_table(
     theme: &Theme,
     hovered_idx: Option<usize>,
 ) -> DataTableLayout {
-    let mut layout = table.layout(
-        area.width as f32,
-        area.height as f32,
-        1.0,
-        1.0,
-        1.0,
-        |col| ColumnMeasure::new(col.title.chars().count() as f32),
-    );
-
-    // TUI is cell-granular: every column paints at a *rounded* offset
-    // (`h_off` below), not the raw fractional `h_scroll`. `hit_test` /
-    // `column_hit` do no rounding of their own — they trust
-    // `DataTableLayout::h_scroll` to already equal what was painted — so
-    // this must be rounded here, once, before the layout is handed back
-    // to callers for hit-testing. Skipping this left a gap whenever
-    // `h_scroll`'s fractional part crossed 0.5: painting rounded up a
-    // full cell while hit-testing added the un-rounded value back,
-    // misrouting clicks on the leftmost visible cell of whichever column
-    // scrolled into view (#550 round 2).
-    layout.h_scroll = table.h_scroll.round();
+    let layout = data_table_layout(area, table);
 
     if area.width == 0 || area.height == 0 {
         return layout;
@@ -982,7 +997,10 @@ mod tests {
         let mut buf = Buffer::empty(area);
         let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
 
-        assert_eq!(layout.h_scroll, 16.0, "TUI layout must carry the rounded offset");
+        assert_eq!(
+            layout.h_scroll, 16.0,
+            "TUI layout must carry the rounded offset"
+        );
 
         // Raw integer coordinate (no `+ 0.5`), exactly as `tui::events`
         // constructs a real pointer position.

--- a/quadraui/src/tui/data_table.rs
+++ b/quadraui/src/tui/data_table.rs
@@ -26,7 +26,7 @@ pub fn draw_data_table(
     theme: &Theme,
     hovered_idx: Option<usize>,
 ) -> DataTableLayout {
-    let layout = table.layout(
+    let mut layout = table.layout(
         area.width as f32,
         area.height as f32,
         1.0,
@@ -34,6 +34,18 @@ pub fn draw_data_table(
         1.0,
         |col| ColumnMeasure::new(col.title.chars().count() as f32),
     );
+
+    // TUI is cell-granular: every column paints at a *rounded* offset
+    // (`h_off` below), not the raw fractional `h_scroll`. `hit_test` /
+    // `column_hit` do no rounding of their own — they trust
+    // `DataTableLayout::h_scroll` to already equal what was painted — so
+    // this must be rounded here, once, before the layout is handed back
+    // to callers for hit-testing. Skipping this left a gap whenever
+    // `h_scroll`'s fractional part crossed 0.5: painting rounded up a
+    // full cell while hit-testing added the un-rounded value back,
+    // misrouting clicks on the leftmost visible cell of whichever column
+    // scrolled into view (#550 round 2).
+    layout.h_scroll = table.h_scroll.round();
 
     if area.width == 0 || area.height == 0 {
         return layout;
@@ -53,7 +65,10 @@ pub fn draw_data_table(
     }
 
     let sep_fg = ratatui_color(theme.separator);
-    let h_off = table.h_scroll.round() as i16;
+    // Same rounded value now carried on `layout.h_scroll` — kept as a
+    // local `i16` here since every paint-position computation below
+    // works in signed cell-offset arithmetic.
+    let h_off = layout.h_scroll as i16;
 
     for (col_idx, rc) in layout.columns.iter().enumerate() {
         if col_idx >= table.columns.len() {
@@ -898,6 +913,164 @@ mod tests {
                 "h_scroll={h_scroll} painted no fully-visible body cell — the assertion loop \
                  above would be vacuous\nrow: {row:?}"
             );
+        }
+    }
+
+    // ── #550 round 2: raw integer pointer coordinates, fractional h_scroll ──
+    //
+    // Every test above (and the primitive-layer sweep in
+    // `primitives::data_table::tests`) drives `hit_test` with cell-centre
+    // coordinates (`cell as f32 + 0.5`). Real TUI pointer input is never
+    // that: `tui::events` builds it as
+    // `Point::new(event.column as f32, event.row as f32)` — a raw
+    // integer cell index. The two only coincide when `h_scroll`'s
+    // fractional part is `< 0.5`; above that, painting rounds up a full
+    // cell while a `+ 0.5` click coordinate still lands inside the
+    // "old" rounding bucket and hides the gap. These tests use raw
+    // integer `x`, matching real input, at deliberately fractional
+    // `h_scroll` values whose fractional part is `>= 0.5`.
+
+    /// Exactly the geometry from the #550 round-2 review: 4 ×
+    /// `Fixed(30.0)` columns (content boundaries 0/30/60/90/120) inside a
+    /// 60-wide viewport.
+    fn make_wide_hscroll_table() -> DataTable {
+        let titles = ["Alpha", "Bravo", "Charlie", "Delta"];
+        DataTable {
+            id: WidgetId::new("wide-hscroll"),
+            columns: titles
+                .iter()
+                .map(|t| Column {
+                    title: (*t).into(),
+                    width: ColumnWidth::Fixed(30.0),
+                    align: ColumnAlign::Left,
+                })
+                .collect(),
+            rows: vec![DataRow {
+                cells: vec![
+                    StyledText::plain("a-one"),
+                    StyledText::plain("b-two"),
+                    StyledText::plain("c-three"),
+                    StyledText::plain("d-four"),
+                ],
+                decoration: Decoration::Normal,
+            }],
+            selected_idx: None,
+            scroll_offset: 0,
+            sort: None,
+            has_focus: false,
+            show_scrollbar: false,
+            min_total_width: Some(120.0),
+            h_scroll: 0.0,
+            column_overrides: Vec::new(),
+            footer: None,
+        }
+    }
+
+    #[test]
+    fn raw_integer_click_at_fractional_h_scroll_hits_the_painted_column() {
+        // The exact repro from the #550 round-2 review: h_scroll = 15.6
+        // → h_off = round(15.6) = 16. The renderer paints column c1
+        // (content [30,60)) at screen [14,44). A real click at integer
+        // screen x=14 is squarely on c1 as painted, and `column_hit` —
+        // the divider-agnostic "which column is painted here" query — is
+        // the API the review's repro exercises directly (it has no
+        // resize-grab zone to land in, unlike `hit_test`'s header
+        // branch; see the next test for that case).
+        let area = Rect::new(0, 0, 60, 3);
+        let mut table = make_wide_hscroll_table();
+        table.h_scroll = 15.6;
+        let mut buf = Buffer::empty(area);
+        let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+        assert_eq!(layout.h_scroll, 16.0, "TUI layout must carry the rounded offset");
+
+        // Raw integer coordinate (no `+ 0.5`), exactly as `tui::events`
+        // constructs a real pointer position.
+        assert_eq!(
+            layout.column_hit(14.0),
+            Some(1),
+            "integer click x=14 sits on c1's painted left edge at h_scroll=15.6"
+        );
+
+        // The pre-fix bug: adding the *un-rounded* 15.6 back would put
+        // this at content x=29.6, inside c0's [0,30) — never c1's.
+        assert_ne!(layout.column_hit(14.0), Some(0));
+
+        // The header branch of `hit_test` sits at the exact same screen
+        // x, but content x=30 lands precisely on the c0/c1 divider's
+        // grab zone (`DIVIDER_GRAB_PX = 3.0`), so per the review's own
+        // analysis it resolves to `HeaderDivider` rather than either
+        // header — never the *wrong* header (`Header { col: 0 }`, the
+        // original defect this fix closes).
+        assert_eq!(
+            layout.hit_test(14.0, 0.0, 0, table.rows.len()),
+            DataTableHit::HeaderDivider { col: 0 },
+            "residual at an exact boundary falls in the pre-existing divider grab zone"
+        );
+        assert_ne!(
+            layout.hit_test(14.0, 0.0, 0, table.rows.len()),
+            DataTableHit::Header { col: 0 },
+        );
+    }
+
+    #[test]
+    fn raw_integer_body_click_at_fractional_h_scroll_hits_the_painted_column() {
+        // Same geometry, but a body-row click — the "cell hit" half of
+        // the same repro.
+        let area = Rect::new(0, 0, 60, 3);
+        let mut table = make_wide_hscroll_table();
+        table.h_scroll = 15.6;
+        let mut buf = Buffer::empty(area);
+        let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+        assert_eq!(
+            layout.hit_test(14.0, 1.0, 0, table.rows.len()),
+            DataTableHit::Row { idx: 0 },
+            "row resolution is unaffected by h_scroll rounding"
+        );
+        assert_eq!(layout.column_hit(14.0), Some(1));
+    }
+
+    #[test]
+    fn raw_integer_header_click_at_fractional_h_scroll_does_not_silently_arm_a_resize_drag() {
+        // The header-click half of the same repro, at several fractional
+        // offsets whose fractional part is >= 0.5: the residual always
+        // falls inside DIVIDER_GRAB_PX of *some* boundary (by
+        // construction — see the module doc), so per #550's own
+        // analysis this resolves to `HeaderDivider`, not a wrong
+        // `Header`. This test pins that this is the ONLY acceptable
+        // non-exact-header outcome — never a header for a different,
+        // wrong column (the original defect: a sort click silently
+        // hitting the wrong column instead of silently arming a
+        // resize-drag).
+        let area = Rect::new(0, 0, 60, 3);
+        for h_scroll in [15.6_f32, 45.7, 75.9] {
+            let mut table = make_wide_hscroll_table();
+            table.h_scroll = h_scroll;
+            let mut buf = Buffer::empty(area);
+            let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+            let h_off = h_scroll.round();
+
+            for x in 0..60u16 {
+                let hit = layout.hit_test(x as f32, 0.0, 0, table.rows.len());
+                if let DataTableHit::Header { col } = hit {
+                    // The column this integer x resolves to must be the
+                    // column actually painted there — content x is
+                    // `x + h_off` (the rounded offset baked into
+                    // `layout.h_scroll`).
+                    let content_x = x as f32 + h_off;
+                    let painted = layout
+                        .columns
+                        .iter()
+                        .position(|rc| content_x >= rc.x && content_x < rc.x + rc.width);
+                    assert_eq!(
+                        painted,
+                        Some(col),
+                        "h_scroll={h_scroll}: integer x={x} resolved to Header{{col: {col}}} \
+                         but the renderer paints column {painted:?} there"
+                    );
+                }
+            }
         }
     }
 

--- a/quadraui/src/tui/data_table.rs
+++ b/quadraui/src/tui/data_table.rs
@@ -775,6 +775,172 @@ mod tests {
         );
     }
 
+    // ── #550: paint/click round-trip under horizontal scrolling ────────
+
+    /// A table laid out wider than its viewport, so `h_scroll` is
+    /// genuinely drivable: 4 × `Fixed(12.0)` columns (48 content cells)
+    /// inside a 24-cell viewport.
+    fn make_h_scrolling_table() -> DataTable {
+        let titles = ["Alpha", "Bravo", "Charlie", "Delta"];
+        DataTable {
+            id: WidgetId::new("hscroll"),
+            columns: titles
+                .iter()
+                .map(|t| Column {
+                    title: (*t).into(),
+                    width: ColumnWidth::Fixed(12.0),
+                    align: ColumnAlign::Left,
+                })
+                .collect(),
+            rows: vec![DataRow {
+                cells: vec![
+                    StyledText::plain("a-one"),
+                    StyledText::plain("b-two"),
+                    StyledText::plain("c-three"),
+                    StyledText::plain("d-four"),
+                ],
+                decoration: Decoration::Normal,
+            }],
+            selected_idx: None,
+            scroll_offset: 0,
+            sort: None,
+            has_focus: false,
+            show_scrollbar: false,
+            min_total_width: Some(48.0),
+            h_scroll: 0.0,
+            column_overrides: Vec::new(),
+            footer: None,
+        }
+    }
+
+    /// The core #550 round-trip: whatever header title the rasteriser
+    /// paints at a given screen cell, hit-testing that cell must name the
+    /// same column — at every scroll offset, including one large enough
+    /// to push the first column fully off-screen.
+    #[test]
+    fn h_scrolled_header_click_resolves_to_the_painted_column() {
+        let area = Rect::new(0, 0, 24, 6);
+        // 0 → nothing scrolled; 14 → "Alpha" partially off; 30 → "Alpha"
+        // and "Bravo" both fully off-screen.
+        for h_scroll in [0.0_f32, 6.0, 14.0, 30.0] {
+            let mut table = make_h_scrolling_table();
+            table.h_scroll = h_scroll;
+            let mut buf = Buffer::empty(area);
+            let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+            let header: String = (0..area.width)
+                .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+                .collect();
+
+            let mut checked = 0;
+            for (col_idx, col) in table.columns.iter().enumerate() {
+                let Some(pos) = find_char_pos(&header, &col.title) else {
+                    continue; // title scrolled off (or clipped) — nothing to click
+                };
+                checked += 1;
+                // Click the last painted char of the title: still inside
+                // the column, and for a fully-visible title far enough
+                // from the left edge that the previous column's divider
+                // grab zone can't claim it.
+                let x = pos + col.title.chars().count() - 1;
+                assert_eq!(
+                    layout.hit_test(x as f32 + 0.5, 0.5, 0, table.rows.len()),
+                    DataTableHit::Header { col: col_idx },
+                    "h_scroll={h_scroll}: cell {x} paints '{}' but hit-tests elsewhere\n\
+                     header: {header:?}",
+                    col.title
+                );
+            }
+            assert!(
+                checked > 0,
+                "h_scroll={h_scroll} painted no fully-visible header title — the assertion \
+                 loop above would be vacuous\nheader: {header:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn h_scrolled_body_cell_click_resolves_to_the_painted_column() {
+        let area = Rect::new(0, 0, 24, 6);
+        for h_scroll in [0.0_f32, 6.0, 14.0, 30.0] {
+            let mut table = make_h_scrolling_table();
+            table.h_scroll = h_scroll;
+            let mut buf = Buffer::empty(area);
+            let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+            let row: String = (0..area.width)
+                .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+                .collect();
+
+            let mut checked = 0;
+            for (col_idx, cell) in table.rows[0].cells.iter().enumerate() {
+                let text: String = cell.spans.iter().map(|s| s.text.as_str()).collect();
+                let Some(pos) = find_char_pos(&row, &text) else {
+                    continue;
+                };
+                checked += 1;
+                // The body band still routes to a row...
+                assert_eq!(
+                    layout.hit_test(pos as f32 + 0.5, 1.5, 0, table.rows.len()),
+                    DataTableHit::Row { idx: 0 },
+                    "h_scroll={h_scroll}: body click should stay row 0"
+                );
+                // ...and `column_hit` names the cell painted there.
+                assert_eq!(
+                    layout.column_hit(pos as f32 + 0.5),
+                    Some(col_idx),
+                    "h_scroll={h_scroll}: cell {pos} paints '{text}' but column_hit disagrees\n\
+                     row: {row:?}"
+                );
+            }
+            assert!(
+                checked > 0,
+                "h_scroll={h_scroll} painted no fully-visible body cell — the assertion loop \
+                 above would be vacuous\nrow: {row:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn h_scrolled_header_divider_click_resolves_to_the_painted_separator() {
+        let area = Rect::new(0, 0, 24, 6);
+        for h_scroll in [0.0_f32, 6.0, 14.0, 30.0] {
+            let mut table = make_h_scrolling_table();
+            table.h_scroll = h_scroll;
+            let mut buf = Buffer::empty(area);
+            let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+            // The rasteriser paints '│' on the right edge cell of every
+            // column but the last, i.e. one cell *before* the boundary
+            // `hit_test` measures the grab zone from.
+            let painted_seps: Vec<u16> = (0..area.width)
+                .filter(|&x| buf[(x, 0)].symbol() == "│")
+                .collect();
+            assert!(
+                !painted_seps.is_empty(),
+                "h_scroll={h_scroll}: expected at least one painted separator"
+            );
+            for sep_x in painted_seps {
+                let hit = layout.hit_test(sep_x as f32 + 0.5, 0.5, 0, table.rows.len());
+                let DataTableHit::HeaderDivider { col } = hit else {
+                    panic!(
+                        "h_scroll={h_scroll}: separator painted at x={sep_x} must hit-test as a \
+                         divider, got {hit:?}"
+                    );
+                };
+                // Round-trip the column index back to the boundary it
+                // owns and confirm it is the one painted here.
+                let boundary = layout.columns[col].x + layout.columns[col].width;
+                assert!(
+                    ((boundary - h_scroll) - (sep_x as f32 + 1.0)).abs() < 0.01,
+                    "h_scroll={h_scroll}: separator at x={sep_x} resolved to divider {col}, \
+                     whose boundary paints at {}",
+                    boundary - h_scroll
+                );
+            }
+        }
+    }
+
     #[test]
     fn vertical_scrollbar_track_excludes_footer_band() {
         // Regression guard: the vertical scrollbar's track must span

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -72,7 +72,7 @@ pub use chart::{draw_chart, tui_chart_layout};
 pub use command_center::{draw_command_center, tui_command_center_layout};
 pub use completions::draw_completions;
 pub use context_menu::{draw_context_menu, draw_context_menu_with_submenus};
-pub use data_table::draw_data_table;
+pub use data_table::{data_table_layout, draw_data_table};
 pub use dialog::{draw_dialog, tui_dialog_layout};
 pub use diff_view::draw_diff_view;
 pub use drop_overlay::draw_drop_overlay;

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -2108,6 +2108,124 @@ fn data_table_divider_before_last_column_resizes_in_drag_direction() {
     );
 }
 
+// ─── DataTableApp: horizontally-scrolled click routing (#550) ──────────────
+//
+// `DataTableApp` sets `min_total_width = 80` cells, so a viewport
+// narrower than that lays the columns out wider than the visible area
+// and `h_scroll` becomes genuinely drivable (`L`/`H` step it by 5).
+//
+// Before #550 the renderer subtracted `h_scroll` when painting but
+// `DataTableLayout::hit_test` did not add it back, so every click
+// resolved against the *unscrolled* column geometry — the defect
+// coord-tui had latent in its Audit table (claude-coordinator#1853),
+// where a header click sorted whichever column happened to sit at that
+// x before scrolling.
+
+/// Which column title carries the sort indicator, read off the painted
+/// header row. The status bar's `sort:` segment is the more direct
+/// signal but does not fit in the narrow viewport these tests need to
+/// force horizontal scrolling in the first place, so the header's own
+/// `▲`/`▼` suffix is the observable.
+fn sorted_header(screen: &str) -> Option<&'static str> {
+    let header = screen.lines().next()?;
+    ["Name", "Status", "Age", "Restarts"]
+        .into_iter()
+        .find(|title| {
+            header.contains(&format!("{title} ▲")) || header.contains(&format!("{title} ▼"))
+        })
+}
+
+/// The Audit regression: with the table scrolled horizontally, clicking
+/// a painted header must sort *that* column — not the one that used to
+/// occupy those cells at `h_scroll == 0`.
+#[test]
+fn data_table_h_scrolled_header_click_sorts_the_column_under_the_cursor() {
+    let mut driver = TuiDriver::new(DataTableApp::new(), 50, 26);
+    assert_eq!(
+        sorted_header(&driver.screen()),
+        Some("Name"),
+        "app starts sorted by Name:\n{}",
+        driver.screen()
+    );
+
+    // Scroll right far enough that "Status" no longer sits over the
+    // cells "Name" occupied at rest.
+    let unscrolled_status_x = driver
+        .find("Status")
+        .unwrap_or_else(|| panic!("Status header not painted:\n{}", driver.screen()))
+        .0;
+    for _ in 0..6 {
+        driver.type_char('L');
+    }
+    let screen = driver.screen();
+    let (status_x, status_y) = driver
+        .find("Status")
+        .unwrap_or_else(|| panic!("Status header not painted after scrolling:\n{screen}"));
+    assert_eq!(
+        status_y, 0.5,
+        "Status should be on the header row:\n{screen}"
+    );
+    assert!(
+        status_x < unscrolled_status_x - 1.0,
+        "'L' should have scrolled the Status header left (was {unscrolled_status_x}, \
+         now {status_x}):\n{screen}"
+    );
+
+    // Click a few cells into the title, clear of the preceding column's
+    // ±3-cell divider grab zone.
+    driver.click(status_x + 4.0, status_y);
+
+    let after = driver.screen();
+    assert_eq!(
+        sorted_header(&after),
+        Some("Status"),
+        "clicking the painted 'Status' header while h-scrolled must sort Status, and must \
+         not sort whichever column occupied those cells before scrolling (the \
+         claude-coordinator#1853 mis-routing):\n{after}"
+    );
+}
+
+/// `h_scroll == 0` routing is untouched: the same header click sorts the
+/// same column it always did.
+#[test]
+fn data_table_unscrolled_header_click_still_sorts_that_column() {
+    let mut driver = TuiDriver::new(DataTableApp::new(), 50, 26);
+    let (x, y) = driver
+        .find("Status")
+        .unwrap_or_else(|| panic!("Status header not painted:\n{}", driver.screen()));
+    driver.click(x + 4.0, y);
+    let after = driver.screen();
+    assert_eq!(
+        sorted_header(&after),
+        Some("Status"),
+        "unscrolled header click must keep routing to the column under the cursor:\n{after}"
+    );
+}
+
+/// A body click while h-scrolled still selects the row under the cursor
+/// — the vertical axis is orthogonal to `h_scroll` and must not shift.
+#[test]
+fn data_table_h_scrolled_body_click_selects_the_row_under_the_cursor() {
+    let mut driver = TuiDriver::new(DataTableApp::new(), 50, 26);
+    for _ in 0..6 {
+        driver.type_char('L');
+    }
+    let screen = driver.screen();
+    // "Running" is a Status-column value; at this scroll offset it is
+    // painted well left of where it sits at rest.
+    let (x, y) = driver
+        .find("Running")
+        .unwrap_or_else(|| panic!("no Running row painted while scrolled:\n{screen}"));
+    driver.click(x, y);
+    let after = driver.screen();
+    let expected_row = y as usize; // header occupies row 0, body starts at 1
+    assert!(
+        after.contains(&format!("row {expected_row} / 20")),
+        "a body click while h-scrolled should select the row it landed on \
+         (expected row {expected_row}):\n{after}"
+    );
+}
+
 // ─── HelpLayerDemo (#431): context-sensitive help registry + cheatsheet ────
 //
 // `HelpLayerDemo` implements `ShellApp` with two panels ("Explorer" and


### PR DESCRIPTION
Closes #550

Automated PR opened by coordinator for review of issue #550.