### PR TITLE
#552: [retry] AppShell double-counts activity_bar_bounds.y on TUI — activity-bar clicks and hover go off-by-one once the title bar is revealed

### DIFF
--- a/quadraui/examples/common/appshell_demo.rs
+++ b/quadraui/examples/common/appshell_demo.rs
@@ -21,11 +21,51 @@
 //! `AppShell` that can drift from what's on screen (the class of `Ctrl+B`
 //! bug this issue fixes).
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use quadraui::compose::app_shell::{AppShellEvent, AppShellLayout, PanelDefinition};
 use quadraui::{
     Backend, Color, Key, Modifiers, NamedKey, Reaction, Rect, ShellApp, ShellConfig, ShellContext,
     StatusBar, StatusBarSegment, UiEvent, WidgetId,
 };
+
+/// Shared handle onto the activity-bar rect the shell last handed this
+/// app in `render_content`, in the backend's native units.
+///
+/// Exists for the issue #552 regression tests: they must click the
+/// *n*-th activity-bar row after revealing the title bar, and the row
+/// origin differs per backend (TUI cells vs GTK pixels). Reading the
+/// real painted bounds beats hardcoding a coordinate that would be
+/// silently wrong on one backend — and `driver_with_shell` hands back a
+/// driver over the opaque `ShellAdapter`, so `driver.app()` cannot reach
+/// this `ShellApp` directly.
+#[derive(Clone, Default)]
+pub struct ActivityProbe {
+    bounds: Rc<Cell<Option<Rect>>>,
+    hovered: Rc<Cell<Option<usize>>>,
+}
+
+// This module is `#[path]`-included by several test binaries and by the
+// `tui_/gtk_appshell_demo` examples. Only `cross_backend_parity` reads the
+// probe, so every other target sees these accessors as dead — the standard
+// cost of a shared example module, not a sign they're unused.
+#[allow(dead_code)]
+impl ActivityProbe {
+    /// The activity bar's rect as of the most recent frame.
+    pub fn bounds(&self) -> Option<Rect> {
+        self.bounds.get()
+    }
+
+    /// `AppShell::hovered_activity_idx()` as of the last pointer move
+    /// this app saw. `AppShell` reports `MouseMoved` as `Ignored`, so the
+    /// event reaches `ShellApp::handle` *after* the shell has already
+    /// updated its hover state — making this an honest read of what the
+    /// shell decided, not a re-derivation.
+    pub fn hovered_idx(&self) -> Option<usize> {
+        self.hovered.get()
+    }
+}
 
 pub struct AppShellDemo {
     last_event: String,
@@ -35,16 +75,29 @@ pub struct AppShellDemo {
     /// jump straight to a panel (no ActivityBar click) and still get the
     /// ActivityBar highlight + sidebar header updated to match.
     pending_panel: Option<WidgetId>,
+    /// Written every frame from `render_content`; read by tests.
+    probe: ActivityProbe,
 }
 
 impl AppShellDemo {
     pub fn new() -> Self {
         Self {
             last_event: "Tab=focus bar | click icons | drag divider | p=jump to Source Control \
-                         | Ctrl+B=toggle sidebar | q=quit"
+                         | Ctrl+B=toggle sidebar | t=toggle title bar | q=quit"
                 .into(),
             pending_panel: None,
+            probe: ActivityProbe::default(),
         }
+    }
+
+    /// Clone the activity-bar geometry handle before moving `self` into a
+    /// driver. See [`ActivityProbe`].
+    ///
+    /// Dead in every target except `cross_backend_parity` — see the note
+    /// on `impl ActivityProbe`.
+    #[allow(dead_code)]
+    pub fn probe(&self) -> ActivityProbe {
+        self.probe.clone()
     }
 
     pub fn config() -> ShellConfig {
@@ -89,6 +142,9 @@ impl Default for AppShellDemo {
 impl ShellApp for AppShellDemo {
     fn render_content(&self, backend: &mut dyn Backend, layout: &AppShellLayout) {
         let lh = backend.line_height();
+        // Publish the activity bar's real painted bounds for the #552
+        // regression tests (see `ActivityProbe`). Harmless in the demo.
+        self.probe.bounds.set(Some(layout.activity_bar_bounds));
 
         if let Some(content) = layout.sidebar_content_bounds {
             let label = StatusBar {
@@ -182,6 +238,40 @@ impl ShellApp for AppShellDemo {
                     "Sidebar hidden (Ctrl+B via ctx.shell_mut())".into()
                 };
                 Reaction::Redraw
+            }
+            // `t` = reveal/hide the title bar at runtime, the way vimcode
+            // toggles its menu bar (`engine.menu_bar_visible`). This is the
+            // transition issue #552 lives in: while the bar is hidden the
+            // activity bar's origin is 0, so a hit-region that wrongly
+            // folded that origin in still lined up. The moment the title
+            // bar is revealed the origin becomes nonzero and the error
+            // appears — which is why static construction tests never saw
+            // it and only a toggle exercises the defect (same trap #547
+            // documented).
+            UiEvent::KeyPressed {
+                key: Key::Char('t'),
+                ..
+            } => {
+                let now_visible = {
+                    let mut shell = ctx.shell_mut();
+                    let next = !shell.title_bar_visible();
+                    shell.set_title_bar_visible(next);
+                    next
+                };
+                self.last_event = if now_visible {
+                    "Title bar shown (t)".into()
+                } else {
+                    "Title bar hidden (t)".into()
+                };
+                Reaction::Redraw
+            }
+            // Pointer moves are `Ignored` by `AppShell` (it updates hover
+            // and passes the event on), so by the time we see one the
+            // shell's hover state is already settled — record it for the
+            // #552 hover regression test.
+            UiEvent::MouseMoved { .. } => {
+                self.probe.hovered.set(ctx.shell().hovered_activity_idx());
+                Reaction::Continue
             }
             UiEvent::MouseDown { position, .. } => {
                 if ctx.in_sidebar(position.x, position.y) {

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -531,9 +531,12 @@ pub trait Backend {
     /// shared [`activity_bar_hits`] helper already produced, and what
     /// `AppShell` assumes in both its click and hover readers.
     ///
-    /// [`Self::activity_bar_layout`] must return the same space, and the
-    /// `backends_agree_*` tests in `compose::app_shell` fail if a backend
-    /// drifts.
+    /// [`Self::activity_bar_layout`] must return the same space. A
+    /// drifting backend fails
+    /// `tui::activity_bar::tests::hit_regions_are_bar_relative_not_absolute`
+    /// / `hit_regions_do_not_move_when_the_bar_does`, plus the
+    /// `activity_click_*_parity` / `activity_hover_*_parity` cross-backend
+    /// tests in `tests/cross_backend_parity.rs`.
     fn draw_activity_bar(
         &mut self,
         rect: Rect,
@@ -570,6 +573,29 @@ pub trait Backend {
     /// use. Note the tab bar's absolute convention is the opposite of
     /// [`Self::draw_activity_bar`]'s bar-relative one — deliberate, and
     /// now stated on both.
+    ///
+    /// # Downstream impact (issue #552)
+    ///
+    /// This changes the actual values `tab_bar_layout` returns, not just
+    /// its doc. `grep -rn "tab_bar_layout" ~/src/claude-coordinator/tui/src
+    /// ~/src/vimcode/src`: `coord-tui`'s `tui/src/app/render.rs:229` only
+    /// reads `.correct_scroll_offset`, unaffected. `vimcode`'s
+    /// `src/gtk/mod.rs` — `tab_hits_to_pixel_hits` (~line 141),
+    /// `abs_visible_slots` (~line 216), `abs_close_record` (~line 198),
+    /// plus the call sites in `src/gtk/click.rs` and `src/gtk/draw.rs` —
+    /// all consume `hits.slot_positions` / `close_bounds` under the
+    /// explicit assumption the doc comment at `gtk/mod.rs:135-137` states
+    /// ("absolute pixel x, from `Backend::tab_bar_layout`"). Since the
+    /// pre-fix implementation didn't actually deliver that, vimcode's
+    /// `tab_hits_to_pixel_hits` — which subtracts `bar_left_x` from
+    /// already-relative input via its `rel()` closure — was very likely
+    /// silently double-subtracting whenever `rect.x != 0` (sidebar
+    /// visible, or the 2nd+ split-group tab bar), shifting GTK tab-bar
+    /// click/close-button hit-testing left by `rect.x`. This PR is
+    /// believed to **fix** that latent bug, not introduce a regression —
+    /// but that is this repo's analysis, not a vimcode-side confirmation;
+    /// vimcode should verify with its own GTK tab-bar click tests before
+    /// relying on the corrected geometry.
     fn tab_bar_layout(&self, rect: Rect, bar: &TabBar) -> TabBarHits;
 
     /// Compute activity bar row hit regions without painting. Returns

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -514,6 +514,26 @@ pub trait Backend {
     /// Draw an activity bar. `hovered_idx` carries per-frame hover
     /// state so the rasteriser can paint a tint on the hovered row.
     /// Returns per-row hit regions for click + tooltip dispatch.
+    ///
+    /// # Coordinate space — **relative to `rect`** (issue #552)
+    ///
+    /// Each [`ActivityBarRowHit`]'s `y_start` / `y_end` is measured from
+    /// the **top edge of `rect`**: the first row starts at `0.0` no
+    /// matter where the bar sits on the target surface. Implementors
+    /// must **not** fold `rect.y` into the returned spans, even though
+    /// they need the absolute value to paint. Callers add the bar origin
+    /// themselves (`hit.y_start + rect.y`).
+    ///
+    /// Note this is deliberately the *opposite* convention from
+    /// [`Self::tab_bar_layout`] / [`Self::draw_tab_bar`], whose
+    /// [`TabBarHits`] spans are absolute. The split is historical but now
+    /// pinned: the activity bar's space is what GTK, macOS, and the
+    /// shared [`activity_bar_hits`] helper already produced, and what
+    /// `AppShell` assumes in both its click and hover readers.
+    ///
+    /// [`Self::activity_bar_layout`] must return the same space, and the
+    /// `backends_agree_*` tests in `compose::app_shell` fail if a backend
+    /// drifts.
     fn draw_activity_bar(
         &mut self,
         rect: Rect,
@@ -524,6 +544,16 @@ pub trait Backend {
     /// Compute the status bar layout without painting. Same measurement
     /// logic as `draw_status_bar` — call after `ScreenLayout::draw()` to
     /// recover hit regions for click dispatch.
+    ///
+    /// Returns `hit_regions` in the same **bar-local** space as
+    /// [`Self::draw_status_bar`] (relative to `rect.x` / `rect.y`).
+    ///
+    /// Audited under issue #552 and **ruled out**: all four paths (TUI /
+    /// GTK × draw / layout) return the primitive's own unshifted
+    /// `StatusBar::layout` output, so paint and no-paint already agree and
+    /// no backend folds the origin in. Unlike the activity bar, nothing
+    /// here needed changing — only this note, so the next reader doesn't
+    /// have to re-derive it.
     fn status_bar_layout(&self, rect: Rect, bar: &StatusBar) -> StatusBarLayout;
 
     /// Compute the tab bar layout without painting. Returns the same
@@ -532,9 +562,20 @@ pub trait Backend {
     /// coordinates**, i.e. shifted by `rect.x` / `rect.y` so callers can
     /// compare them directly against raw click coordinates without any
     /// further adjustment.
+    ///
+    /// Audited under issue #552 and **fixed**: this was documented
+    /// absolute but returned bar-relative x on *both* TUI and GTK, because
+    /// only `draw_tab_bar` applied the origin shift. Both impls now route
+    /// through [`shift_tab_bar_hits`], the same helper the rasterisers
+    /// use. Note the tab bar's absolute convention is the opposite of
+    /// [`Self::draw_activity_bar`]'s bar-relative one — deliberate, and
+    /// now stated on both.
     fn tab_bar_layout(&self, rect: Rect, bar: &TabBar) -> TabBarHits;
 
-    /// Compute activity bar row hit regions without painting.
+    /// Compute activity bar row hit regions without painting. Returns
+    /// the same **bar-relative** spans as [`Self::draw_activity_bar`] —
+    /// `y_start` / `y_end` measured from `rect.y`, first row at `0.0`.
+    /// See that method for the full contract (issue #552).
     fn activity_bar_layout(&self, rect: Rect, bar: &ActivityBar) -> Vec<ActivityBarRowHit>;
 
     /// Draw a terminal cell grid. No hit-region data is returned;
@@ -912,7 +953,46 @@ pub trait Backend {
 
 // ── Shared layout helpers ───────────────────────────────────────────────
 
+/// Shift every x-span in `hits` right by `dx`.
+///
+/// [`tab_bar_layout_to_hits`] yields **bar-relative** x (the primitive
+/// measures from `0.0`), but the [`TabBarHits`] contract is
+/// target-surface (absolute) coordinates. Rasterisers and the no-paint
+/// `tab_bar_layout` variants both call this with `rect.x` so the two
+/// paths return the same space.
+///
+/// Audited under issue #552: `draw_tab_bar` applied this shift on both
+/// TUI and GTK, but `Backend::tab_bar_layout` applied it on neither — so
+/// the documented-absolute no-paint path silently returned relative x,
+/// off by `rect.x`. That is nonzero for any tab bar right of a sidebar,
+/// i.e. the same latent seam as the activity bar's, one primitive over.
+pub fn shift_tab_bar_hits(hits: &mut TabBarHits, dx: f64) {
+    if dx == 0.0 {
+        return;
+    }
+    for sp in &mut hits.slot_positions {
+        // `(0.0, 0.0)` is the sentinel for tabs scrolled out of view —
+        // leave it recognisable rather than shifting it to `(dx, dx)`.
+        if *sp != (0.0, 0.0) {
+            sp.0 += dx;
+            sp.1 += dx;
+        }
+    }
+    for cb in hits.close_bounds.iter_mut().flatten() {
+        cb.0 += dx;
+        cb.1 += dx;
+    }
+    for rb in &mut hits.right_segment_bounds {
+        rb.0 += dx;
+        rb.1 += dx;
+    }
+}
+
 /// Convert a `TabBarLayout` to the legacy `TabBarHits` struct.
+///
+/// Spans are **bar-relative** on return; callers that owe the
+/// [`TabBarHits`] absolute contract must follow up with
+/// [`shift_tab_bar_hits`] using `rect.x`.
 pub fn tab_bar_layout_to_hits(layout: &TabBarLayout, bar: &TabBar) -> TabBarHits {
     let mut slot_positions = vec![(0.0, 0.0); bar.tabs.len()];
     let mut close_bounds = vec![None; bar.tabs.len()];
@@ -940,6 +1020,10 @@ pub fn tab_bar_layout_to_hits(layout: &TabBarLayout, bar: &TabBar) -> TabBarHits
 }
 
 /// Compute activity bar hit regions from geometry (no paint).
+///
+/// Spans are **relative to `rect`** per the [`Backend::draw_activity_bar`]
+/// contract: the first top-pinned row starts at `0.0` and only `rect.height`
+/// is consulted (to pin the bottom group), never `rect.y`. Issue #552.
 pub fn activity_bar_hits(rect: Rect, bar: &ActivityBar, lh: f32) -> Vec<ActivityBarRowHit> {
     let mut hits = Vec::new();
     let mut y = 0.0_f32;

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1712,6 +1712,9 @@ impl Backend for GtkBackend {
         );
 
         let mut hits = tab_bar_layout_to_hits(&layout, bar);
+        // Match `draw_tab_bar` (gtk/tab_bar.rs), which shifts by the same
+        // origin: `TabBarHits` are target-surface coordinates. Issue #552.
+        crate::backend::shift_tab_bar_hits(&mut hits, rect.x as f64);
 
         let active_idx = bar.tabs.iter().position(|t| t.is_active);
         let reserved_px: f32 = bar

--- a/quadraui/src/gtk/tab_bar.rs
+++ b/quadraui/src/gtk/tab_bar.rs
@@ -338,20 +338,9 @@ pub fn draw_tab_bar(
     // `TabBarHits` contract is target-surface coordinates (matching the TUI
     // rasteriser and the painted glyphs above, which all add `x_offset`).
     // Shift every hit range so consumers can hit-test against raw click x.
-    for sp in &mut hits.slot_positions {
-        if *sp != (0.0, 0.0) {
-            sp.0 += x_offset;
-            sp.1 += x_offset;
-        }
-    }
-    for cb in hits.close_bounds.iter_mut().flatten() {
-        cb.0 += x_offset;
-        cb.1 += x_offset;
-    }
-    for rb in &mut hits.right_segment_bounds {
-        rb.0 += x_offset;
-        rb.1 += x_offset;
-    }
+    // Shared with `Backend::tab_bar_layout` so the paint and no-paint
+    // paths cannot drift apart again (issue #552).
+    crate::backend::shift_tab_bar_hits(&mut hits, x_offset);
     hits.correct_scroll_offset = correct_scroll_offset;
     hits.available_cols = available_cols;
     hits

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -10,6 +10,23 @@
 //!
 //! Returns per-row [`ActivityBarRowHit`]s so callers can route clicks
 //! and query tooltips against the same frame's painted positions.
+//!
+//! # Coordinate space (issue #552)
+//!
+//! Spans are **bar-relative**, matching the [`crate::Backend::draw_activity_bar`]
+//! contract: this function paints into `(0, 0, width, height)` and is never
+//! handed the bar's origin at all (`MacBackend::draw_activity_bar` passes only
+//! `rect.width` / `rect.height`), so it *cannot* fold the origin in — the
+//! mistake the TUI rasteriser made. Audited and compliant; no change needed.
+//!
+//! Known divergence, deliberately left alone: this rasteriser emits **top
+//! items first, then bottom-pinned**, whereas the TUI and GTK rasterisers
+//! follow `ActivityBarLayout::visible_items`, which is bottom-pinned first.
+//! The flat index a backend derives from its own list is what
+//! `hovered_idx` is compared against, so each backend is self-consistent —
+//! but a host that hardcoded an index across backends would disagree. Out
+//! of scope for the coordinate-space fix; flagged here so it isn't
+//! rediscovered from scratch.
 
 use core_graphics::geometry::CGRect;
 use core_graphics::sys::CGContextRef;

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -159,8 +159,11 @@ pub enum ActivityBarHit {
 /// it. See issue #552; the height half of the same seam was #547.
 ///
 /// Rasterisers: keep the absolute value for *painting*, but push the
-/// bar-relative offset here. The `backends_agree_on_*` tests in
-/// `compose::app_shell` pin this across TUI/GTK.
+/// bar-relative offset here. Pinned across TUI/GTK by
+/// `tui::activity_bar::tests::hit_regions_are_bar_relative_not_absolute`
+/// / `hit_regions_do_not_move_when_the_bar_does`, plus the
+/// `activity_click_*_parity` / `activity_hover_*_parity` cross-backend
+/// tests in `tests/cross_backend_parity.rs`.
 ///
 /// [`Backend::draw_activity_bar`]: crate::Backend::draw_activity_bar
 /// [`TabBarHits`]: crate::TabBarHits

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -134,9 +134,43 @@ pub enum ActivityBarHit {
 /// span. Apps that need both click routing AND hover tooltips (e.g.
 /// vimcode's GTK activity bar with `connect_query_tooltip`) read
 /// from this list rather than re-resolving via the layout.
+///
+/// # Coordinate space — **relative to the bar** (issue #552)
+///
+/// `y_start` / `y_end` are measured from the **top edge of the `rect`
+/// passed to [`Backend::draw_activity_bar`]**, i.e. the first row always
+/// starts at `0.0` regardless of where the bar sits on screen. They are
+/// **not** target-surface (absolute) coordinates — this is the opposite
+/// convention from [`TabBarHits`], whose `x` spans *are* absolute.
+///
+/// Callers therefore add the bar's origin themselves before comparing
+/// against a raw click position:
+///
+/// ```ignore
+/// let hit_top = hit.y_start as f32 + activity_bar_bounds.y;
+/// ```
+///
+/// This is the space every backend already agreed on except the TUI's
+/// `draw_activity_bar`, which leaked its absolute paint `y` into the
+/// returned regions. Because `AppShell` adds the origin a second time,
+/// TUI hits were shifted down by `activity_bar_bounds.y` — invisible
+/// while the title bar was hidden (origin `0`), a one-row off-by-one for
+/// clicks *and* hover the moment `set_title_bar_visible(true)` revealed
+/// it. See issue #552; the height half of the same seam was #547.
+///
+/// Rasterisers: keep the absolute value for *painting*, but push the
+/// bar-relative offset here. The `backends_agree_on_*` tests in
+/// `compose::app_shell` pin this across TUI/GTK.
+///
+/// [`Backend::draw_activity_bar`]: crate::Backend::draw_activity_bar
+/// [`TabBarHits`]: crate::TabBarHits
 #[derive(Debug, Clone)]
 pub struct ActivityBarRowHit {
+    /// Top edge of the row, **relative to the bar's `rect.y`** (first
+    /// row is `0.0`). Add the bar origin before hit-testing a click.
     pub y_start: f64,
+    /// Bottom edge (exclusive) of the row, **relative to the bar's
+    /// `rect.y`**. Add the bar origin before hit-testing a click.
     pub y_end: f64,
     pub id: WidgetId,
     pub tooltip: String,
@@ -148,8 +182,18 @@ pub struct ActivityBarRowHit {
 pub struct ActivityBarLayout {
     pub viewport_width: f32,
     pub viewport_height: f32,
-    /// All visible items — top-pinned first (in order), then
-    /// bottom-pinned (in order).
+    /// All visible items — **bottom-pinned first** (in order), then
+    /// top-pinned (in order). That is the order [`ActivityBar::layout`]
+    /// appends them in, because bottom items are placed first (they win
+    /// on collision, see that method's "Collision policy"). It is *not*
+    /// visual top-to-bottom order.
+    ///
+    /// This matters because backends `enumerate()` this list to derive
+    /// the flat index they compare against `hovered_idx`, and
+    /// `AppShell` derives that same index by position in the returned
+    /// `ActivityBarRowHit` list — so the two agree, but neither is
+    /// "the n-th icon from the top". Corrected while fixing #552; the
+    /// doc previously claimed top-first, which no caller could rely on.
     pub visible_items: Vec<VisibleActivityItem>,
     pub hit_regions: Vec<(Rect, ActivityBarHit)>,
 }

--- a/quadraui/src/tui/activity_bar.rs
+++ b/quadraui/src/tui/activity_bar.rs
@@ -122,9 +122,20 @@ pub fn draw_activity_bar(
             }
         }
 
+        // Hit regions are **bar-relative**, not absolute: report the
+        // row offset within `area`, not the screen row `y` we painted
+        // at. Keeping `area.y` in here double-counted the bar origin,
+        // because `AppShell` adds `activity_bar_bounds.y` itself in
+        // both its click and hover readers — a shift that was zero
+        // (invisible) while the title bar was hidden and became a
+        // one-row off-by-one the instant `set_title_bar_visible(true)`
+        // revealed it. GTK, macOS, and `backend::activity_bar_hits`
+        // all already used this space; the TUI was the lone outlier.
+        // Issue #552 (the coordinate-space half of #547's height fix).
+        let rel_y = (y - area.y) as f64;
         regions.push(ActivityBarRowHit {
-            y_start: y as f64,
-            y_end: (y + 1) as f64,
+            y_start: rel_y,
+            y_end: rel_y + 1.0,
             id: item.id.clone(),
             tooltip: item.tooltip.clone(),
         });
@@ -133,4 +144,138 @@ pub fn draw_activity_bar(
     }
 
     regions
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::activity_bar::ActivityItem;
+    use crate::types::WidgetId;
+
+    fn item(id: &str, icon: &str) -> ActivityItem {
+        ActivityItem {
+            id: WidgetId::new(id),
+            icon: icon.into(),
+            tooltip: format!("{id} tooltip"),
+            is_active: false,
+            is_keyboard_selected: false,
+        }
+    }
+
+    fn bar() -> ActivityBar {
+        ActivityBar {
+            id: WidgetId::new("activity"),
+            top_items: vec![item("explorer", "E"), item("search", "S"), item("git", "G")],
+            bottom_items: vec![item("settings", "*")],
+            active_accent: None,
+            selection_bg: None,
+            is_keyboard_focused: false,
+        }
+    }
+
+    /// The #552 contract, stated as an assertion: hit regions are
+    /// **bar-relative**, so the top row starts at `0.0` no matter where
+    /// the bar is painted.
+    ///
+    /// This is the test that fails against pre-fix `develop`: with
+    /// `area.y == 3` the rasteriser returned `y_start == 3.0` for the
+    /// first top row (its absolute paint row), which `AppShell` then
+    /// shifted by `activity_bar_bounds.y` a second time.
+    ///
+    /// Looks rows up **by id** rather than by position: `visible_items`
+    /// (and therefore this list) is bottom-pinned-first, not visual
+    /// top-to-bottom order.
+    #[test]
+    fn hit_regions_are_bar_relative_not_absolute() {
+        let b = bar();
+        let theme = Theme::default();
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
+        let area = Rect::new(0, 3, 3, 10);
+        let hits = draw_activity_bar(&mut buf, area, &b, &theme, None);
+
+        let span = |id: &str| {
+            let h = hits
+                .iter()
+                .find(|h| h.id.as_str() == id)
+                .unwrap_or_else(|| panic!("no hit region for {id:?}"));
+            (h.y_start, h.y_end)
+        };
+
+        assert_eq!(
+            span("explorer"),
+            (0.0, 1.0),
+            "the top row must start at 0.0 relative to the bar, not at \
+             area.y ({}) — folding the origin in here double-counts it \
+             against AppShell's own `+ activity_bar_bounds.y` (issue #552)",
+            area.y
+        );
+        assert_eq!(span("search"), (1.0, 2.0), "second row is one row down");
+        assert_eq!(span("git"), (2.0, 3.0));
+        // Bottom-pinned: `area.height` (10) - 1 row, still measured from
+        // the bar's own top edge, not the screen's.
+        assert_eq!(span("settings"), (9.0, 10.0));
+    }
+
+    /// The same regions must come back for *any* `area.y`. Pinning
+    /// invariance rather than a single value is what stops the bug from
+    /// reappearing: the pre-fix output was correct at `area.y == 0` (title
+    /// bar hidden) and wrong everywhere else, which is exactly why every
+    /// existing static test passed.
+    #[test]
+    fn hit_regions_do_not_move_when_the_bar_does() {
+        let b = bar();
+        let theme = Theme::default();
+
+        let spans = |y: u16| {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 40, 30));
+            let hits = draw_activity_bar(&mut buf, Rect::new(0, y, 3, 10), &b, &theme, None);
+            hits.iter()
+                .map(|h| (h.y_start, h.y_end))
+                .collect::<Vec<_>>()
+        };
+
+        let at_zero = spans(0);
+        assert!(!at_zero.is_empty(), "sanity: some rows were painted");
+        for y in [1u16, 2, 5] {
+            assert_eq!(
+                spans(y),
+                at_zero,
+                "hit regions must be independent of the bar's screen origin; \
+                 they differed at area.y = {y} (issue #552)"
+            );
+        }
+    }
+
+    /// Painting still uses the absolute row — the fix must not move the
+    /// glyphs, only the reported regions. The operator's note on
+    /// vimcode#634 was explicit that rendering was already correct and
+    /// only the click mapping was wrong.
+    #[test]
+    fn icons_still_paint_at_the_absolute_row() {
+        let b = bar();
+        let theme = Theme::default();
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
+        let area = Rect::new(0, 3, 4, 10);
+        draw_activity_bar(&mut buf, area, &b, &theme, None);
+
+        let row_text = |y: u16| {
+            (area.x..area.x + area.width)
+                .map(|x| buf[(x, y)].symbol().to_string())
+                .collect::<String>()
+        };
+        assert!(
+            row_text(3).contains('E'),
+            "first icon should paint on the bar's first *screen* row (3), \
+             got {:?}",
+            row_text(3)
+        );
+        assert!(
+            row_text(4).contains('S'),
+            "second icon on screen row 4, got {:?}",
+            row_text(4)
+        );
+    }
 }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1110,6 +1110,11 @@ impl Backend for TuiBackend {
         );
 
         let mut hits = tab_bar_layout_to_hits(&layout, bar);
+        // `TabBarHits` are target-surface (absolute) coordinates per the
+        // trait doc — the same space `draw_tab_bar` returns. Without this
+        // the no-paint path returned bar-relative x, off by `rect.x`
+        // (nonzero for any tab bar right of a sidebar). Issue #552.
+        crate::backend::shift_tab_bar_hits(&mut hits, rect.x as f64);
 
         let active_idx = bar.tabs.iter().position(|t| t.is_active);
         let reserved: usize = bar
@@ -3163,6 +3168,131 @@ mod tests {
             matches!(&out[2], UiEvent::MouseMoved { position, .. } if position.x == 6.0),
             "second run must collapse to x=6, got {:?}",
             out[2]
+        );
+    }
+
+    // ── Issue #552 sibling audit: tab-bar hit geometry ──────────────
+    //
+    // `TabBarHits` is documented as **target-surface (absolute)**
+    // coordinates — the opposite convention from `ActivityBarRowHit`,
+    // which is bar-relative. `draw_tab_bar` honoured that on both TUI and
+    // GTK by shifting the primitive's bar-relative output by the bar's
+    // origin. `Backend::tab_bar_layout` honoured it on neither: it
+    // returned `tab_bar_layout_to_hits` verbatim, so the no-paint path
+    // was off by `rect.x` — nonzero for any tab bar sitting right of a
+    // sidebar, which is every AppShell layout.
+    //
+    // Same class of defect as #552 itself (a hit-region seam silently
+    // disagreeing about coordinate space), one primitive over, found by
+    // the audit the issue asked for. Both backends now route through the
+    // shared `backend::shift_tab_bar_hits`.
+
+    fn audit_bar() -> TabBar {
+        TabBar {
+            id: WidgetId::new("tabs"),
+            tabs: vec![
+                crate::primitives::tab_bar::TabItem {
+                    label: "main.rs".into(),
+                    is_active: true,
+                    is_dirty: false,
+                    is_preview: false,
+                    is_closable: true,
+                },
+                crate::primitives::tab_bar::TabItem {
+                    label: "lib.rs".into(),
+                    is_active: false,
+                    is_dirty: false,
+                    is_preview: false,
+                    is_closable: true,
+                },
+            ],
+            right_segments: vec![],
+            active_accent: None,
+            scroll_offset: 0,
+            show_tab_close: true,
+            compact: false,
+        }
+    }
+
+    #[test]
+    fn tab_bar_layout_returns_absolute_x_not_bar_relative() {
+        let backend = TuiBackend::new();
+        let bar = audit_bar();
+
+        let at_origin = backend.tab_bar_layout(QRect::new(0.0, 0.0, 40.0, 1.0), &bar);
+        let shifted = backend.tab_bar_layout(QRect::new(12.0, 0.0, 40.0, 1.0), &bar);
+
+        assert!(
+            !at_origin.slot_positions.is_empty(),
+            "sanity: some tabs should be laid out"
+        );
+        for (i, (base, moved)) in at_origin
+            .slot_positions
+            .iter()
+            .zip(shifted.slot_positions.iter())
+            .enumerate()
+        {
+            if *base == (0.0, 0.0) {
+                // Scrolled-out sentinel — must stay recognisable, not
+                // become (12.0, 12.0).
+                assert_eq!(
+                    *moved,
+                    (0.0, 0.0),
+                    "tab {i}: the scrolled-out sentinel must not be shifted"
+                );
+                continue;
+            }
+            assert_eq!(
+                (moved.0, moved.1),
+                (base.0 + 12.0, base.1 + 12.0),
+                "tab {i}: `tab_bar_layout` is documented to return \
+                 target-surface coordinates, so moving the bar right by 12 \
+                 must move its hit spans right by 12 (issue #552 audit)"
+            );
+        }
+    }
+
+    /// The no-paint path must agree with the painting path, since callers
+    /// use them interchangeably to route the same clicks. Runs
+    /// `draw_tab_bar` through a real frame scope so it goes down the
+    /// production rasteriser, not a reimplementation of it.
+    #[test]
+    fn tab_bar_layout_agrees_with_draw_tab_bar_on_coordinate_space() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut backend = TuiBackend::new();
+        backend.begin_frame(Viewport::new(80.0, 24.0, 1.0));
+        let bar = audit_bar();
+        // Nonzero x: the whole point. At x = 0 the two paths agreed even
+        // before the fix, which is exactly how the defect stayed hidden.
+        let rect = QRect::new(12.0, 0.0, 40.0, 1.0);
+
+        let from_layout = backend.tab_bar_layout(rect, &bar);
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("test terminal");
+        let mut painted = None;
+        terminal
+            .draw(|frame| {
+                painted =
+                    Some(backend.enter_frame_scope(frame, |b| b.draw_tab_bar(rect, &bar, None)));
+            })
+            .expect("draw");
+        let from_paint = painted.expect("draw closure ran");
+
+        assert!(
+            from_paint.slot_positions.iter().any(|s| *s != (0.0, 0.0)),
+            "sanity: the rasteriser should have placed at least one tab"
+        );
+        assert_eq!(
+            from_layout.slot_positions, from_paint.slot_positions,
+            "`tab_bar_layout` and `draw_tab_bar` must report tab slots in \
+             the same coordinate space (issue #552 audit)"
+        );
+        assert_eq!(
+            from_layout.close_bounds, from_paint.close_bounds,
+            "close-button spans must match between the paint and no-paint \
+             paths too"
         );
     }
 }

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -27,7 +27,7 @@ use pipeline_app::PipelineApp;
 
 #[path = "../examples/common/appshell_demo.rs"]
 mod appshell_demo;
-use appshell_demo::AppShellDemo;
+use appshell_demo::{ActivityProbe, AppShellDemo};
 
 #[path = "../examples/common/data_table_app.rs"]
 mod data_table_app;
@@ -45,6 +45,19 @@ trait ExampleDriver {
     fn click_text(&mut self, needle: &str);
     fn screen_has(&self, needle: &str) -> bool;
     fn exited(&self) -> bool;
+
+    /// Click at an explicit point in this backend's native units.
+    ///
+    /// Shared bodies must derive the point from geometry the *shell*
+    /// reported (see `ActivityProbe`), never from a literal — a literal
+    /// would be cells on one backend and pixels on the other.
+    fn click_at(&mut self, x: f32, y: f32);
+    /// Move the pointer, buttons up, to update hover state.
+    fn hover_at(&mut self, x: f32, y: f32);
+    /// Height of one activity-bar row in this backend's native units.
+    /// This is the one genuinely per-backend number the #552 bodies need:
+    /// the TUI bar is one text row per icon, GTK a fixed 48px button.
+    fn activity_row_height(&self) -> f32;
 }
 
 impl<A: AppLogic> ExampleDriver for TuiDriver<A> {
@@ -70,6 +83,20 @@ impl<A: AppLogic> ExampleDriver for TuiDriver<A> {
     fn exited(&self) -> bool {
         TuiDriver::exited(self)
     }
+
+    fn click_at(&mut self, x: f32, y: f32) {
+        TuiDriver::click(self, x, y);
+    }
+
+    fn hover_at(&mut self, x: f32, y: f32) {
+        TuiDriver::mouse_move(self, x, y);
+    }
+
+    fn activity_row_height(&self) -> f32 {
+        // `tui::activity_bar` lays out with a row height of 1.0 — one
+        // terminal text row per icon.
+        1.0
+    }
 }
 
 impl<A: AppLogic> ExampleDriver for GtkDriver<A> {
@@ -94,6 +121,18 @@ impl<A: AppLogic> ExampleDriver for GtkDriver<A> {
 
     fn exited(&self) -> bool {
         GtkDriver::exited(self)
+    }
+
+    fn click_at(&mut self, x: f32, y: f32) {
+        GtkDriver::click(self, x, y);
+    }
+
+    fn hover_at(&mut self, x: f32, y: f32) {
+        GtkDriver::mouse_move(self, x, y);
+    }
+
+    fn activity_row_height(&self) -> f32 {
+        quadraui::gtk::ACTIVITY_ROW_PX as f32
     }
 }
 
@@ -405,5 +444,241 @@ fn data_table_rightmost_column_stays_flush_after_multiple_drags_parity_tui_and_g
     assert!(
         gtk_flush,
         "GTK: table must still fill its viewport after multiple divider drags"
+    );
+}
+
+// ─── Issue #552: activity-bar hit regions vs. a revealed title bar ───────
+//
+// `Backend::draw_activity_bar` returns `ActivityBarRowHit`s whose
+// `y_start`/`y_end` are **bar-relative** — measured from the `rect` the bar
+// was drawn into. `AppShell` adds `activity_bar_bounds.y` itself in both its
+// click reader (`cached_activity_hit`) and its hover reader
+// (`update_hover`). The TUI rasteriser used to fold that origin in a second
+// time, so every TUI hit region sat `activity_bar_bounds.y` too low.
+//
+// That offset is **zero while the title bar is hidden**, which is why the
+// bug was invisible to every existing test: they all construct in a fixed
+// state, and `AppShell`'s own layout assertions only ever check
+// `activity_bar_bounds.y` against the title bar, never a hit region against
+// a click. Only the *transition* — hidden bar, then `set_title_bar_visible(
+// true)` — makes the origin nonzero and the double-count observable. Same
+// trap #547 documented ("static construction tests cannot catch it … only a
+// toggle exercises the defect"); this is its coordinate-space half.
+//
+// Symptom downstream (JDonaghy/vimcode#634, three consecutive failed smoke
+// rounds): reveal the menu bar, click the Search icon, and the *adjacent*
+// panel opens — icons painted correctly, click-to-action mapping off by one
+// row. Hover drifted identically, because both readers share the bug.
+//
+// GTK was always correct here, so the GTK half of each test below is the
+// parity guard `GtkDriver` (#301/#446) exists for: it pins the behaviour
+// TUI now has to match, and would catch a "fix" that merely moved the error
+// to the other backend.
+
+/// Center of activity-bar row `idx` in the driver's native units, derived
+/// from the bounds the *shell* reported this frame — never a literal.
+fn activity_row_center<D: ExampleDriver>(d: &D, probe: &ActivityProbe, idx: usize) -> (f32, f32) {
+    let ab = probe
+        .bounds()
+        .expect("render_content should have published activity_bar_bounds");
+    let row_h = d.activity_row_height();
+    (ab.x + ab.width / 2.0, ab.y + row_h * (idx as f32 + 0.5))
+}
+
+/// Reveal the title bar (`t`), then click the center of activity-bar row
+/// `idx`. Returns whether the *expected* panel's sidebar header is showing
+/// afterwards, plus the `last_event` line the shell reported.
+///
+/// Row 1 is Search and row 2 is Source Control. Both are deliberately
+/// **not** the initially-active panel (Explorer, row 0): clicking the
+/// already-active icon is a sidebar *toggle*, not a panel switch, so it
+/// would mask an off-by-one instead of exposing it.
+fn run_activity_click_after_title_bar_reveal<D: ExampleDriver>(
+    d: &mut D,
+    probe: &ActivityProbe,
+    idx: usize,
+    expected_header: &str,
+) -> bool {
+    // Title bar starts hidden: `AppShellDemo::config()` never calls
+    // `with_title_bar`, so `activity_bar_bounds.y == 0` and the old
+    // double-count added nothing.
+    let ab_before = probe.bounds().expect("bounds published on first frame");
+
+    d.type_char('t');
+
+    let ab_after = probe.bounds().expect("bounds republished after reveal");
+    assert!(
+        ab_after.y > ab_before.y,
+        "revealing the title bar must push the activity bar down — otherwise \
+         this test proves nothing (before={}, after={})",
+        ab_before.y,
+        ab_after.y
+    );
+
+    let (x, y) = activity_row_center(d, probe, idx);
+    d.click_at(x, y);
+    d.screen_has(expected_header)
+}
+
+#[test]
+fn activity_click_hits_the_clicked_row_after_title_bar_reveal_parity() {
+    // Row 1 = Search. Pre-fix the TUI resolved this click into a different
+    // row's region (or none at all), so "SEARCH" never appeared.
+    let tui_app = AppShellDemo::new();
+    let tui_probe = tui_app.probe();
+    let mut tui = tui_driver_with_shell(tui_app, AppShellDemo::config(), 100, 30);
+
+    let gtk_app = AppShellDemo::new();
+    let gtk_probe = gtk_app.probe();
+    let mut gtk = gtk_driver_with_shell(gtk_app, AppShellDemo::config(), 800, 480);
+
+    let tui_hit = run_activity_click_after_title_bar_reveal(&mut tui, &tui_probe, 1, "SEARCH");
+    let gtk_hit = run_activity_click_after_title_bar_reveal(&mut gtk, &gtk_probe, 1, "SEARCH");
+
+    assert!(
+        tui_hit,
+        "TUI: clicking activity row 1 with the title bar revealed must open \
+         the Search panel, not a neighbour (issue #552):\n{}",
+        tui.screen()
+    );
+    assert!(
+        gtk_hit,
+        "GTK: clicking activity row 1 with the title bar revealed must open \
+         the Search panel (this backend was always correct — it is the \
+         parity guard that the fix did not just move the error here)"
+    );
+    assert_eq!(
+        tui_hit, gtk_hit,
+        "both backends must agree on which panel a row-1 click opens"
+    );
+}
+
+#[test]
+fn activity_click_row_two_hits_row_two_after_title_bar_reveal_parity() {
+    // A second, further-down row: an off-by-one shows up at every index, so
+    // pinning two of them rules out a fix that merely re-centred row 1.
+    let tui_app = AppShellDemo::new();
+    let tui_probe = tui_app.probe();
+    let mut tui = tui_driver_with_shell(tui_app, AppShellDemo::config(), 100, 30);
+
+    let gtk_app = AppShellDemo::new();
+    let gtk_probe = gtk_app.probe();
+    let mut gtk = gtk_driver_with_shell(gtk_app, AppShellDemo::config(), 800, 480);
+
+    let tui_hit =
+        run_activity_click_after_title_bar_reveal(&mut tui, &tui_probe, 2, "SOURCE CONTROL");
+    let gtk_hit =
+        run_activity_click_after_title_bar_reveal(&mut gtk, &gtk_probe, 2, "SOURCE CONTROL");
+
+    assert!(
+        tui_hit,
+        "TUI: clicking activity row 2 must open Source Control:\n{}",
+        tui.screen()
+    );
+    assert!(
+        gtk_hit,
+        "GTK: clicking activity row 2 must open Source Control"
+    );
+}
+
+/// Hover the center of visual activity row `idx` and report what the shell
+/// decided is hovered.
+///
+/// Note the returned index is a position in the shell's hit-region list,
+/// which is **bottom-pinned-first** (see `ActivityBarLayout::visible_items`)
+/// — so it is deliberately not asserted against `idx` directly. What
+/// matters for #552 is that the answer does not *change* when the bar
+/// moves.
+fn hover_row<D: ExampleDriver>(d: &mut D, probe: &ActivityProbe, idx: usize) -> Option<usize> {
+    let (x, y) = activity_row_center(d, probe, idx);
+    d.hover_at(x, y);
+    probe.hovered_idx()
+}
+
+/// For visual row `idx`: hover it with the title bar hidden (the state in
+/// which the double-count added zero, i.e. the known-good baseline), then
+/// reveal the title bar and hover the same visual row again. Returns both
+/// answers.
+///
+/// Hover shared the click path's double-counted comparison, which is why
+/// the reported symptom was "hovering icon N highlights icon N+1" — the
+/// highlight followed the wrong icon exactly as activation did. Comparing
+/// hidden vs revealed states the invariant without hard-coding the shell's
+/// internal ordering: revealing chrome above the bar must not change which
+/// icon a given on-screen row belongs to.
+fn hover_before_and_after_title_bar_reveal<D: ExampleDriver>(
+    d: &mut D,
+    probe: &ActivityProbe,
+    idx: usize,
+) -> (Option<usize>, Option<usize>) {
+    let hidden = hover_row(d, probe, idx);
+    d.type_char('t');
+    let revealed = hover_row(d, probe, idx);
+    (hidden, revealed)
+}
+
+#[test]
+fn activity_hover_highlights_the_hovered_row_after_title_bar_reveal_parity() {
+    for idx in [0usize, 1, 2] {
+        let tui_app = AppShellDemo::new();
+        let tui_probe = tui_app.probe();
+        let mut tui = tui_driver_with_shell(tui_app, AppShellDemo::config(), 100, 30);
+
+        let gtk_app = AppShellDemo::new();
+        let gtk_probe = gtk_app.probe();
+        let mut gtk = gtk_driver_with_shell(gtk_app, AppShellDemo::config(), 800, 480);
+
+        let (tui_hidden, tui_revealed) =
+            hover_before_and_after_title_bar_reveal(&mut tui, &tui_probe, idx);
+        let (gtk_hidden, gtk_revealed) =
+            hover_before_and_after_title_bar_reveal(&mut gtk, &gtk_probe, idx);
+
+        assert!(
+            tui_hidden.is_some(),
+            "sanity: hovering row {idx} with the title bar hidden should \
+             highlight *something* on TUI"
+        );
+        assert_eq!(
+            tui_revealed, tui_hidden,
+            "TUI: revealing the title bar must not change which activity \
+             icon visual row {idx} maps to — hover drifted by \
+             activity_bar_bounds.y (issue #552)"
+        );
+        assert_eq!(
+            gtk_revealed, gtk_hidden,
+            "GTK: hover must be stable across the title-bar reveal (this \
+             backend was already correct — parity guard)"
+        );
+        assert_eq!(
+            tui_revealed, gtk_revealed,
+            "both backends must agree on the hovered activity row for \
+             visual row {idx}"
+        );
+    }
+}
+
+/// Guard for the assertion above: `hover_row` must actually discriminate
+/// between rows, otherwise "stable across the reveal" would be satisfied by
+/// a hover that always returned the same thing (or always `None`).
+#[test]
+fn activity_hover_distinguishes_adjacent_rows_after_title_bar_reveal() {
+    let app = AppShellDemo::new();
+    let probe = app.probe();
+    let mut d = tui_driver_with_shell(app, AppShellDemo::config(), 100, 30);
+
+    d.type_char('t');
+    let row0 = hover_row(&mut d, &probe, 0);
+    let row1 = hover_row(&mut d, &probe, 1);
+    let row2 = hover_row(&mut d, &probe, 2);
+
+    assert!(
+        row0.is_some() && row1.is_some() && row2.is_some(),
+        "every activity row should highlight something once hovered: \
+         {row0:?} {row1:?} {row2:?}"
+    );
+    assert!(
+        row0 != row1 && row1 != row2 && row0 != row2,
+        "three distinct rows must map to three distinct icons — got \
+         {row0:?} {row1:?} {row2:?}"
     );
 }


### PR DESCRIPTION
Closes #552

Automated PR opened by coordinator for review of issue #552.