### PR TITLE
#494: Test-debt: remove hardcoded driver-test coordinates; origin-parametrize round-trip harnesses (LESSONS non-zero-origin rule)

### DIFF
--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -2526,6 +2526,8 @@ impl Backend for GtkBackend {
         crate::gtk::draw_toast_stack(
             cr,
             pango_layout,
+            rect.x as f64,
+            rect.y as f64,
             rect.width as f64,
             rect.height as f64,
             stack,
@@ -2659,7 +2661,7 @@ impl Backend for GtkBackend {
         // runs outside the frame scope (from click handlers). Use a
         // fixed-size approximation — same pattern as menu_bar_layout
         // which uses current_char_width.
-        stack.layout(rect.width, rect.height, 12.0, 8.0, |i| {
+        stack.layout(rect.x, rect.y, rect.width, rect.height, 12.0, 8.0, |i| {
             let toast = &stack.toasts[i];
             let h = if toast.body.is_empty() {
                 self.current_line_height as f32 + 16.0

--- a/quadraui/src/gtk/menu_bar.rs
+++ b/quadraui/src/gtk/menu_bar.rs
@@ -81,7 +81,16 @@ pub fn draw_menu_bar(
             (theme.tab_inactive_fg, theme.tab_bar_bg)
         };
 
-        let item_x = x + vi.bounds.x as f64;
+        // `vi.bounds.x` is already absolute — `gtk_menu_bar_layout` seeds
+        // `MenuBar::layout`'s internal cursor at `bounds.x = x`, so item
+        // bounds already carry the bar's origin. Adding `x` again here
+        // double-counted it, invisibly at `x == 0` (every existing test)
+        // and shifting painted glyphs away from their own hit-test bounds
+        // at any other origin — the same LESSONS.md "layout helpers must
+        // return coords in the same frame across backends" bug class
+        // already found and fixed in the TUI and macOS twins
+        // (quadraui#494).
+        let item_x = vi.bounds.x as f64;
         let item_w = vi.bounds.width as f64;
 
         if is_active {
@@ -166,4 +175,156 @@ fn alt_char_byte_range(label: &str, display: &str) -> Option<(usize, usize)> {
         byte_start += ch.len_utf8();
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::menu_bar::{MenuBarHit, MenuBarItem};
+    use crate::types::{Color, WidgetId};
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    const W: i32 = 300;
+    const H: i32 = 40;
+
+    fn make_bar() -> MenuBar {
+        MenuBar {
+            id: WidgetId::new("bar"),
+            items: vec![
+                MenuBarItem {
+                    id: WidgetId::new("bar:file"),
+                    label: "&File".into(),
+                    disabled: false,
+                    submenu: None,
+                },
+                MenuBarItem {
+                    id: WidgetId::new("bar:edit"),
+                    label: "&Edit".into(),
+                    disabled: false,
+                    submenu: None,
+                },
+            ],
+            open_item: None,
+            focused_item: None,
+        }
+    }
+
+    /// White bar background so only glyphs (not the bar's own background
+    /// fill, which otherwise paints every cell from `origin_x` onward and
+    /// would swamp the pixel scan below) show up as non-white pixels.
+    fn test_theme() -> Theme {
+        Theme {
+            tab_bar_bg: Color::rgb(255, 255, 255),
+            tab_inactive_fg: Color::rgb(0, 0, 0),
+            tab_active_fg: Color::rgb(0, 0, 0),
+            tab_active_bg: Color::rgb(255, 255, 255),
+            ..Theme::default()
+        }
+    }
+
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    fn is_painted(data: &[u8], stride: usize, x: i32, y: i32) -> bool {
+        if x < 0 || y < 0 || x >= W || y >= H {
+            return false;
+        }
+        let (r, g, b) = pixel(data, stride, x, y);
+        !(r == 255 && g == 255 && b == 255)
+    }
+
+    /// Leftmost painted column in row `y`, scanning `[x_from, W)`.
+    fn leftmost_painted_in_row(data: &[u8], stride: usize, y: i32, x_from: i32) -> Option<i32> {
+        (x_from..W).find(|&x| is_painted(data, stride, x, y))
+    }
+
+    /// Paint→click round trip at `(origin_x, origin_y)`: paints the bar,
+    /// then for each item, confirms the painted label's leftmost pixel
+    /// lands close to `vi.bounds.x` (plus the fixed 8px padding
+    /// `gtk_menu_bar_layout`'s measure closure reserves) — not shifted an
+    /// extra `origin_x` to the right — and that `hit_test` at the
+    /// item's own painted position still resolves to that item.
+    ///
+    /// This is the LESSONS.md "layout helpers must return coords in the
+    /// same frame across backends" regression shape (quadraui#494):
+    /// `vi.bounds.x` is already absolute (the bar's `layout()` seeds its
+    /// cursor at `bounds.x = origin_x`), so `draw_menu_bar` must paint at
+    /// `vi.bounds.x` directly, not `origin_x + vi.bounds.x` — the bug this
+    /// test guards against painted glyphs `origin_x` cells to the right of
+    /// where `hit_test` expects them, invisible at `origin_x == 0`.
+    fn paint_and_click_round_trip_at(origin_x: f64, origin_y: f64) {
+        let mut surface = ImageSurface::create(Format::ARgb32, W, H).expect("create ImageSurface");
+        let bar = make_bar();
+        let layout = {
+            let cr = Context::new(&surface).expect("Context::new");
+            cr.set_source_rgb(1.0, 1.0, 1.0);
+            cr.paint().ok();
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            draw_menu_bar(
+                &cr,
+                &pango_layout,
+                origin_x,
+                origin_y,
+                (W as f64) - origin_x,
+                20.0,
+                &bar,
+                &test_theme(),
+            )
+        };
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        assert_eq!(layout.visible_items.len(), 2, "both items should fit");
+        for vi in &layout.visible_items {
+            let row_y = (origin_y + 10.0) as i32; // inside the 20px-tall bar
+            let scan_from = vi.bounds.x.floor() as i32;
+            let painted_x = leftmost_painted_in_row(&data, stride, row_y, scan_from)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "item {} ({:?}) should paint a visible glyph on row {row_y} at or after x={scan_from}",
+                        vi.item_idx, vi.id,
+                    )
+                });
+            // 8px left padding (see `gtk_menu_bar_layout`'s measure
+            // closure: `pixel_size().0 + 16.0`, split evenly). Generous
+            // tolerance for antialiasing/font metrics — the point is
+            // catching a whole extra `origin_x` of drift (7px in the
+            // non-zero-origin test below), not pixel-perfect kerning.
+            let expected = vi.bounds.x + 8.0;
+            assert!(
+                (painted_x as f32 - expected).abs() < 4.0,
+                "item {} painted glyph at x={painted_x}, expected near {expected} \
+                 (vi.bounds.x={}, origin_x={origin_x}) — painting must not add \
+                 origin_x on top of vi.bounds.x, which is already absolute",
+                vi.item_idx,
+                vi.bounds.x,
+            );
+
+            // Round-trip: a click at the item's own (absolute) bounds
+            // centre must resolve back to that item via `hit_test`.
+            let cx = vi.bounds.x + vi.bounds.width / 2.0;
+            let cy = vi.bounds.y + vi.bounds.height / 2.0;
+            assert_eq!(
+                layout.hit_test(cx, cy),
+                MenuBarHit::Item(vi.item_idx),
+                "item {} centre should hit-test back to itself",
+                vi.item_idx,
+            );
+        }
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        paint_and_click_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md):
+    /// same round trip, painted at a shifted bar origin.
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        paint_and_click_round_trip_at(7.0, 13.0);
+    }
 }

--- a/quadraui/src/gtk/toast.rs
+++ b/quadraui/src/gtk/toast.rs
@@ -31,14 +31,24 @@ fn severity_bg(severity: ToastSeverity, theme: &Theme) -> Color {
 }
 
 /// Compute the GTK pixel-unit layout for a [`ToastStack`] without painting.
+///
+/// `(origin_x, origin_y)` is baked into the returned bounds (absolute
+/// window coordinates, matching `gtk_menu_bar_layout` / `gtk_panel_layout`)
+/// — hosts call `layout.hit_test(x, y)` with raw click coordinates, no
+/// localisation needed.
+#[allow(clippy::too_many_arguments)]
 pub fn gtk_toast_stack_layout(
     stack: &ToastStack,
     pango_layout: &pango::Layout,
+    origin_x: f32,
+    origin_y: f32,
     viewport_width: f32,
     viewport_height: f32,
     line_height: f64,
 ) -> ToastStackLayout {
     stack.layout(
+        origin_x,
+        origin_y,
         viewport_width,
         viewport_height,
         GTK_TOAST_MARGIN_PX,
@@ -75,6 +85,8 @@ pub fn gtk_toast_stack_layout(
 pub fn draw_toast_stack(
     cr: &Context,
     pango_layout: &pango::Layout,
+    origin_x: f64,
+    origin_y: f64,
     viewport_width: f64,
     viewport_height: f64,
     stack: &ToastStack,
@@ -84,6 +96,8 @@ pub fn draw_toast_stack(
     let layout = gtk_toast_stack_layout(
         stack,
         pango_layout,
+        origin_x as f32,
+        origin_y as f32,
         viewport_width as f32,
         viewport_height as f32,
         line_height,
@@ -165,5 +179,131 @@ fn paint_toast(
             );
             super::painted_text::show_layout(cr, pango_layout);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::toast::{ToastCorner, ToastHit, ToastItem, ToastSeverity, ToastStack};
+    use crate::types::WidgetId;
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    // Fixed overlay size, independent of the test's origin — this file
+    // had no test module at all before quadraui#494 (the reviewed gap:
+    // `gtk_toast_stack_layout`/`draw_toast_stack` never received the
+    // overlay's origin, so a non-zero-origin toast stack — e.g.
+    // coord-tui's `main_content_bounds`, which sits right of a sidebar —
+    // painted at the wrong screen position and hit-tested against the
+    // wrong coordinates).
+    const VIEW_W: f64 = 340.0;
+    const VIEW_H: f64 = 200.0;
+    const LINE_HEIGHT: f64 = 16.0;
+    const BOX_COLOR: Color = Color::rgb(10, 20, 30);
+
+    /// A toast with a distinct `accent` fill (overrides the severity
+    /// tint) so its painted box is trivially distinguishable from the
+    /// white canvas background by colour, without scanning for glyphs.
+    fn colored_toast(id: &str, title: &str) -> ToastItem {
+        ToastItem {
+            id: WidgetId::new(id),
+            title: title.into(),
+            body: String::new(),
+            severity: ToastSeverity::Info,
+            action: None,
+            accent: Some(BOX_COLOR),
+        }
+    }
+
+    fn stack_br(toasts: Vec<ToastItem>) -> ToastStack {
+        ToastStack {
+            id: WidgetId::new("toasts"),
+            corner: ToastCorner::BottomRight,
+            toasts,
+        }
+    }
+
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    /// Paint→click round trip at `(origin_x, origin_y)`: paints a single
+    /// toast through [`draw_toast_stack`], confirms the box's fill
+    /// colour lands at the origin-shifted *absolute* position — not the
+    /// viewport-local one `gtk_toast_stack_layout` used to compute
+    /// internally before shifting — and that `hit_test` resolves clicks
+    /// at that same absolute position through Dismiss and Body.
+    ///
+    /// Canvas grows with the origin (`VIEW_W`/`VIEW_H` stay fixed) so a
+    /// dropped-origin regression shows up as a shifted absolute paint
+    /// position rather than being masked by a shrinking viewport.
+    fn paint_and_click_round_trip_at(origin_x: f64, origin_y: f64) {
+        let canvas_w = (origin_x + VIEW_W).ceil() as i32;
+        let canvas_h = (origin_y + VIEW_H).ceil() as i32;
+        let mut surface =
+            ImageSurface::create(Format::ARgb32, canvas_w, canvas_h).expect("create ImageSurface");
+        let stack = stack_br(vec![colored_toast("t1", "Hello")]);
+
+        let layout = {
+            let cr = Context::new(&surface).expect("Context::new");
+            cr.set_source_rgb(1.0, 1.0, 1.0);
+            cr.paint().ok();
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            draw_toast_stack(
+                &cr,
+                &pango_layout,
+                origin_x,
+                origin_y,
+                VIEW_W,
+                VIEW_H,
+                &stack,
+                &Theme::default(),
+                LINE_HEIGHT,
+            )
+        };
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        assert_eq!(layout.visible_toasts.len(), 1);
+        let vt = &layout.visible_toasts[0];
+
+        // Probe near the box's own bottom-left corner — inset, away
+        // from glyphs/dismiss — must be the toast's fill colour at the
+        // *absolute* bounds `draw_toast_stack` painted into.
+        let probe_x = (vt.bounds.x + 2.0) as i32;
+        let probe_y = (vt.bounds.y + vt.bounds.height - 2.0) as i32;
+        assert_eq!(
+            pixel(&data, stride, probe_x, probe_y),
+            (BOX_COLOR.r, BOX_COLOR.g, BOX_COLOR.b),
+            "toast box should be painted at its own absolute bounds \
+             (origin=({origin_x}, {origin_y}), bounds={:?})",
+            vt.bounds,
+        );
+
+        // Round trip: absolute clicks at the dismiss and body positions
+        // resolve through hit_test.
+        let db = vt.dismiss_bounds.expect("dismiss bounds present");
+        let hit = layout.hit_test(db.x + db.width * 0.5, db.y + db.height * 0.5);
+        assert_eq!(hit, ToastHit::Dismiss(WidgetId::new("t1")));
+
+        let body_hit = layout.hit_test(vt.bounds.x + 5.0, vt.bounds.y + vt.bounds.height * 0.5);
+        assert_eq!(body_hit, ToastHit::Body(WidgetId::new("t1")));
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        paint_and_click_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"): before this fix `gtk_toast_stack_layout` had no
+    /// origin parameter at all, so `draw_toast_stack` could only ever
+    /// paint correctly when the overlay's own rect started at `(0, 0)`.
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        paint_and_click_round_trip_at(7.0, 13.0);
     }
 }

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -2525,7 +2525,9 @@ mod tests {
     #[test]
     fn toast_layout_empty() {
         let stack = make_toast_stack(ToastCorner::BottomRight, vec![]);
-        let layout = stack.layout(800.0, 600.0, 16.0, 8.0, |_| ToastMeasure::new(300.0, 64.0));
+        let layout = stack.layout(0.0, 0.0, 800.0, 600.0, 16.0, 8.0, |_| {
+            ToastMeasure::new(300.0, 64.0)
+        });
         assert_eq!(layout.visible_toasts.len(), 0);
         assert_eq!(layout.hit_test(100.0, 100.0), ToastHit::Empty);
     }
@@ -2540,7 +2542,9 @@ mod tests {
                 make_toast("third", "Third"),
             ],
         );
-        let layout = stack.layout(800.0, 600.0, 16.0, 8.0, |_| ToastMeasure::new(300.0, 64.0));
+        let layout = stack.layout(0.0, 0.0, 800.0, 600.0, 16.0, 8.0, |_| {
+            ToastMeasure::new(300.0, 64.0)
+        });
         assert_eq!(layout.visible_toasts.len(), 3);
         // Newest (idx=2, "third") pinned at the bottom.
         let newest = &layout.visible_toasts[0];
@@ -2561,7 +2565,9 @@ mod tests {
             ToastCorner::TopLeft,
             vec![make_toast("a", "A"), make_toast("b", "B")],
         );
-        let layout = stack.layout(800.0, 600.0, 10.0, 5.0, |_| ToastMeasure::new(200.0, 50.0));
+        let layout = stack.layout(0.0, 0.0, 800.0, 600.0, 10.0, 5.0, |_| {
+            ToastMeasure::new(200.0, 50.0)
+        });
         assert_eq!(layout.visible_toasts.len(), 2);
         // Iteration is oldest-first for top corners.
         let first = &layout.visible_toasts[0];
@@ -2580,7 +2586,7 @@ mod tests {
             label: "Open log".to_string(),
         });
         let stack = make_toast_stack(ToastCorner::BottomRight, vec![toast]);
-        let layout = stack.layout(800.0, 600.0, 16.0, 8.0, |_| ToastMeasure {
+        let layout = stack.layout(0.0, 0.0, 800.0, 600.0, 16.0, 8.0, |_| ToastMeasure {
             width: 300.0,
             height: 64.0,
             dismiss_width: 24.0,
@@ -2623,12 +2629,61 @@ mod tests {
                 .map(|i| make_toast(&format!("t{i}"), &format!("T{i}")))
                 .collect(),
         );
-        let layout = stack.layout(800.0, 200.0, 10.0, 8.0, |_| ToastMeasure::new(300.0, 64.0));
+        let layout = stack.layout(0.0, 0.0, 800.0, 200.0, 10.0, 8.0, |_| {
+            ToastMeasure::new(300.0, 64.0)
+        });
         // Bottom stack. Newest at y = 200 - 10 - 64 = 126. Each subsequent
         // goes up 64+8=72. Next: 126-72=54. Next: 54-72=-18 (would be off-top).
         // So only 2-3 fit. Specifically we break when y_cursor <= 0.
         assert!(layout.visible_toasts.len() >= 2);
         assert!(layout.visible_toasts.len() <= 3);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md):
+    /// `ToastStack::layout` previously had no origin parameter at all,
+    /// so it could only ever be called with an implicit `(0, 0)`
+    /// origin — a shape no `*_toast_stack_layout` backend wrapper could
+    /// correct for. Confirms every returned bound (toast, dismiss,
+    /// action, hit region) shifts rigidly by `(origin_x, origin_y)`
+    /// relative to the origin-`(0, 0)` layout for the same stack.
+    #[test]
+    fn toast_layout_nonzero_origin_shifts_every_bound() {
+        let mut toast = make_toast("t1", "Build failed");
+        toast.action = Some(ToastAction {
+            id: WidgetId::new("open_log"),
+            label: "Open log".to_string(),
+        });
+        let stack = make_toast_stack(ToastCorner::BottomRight, vec![toast]);
+        let measure = |_: usize| ToastMeasure {
+            width: 300.0,
+            height: 64.0,
+            dismiss_width: 24.0,
+            action_width: 80.0,
+        };
+        let origin = stack.layout(0.0, 0.0, 800.0, 600.0, 16.0, 8.0, measure);
+        let shifted = stack.layout(7.0, 13.0, 800.0, 600.0, 16.0, 8.0, measure);
+
+        let o = &origin.visible_toasts[0];
+        let s = &shifted.visible_toasts[0];
+        assert_eq!(s.bounds.x, o.bounds.x + 7.0);
+        assert_eq!(s.bounds.y, o.bounds.y + 13.0);
+        assert_eq!(s.bounds.width, o.bounds.width);
+        assert_eq!(
+            s.dismiss_bounds.unwrap().x,
+            o.dismiss_bounds.unwrap().x + 7.0
+        );
+        assert_eq!(
+            s.action_bounds.unwrap().y,
+            o.action_bounds.unwrap().y + 13.0
+        );
+
+        // Round trip: an absolute hit against the shifted layout must
+        // resolve the same way the origin layout resolves its local hit.
+        let db = s.dismiss_bounds.unwrap();
+        assert_eq!(
+            shifted.hit_test(db.x + 5.0, db.y + 10.0),
+            ToastHit::Dismiss(WidgetId::new("t1")),
+        );
     }
 
     // ── D6 Terminal layout API tests ──────────────────────────────────

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -1109,6 +1109,8 @@ impl Backend for MacBackend {
             super::toast::draw_toast_stack(
                 ctx,
                 font,
+                rect.x as f64,
+                rect.y as f64,
                 rect.width as f64,
                 rect.height as f64,
                 stack,
@@ -1125,6 +1127,8 @@ impl Backend for MacBackend {
         super::toast::mac_toast_stack_layout(
             stack,
             font,
+            rect.x,
+            rect.y,
             rect.width,
             rect.height,
             self.current_line_height,

--- a/quadraui/src/macos/chart.rs
+++ b/quadraui/src/macos/chart.rs
@@ -573,6 +573,28 @@ mod tests {
     }
 
     #[test]
+    fn hit_test_inside_plot_area_at_nonzero_origin() {
+        // Regression for quadraui#494 / LESSONS.md "Layout helpers must
+        // return coords in the same frame across backends": every other
+        // test in this file lays out at origin (0, 0), where an
+        // origin-offset bug is invisible (see #44's mac_tree_layout).
+        // `mac_chart_layout` bakes `x`/`y` straight into `plot_area`
+        // (absolute frame, matching the GTK/TUI twins) — call it
+        // directly (no paint needed; it's a pure fn) at a non-zero
+        // origin and prove a click at the resulting absolute plot-area
+        // centre still resolves through `hit_test`. Not exercised by
+        // `cargo build --features macos` on this (Linux) machine —
+        // this crate's macOS backend is verified on real Mac hardware.
+        let chart = sample_line();
+        let origin_x = 7.0_f64;
+        let origin_y = 13.0_f64;
+        let layout = mac_chart_layout(&chart, origin_x, origin_y, W as f64, H as f64, 16.0, 8.0);
+        let cx = layout.plot_area.x + layout.plot_area.width * 0.5;
+        let cy = layout.plot_area.y + layout.plot_area.height * 0.5;
+        assert_eq!(layout.hit_test(cx, cy), ChartHit::Body(WidgetId::new("ch")),);
+    }
+
+    #[test]
     fn hover_marker_painted_when_set() {
         let chart = sample_line();
         let (surface, layout) = paint_via_backend(&chart, Some((0, 2)));

--- a/quadraui/src/macos/command_center.rs
+++ b/quadraui/src/macos/command_center.rs
@@ -286,6 +286,37 @@ mod tests {
         );
     }
 
+    #[test]
+    fn hit_test_resolves_back_forward_search_at_nonzero_origin() {
+        // Regression for quadraui#494 / LESSONS.md "Layout helpers must
+        // return coords in the same frame across backends": every other
+        // test in this file lays out at origin (0, 0). `mac_command_
+        // center_layout` bakes `x`/`y` straight into `back_bounds` /
+        // `forward_bounds` / `search_bounds` (absolute frame, matching
+        // the GTK/TUI twins) — call it directly (pure fn, no paint
+        // needed) at a non-zero origin and prove clicks at the
+        // resulting absolute bounds still resolve through `hit_test`.
+        let cc = sample_cc();
+        let f = font();
+        let layout = mac_command_center_layout(&cc, &f, 7.0, 13.0, W as f64, H as f64);
+        let back = layout.back_bounds.unwrap();
+        let fwd = layout.forward_bounds.unwrap();
+        let search = layout.search_bounds.unwrap();
+
+        assert_eq!(
+            layout.hit_test(back.x + 1.0, back.y + 1.0),
+            CommandCenterHit::Back,
+        );
+        assert_eq!(
+            layout.hit_test(fwd.x + 1.0, fwd.y + 1.0),
+            CommandCenterHit::Forward,
+        );
+        assert_eq!(
+            layout.hit_test(search.x + 5.0, search.y + 5.0),
+            CommandCenterHit::SearchBox,
+        );
+    }
+
     /// `cargo test -p quadraui --features macos -- --ignored --nocapture macos::command_center::tests::dump_smoke_ppm`
     ///
     /// Paints the sample CC (back enabled, forward disabled, "project"

--- a/quadraui/src/macos/completions.rs
+++ b/quadraui/src/macos/completions.rs
@@ -181,11 +181,25 @@ mod tests {
     }
 
     fn layout_for(c: &Completions) -> CompletionsLayout {
+        layout_for_at(c, 0.0, 0.0)
+    }
+
+    /// Like [`layout_for`] but anchors the cursor + viewport at an
+    /// arbitrary `(origin_x, origin_y)` instead of always `(0, 0)`.
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"): `Completions::layout` already threads
+    /// `viewport.x`/`viewport.y` through to absolute placement math (it
+    /// was never the #494 gap), but this test module only ever
+    /// exercised a `(0, 0)`-origin viewport, so a placement regression
+    /// at a real (non-zero) editor/panel origin would have gone
+    /// undetected.
+    fn layout_for_at(c: &Completions, origin_x: f32, origin_y: f32) -> CompletionsLayout {
         c.layout(
-            20.0,
-            20.0,
+            origin_x + 20.0,
+            origin_y + 20.0,
             16.0,
-            QRect::new(0.0, 0.0, W as f32, H as f32),
+            QRect::new(origin_x, origin_y, W as f32 - origin_x, H as f32 - origin_y),
             120.0,
             80.0,
             |_| CompletionItemMeasure::new(16.0),
@@ -250,14 +264,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn hit_test_resolves_visible_items() {
+    /// Shared body for `hit_test_resolves_visible_items` — see
+    /// [`layout_for_at`] for the quadraui#494 non-zero-origin rationale.
+    fn hit_test_resolves_visible_items_at(origin_x: f32, origin_y: f32) {
         let c = sample();
-        let l = layout_for(&c);
+        let l = layout_for_at(&c, origin_x, origin_y);
+        assert!(
+            !l.visible_items.is_empty(),
+            "sample popup should show items"
+        );
         for vis in &l.visible_items {
             let cx = vis.bounds.x + vis.bounds.width * 0.5;
             let cy = vis.bounds.y + vis.bounds.height * 0.5;
             assert_eq!(l.hit_test(cx, cy), CompletionsHit::Item(vis.item_idx));
         }
+    }
+
+    #[test]
+    fn hit_test_resolves_visible_items() {
+        hit_test_resolves_visible_items_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494): same round trip,
+    /// with the popup's cursor + viewport anchored at a shifted origin.
+    #[test]
+    fn hit_test_resolves_visible_items_at_nonzero_origin() {
+        hit_test_resolves_visible_items_at(7.0, 13.0);
     }
 }

--- a/quadraui/src/macos/data_table.rs
+++ b/quadraui/src/macos/data_table.rs
@@ -540,4 +540,49 @@ mod tests {
         );
         assert!(matches!(hit, DataTableHit::Row { idx: 1 }));
     }
+
+    #[test]
+    fn layout_returns_local_coords_when_area_offset() {
+        // Cross-backend contract: `mac_data_table_layout` explicitly
+        // discards `x`/`y` (`let _ = (x, y);` in the fn body) — the
+        // returned bounds are LOCAL (origin 0, 0) regardless of where
+        // the table is painted, matching the tree/form/list/palette
+        // family (unlike chart/command_center/menu_bar/panel/msv in
+        // this same batch, which bake x/y into their bounds). Only
+        // `draw_data_table`'s paint path adds `x`/`y` back in.
+        //
+        // Regression guard for quadraui#494 / LESSONS.md "Layout
+        // helpers must return coords in the same frame across
+        // backends": prove the origin genuinely has no effect on the
+        // returned layout, then round-trip a click through hit_test —
+        // callers never localise here since bounds are already local.
+        let table = sample_table();
+        let f = font();
+        let layout_origin = mac_data_table_layout(&table, &f, 0.0, 0.0, W as f64, H as f64, 16.0);
+        let layout_offset = mac_data_table_layout(&table, &f, 7.0, 13.0, W as f64, H as f64, 16.0);
+        assert_eq!(
+            layout_origin, layout_offset,
+            "mac_data_table_layout must ignore (x, y) — bounds are local by construction",
+        );
+
+        let total = table.rows.len();
+
+        // Header row center → Header { col: 0 }.
+        let hit = layout_offset.hit_test(
+            layout_offset.columns[0].x + layout_offset.columns[0].width * 0.5,
+            layout_offset.header_height * 0.5,
+            table.scroll_offset,
+            total,
+        );
+        assert!(matches!(hit, DataTableHit::Header { col: 0 }));
+
+        // Body row 1 (selected) → Row { idx: 1 }.
+        let hit = layout_offset.hit_test(
+            10.0,
+            layout_offset.header_height + layout_offset.row_height * 1.5,
+            table.scroll_offset,
+            total,
+        );
+        assert!(matches!(hit, DataTableHit::Row { idx: 1 }));
+    }
 }

--- a/quadraui/src/macos/menu_bar.rs
+++ b/quadraui/src/macos/menu_bar.rs
@@ -80,7 +80,17 @@ pub unsafe fn draw_menu_bar(
             (theme.tab_inactive_fg, theme.tab_bar_bg)
         };
 
-        let item_x = x + vi.bounds.x as f64;
+        // `vi.bounds.x` is already absolute — `mac_menu_bar_layout` passes
+        // `bounds.x = x` into `MenuBar::layout`, which starts its internal
+        // cursor at `bounds.x`, so item bounds already carry the bar's
+        // origin. Adding `x` again here double-counted it, invisibly at
+        // `x == 0` (every existing test) and shifting painted glyphs away
+        // from their own hit-test bounds at any other origin — the
+        // LESSONS.md "layout helpers must return coords in the same frame
+        // across backends" bug class. Same bug found and fixed in
+        // `tui::menu_bar::draw_menu_bar` via the quadraui#494 non-zero-
+        // origin regression test.
+        let item_x = vi.bounds.x as f64;
         let item_w = vi.bounds.width as f64;
 
         if is_active {
@@ -258,6 +268,39 @@ mod tests {
         let (_surface, layout) = paint_via_backend(&bar);
         // Clickable items (File, Edit) resolve as Item(i). Disabled
         // View falls through to Bar — matches the primitive contract.
+        for (i, vi) in layout.visible_items.iter().enumerate() {
+            let cx = vi.bounds.x + vi.bounds.width * 0.5;
+            let cy = vi.bounds.y + vi.bounds.height * 0.5;
+            let expected = if vi.clickable {
+                MenuBarHit::Item(i)
+            } else {
+                MenuBarHit::Bar
+            };
+            assert_eq!(
+                layout.hit_test(cx, cy),
+                expected,
+                "item {} (clickable={})",
+                i,
+                vi.clickable
+            );
+        }
+    }
+
+    #[test]
+    fn hit_test_resolves_clickable_items_at_nonzero_origin() {
+        // Regression for quadraui#494 / LESSONS.md "Layout helpers must
+        // return coords in the same frame across backends": every other
+        // test in this file lays out at origin (0, 0). `mac_menu_bar_
+        // layout` bakes `x`/`y` straight into `visible_items[].bounds`
+        // (absolute frame, matching the GTK/TUI twins) via
+        // `MenuBar::layout`, whose cursor starts at `bounds.x` — call it
+        // directly (pure fn, no paint needed) at a non-zero origin and
+        // prove hit_test still resolves the right item.
+        let bar = sample_bar();
+        let f = font();
+        let origin_x = 7.0;
+        let origin_y = 13.0;
+        let layout = mac_menu_bar_layout(&f, origin_x, origin_y, W as f64, H as f64, &bar);
         for (i, vi) in layout.visible_items.iter().enumerate() {
             let cx = vi.bounds.x + vi.bounds.width * 0.5;
             let cy = vi.bounds.y + vi.bounds.height * 0.5;

--- a/quadraui/src/macos/multi_section_view.rs
+++ b/quadraui/src/macos/multi_section_view.rs
@@ -764,6 +764,46 @@ mod tests {
     }
 
     #[test]
+    fn hit_test_resolves_header_and_body_at_nonzero_origin() {
+        // Regression for quadraui#494 / LESSONS.md "Layout helpers must
+        // return coords in the same frame across backends": the sibling
+        // at-origin test above only exercises (0, 0), where an origin
+        // bug is invisible. `mac_msv_layout` bakes `bounds.x`/`bounds.y`
+        // straight into every returned Rect (absolute frame, matching
+        // the GTK/TUI twins) — call it directly (pure fn, no paint
+        // needed) at a non-zero origin and round-trip both a header
+        // click AND a section body click through `hit_test` (the
+        // existing at-origin test only covers a header click).
+        let view = two_section_view();
+        let origin = QRect::new(7.0, 13.0, W as f32, H as f32);
+        let layout = mac_msv_layout(&view, origin, 16.0);
+
+        let hdr = layout.sections[0].header_bounds;
+        let cx = hdr.x + hdr.width * 0.5;
+        let cy = hdr.y + hdr.height * 0.5;
+        let hit = layout.hit_test(cx, cy);
+        assert!(
+            matches!(hit, MultiSectionViewHit::Header { section: 0, .. }),
+            "header click hit was {:?}",
+            hit,
+        );
+
+        let body = layout.sections[0].body_bounds;
+        assert!(
+            body.width > 0.0 && body.height > 0.0,
+            "section 0 body must have non-zero size to round-trip a click",
+        );
+        let bx = body.x + body.width * 0.5;
+        let by = body.y + body.height * 0.5;
+        let hit = layout.hit_test(bx, by);
+        assert!(
+            matches!(hit, MultiSectionViewHit::Body { section: 0 }),
+            "body click hit was {:?}",
+            hit,
+        );
+    }
+
+    #[test]
     fn collapsed_section_zero_body_height() {
         let mut view = two_section_view();
         view.sections[0].collapsed = true;

--- a/quadraui/src/macos/panel.rs
+++ b/quadraui/src/macos/panel.rs
@@ -264,6 +264,36 @@ mod tests {
     }
 
     #[test]
+    fn hit_test_resolves_action_vs_title_vs_content_at_nonzero_origin() {
+        // Regression for quadraui#494 / LESSONS.md "Layout helpers must
+        // return coords in the same frame across backends": every other
+        // test in this file lays out at origin (0, 0). `mac_panel_
+        // layout` bakes `x`/`y` straight into `bounds` (absolute frame,
+        // matching the GTK/TUI twins) — call it directly (pure fn, no
+        // paint needed) at a non-zero origin and prove action/title/
+        // content clicks still resolve through `hit_test`.
+        let panel = sample_panel();
+        let layout = mac_panel_layout(&panel, 7.0, 13.0, W as f64, H as f64, 16.0);
+
+        let first_action = &layout.visible_actions[0];
+        let hit = layout.hit_test(
+            first_action.bounds.x + first_action.bounds.width * 0.5,
+            first_action.bounds.y + first_action.bounds.height * 0.5,
+        );
+        assert!(matches!(hit, PanelHit::Action(_)));
+
+        // Title body (left of actions).
+        let tb = layout.title_bar_bounds.unwrap();
+        let hit = layout.hit_test(tb.x + 10.0, tb.y + tb.height * 0.5);
+        assert!(matches!(hit, PanelHit::TitleBar(_)), "hit was {:?}", hit);
+
+        // Content area.
+        let cb = layout.content_bounds;
+        let hit = layout.hit_test(cb.x + cb.width * 0.5, cb.y + cb.height * 0.5);
+        assert!(matches!(hit, PanelHit::Content(_)));
+    }
+
+    #[test]
     fn collapsed_panel_zero_content_height() {
         let mut panel = sample_panel();
         panel.collapsed = true;

--- a/quadraui/src/macos/pipeline_view.rs
+++ b/quadraui/src/macos/pipeline_view.rs
@@ -316,3 +316,135 @@ extern "C" {
     fn CGContextClosePath(c: CGContextRef);
     fn CGContextFillPath(c: CGContextRef);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::pipeline_view::{PipelineHit, PipelineStage};
+    use crate::types::WidgetId;
+    use crate::Backend;
+
+    const W: u32 = 300;
+    const H: u32 = 80;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn make_view() -> PipelineView {
+        PipelineView {
+            id: WidgetId::new("pipe"),
+            stages: vec![
+                PipelineStage {
+                    label: "Build".into(),
+                    status: StageStatus::Done,
+                    action: None,
+                },
+                PipelineStage {
+                    label: "Test".into(),
+                    status: StageStatus::Active,
+                    action: Some("Retry".into()),
+                },
+            ],
+            focused_stage: None,
+        }
+    }
+
+    fn paint_via_backend(view: &PipelineView) -> (BitmapSurface, PipelineViewLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_pipeline_view(QRect::new(0.0, 0.0, W as f32, H as f32), view);
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn draws_without_panic_and_has_two_stages() {
+        let view = make_view();
+        let (_surface, layout) = paint_via_backend(&view);
+        assert_eq!(layout.stages.len(), 2);
+    }
+
+    /// Shared body for the action↔click round trip, run at both the
+    /// origin and a non-zero origin (quadraui#494 / LESSONS.md "Layout
+    /// helpers must return coords in the same frame across backends").
+    /// `mac_pipeline_view_layout` bakes `x`/`y` straight into the
+    /// returned bounds (absolute frame, matching the GTK/TUI twins) —
+    /// and *also* adds `MAC_FOCUS_INDICATOR_H` to `y` itself before
+    /// laying out, an extra reason a non-zero-origin regression is
+    /// plausible here. Deriving `ab`/`bb` from the layout (not
+    /// hardcoding them) means this exercises whatever origin math the
+    /// function actually does, at any origin. Calls
+    /// `mac_pipeline_view_layout` directly (pure fn, no font/paint
+    /// dependency — it forwards to `PipelineView::layout`, which is
+    /// plain geometry).
+    fn layout_hit_test_action_round_trip_at(origin_x: f64, origin_y: f64) {
+        let view = make_view();
+        let layout = mac_pipeline_view_layout(&view, origin_x, origin_y, 300.0, 80.0);
+
+        // Box top must sit exactly at origin_y + MAC_FOCUS_INDICATOR_H,
+        // not a hardcoded absolute value — pins the offset math
+        // independently of the hit_test round trip below.
+        let bb0 = layout.stages[0].box_bounds;
+        assert!(
+            (bb0.y as f64 - (origin_y + MAC_FOCUS_INDICATOR_H)).abs() < 0.001,
+            "stage box top should be origin_y + MAC_FOCUS_INDICATOR_H, got {}",
+            bb0.y,
+        );
+
+        // Stage 1 has action bounds.
+        let ab = layout.stages[1]
+            .action_bounds
+            .expect("action bounds for stage 1");
+        let hit = layout.hit_test(ab.x + ab.width / 2.0, ab.y + ab.height / 2.0);
+        assert_eq!(hit, PipelineHit::Action(1));
+    }
+
+    #[test]
+    fn layout_hit_test_action_round_trip() {
+        layout_hit_test_action_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn layout_hit_test_action_round_trip_at_nonzero_origin() {
+        layout_hit_test_action_round_trip_at(7.0, 13.0);
+    }
+
+    fn layout_hit_test_body_round_trip_at(origin_x: f64, origin_y: f64) {
+        let view = make_view();
+        let layout = mac_pipeline_view_layout(&view, origin_x, origin_y, 300.0, 80.0);
+
+        let bb = layout.stages[0].box_bounds;
+        assert!(
+            (bb.y as f64 - (origin_y + MAC_FOCUS_INDICATOR_H)).abs() < 0.001,
+            "stage box top should be origin_y + MAC_FOCUS_INDICATOR_H, got {}",
+            bb.y,
+        );
+        // Stage 0 has no action, so a click inside its box resolves to Body.
+        let hit = layout.hit_test(bb.x + 1.0, bb.y + 1.0);
+        assert_eq!(hit, PipelineHit::Body(0));
+    }
+
+    #[test]
+    fn layout_hit_test_body_round_trip() {
+        layout_hit_test_body_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn layout_hit_test_body_round_trip_at_nonzero_origin() {
+        layout_hit_test_body_round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/macos/progress.rs
+++ b/quadraui/src/macos/progress.rs
@@ -216,8 +216,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn cancellable_bar_reserves_cancel_bounds() {
+    /// Shared body for the cancel-bounds↔hit_test round trip, run at
+    /// both the origin and a non-zero origin (quadraui#494 /
+    /// LESSONS.md "Layout helpers must return coords in the same
+    /// frame across backends"). `mac_progress_layout` bakes `x`/`y`
+    /// straight into the returned `cancel_bounds` (absolute frame,
+    /// matching the GTK/TUI twins) — call it directly (pure fn, no
+    /// paint needed) and prove a click at the resulting absolute
+    /// cancel-bounds position still resolves through `hit_test`.
+    fn cancellable_bar_reserves_cancel_bounds_at(origin_x: f64, origin_y: f64) {
         let bar = ProgressBar {
             id: WidgetId::new("pb"),
             label: String::new(),
@@ -226,13 +233,24 @@ mod tests {
             cancellable: true,
             accent: None,
         };
-        let (_surface, layout) = paint_via_backend(&bar);
+        let layout = mac_progress_layout(&bar, origin_x, origin_y, W as f64, H as f64);
         let cb = layout.cancel_bounds.expect("cancel bounds present");
         assert!((cb.width - CANCEL_WIDTH_PX).abs() < 0.01);
         // Hit-test at the cancel center returns Cancel.
         let cx = cb.x + cb.width * 0.5;
         let cy = cb.y + cb.height * 0.5;
         assert!(matches!(layout.hit_test(cx, cy), ProgressBarHit::Cancel(_),));
+    }
+
+    #[test]
+    fn cancellable_bar_reserves_cancel_bounds() {
+        cancellable_bar_reserves_cancel_bounds_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn cancellable_bar_reserves_cancel_bounds_at_nonzero_origin() {
+        cancellable_bar_reserves_cancel_bounds_at(7.0, 13.0);
     }
 
     #[test]

--- a/quadraui/src/macos/sidebar_panel.rs
+++ b/quadraui/src/macos/sidebar_panel.rs
@@ -109,3 +109,117 @@ pub unsafe fn draw_sidebar_panel(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::sidebar_panel::SidebarPanelHit;
+    use crate::primitives::toolbar::{Toolbar, ToolbarButton};
+    use crate::types::WidgetId;
+    use crate::Backend;
+
+    const W: u32 = 240;
+    const H: u32 = 200;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed")
+    }
+
+    fn panel_with_toolbar() -> SidebarPanel {
+        SidebarPanel {
+            id: WidgetId::new("sb"),
+            toolbar: Some(Toolbar {
+                id: WidgetId::new("sb:toolbar"),
+                buttons: vec![ToolbarButton::Action {
+                    id: WidgetId::new("refine"),
+                    label: "Refine".into(),
+                    icon: None,
+                    key_hint: None,
+                    enabled: true,
+                    is_active: false,
+                    tooltip: String::new(),
+                }],
+                bg: None,
+                focused_index: None,
+            }),
+            toolbar_height: None,
+        }
+    }
+
+    fn paint_via_backend(panel: &SidebarPanel) -> (BitmapSurface, SidebarPanelLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l =
+                b.draw_sidebar_panel(QRect::new(0.0, 0.0, W as f32, H as f32), panel, None, None);
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn toolbar_reserves_header_slot_content_starts_below() {
+        let panel = panel_with_toolbar();
+        let (_surface, layout) = paint_via_backend(&panel);
+        let tb = layout.toolbar_bounds.expect("toolbar bounds present");
+        assert_eq!(tb.y, 0.0);
+        assert!(
+            layout.content_bounds.y >= tb.y + tb.height,
+            "content should start below the toolbar slot: tb.bottom={}, content.y={}",
+            tb.y + tb.height,
+            layout.content_bounds.y,
+        );
+    }
+
+    #[test]
+    fn no_toolbar_gives_full_rect_to_content() {
+        let panel = SidebarPanel {
+            id: WidgetId::new("sb"),
+            toolbar: None,
+            toolbar_height: None,
+        };
+        let (_surface, layout) = paint_via_backend(&panel);
+        assert!(layout.toolbar_bounds.is_none());
+        assert_eq!(layout.content_bounds.y, 0.0);
+        assert_eq!(layout.content_bounds.height, H as f32);
+    }
+
+    /// Shared body for the header-click↔toolbar-button round trip, run
+    /// at both the origin and a non-zero origin (quadraui#494 /
+    /// LESSONS.md "Layout helpers must return coords in the same frame
+    /// across backends"). `mac_sidebar_panel_layout` bakes `x`/`y`
+    /// straight into `panel.layout`'s returned bounds (absolute frame,
+    /// matching the GTK/TUI twins) — call it directly (pure fn, no
+    /// paint needed) and prove a click near the header's top-left
+    /// still resolves to the toolbar button through `hit_test`.
+    fn click_in_header_round_trip_at(origin_x: f64, origin_y: f64) {
+        let panel = panel_with_toolbar();
+        let f = font();
+        let layout =
+            mac_sidebar_panel_layout(&panel, &f, 16.0, origin_x, origin_y, W as f64, H as f64);
+        match layout.hit_test(origin_x as f32 + 2.0, origin_y as f32) {
+            SidebarPanelHit::ToolbarButton(id) => assert_eq!(id.as_str(), "refine"),
+            other => panic!("expected ToolbarButton, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn click_in_header_resolves_to_toolbar_button() {
+        click_in_header_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn click_in_header_resolves_to_toolbar_button_at_nonzero_origin() {
+        click_in_header_round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/macos/spinner.rs
+++ b/quadraui/src/macos/spinner.rs
@@ -167,16 +167,36 @@ mod tests {
         );
     }
 
-    #[test]
-    fn hit_test_inside_bounds_returns_body() {
+    /// Shared body for the click↔hit_test round trip, run at both the
+    /// origin and a non-zero origin (quadraui#494 / LESSONS.md "Layout
+    /// helpers must return coords in the same frame across backends").
+    /// `mac_spinner_layout` bakes `x`/`y` straight into `bounds`
+    /// (absolute frame, matching the GTK/TUI twins) — call it directly
+    /// (pure fn, no paint needed) and prove a click at the resulting
+    /// absolute bounds position still resolves through `hit_test`.
+    fn hit_test_inside_bounds_returns_body_at(origin_x: f64, origin_y: f64) {
         let spinner = sample_spinner();
-        let (_, layout) = paint_via_backend(&spinner);
+        let f = font();
+        let layout = mac_spinner_layout(&spinner, &f, origin_x, origin_y);
         let cx = layout.bounds.x + layout.bounds.width * 0.5;
         let cy = layout.bounds.y + layout.bounds.height * 0.5;
         assert_eq!(
             layout.hit_test(cx, cy, &spinner.id),
             SpinnerHit::Body(spinner.id.clone()),
         );
+        // (-1, -1) is outside the bounds regardless of origin, since
+        // both test origins used here are non-negative.
         assert_eq!(layout.hit_test(-1.0, -1.0, &spinner.id), SpinnerHit::Empty,);
+    }
+
+    #[test]
+    fn hit_test_inside_bounds_returns_body() {
+        hit_test_inside_bounds_returns_body_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn hit_test_inside_bounds_returns_body_at_nonzero_origin() {
+        hit_test_inside_bounds_returns_body_at(7.0, 13.0);
     }
 }

--- a/quadraui/src/macos/split.rs
+++ b/quadraui/src/macos/split.rs
@@ -163,10 +163,18 @@ mod tests {
         assert_eq!((r, g, b), (255, 255, 255), "left pane should be unpainted");
     }
 
-    #[test]
-    fn hit_test_resolves_divider_and_panes() {
+    /// Shared body for the divider/first-pane/second-pane hit_test
+    /// round trip, run at both the origin and a non-zero origin
+    /// (quadraui#494 / LESSONS.md "Layout helpers must return coords
+    /// in the same frame across backends"). `mac_split_layout` bakes
+    /// `bounds.x`/`bounds.y` into `first_bounds`/`divider_bounds`/
+    /// `second_bounds` (absolute frame, matching the GTK/TUI twins) —
+    /// call it directly (pure fn, no paint needed) and prove clicks at
+    /// the resulting absolute positions still resolve through
+    /// `hit_test` for all three regions.
+    fn hit_test_resolves_divider_and_panes_at(origin_x: f64, origin_y: f64) {
         let split = sample_split(SplitDirection::Horizontal);
-        let (_surface, layout) = paint_via_backend(&split);
+        let layout = mac_split_layout(&split, origin_x, origin_y, W as f64, H as f64);
 
         let d = layout.divider_bounds;
         let hit = layout.hit_test(d.x + d.width / 2.0, d.y + d.height / 2.0);
@@ -176,13 +184,32 @@ mod tests {
             hit
         );
 
-        // First pane: well left of the divider.
-        let hit = layout.hit_test(10.0, 10.0);
-        assert!(matches!(hit, SplitHit::FirstPane(_)));
+        // First pane: well left of the divider, relative to origin.
+        let hit = layout.hit_test(origin_x as f32 + 10.0, origin_y as f32 + 10.0);
+        assert!(
+            matches!(hit, SplitHit::FirstPane(_)),
+            "first pane hit was {:?}",
+            hit
+        );
 
-        // Second pane: well right of the divider.
-        let hit = layout.hit_test((W - 10) as f32, 10.0);
-        assert!(matches!(hit, SplitHit::SecondPane(_)));
+        // Second pane: well right of the divider, relative to origin.
+        let hit = layout.hit_test(origin_x as f32 + W as f32 - 10.0, origin_y as f32 + 10.0);
+        assert!(
+            matches!(hit, SplitHit::SecondPane(_)),
+            "second pane hit was {:?}",
+            hit
+        );
+    }
+
+    #[test]
+    fn hit_test_resolves_divider_and_panes() {
+        hit_test_resolves_divider_and_panes_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn hit_test_resolves_divider_and_panes_at_nonzero_origin() {
+        hit_test_resolves_divider_and_panes_at(7.0, 13.0);
     }
 
     #[test]

--- a/quadraui/src/macos/status_bar.rs
+++ b/quadraui/src/macos/status_bar.rs
@@ -245,6 +245,14 @@ mod tests {
     /// the layout (for hit_test). Establishes the harness shape every
     /// chrome rasteriser test follows.
     fn paint_via_backend(bar: &StatusBar) -> (BitmapSurface, StatusBarLayout) {
+        paint_via_backend_at(bar, 0.0, 0.0)
+    }
+
+    /// Like [`paint_via_backend`] but paints at an arbitrary `(x, y)`
+    /// origin instead of always `(0, 0)`. Lets tests exercise the
+    /// paint-time `x`/`y` shift independently of the bar-local
+    /// `StatusBarLayout` it returns.
+    fn paint_via_backend_at(bar: &StatusBar, x: f32, y: f32) -> (BitmapSurface, StatusBarLayout) {
         let surface = BitmapSurface::new(W, H);
         // Clear so we can distinguish "painted by status_bar" from
         // "untouched memory" cleanly.
@@ -256,7 +264,12 @@ mod tests {
 
         let layout = std::cell::RefCell::new(None);
         backend.enter_frame_scope(surface.context_ptr(), |b| {
-            let l = b.draw_status_bar(QRect::new(0.0, 0.0, W as f32, H as f32), bar, None, None);
+            let l = b.draw_status_bar(
+                QRect::new(x, y, W as f32 - x, H as f32 - y),
+                bar,
+                None,
+                None,
+            );
             *layout.borrow_mut() = Some(l);
         });
         backend.end_frame();
@@ -293,13 +306,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn round_trip_click_hits_clickable_segment() {
-        // Paint the bar, then hit-test a coordinate inside the
-        // clickable "Save" segment's painted bounds. Assert the layout
-        // reports a hit on the segment's action_id.
+    /// Shared body for `round_trip_click_hits_clickable_segment` and its
+    /// `_at_nonzero_origin` sibling. Paints `sample_bar()` at
+    /// `(origin_x, origin_y)`, then round-trips an absolute click through
+    /// localisation the way a real host (`ScreenLayout` / `AppLogic`)
+    /// does before calling `hit_test`, and — since this file's rasteriser
+    /// DOES use `x`/`y` for paint even though the returned layout is
+    /// bar-local (see module doc comment) — also checks the *painted*
+    /// segment lands at the origin-shifted absolute position. Guards
+    /// against a #44-class paint/layout frame mismatch
+    /// (quadraui#494 / LESSONS.md "Layout helpers must return coords in
+    /// the same frame across backends").
+    fn round_trip_click_hits_clickable_segment_at(origin_x: f32, origin_y: f32) {
         let bar = sample_bar();
-        let (_surface, layout) = paint_via_backend(&bar);
+        let (surface, layout) = paint_via_backend_at(&bar, origin_x, origin_y);
 
         let save = layout
             .visible_segments
@@ -307,15 +327,31 @@ mod tests {
             .filter(|vs| vs.side == StatusSegmentSide::Left)
             .nth(1)
             .expect("save segment visible");
-        let hit_x = save.bounds.x + save.bounds.width * 0.5;
-        let hit_y = save.bounds.y + save.bounds.height * 0.5;
-        let hit = layout.hit_test(hit_x, hit_y);
+
+        // Paint-vs-layout frame check: the segment's bg must be painted
+        // at the origin-shifted absolute x, not at the bar-local x.
+        let probe_x = (origin_x + save.bounds.x) as u32 + 1;
+        let probe_y = origin_y as u32 + 2;
+        let (r, g, b, _) = surface.pixel(probe_x, probe_y);
+        assert_eq!(
+            (r, g, b),
+            (40, 80, 120),
+            "painted Save segment bg should be at absolute x = origin_x + local bounds.x",
+        );
+
+        // Round trip: absolute click position -> localise like a real
+        // host -> hit_test against the bar-local layout.
+        let abs_x = origin_x + save.bounds.x + save.bounds.width * 0.5;
+        let abs_y = origin_y + save.bounds.y + save.bounds.height * 0.5;
+        let local_x = abs_x - origin_x;
+        let local_y = abs_y - origin_y;
+        let hit = layout.hit_test(local_x, local_y);
         assert_eq!(
             hit,
             StatusBarHit::Segment(WidgetId::new("status:save")),
-            "expected clickable Save segment hit at ({}, {})",
-            hit_x,
-            hit_y,
+            "expected clickable Save segment hit at local ({}, {})",
+            local_x,
+            local_y,
         );
 
         // Sanity check: the right segment is non-clickable, so a hit
@@ -334,6 +370,20 @@ mod tests {
             StatusBarHit::Empty,
             "non-clickable right segment must hit Empty",
         );
+    }
+
+    #[test]
+    fn round_trip_click_hits_clickable_segment() {
+        round_trip_click_hits_clickable_segment_at(0.0, 0.0);
+    }
+
+    #[test]
+    fn round_trip_click_hits_clickable_segment_at_nonzero_origin() {
+        // The origin-(0,0) variant above can't exercise localisation —
+        // `abs_x - x` is a no-op when `x == 0`. Paint at a non-zero
+        // origin so the round trip only passes if paint and layout agree
+        // on which frame `x`/`y` apply in.
+        round_trip_click_hits_clickable_segment_at(7.0, 4.0);
     }
 
     #[test]

--- a/quadraui/src/macos/text_display.rs
+++ b/quadraui/src/macos/text_display.rs
@@ -244,6 +244,14 @@ mod tests {
     }
 
     fn paint(td: &TextDisplay) -> (BitmapSurface, TextDisplayLayout) {
+        paint_at(td, QRect::new(0.0, 0.0, W as f32, H as f32))
+    }
+
+    /// Like [`paint`] but paints (and derives the layout) at an
+    /// arbitrary `rect` instead of always `QRect::new(0.0, 0.0, ...)`.
+    /// Lets tests exercise the paint-time `x`/`y`/title-strip shift
+    /// independently of the body-local `TextDisplayLayout` it returns.
+    fn paint_at(td: &TextDisplay, rect: QRect) -> (BitmapSurface, TextDisplayLayout) {
         let surface = BitmapSurface::new(W, H);
         surface.fill(0.0, 0.0, 0.0, 0.0);
         let mut backend = MacBackend::new();
@@ -251,8 +259,8 @@ mod tests {
         backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
         let layout = std::cell::RefCell::new(None);
         backend.enter_frame_scope(surface.context_ptr(), |b| {
-            b.draw_text_display(QRect::new(0.0, 0.0, W as f32, H as f32), td);
-            let l = b.text_display_layout(QRect::new(0.0, 0.0, W as f32, H as f32), td);
+            b.draw_text_display(rect, td);
+            let l = b.text_display_layout(rect, td);
             *layout.borrow_mut() = Some(l);
         });
         backend.end_frame();
@@ -324,6 +332,55 @@ mod tests {
         let cx = vis.bounds.x + vis.bounds.width / 2.0;
         let cy = vis.bounds.y + vis.bounds.height / 2.0;
         match layout.hit_test(cx, cy) {
+            TextDisplayHit::Line(idx) => assert_eq!(idx, vis.line_idx),
+            other => panic!("expected Line, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn layout_hit_test_resolves_lines_at_nonzero_origin() {
+        // Regression for quadraui#494 / LESSONS.md "Layout helpers must
+        // return coords in the same frame across backends": the module
+        // doc comment says `mac_text_display_layout`'s coordinates are
+        // body-local (y=0 at the top of the body region) —
+        // `TextDisplay::layout` never receives x/y at all. The plain
+        // `layout_hit_test_resolves_lines` case above paints at
+        // `QRect::new(0, 0, ...)` with no title, so `body_y == rect.y
+        // == 0` there too — localisation is a no-op and can't catch a
+        // paint/layout frame mismatch (the #44-class bug this doc
+        // section documents). Paint at a non-zero rect origin WITH a
+        // title row present (so `body_y = rect.y + line_height !=
+        // rect.y`), then round-trip an absolute click the way a real
+        // host does: localise via `abs - (rect.x, body_y)` before
+        // calling `hit_test`.
+        let mut td = make_td(20, false);
+        td.title = Some(StyledText::plain("Logs"));
+
+        let rect_x = 9.0_f32;
+        let rect_y = 17.0_f32;
+        let rect = QRect::new(rect_x, rect_y, W as f32 - rect_x, H as f32 - rect_y);
+        let (_surface, layout) = paint_at(&td, rect);
+
+        // MacBackend::new()'s default `current_line_height`, matching
+        // `paint_at`'s backend construction (no explicit line-height
+        // override in this test module).
+        let line_height = 16.0_f32;
+        let body_y = rect_y + line_height;
+
+        let vis = &layout.visible_lines[0];
+        // Sanity: layout stays body-local even though paint used a
+        // non-zero rect + title strip.
+        assert_eq!(
+            vis.bounds.y, 0.0,
+            "visible_lines bounds.y must be body-local, got {}",
+            vis.bounds.y,
+        );
+
+        let abs_x = rect_x + vis.bounds.x + vis.bounds.width * 0.5;
+        let abs_y = body_y + vis.bounds.y + vis.bounds.height * 0.5;
+        let local_x = abs_x - rect_x;
+        let local_y = abs_y - body_y;
+        match layout.hit_test(local_x, local_y) {
             TextDisplayHit::Line(idx) => assert_eq!(idx, vis.line_idx),
             other => panic!("expected Line, got {:?}", other),
         }

--- a/quadraui/src/macos/toast.rs
+++ b/quadraui/src/macos/toast.rs
@@ -39,14 +39,24 @@ fn severity_bg(severity: ToastSeverity, theme: &Theme) -> Color {
 }
 
 /// Compute the macOS pixel-unit layout for a [`ToastStack`].
+///
+/// `(origin_x, origin_y)` is baked into the returned bounds (absolute
+/// screen coordinates, matching `mac_menu_bar_layout` / `mac_panel_layout`)
+/// — hosts call `layout.hit_test(x, y)` with raw click coordinates, no
+/// localisation needed.
+#[allow(clippy::too_many_arguments)]
 pub fn mac_toast_stack_layout(
     stack: &ToastStack,
     font: &CTFont,
+    origin_x: f32,
+    origin_y: f32,
     viewport_width: f32,
     viewport_height: f32,
     line_height: f64,
 ) -> ToastStackLayout {
     stack.layout(
+        origin_x,
+        origin_y,
         viewport_width,
         viewport_height,
         TOAST_MARGIN_PX,
@@ -87,6 +97,8 @@ pub fn mac_toast_stack_layout(
 pub unsafe fn draw_toast_stack(
     ctx: CGContextRef,
     font: &CTFont,
+    origin_x: f64,
+    origin_y: f64,
     viewport_width: f64,
     viewport_height: f64,
     stack: &ToastStack,
@@ -96,6 +108,8 @@ pub unsafe fn draw_toast_stack(
     let layout = mac_toast_stack_layout(
         stack,
         font,
+        origin_x as f32,
+        origin_y as f32,
         viewport_width as f32,
         viewport_height as f32,
         line_height,
@@ -247,6 +261,23 @@ mod tests {
     }
 
     fn paint_via_backend(stack: &ToastStack) -> (BitmapSurface, ToastStackLayout) {
+        paint_via_backend_at(stack, 0.0, 0.0)
+    }
+
+    /// Like [`paint_via_backend`] but paints the toast overlay anchored
+    /// at an arbitrary `(origin_x, origin_y)` instead of always `(0, 0)`.
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"): `mac_toast_stack_layout` bakes the origin straight
+    /// into the returned bounds (absolute frame, matching
+    /// `mac_menu_bar_layout` / `mac_panel_layout`), so `hit_test` must
+    /// keep resolving against raw (unshifted) click coordinates at any
+    /// origin, not just `(0, 0)`.
+    fn paint_via_backend_at(
+        stack: &ToastStack,
+        origin_x: f32,
+        origin_y: f32,
+    ) -> (BitmapSurface, ToastStackLayout) {
         let surface = BitmapSurface::new(W, H);
         surface.fill(0.0, 0.0, 0.0, 0.0);
         let mut backend = MacBackend::new();
@@ -254,7 +285,10 @@ mod tests {
         backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
         let layout = std::cell::RefCell::new(None);
         backend.enter_frame_scope(surface.context_ptr(), |b| {
-            let l = b.draw_toast_stack(QRect::new(0.0, 0.0, W as f32, H as f32), stack);
+            let l = b.draw_toast_stack(
+                QRect::new(origin_x, origin_y, W as f32 - origin_x, H as f32 - origin_y),
+                stack,
+            );
             *layout.borrow_mut() = Some(l);
         });
         backend.end_frame();
@@ -302,10 +336,12 @@ mod tests {
         assert_eq!((r, g, b), (expected.r, expected.g, expected.b));
     }
 
-    #[test]
-    fn hit_test_dismiss_vs_body() {
+    /// Shared body for `hit_test_dismiss_vs_body` — see
+    /// [`paint_via_backend_at`] for the quadraui#494 non-zero-origin
+    /// rationale.
+    fn hit_test_dismiss_vs_body_at(origin_x: f32, origin_y: f32) {
         let stack = sample_stack();
-        let (_surface, layout) = paint_via_backend(&stack);
+        let (_surface, layout) = paint_via_backend_at(&stack, origin_x, origin_y);
         let t = &layout.visible_toasts[0];
         let db = t.dismiss_bounds.expect("dismiss bounds present");
         let hit = layout.hit_test(db.x + db.width * 0.5, db.y + db.height * 0.5);
@@ -317,7 +353,21 @@ mod tests {
     }
 
     #[test]
-    fn action_button_reserves_action_bounds() {
+    fn hit_test_dismiss_vs_body() {
+        hit_test_dismiss_vs_body_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494): same round trip,
+    /// painted at a shifted overlay origin.
+    #[test]
+    fn hit_test_dismiss_vs_body_at_nonzero_origin() {
+        hit_test_dismiss_vs_body_at(7.0, 13.0);
+    }
+
+    /// Shared body for `action_button_reserves_action_bounds` — see
+    /// [`paint_via_backend_at`] for the quadraui#494 non-zero-origin
+    /// rationale.
+    fn action_button_reserves_action_bounds_at(origin_x: f32, origin_y: f32) {
         let stack = ToastStack {
             id: WidgetId::new("toasts"),
             corner: ToastCorner::BottomRight,
@@ -329,12 +379,22 @@ mod tests {
                 ..toast("t", "Did the thing", ToastSeverity::Info)
             }],
         };
-        let (_surface, layout) = paint_via_backend(&stack);
+        let (_surface, layout) = paint_via_backend_at(&stack, origin_x, origin_y);
         let t = &layout.visible_toasts[0];
         let ab = t.action_bounds.expect("action bounds present");
         // Hit-test the action returns Action.
         let hit = layout.hit_test(ab.x + ab.width * 0.5, ab.y + ab.height * 0.5);
         assert!(matches!(hit, ToastHit::Action(_)), "hit was {:?}", hit);
+    }
+
+    #[test]
+    fn action_button_reserves_action_bounds() {
+        action_button_reserves_action_bounds_at(0.0, 0.0);
+    }
+
+    #[test]
+    fn action_button_reserves_action_bounds_at_nonzero_origin() {
+        action_button_reserves_action_bounds_at(7.0, 13.0);
     }
 
     #[test]

--- a/quadraui/src/macos/toolbar.rs
+++ b/quadraui/src/macos/toolbar.rs
@@ -261,3 +261,152 @@ extern "C" {
     fn CGContextStrokePath(c: CGContextRef);
     fn CGContextStrokeRect(c: CGContextRef, rect: CGRect);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::headless::BitmapSurface;
+    use super::super::text::make_font;
+    use super::super::MacBackend;
+    use super::*;
+    use crate::event::{Rect as QRect, Viewport};
+    use crate::primitives::toolbar::ToolbarHit;
+    use crate::types::WidgetId;
+    use crate::Backend;
+
+    const W: u32 = 240;
+    const H: u32 = 40;
+
+    fn font() -> CTFont {
+        make_font("Menlo", 14.0).expect("Menlo installed on every macOS host")
+    }
+
+    fn mk_action(id: &str, label: &str, enabled: bool) -> ToolbarButton {
+        ToolbarButton::Action {
+            id: WidgetId::new(id),
+            label: label.into(),
+            icon: None,
+            key_hint: None,
+            enabled,
+            is_active: false,
+            tooltip: String::new(),
+        }
+    }
+
+    /// Two-button bar, both enabled, no separators/labels — so
+    /// `visible_items` order matches `buttons` order 1:1 and index 0
+    /// is always the "Refine" action.
+    fn sample_bar() -> Toolbar {
+        Toolbar {
+            id: WidgetId::new("tb"),
+            buttons: vec![
+                mk_action("tb:refine", "Refine", true),
+                mk_action("tb:drop", "Drop", true),
+            ],
+            bg: None,
+            focused_index: None,
+        }
+    }
+
+    /// Paint a bar through the full `MacBackend::draw_toolbar` path at
+    /// origin `(0, 0)` and return both the surface and the resolved
+    /// layout (for hit_test). Establishes the harness shape every
+    /// chrome rasteriser test in this crate follows (see e.g.
+    /// `macos::panel::tests::paint_via_backend`).
+    fn paint_via_backend(bar: &Toolbar) -> (BitmapSurface, ToolbarLayout) {
+        paint_via_backend_at(bar, 0.0, 0.0)
+    }
+
+    /// Like [`paint_via_backend`] but paints at an arbitrary `(x, y)`
+    /// origin. Unlike `StatusBar`/`TextDisplay` in this same module
+    /// family (bar/body-LOCAL layouts — see their doc comments),
+    /// `Toolbar::layout` bakes `x`/`y` straight into each item's
+    /// `bounds` (ABSOLUTE frame, matching `mac_toolbar_layout`'s doc
+    /// comment). This lets tests confirm painted buttons and the
+    /// returned layout still agree at a non-zero origin.
+    fn paint_via_backend_at(bar: &Toolbar, x: f32, y: f32) -> (BitmapSurface, ToolbarLayout) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+
+        let layout = std::cell::RefCell::new(None);
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let l = b.draw_toolbar(
+                QRect::new(x, y, W as f32 - x, H as f32 - y),
+                bar,
+                None,
+                None,
+            );
+            *layout.borrow_mut() = Some(l);
+        });
+        backend.end_frame();
+        (surface, layout.into_inner().unwrap())
+    }
+
+    #[test]
+    fn round_trip_click_hits_enabled_button() {
+        // Paint at origin (0, 0), then hit-test the centre of the
+        // first visible ("Refine") button's painted bounds. Assert the
+        // layout reports a hit on that button's id.
+        let bar = sample_bar();
+        let (_surface, layout) = paint_via_backend(&bar);
+        assert_eq!(layout.visible_items.len(), 2);
+
+        let refine = &layout.visible_items[0];
+        let hit = layout.hit_test(
+            refine.bounds.x + refine.bounds.width * 0.5,
+            refine.bounds.y + refine.bounds.height * 0.5,
+        );
+        assert_eq!(
+            hit,
+            ToolbarHit::Button(WidgetId::new("tb:refine")),
+            "expected Refine button hit",
+        );
+    }
+
+    #[test]
+    fn round_trip_click_hits_enabled_button_at_nonzero_origin() {
+        // Regression for quadraui#494 / LESSONS.md "Layout helpers must
+        // return coords in the same frame across backends": the
+        // origin-(0,0) test above can't distinguish a `Toolbar::layout`
+        // that (correctly) bakes `x`/`y` into `bounds` from one that
+        // (incorrectly) ignores them — both look identical when
+        // x == y == 0. Paint at a non-zero origin and confirm both the
+        // painted button position and the `hit_test` round trip agree
+        // on the same absolute frame. This file has no `#[cfg(test)]`
+        // module prior to quadraui#494; unlike sibling files' nonzero-
+        // origin regressions this isn't a refactor of a pre-existing
+        // test, so it's written fresh per LESSONS.md's guidance and is
+        // unverified by the compiler in this sandbox (no macOS target).
+        let bar = sample_bar();
+        let origin_x = 7.0_f32;
+        let origin_y = 13.0_f32;
+        let (_surface, layout) = paint_via_backend_at(&bar, origin_x, origin_y);
+
+        let refine = &layout.visible_items[0];
+        assert!(
+            (refine.bounds.x - origin_x).abs() < 0.01,
+            "first button should start at origin_x={}, got {}",
+            origin_x,
+            refine.bounds.x,
+        );
+        assert!(
+            (refine.bounds.y - origin_y).abs() < 0.01,
+            "first button should start at origin_y={}, got {}",
+            origin_y,
+            refine.bounds.y,
+        );
+
+        let hit = layout.hit_test(
+            refine.bounds.x + refine.bounds.width * 0.5,
+            refine.bounds.y + refine.bounds.height * 0.5,
+        );
+        assert_eq!(
+            hit,
+            ToolbarHit::Button(WidgetId::new("tb:refine")),
+            "expected Refine button hit at non-zero origin",
+        );
+    }
+}

--- a/quadraui/src/primitives/toast.rs
+++ b/quadraui/src/primitives/toast.rs
@@ -166,6 +166,11 @@ pub struct ToastStackLayout {
     pub hit_regions: Vec<(Rect, ToastHit)>,
 }
 
+/// Translate a `Rect` by `(dx, dy)`, keeping its size.
+fn shift_rect(r: Rect, dx: f32, dy: f32) -> Rect {
+    Rect::new(r.x + dx, r.y + dy, r.width, r.height)
+}
+
 impl ToastStackLayout {
     pub fn hit_test(&self, x: f32, y: f32) -> ToastHit {
         for (rect, hit) in &self.hit_regions {
@@ -182,8 +187,15 @@ impl ToastStack {
     ///
     /// # Arguments
     ///
-    /// - `viewport_width`, `viewport_height` — the app's overlay area.
-    ///   Toasts are positioned relative to this.
+    /// - `origin_x`, `origin_y` — the top-left corner of the app's
+    ///   overlay area, in the backend's absolute (screen/buffer) frame.
+    ///   Returned `bounds` / `hit_regions` are absolute — callers pass
+    ///   `hit_test` raw click coordinates in that same frame, matching
+    ///   the `MenuBar`/`Panel` convention (unlike `TreeView`'s
+    ///   viewport-local frame). Pass `(0.0, 0.0)` for an overlay
+    ///   anchored at the buffer/window origin.
+    /// - `viewport_width`, `viewport_height` — the app's overlay area
+    ///   size. Toasts are positioned relative to this.
     /// - `margin` — spacing between the stack and the viewport edges.
     /// - `gap` — vertical gap between consecutive toasts.
     /// - `measure_toast(i)` — per-toast width/height/sub-region widths.
@@ -198,8 +210,11 @@ impl ToastStack {
     /// Toasts are iterated oldest-first (matching `self.toasts` order);
     /// the layout positions them in reverse of that for bottom corners
     /// so the newest stays pinned.
+    #[allow(clippy::too_many_arguments)]
     pub fn layout<F>(
         &self,
+        origin_x: f32,
+        origin_y: f32,
         viewport_width: f32,
         viewport_height: f32,
         margin: f32,
@@ -333,6 +348,28 @@ impl ToastStack {
                 if y_cursor >= viewport_height {
                     break;
                 }
+            }
+        }
+
+        // Shift from the viewport-local frame computed above into the
+        // caller's absolute frame. Matches `MenuBar::layout` /
+        // `Panel::layout`'s convention (bounds already carry the origin,
+        // so paint loops use them verbatim and hosts `hit_test` with raw
+        // click coordinates) rather than `TreeView`'s local-frame
+        // convention. Before this, `ToastStack::layout` had no origin
+        // parameter at all, so every backend's `*_toast_stack_layout`
+        // silently dropped `rect.x` / `rect.y` — invisible at the origin
+        // (every prior test) and a real drift for any non-zero-origin
+        // overlay (quadraui#494 / LESSONS.md "Layout helpers must return
+        // coords in the same frame across backends").
+        if origin_x != 0.0 || origin_y != 0.0 {
+            for vt in &mut visible_toasts {
+                vt.bounds = shift_rect(vt.bounds, origin_x, origin_y);
+                vt.dismiss_bounds = vt.dismiss_bounds.map(|r| shift_rect(r, origin_x, origin_y));
+                vt.action_bounds = vt.action_bounds.map(|r| shift_rect(r, origin_x, origin_y));
+            }
+            for (rect, _) in &mut hit_regions {
+                *rect = shift_rect(*rect, origin_x, origin_y);
             }
         }
 

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1502,7 +1502,8 @@ impl Backend for TuiBackend {
         rect: QRect,
         stack: &crate::primitives::toast::ToastStack,
     ) -> crate::primitives::toast::ToastStackLayout {
-        crate::tui::tui_toast_stack_layout(stack, rect.width, rect.height)
+        let area = q_rect_to_ratatui(rect);
+        crate::tui::tui_toast_stack_layout(stack, area)
     }
 
     fn draw_pipeline_view(
@@ -2164,7 +2165,7 @@ mod tests {
             _r: QRect,
             stack: &crate::primitives::toast::ToastStack,
         ) -> crate::primitives::toast::ToastStackLayout {
-            stack.layout(_r.width, _r.height, 1.0, 1.0, |_| {
+            stack.layout(_r.x, _r.y, _r.width, _r.height, 1.0, 1.0, |_| {
                 crate::primitives::toast::ToastMeasure::new(40.0, 1.0)
             })
         }
@@ -2174,7 +2175,7 @@ mod tests {
             _r: QRect,
             stack: &crate::primitives::toast::ToastStack,
         ) -> crate::primitives::toast::ToastStackLayout {
-            stack.layout(_r.width, _r.height, 1.0, 1.0, |_| {
+            stack.layout(_r.x, _r.y, _r.width, _r.height, 1.0, 1.0, |_| {
                 crate::primitives::toast::ToastMeasure::new(40.0, 1.0)
             })
         }

--- a/quadraui/src/tui/board.rs
+++ b/quadraui/src/tui/board.rs
@@ -472,9 +472,15 @@ mod tests {
 
     // ── Layout / hit-test round-trip ──────────────────────────────────
 
-    #[test]
-    fn hit_test_card_round_trip() {
-        let area = Rect::new(0, 0, 60, 10);
+    /// Shared body for `hit_test_card_round_trip[_at_nonzero_origin]`:
+    /// `tui_board_layout` bakes `area.x`/`area.y` into the returned bounds
+    /// (absolute frame, see `board_layout`'s `origin_x`/`origin_y`
+    /// threading), so a click must resolve correctly at a non-zero origin
+    /// too — not just at `(0, 0)`, where the LESSONS.md "layout helpers
+    /// must return coords in the same frame across backends" bug class is
+    /// invisible (quadraui#494).
+    fn hit_test_card_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 60, 10);
         let mut buf = Buffer::empty(area);
         let model = make_model();
         let layout = draw_board(&mut buf, area, &model, &Theme::default());
@@ -490,8 +496,19 @@ mod tests {
     }
 
     #[test]
-    fn hit_test_column_header_round_trip() {
-        let area = Rect::new(0, 0, 60, 10);
+    fn hit_test_card_round_trip() {
+        hit_test_card_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn hit_test_card_round_trip_at_nonzero_origin() {
+        hit_test_card_round_trip_at(7, 13);
+    }
+
+    /// Shared body for `hit_test_column_header_round_trip[_at_nonzero_origin]`
+    /// — see `hit_test_card_round_trip_at` for the non-zero-origin rationale.
+    fn hit_test_column_header_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 60, 10);
         let mut buf = Buffer::empty(area);
         let model = make_model();
         let layout = draw_board(&mut buf, area, &model, &Theme::default());
@@ -501,6 +518,16 @@ mod tests {
             BoardHit::ColumnHeader(id) => assert_eq!(id.as_str(), "col:backlog"),
             other => panic!("expected ColumnHeader hit, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn hit_test_column_header_round_trip() {
+        hit_test_column_header_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn hit_test_column_header_round_trip_at_nonzero_origin() {
+        hit_test_column_header_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/chart.rs
+++ b/quadraui/src/tui/chart.rs
@@ -527,21 +527,36 @@ mod tests {
         buf[(x, y)].symbol().chars().next().unwrap_or(' ')
     }
 
-    #[test]
-    fn sparkline_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 5, 1);
+    /// Shared body for `sparkline_paint_and_click_round_trip[_at_nonzero_origin]`:
+    /// `tui_chart_layout` bakes `area.x`/`area.y` into `Chart::layout`'s
+    /// `origin_x`/`origin_y` (absolute frame), so paint + click must agree
+    /// at a non-zero origin too, per LESSONS.md's "layout helpers must
+    /// return coords in the same frame across backends" (quadraui#494).
+    fn sparkline_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 5, 1);
         let mut buf = Buffer::empty(area);
         let chart = spark(vec![0.0, 0.25, 0.5, 0.75, 1.0]);
         let layout = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
 
-        assert_eq!(cell_char(&buf, 0, 0), '▁');
-        assert_eq!(cell_char(&buf, 4, 0), '█');
+        assert_eq!(cell_char(&buf, origin_x, origin_y), '▁');
+        assert_eq!(cell_char(&buf, origin_x + 4, origin_y), '█');
 
+        let (ox, oy) = (origin_x as f32, origin_y as f32);
         assert_eq!(
-            layout.hit_test(2.5, 0.5),
+            layout.hit_test(ox + 2.5, oy + 0.5),
             ChartHit::Body(WidgetId::new("c"))
         );
-        assert_eq!(layout.hit_test(10.0, 0.5), ChartHit::Empty);
+        assert_eq!(layout.hit_test(ox + 10.0, oy + 0.5), ChartHit::Empty);
+    }
+
+    #[test]
+    fn sparkline_paint_and_click_round_trip() {
+        sparkline_paint_and_click_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn sparkline_paint_and_click_round_trip_at_nonzero_origin() {
+        sparkline_paint_and_click_round_trip_at(7, 13);
     }
 
     #[test]
@@ -597,10 +612,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn bar_chart_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 10, 5);
-        let mut buf = Buffer::empty(area);
+    /// Shared body for `bar_chart_paint_and_click_round_trip[_at_nonzero_origin]`
+    /// — see `sparkline_paint_and_click_round_trip_at` for the non-zero-origin
+    /// rationale (quadraui#494).
+    fn bar_chart_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 10, 5);
+        // A full-screen-sized buffer, not one exactly matching `area`:
+        // y-axis tick-label painting can spill a few cells left of
+        // `area.x` when there's no reserved label gutter (pre-existing
+        // rasteriser behaviour, unrelated to this regression guard) —
+        // mirrors `tui/activity_bar.rs`'s tests, which likewise paint
+        // into a buffer larger than the widget's own area.
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 10, origin_y + 5));
         let chart = Chart {
             id: WidgetId::new("c"),
             kind: ChartKind::Bar,
@@ -627,16 +650,32 @@ mod tests {
         let bar_y = pa.y.round() as u16 + (pa.height.round() as u16) - 2;
         assert_eq!(cell_char(&buf, bar_x, bar_y), '█');
 
+        // No y_label/legend, so the plot area's origin equals `area`'s.
+        let (ox, oy) = (origin_x as f32, origin_y as f32);
         assert_eq!(
-            layout.hit_test(5.0, 2.0),
+            layout.hit_test(ox + 5.0, oy + 2.0),
             ChartHit::Body(WidgetId::new("c"))
         );
     }
 
     #[test]
-    fn legend_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 30, 10);
-        let mut buf = Buffer::empty(area);
+    fn bar_chart_paint_and_click_round_trip() {
+        bar_chart_paint_and_click_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn bar_chart_paint_and_click_round_trip_at_nonzero_origin() {
+        bar_chart_paint_and_click_round_trip_at(7, 13);
+    }
+
+    /// Shared body for `legend_paint_and_click_round_trip[_at_nonzero_origin]`
+    /// — see `sparkline_paint_and_click_round_trip_at` for the non-zero-origin
+    /// rationale (quadraui#494).
+    fn legend_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 30, 10);
+        // See `bar_chart_paint_and_click_round_trip_at`: a full-screen
+        // buffer, since axis-label painting can spill left of `area.x`.
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 30, origin_y + 10));
         let chart = Chart {
             id: WidgetId::new("c"),
             kind: ChartKind::Line,
@@ -676,6 +715,16 @@ mod tests {
             layout.hit_test(mid, lb.y + 0.5),
             ChartHit::Legend(WidgetId::new("c"), 0)
         );
+    }
+
+    #[test]
+    fn legend_paint_and_click_round_trip() {
+        legend_paint_and_click_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn legend_paint_and_click_round_trip_at_nonzero_origin() {
+        legend_paint_and_click_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/command_center.rs
+++ b/quadraui/src/tui/command_center.rs
@@ -121,42 +121,69 @@ mod tests {
         }
     }
 
-    #[test]
-    fn arrows_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 40, 1);
+    /// Shared body for `arrows_paint_and_click_round_trip[_at_nonzero_origin]`:
+    /// `tui_command_center_layout` bakes `area.x`/`area.y` into
+    /// `CommandCenter::layout`'s `bounds` (absolute frame), so paint + click
+    /// must agree at a non-zero origin too, per LESSONS.md's "layout
+    /// helpers must return coords in the same frame across backends"
+    /// (quadraui#494).
+    fn arrows_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 1);
         let mut buf = Buffer::empty(area);
         let cc = mk_cc("Search");
         let layout = draw_command_center(&mut buf, area, &cc, &Theme::default());
 
         let bb = layout.back_bounds.unwrap();
         let bx = bb.x.round() as u16;
-        assert_eq!(cell_char(&buf, bx, 0), '◀');
+        assert_eq!(cell_char(&buf, bx, origin_y), '◀');
 
-        let hit = layout.hit_test(bb.x + 0.5, 0.5);
+        let hit = layout.hit_test(bb.x + 0.5, origin_y as f32 + 0.5);
         assert_eq!(hit, CommandCenterHit::Back);
 
         let fb = layout.forward_bounds.unwrap();
         let fx = fb.x.round() as u16;
-        assert_eq!(cell_char(&buf, fx, 0), '▶');
+        assert_eq!(cell_char(&buf, fx, origin_y), '▶');
 
-        let hit = layout.hit_test(fb.x + 0.5, 0.5);
+        let hit = layout.hit_test(fb.x + 0.5, origin_y as f32 + 0.5);
         assert_eq!(hit, CommandCenterHit::Forward);
     }
 
     #[test]
-    fn search_box_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 40, 1);
+    fn arrows_paint_and_click_round_trip() {
+        arrows_paint_and_click_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn arrows_paint_and_click_round_trip_at_nonzero_origin() {
+        arrows_paint_and_click_round_trip_at(7, 13);
+    }
+
+    /// Shared body for `search_box_paint_and_click_round_trip[_at_nonzero_origin]`
+    /// — see `arrows_paint_and_click_round_trip_at` for the non-zero-origin
+    /// rationale (quadraui#494).
+    fn search_box_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 1);
         let mut buf = Buffer::empty(area);
         let cc = mk_cc("Test");
         let layout = draw_command_center(&mut buf, area, &cc, &Theme::default());
 
         let sb = layout.search_bounds.unwrap();
         let sx = sb.x.round() as u16;
-        assert_eq!(cell_char(&buf, sx, 0), '[');
-        assert_eq!(cell_char(&buf, sx + 1, 0), 'T');
+        assert_eq!(cell_char(&buf, sx, origin_y), '[');
+        assert_eq!(cell_char(&buf, sx + 1, origin_y), 'T');
 
-        let hit = layout.hit_test(sb.x + 2.0, 0.5);
+        let hit = layout.hit_test(sb.x + 2.0, origin_y as f32 + 0.5);
         assert_eq!(hit, CommandCenterHit::SearchBox);
+    }
+
+    #[test]
+    fn search_box_paint_and_click_round_trip() {
+        search_box_paint_and_click_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn search_box_paint_and_click_round_trip_at_nonzero_origin() {
+        search_box_paint_and_click_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/data_table.rs
+++ b/quadraui/src/tui/data_table.rs
@@ -655,6 +655,29 @@ mod tests {
         assert_eq!(hit, DataTableHit::Header { col: 1 });
     }
 
+    /// LESSONS.md non-zero-origin regression guard (quadraui#494):
+    /// `data_table_layout` never reads `area.x`/`area.y` (see its doc
+    /// comment) — it, and therefore `hit_test`, is table-**local**, unlike
+    /// most of this batch's other layout fns which bake the origin in.
+    /// Painting still happens at the absolute `area.x`/`area.y` (mirrors
+    /// `tui/activity_bar.rs`'s relative-hit-regions / absolute-paint split),
+    /// so this scans the buffer at the shifted absolute position but keeps
+    /// the resulting index — and the `hit_test` call — table-local.
+    #[test]
+    fn paint_click_round_trip_header_at_nonzero_origin() {
+        let table = make_table();
+        let area = Rect::new(7, 13, 40, 10);
+        let mut buf = Buffer::empty(area);
+        let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+        let header: String = (area.x..area.x + 40)
+            .map(|x| buf[(x, area.y)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        let status_pos = header.find("Status").expect("Status should be in header");
+        let hit = layout.hit_test(status_pos as f32 + 3.0, 0.5, 0, table.rows.len());
+        assert_eq!(hit, DataTableHit::Header { col: 1 });
+    }
+
     #[test]
     fn paint_click_round_trip_row() {
         let table = make_table();
@@ -669,6 +692,52 @@ mod tests {
         let pod_pos = row1.find("pod-xyz").expect("pod-xyz should be in row 1");
         let hit = layout.hit_test(pod_pos as f32, 2.5, 0, table.rows.len());
         assert_eq!(hit, DataTableHit::Row { idx: 1 });
+    }
+
+    /// Non-zero-origin sibling of `paint_click_round_trip_row` — see
+    /// `paint_click_round_trip_header_at_nonzero_origin` (quadraui#494).
+    #[test]
+    fn paint_click_round_trip_row_at_nonzero_origin() {
+        let table = make_table();
+        let area = Rect::new(7, 13, 40, 10);
+        let mut buf = Buffer::empty(area);
+        let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+
+        // Row 1 paints on the *absolute* screen row `area.y + 2`.
+        let row1: String = (area.x..area.x + 40)
+            .map(|x| buf[(x, area.y + 2)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        let pod_pos = row1.find("pod-xyz").expect("pod-xyz should be in row 1");
+        let hit = layout.hit_test(pod_pos as f32, 2.5, 0, table.rows.len());
+        assert_eq!(hit, DataTableHit::Row { idx: 1 });
+    }
+
+    /// Direct "bounds do not move" guard, mirroring
+    /// `tui/activity_bar.rs`'s `hit_regions_do_not_move_when_the_bar_does`:
+    /// the resolved column bounds must be byte-for-byte identical no matter
+    /// where `area` sits on screen, since `data_table_layout` is table-local
+    /// by construction (quadraui#494).
+    #[test]
+    fn column_bounds_do_not_move_when_the_table_does() {
+        let table = make_table();
+        let cols_at = |origin_x: u16, origin_y: u16| {
+            let area = Rect::new(origin_x, origin_y, 40, 10);
+            let mut buf = Buffer::empty(area);
+            let layout = draw_data_table(&mut buf, area, &table, &Theme::default(), None);
+            layout
+                .columns
+                .iter()
+                .map(|c| (c.x, c.width))
+                .collect::<Vec<_>>()
+        };
+
+        let at_zero = cols_at(0, 0);
+        assert!(!at_zero.is_empty(), "sanity: some columns were resolved");
+        assert_eq!(
+            cols_at(7, 13),
+            at_zero,
+            "column bounds must be table-local, independent of area.x/area.y"
+        );
     }
 
     /// A table with many more rows than fit the viewport, for footer

--- a/quadraui/src/tui/dialog.rs
+++ b/quadraui/src/tui/dialog.rs
@@ -583,12 +583,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn body_toolbar_click_routes_to_body_toolbar_button() {
+    /// Shared body for `body_toolbar_click_routes_to_body_toolbar_button[_at_nonzero_origin]`:
+    /// `tui_dialog_layout` bakes `viewport.x`/`viewport.y` into `Dialog::layout`'s
+    /// `box_x`/`box_y` (absolute frame), so paint + click must agree at a
+    /// non-zero viewport origin too, per LESSONS.md's "layout helpers must
+    /// return coords in the same frame across backends" (quadraui#494). The
+    /// dialog is centered in an 80×30 viewport and never exceeds ~60×30, so
+    /// a buffer sized to the viewport's far corner (`origin + 80/30`) always
+    /// has room for it.
+    fn body_toolbar_click_routes_to_body_toolbar_button_at(origin_x: f32, origin_y: f32) {
         let d = make_toolbar_dialog();
-        let viewport = crate::event::Rect::new(0.0, 0.0, 80.0, 30.0);
+        let viewport = crate::event::Rect::new(origin_x, origin_y, 80.0, 30.0);
         let layout = tui_dialog_layout(&d, viewport);
-        let mut buf = Buffer::empty(Rect::new(0, 0, 80, 30));
+        let buf_w = (origin_x + 80.0).ceil() as u16;
+        let buf_h = (origin_y + 30.0).ceil() as u16;
+        let mut buf = Buffer::empty(Rect::new(0, 0, buf_w, buf_h));
         draw_dialog(&mut buf, &d, &layout, &Theme::default());
 
         let tl = layout
@@ -615,9 +624,21 @@ mod tests {
     }
 
     #[test]
-    fn body_toolbar_apply_button_also_routes() {
+    fn body_toolbar_click_routes_to_body_toolbar_button() {
+        body_toolbar_click_routes_to_body_toolbar_button_at(0.0, 0.0);
+    }
+
+    #[test]
+    fn body_toolbar_click_routes_to_body_toolbar_button_at_nonzero_origin() {
+        body_toolbar_click_routes_to_body_toolbar_button_at(7.0, 13.0);
+    }
+
+    /// Shared body for `body_toolbar_apply_button_also_routes[_at_nonzero_origin]`
+    /// — see `body_toolbar_click_routes_to_body_toolbar_button_at` for the
+    /// non-zero-origin rationale (quadraui#494).
+    fn body_toolbar_apply_button_also_routes_at(origin_x: f32, origin_y: f32) {
         let d = make_toolbar_dialog();
-        let viewport = crate::event::Rect::new(0.0, 0.0, 80.0, 30.0);
+        let viewport = crate::event::Rect::new(origin_x, origin_y, 80.0, 30.0);
         let layout = tui_dialog_layout(&d, viewport);
 
         let tl = layout
@@ -638,6 +659,16 @@ mod tests {
             }
             other => panic!("expected BodyToolbarButton(apply), got {:?}", other),
         }
+    }
+
+    #[test]
+    fn body_toolbar_apply_button_also_routes() {
+        body_toolbar_apply_button_also_routes_at(0.0, 0.0);
+    }
+
+    #[test]
+    fn body_toolbar_apply_button_also_routes_at_nonzero_origin() {
+        body_toolbar_apply_button_also_routes_at(7.0, 13.0);
     }
 
     // ── Serde round-trip for DialogInput::Toolbar ─────────────────────────

--- a/quadraui/src/tui/form.rs
+++ b/quadraui/src/tui/form.rs
@@ -963,10 +963,17 @@ mod tests {
         assert!(row.contains(".*"), "expected '.*' in row: {row:?}");
     }
 
-    #[test]
-    fn toggle_group_click_hits_correct_item() {
-        let area = Rect::new(0, 0, 40, 3);
-        let mut buf = Buffer::empty(area);
+    /// Shared body for the ToggleGroup paint↔click round trip, run at both
+    /// the origin and a non-zero `area` origin (quadraui#494 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"). `tui_form_layout`/`Form::layout` never read `area.x`/
+    /// `area.y` — the returned layout is field-local by construction, even
+    /// though `draw_form` separately adds `area.x`/`area.y` per cell when
+    /// painting. So `hit_test` always takes LOCAL coordinates (painted
+    /// column minus `area.x`), regardless of where the form is painted.
+    fn toggle_group_click_hits_correct_item_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 3);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 40, origin_y + 3));
         let f = make_toggle_group_form();
         draw_form(&mut buf, area, &f, &Theme::default());
 
@@ -989,45 +996,63 @@ mod tests {
             }
         });
 
-        // Find where "Aa" is painted (first toggle).
+        // Find where "Aa" is painted (first toggle) on the form's absolute row.
         let mut aa_col = None;
-        for x in 0..40u16 {
-            if cell_char(&buf, x, 0) == 'A' {
-                if x + 1 < 40 && cell_char(&buf, x + 1, 0) == 'a' {
+        for x in area.x..area.x + area.width {
+            if cell_char(&buf, x, area.y) == 'A' {
+                if x + 1 < area.x + area.width && cell_char(&buf, x + 1, area.y) == 'a' {
                     aa_col = Some(x);
                     break;
                 }
             }
         }
         let aa_col = aa_col.expect("'Aa' must be painted");
-        let hit = layout.hit_test(aa_col as f32, 0.0);
+        let hit = layout.hit_test((aa_col - area.x) as f32, 0.0);
         assert_eq!(hit, FormHit::Field(WidgetId::new("case")));
 
         // Find where "Ab|" is painted (second toggle).
         let mut ab_col = None;
-        for x in (aa_col + 2)..40u16 {
-            if cell_char(&buf, x, 0) == 'A' {
-                if x + 1 < 40 && cell_char(&buf, x + 1, 0) == 'b' {
+        for x in (aa_col + 2)..area.x + area.width {
+            if cell_char(&buf, x, area.y) == 'A' {
+                if x + 1 < area.x + area.width && cell_char(&buf, x + 1, area.y) == 'b' {
                     ab_col = Some(x);
                     break;
                 }
             }
         }
         let ab_col = ab_col.expect("'Ab|' must be painted");
-        let hit = layout.hit_test(ab_col as f32, 0.0);
+        let hit = layout.hit_test((ab_col - area.x) as f32, 0.0);
         assert_eq!(hit, FormHit::Field(WidgetId::new("word")));
 
         // Find ".*" (third toggle).
         let mut dot_col = None;
-        for x in (ab_col + 3)..40u16 {
-            if cell_char(&buf, x, 0) == '.' && x + 1 < 40 && cell_char(&buf, x + 1, 0) == '*' {
+        for x in (ab_col + 3)..area.x + area.width {
+            if cell_char(&buf, x, area.y) == '.'
+                && x + 1 < area.x + area.width
+                && cell_char(&buf, x + 1, area.y) == '*'
+            {
                 dot_col = Some(x);
                 break;
             }
         }
         let dot_col = dot_col.expect("'.*' must be painted");
-        let hit = layout.hit_test(dot_col as f32, 0.0);
+        let hit = layout.hit_test((dot_col - area.x) as f32, 0.0);
         assert_eq!(hit, FormHit::Field(WidgetId::new("regex")));
+    }
+
+    #[test]
+    fn toggle_group_click_hits_correct_item() {
+        toggle_group_click_hits_correct_item_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494): same round trip,
+    /// painted at a shifted `area` origin, proving the local-frame contract
+    /// holds even when the form isn't painted at (0, 0). See
+    /// `toggle_group_click_hits_correct_item_at` for why `hit_test` still
+    /// takes local (not absolute) coordinates here.
+    #[test]
+    fn toggle_group_click_hits_correct_item_at_nonzero_origin() {
+        toggle_group_click_hits_correct_item_at(7, 13);
     }
 
     // ── ButtonRow paint↔click round-trip ────────────────────────────────
@@ -1084,10 +1109,13 @@ mod tests {
         assert!(row.contains("[All]"), "expected '[All]' in row: {row:?}");
     }
 
-    #[test]
-    fn button_row_click_hits_correct_item() {
-        let area = Rect::new(0, 0, 40, 3);
-        let mut buf = Buffer::empty(area);
+    /// Shared body for the ButtonRow paint↔click round trip — see
+    /// `toggle_group_click_hits_correct_item_at` for why `hit_test` takes
+    /// local (not absolute) coordinates even at a non-zero `area` origin
+    /// (quadraui#494 / LESSONS.md local-vs-absolute-frame guard).
+    fn button_row_click_hits_correct_item_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 3);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 40, origin_y + 3));
         let f = make_button_row_form();
         draw_form(&mut buf, area, &f, &Theme::default());
 
@@ -1110,45 +1138,66 @@ mod tests {
             }
         });
 
-        // Find "[Next]" — the 'N' inside brackets.
+        // Find "[Next]" — the 'N' inside brackets, on the form's absolute row.
         let mut next_col = None;
-        for x in 0..40u16 {
-            if cell_char(&buf, x, 0) == '[' && x + 1 < 40 && cell_char(&buf, x + 1, 0) == 'N' {
+        for x in area.x..area.x + area.width {
+            if cell_char(&buf, x, area.y) == '['
+                && x + 1 < area.x + area.width
+                && cell_char(&buf, x + 1, area.y) == 'N'
+            {
                 next_col = Some(x);
                 break;
             }
         }
         let next_col = next_col.expect("'[Next]' must be painted");
-        let hit = layout.hit_test(next_col as f32, 0.0);
+        let hit = layout.hit_test((next_col - area.x) as f32, 0.0);
         assert_eq!(hit, FormHit::Field(WidgetId::new("next")));
 
         // Click inside "Next" text (col + 2).
-        let hit = layout.hit_test((next_col + 2) as f32, 0.0);
+        let hit = layout.hit_test((next_col + 2 - area.x) as f32, 0.0);
         assert_eq!(hit, FormHit::Field(WidgetId::new("next")));
 
         // Find "[Repl]".
         let mut repl_col = None;
-        for x in (next_col + 5)..40u16 {
-            if cell_char(&buf, x, 0) == '[' && x + 1 < 40 && cell_char(&buf, x + 1, 0) == 'R' {
+        for x in (next_col + 5)..area.x + area.width {
+            if cell_char(&buf, x, area.y) == '['
+                && x + 1 < area.x + area.width
+                && cell_char(&buf, x + 1, area.y) == 'R'
+            {
                 repl_col = Some(x);
                 break;
             }
         }
         let repl_col = repl_col.expect("'[Repl]' must be painted");
-        let hit = layout.hit_test(repl_col as f32, 0.0);
+        let hit = layout.hit_test((repl_col - area.x) as f32, 0.0);
         assert_eq!(hit, FormHit::Field(WidgetId::new("replace")));
 
         // Find "[All]".
         let mut all_col = None;
-        for x in (repl_col + 5)..40u16 {
-            if cell_char(&buf, x, 0) == '[' && x + 1 < 40 && cell_char(&buf, x + 1, 0) == 'A' {
+        for x in (repl_col + 5)..area.x + area.width {
+            if cell_char(&buf, x, area.y) == '['
+                && x + 1 < area.x + area.width
+                && cell_char(&buf, x + 1, area.y) == 'A'
+            {
                 all_col = Some(x);
                 break;
             }
         }
         let all_col = all_col.expect("'[All]' must be painted");
-        let hit = layout.hit_test(all_col as f32, 0.0);
+        let hit = layout.hit_test((all_col - area.x) as f32, 0.0);
         assert_eq!(hit, FormHit::Field(WidgetId::new("all")));
+    }
+
+    #[test]
+    fn button_row_click_hits_correct_item() {
+        button_row_click_hits_correct_item_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494): same round trip,
+    /// painted at a shifted `area` origin.
+    #[test]
+    fn button_row_click_hits_correct_item_at_nonzero_origin() {
+        button_row_click_hits_correct_item_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/menu_bar.rs
+++ b/quadraui/src/tui/menu_bar.rs
@@ -65,7 +65,16 @@ pub fn draw_menu_bar(buf: &mut Buffer, area: Rect, bar: &MenuBar, theme: &Theme)
             (ratatui_color(theme.tab_inactive_fg), bar_bg)
         };
 
-        let start_x = area.x + vi.bounds.x.round() as u16;
+        // `vi.bounds.x` is already absolute — `tui_menu_bar_layout` passes
+        // `bounds.x = area.x` into `MenuBar::layout`, which starts its
+        // internal cursor at `bounds.x`, so item bounds already carry the
+        // bar's origin. Adding `area.x` again here double-counted it,
+        // invisibly at `area.x == 0` (every existing test) and shifting
+        // painted glyphs away from their own hit-test bounds at any other
+        // origin — the LESSONS.md "layout helpers must return coords in
+        // the same frame across backends" bug class. Found via the
+        // quadraui#494 non-zero-origin regression test.
+        let start_x = vi.bounds.x.round() as u16;
         let end_x = start_x + vi.bounds.width.round() as u16;
 
         if is_active {
@@ -151,10 +160,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 40, 1);
-        let mut buf = Buffer::empty(area);
+    /// Shared body for the paint↔click round trip, run at both the origin
+    /// and a non-zero `area` origin (quadraui#494 / LESSONS.md "Layout
+    /// helpers must return coords in the same frame across backends").
+    /// `tui_menu_bar_layout` bakes `area.x`/`area.y` straight into the
+    /// returned bounds (absolute frame, matching the GTK/macOS twins), so
+    /// unlike `activity_bar.rs`'s bar-relative hit regions, both the
+    /// painted glyph position AND the `hit_test` coordinates here must
+    /// shift together with the origin.
+    fn paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 1);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 40, origin_y + 1));
         let bar = make_bar();
         let layout = draw_menu_bar(&mut buf, area, &bar, &Theme::default());
 
@@ -174,7 +190,7 @@ mod tests {
             let first_display_char = label.chars().find(|&c| c != '&').unwrap();
             let start_col = vi.bounds.x.round() as u16 + 1; // after padding
             assert_eq!(
-                cell_char(&buf, start_col, 0),
+                cell_char(&buf, start_col, area.y),
                 first_display_char,
                 "first display char of item {} should be '{}' at col {}",
                 vi.item_idx,
@@ -182,6 +198,20 @@ mod tests {
                 start_col,
             );
         }
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        paint_and_click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494): same round trip,
+    /// painted at a shifted `area` origin — proves `hit_test` still
+    /// resolves against the absolute (not local) bounds `draw_menu_bar`
+    /// painted into.
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        paint_and_click_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/multi_section_view.rs
+++ b/quadraui/src/tui/multi_section_view.rs
@@ -843,9 +843,20 @@ mod tests {
     /// hit_test that coordinate, assert the hit identifies the same
     /// section. Uses a fractional `EqualShare` distribution (4 sections
     /// in 21 cells = 5.25 each) — the worst case for paint/click drift.
-    #[test]
-    fn header_clicks_land_in_painted_section_under_fractional_distribution() {
-        let area = TuiRect::new(0, 0, 30, 21);
+    ///
+    /// Run at both the origin and a non-zero `area` origin (quadraui#494 /
+    /// LESSONS.md "Layout helpers must return coords in the same frame
+    /// across backends"). `tui_msv_layout` bakes `area.x`/`area.y`
+    /// straight into the returned bounds (absolute frame), and
+    /// `paint_then_layout` already takes `area` as a parameter, so this
+    /// re-runs the identical logic at a shifted origin. `find_row_with`/
+    /// `row_text` derive their scan range from `buf.area` (not a
+    /// hardcoded rect), so they track the origin too.
+    fn header_clicks_land_in_painted_section_under_fractional_distribution_at(
+        origin_x: u16,
+        origin_y: u16,
+    ) {
+        let area = TuiRect::new(origin_x, origin_y, 30, 21);
         let mut buf = Buffer::empty(area);
         let v = view_with(vec![
             tree_section("alpha", &["a1", "a2", "a3"], SectionSize::EqualShare),
@@ -884,15 +895,34 @@ mod tests {
         }
     }
 
+    #[test]
+    fn header_clicks_land_in_painted_section_under_fractional_distribution() {
+        header_clicks_land_in_painted_section_under_fractional_distribution_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn header_clicks_land_in_painted_section_under_fractional_distribution_at_nonzero_origin() {
+        header_clicks_land_in_painted_section_under_fractional_distribution_at(7, 13);
+    }
+
     /// Round-trip: paint, find each section's body item rows (rows
     /// containing item glyphs but NOT the title), hit_test those
     /// coordinates, assert each lands in the SAME section's `Body`.
     /// Catches the off-by-one drift that the band-aid #296 smokes
     /// chased — a body row paints in section N but hit_test returns
     /// Body{N-1} or Header{N+1}.
-    #[test]
-    fn body_clicks_land_in_painted_section_under_fractional_distribution() {
-        let area = TuiRect::new(0, 0, 30, 21);
+    ///
+    /// Run at both the origin and a non-zero `area` origin (quadraui#494 /
+    /// LESSONS.md non-zero-origin regression guard) — see
+    /// `header_clicks_land_in_painted_section_under_fractional_distribution_at`
+    /// for why this needs no coordinate translation beyond passing a
+    /// shifted `area` through.
+    fn body_clicks_land_in_painted_section_under_fractional_distribution_at(
+        origin_x: u16,
+        origin_y: u16,
+    ) {
+        let area = TuiRect::new(origin_x, origin_y, 30, 21);
         let mut buf = Buffer::empty(area);
         let v = view_with(vec![
             tree_section("alpha", &["a1", "a2", "a3"], SectionSize::EqualShare),
@@ -949,6 +979,17 @@ mod tests {
                 ),
             }
         }
+    }
+
+    #[test]
+    fn body_clicks_land_in_painted_section_under_fractional_distribution() {
+        body_clicks_land_in_painted_section_under_fractional_distribution_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn body_clicks_land_in_painted_section_under_fractional_distribution_at_nonzero_origin() {
+        body_clicks_land_in_painted_section_under_fractional_distribution_at(7, 13);
     }
 
     /// Sections with overflowing content reserve a 1-cell scrollbar

--- a/quadraui/src/tui/panel.rs
+++ b/quadraui/src/tui/panel.rs
@@ -146,26 +146,43 @@ mod tests {
         }
     }
 
-    #[test]
-    fn title_bar_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 30, 10);
-        let mut buf = Buffer::empty(area);
+    /// Shared body for the title-bar paint↔click round trip, run at both
+    /// the origin and a non-zero `area` origin (quadraui#494 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"). `tui_panel_layout` bakes `area.x`/`area.y` straight
+    /// into the returned bounds (absolute frame, matching the GTK/macOS
+    /// twins), so both the painted glyph position AND the `hit_test`
+    /// coordinates must shift together with the origin.
+    fn title_bar_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 30, 10);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 30, origin_y + 10));
         let panel = titled_panel();
         let layout = draw_panel(&mut buf, area, &panel, &Theme::default());
 
-        // Title text should appear starting at column 1.
-        assert_eq!(cell_char(&buf, 1, 0), 'M');
-        assert_eq!(cell_char(&buf, 2, 0), 'y');
+        // Title text should appear starting at column area.x + 1.
+        assert_eq!(cell_char(&buf, area.x + 1, area.y), 'M');
+        assert_eq!(cell_char(&buf, area.x + 2, area.y), 'y');
 
-        // Hit the title bar body (column 1) → TitleBar.
-        let hit = layout.hit_test(1.5, 0.5);
+        // Hit the title bar body (column area.x + 1) → TitleBar.
+        let hit = layout.hit_test(area.x as f32 + 1.5, area.y as f32 + 0.5);
         assert_eq!(hit, PanelHit::TitleBar(WidgetId::new("panel")));
     }
 
     #[test]
-    fn action_button_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 30, 10);
-        let mut buf = Buffer::empty(area);
+    fn title_bar_paint_and_click_round_trip() {
+        title_bar_paint_and_click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494): same round trip,
+    /// painted at a shifted `area` origin.
+    #[test]
+    fn title_bar_paint_and_click_round_trip_at_nonzero_origin() {
+        title_bar_paint_and_click_round_trip_at(7, 13);
+    }
+
+    fn action_button_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 30, 10);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 30, origin_y + 10));
         let panel = titled_panel();
         let layout = draw_panel(&mut buf, area, &panel, &Theme::default());
 
@@ -180,22 +197,32 @@ mod tests {
         let glyph_x = ax + aw / 2;
 
         // The "×" glyph should be painted at the centre of the button.
-        assert_eq!(cell_char(&buf, glyph_x, 0), '×');
+        assert_eq!(cell_char(&buf, glyph_x, area.y), '×');
 
         // Hit-test at that glyph position → Action("close").
-        let hit = layout.hit_test(glyph_x as f32 + 0.5, 0.5);
+        let hit = layout.hit_test(glyph_x as f32 + 0.5, area.y as f32 + 0.5);
         assert_eq!(hit, PanelHit::Action(WidgetId::new("close")));
     }
 
     #[test]
-    fn content_region_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 20, 10);
-        let mut buf = Buffer::empty(area);
+    fn action_button_paint_and_click_round_trip() {
+        action_button_paint_and_click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn action_button_paint_and_click_round_trip_at_nonzero_origin() {
+        action_button_paint_and_click_round_trip_at(7, 13);
+    }
+
+    fn content_region_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 20, 10);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 20, origin_y + 10));
         let panel = titled_panel();
         let layout = draw_panel(&mut buf, area, &panel, &Theme::default());
 
-        // Content should start at y=1 (below 1-cell title bar).
-        assert!(layout.content_bounds.y >= 1.0);
+        // Content should start at area.y + 1 (below 1-cell title bar).
+        assert!(layout.content_bounds.y >= area.y as f32 + 1.0);
         assert!(layout.content_bounds.height > 0.0);
 
         // Hit-test inside content → Content.
@@ -203,6 +230,17 @@ mod tests {
         let cy = layout.content_bounds.y + 1.0;
         let hit = layout.hit_test(cx, cy);
         assert_eq!(hit, PanelHit::Content(WidgetId::new("panel")));
+    }
+
+    #[test]
+    fn content_region_paint_and_click_round_trip() {
+        content_region_paint_and_click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn content_region_paint_and_click_round_trip_at_nonzero_origin() {
+        content_region_paint_and_click_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/pipeline_view.rs
+++ b/quadraui/src/tui/pipeline_view.rs
@@ -280,12 +280,31 @@ mod tests {
         assert_eq!(cell_char(&buf, 0, 1), '╭');
     }
 
-    #[test]
-    fn layout_hit_test_action_round_trip() {
-        let area = Rect::new(0, 0, 40, 5);
+    /// Shared body for the action↔click round trip, run at both the
+    /// origin and a non-zero `area` origin (quadraui#494 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"). `tui_pipeline_view_layout` bakes `area.x`/`area.y`
+    /// straight into the returned bounds (absolute frame, matching the
+    /// GTK/macOS twins) — and *also* adds `TUI_FOCUS_INDICATOR_H` to
+    /// `area.y` itself before laying out, an extra reason a non-zero
+    /// `area.y` regression is plausible here. Deriving `ab`/`bb` from the
+    /// layout (not hardcoding them) means this exercises whatever origin
+    /// math the function actually does, at any origin.
+    fn layout_hit_test_action_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 5);
         let mut buf = Buffer::empty(area);
         let view = make_view();
         let layout = draw_pipeline_view(&mut buf, area, &view, &Theme::default());
+
+        // Box top must sit exactly one row below area.y + the reserved
+        // focus-indicator row, not at a hardcoded absolute row — pins the
+        // offset math independently of the hit_test round trip below.
+        let bb0 = layout.stages[0].box_bounds;
+        assert_eq!(
+            bb0.y,
+            (area.y + TUI_FOCUS_INDICATOR_H) as f32,
+            "stage box top should be area.y + TUI_FOCUS_INDICATOR_H"
+        );
 
         // Stage 1 has action bounds.
         let ab = layout.stages[1]
@@ -296,15 +315,41 @@ mod tests {
     }
 
     #[test]
-    fn layout_hit_test_body_round_trip() {
-        let area = Rect::new(0, 0, 40, 5);
+    fn layout_hit_test_action_round_trip() {
+        layout_hit_test_action_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn layout_hit_test_action_round_trip_at_nonzero_origin() {
+        layout_hit_test_action_round_trip_at(7, 13);
+    }
+
+    fn layout_hit_test_body_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 5);
         let mut buf = Buffer::empty(area);
         let view = make_view();
         let layout = draw_pipeline_view(&mut buf, area, &view, &Theme::default());
 
         let bb = layout.stages[0].box_bounds;
+        assert_eq!(
+            bb.y,
+            (area.y + TUI_FOCUS_INDICATOR_H) as f32,
+            "stage box top should be area.y + TUI_FOCUS_INDICATOR_H"
+        );
         let hit = layout.hit_test(bb.x + 1.0, bb.y + 1.0);
         assert_eq!(hit, PipelineHit::Body(0));
+    }
+
+    #[test]
+    fn layout_hit_test_body_round_trip() {
+        layout_hit_test_body_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494).
+    #[test]
+    fn layout_hit_test_body_round_trip_at_nonzero_origin() {
+        layout_hit_test_body_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/progress.rs
+++ b/quadraui/src/tui/progress.rs
@@ -129,28 +129,46 @@ mod tests {
         }
     }
 
-    #[test]
-    fn determinate_fill_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 20, 1);
+    // Shared bodies parametrized over the area's origin — LESSONS.md
+    // "Layout helpers must return coords in the same frame across
+    // backends" (quadraui#494). `tui_progress_layout` bakes `area.x`/
+    // `area.y` straight into `bar.layout`'s returned bounds (absolute
+    // frame), so the regression guard is a full paint+hit_test round
+    // trip re-run at a non-zero origin, not a relative-coords check.
+
+    fn determinate_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 20, 1);
         let mut buf = Buffer::empty(area);
         let bar = det_bar(0.5);
         let layout = draw_progress(&mut buf, area, &bar, &Theme::default());
 
-        // Fill should cover ~10 cells (50% of 20).
+        // Fill should cover ~10 cells (50% of 20) starting at the area's origin.
         let fb = layout.fill_bounds.expect("fill bounds present");
         let fill_end = (fb.x + fb.width).round() as u16;
-        assert_eq!(fill_end, 10);
-        assert_eq!(cell_char(&buf, 0, 0), '█');
-        assert_eq!(cell_char(&buf, 9, 0), '█');
-        assert_eq!(cell_char(&buf, 10, 0), '░');
+        assert_eq!(fill_end, origin_x + 10);
+        assert_eq!(cell_char(&buf, origin_x, origin_y), '█');
+        assert_eq!(cell_char(&buf, origin_x + 9, origin_y), '█');
+        assert_eq!(cell_char(&buf, origin_x + 10, origin_y), '░');
 
-        let hit = layout.hit_test(5.0, 0.5);
+        let hit = layout.hit_test(origin_x as f32 + 5.0, origin_y as f32 + 0.5);
         assert_eq!(hit, ProgressBarHit::Body(WidgetId::new("prog")));
     }
 
     #[test]
-    fn cancel_button_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 20, 1);
+    fn determinate_fill_paint_and_click_round_trip() {
+        determinate_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md):
+    /// the same fill+hit_test round trip must hold when the bar isn't
+    /// painted at the screen origin.
+    #[test]
+    fn determinate_fill_paint_and_click_round_trip_at_nonzero_origin() {
+        determinate_round_trip_at(7, 13);
+    }
+
+    fn cancel_button_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 20, 1);
         let mut buf = Buffer::empty(area);
         let mut bar = det_bar(0.5);
         bar.cancellable = true;
@@ -158,10 +176,21 @@ mod tests {
 
         let cb = layout.cancel_bounds.expect("cancel bounds present");
         let cx = cb.x.round() as u16 + 1;
-        assert_eq!(cell_char(&buf, cx, 0), '×');
+        assert_eq!(cell_char(&buf, cx, origin_y), '×');
 
-        let hit = layout.hit_test(cx as f32 + 0.5, 0.5);
+        let hit = layout.hit_test(cx as f32 + 0.5, origin_y as f32 + 0.5);
         assert_eq!(hit, ProgressBarHit::Cancel(WidgetId::new("prog")));
+    }
+
+    #[test]
+    fn cancel_button_paint_and_click_round_trip() {
+        cancel_button_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md).
+    #[test]
+    fn cancel_button_paint_and_click_round_trip_at_nonzero_origin() {
+        cancel_button_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/sidebar_panel.rs
+++ b/quadraui/src/tui/sidebar_panel.rs
@@ -123,16 +123,34 @@ mod tests {
         assert_eq!(layout.content_bounds.height, 9.0);
     }
 
-    #[test]
-    fn click_in_header_resolves_to_toolbar_button() {
-        let area = Rect::new(0, 0, 40, 10);
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends"
+    // (quadraui#494). `tui_sidebar_panel_layout` bakes `area.x`/
+    // `area.y` straight into `panel.layout`'s returned bounds
+    // (absolute frame), so the regression guard is a full
+    // paint+hit_test round trip re-run at a non-zero origin.
+    fn click_in_header_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 10);
         let mut buf = Buffer::empty(area);
         let panel = panel_with_toolbar();
         let layout = draw_sidebar_panel(&mut buf, area, &panel, &Theme::default(), None, None);
-        match layout.hit_test(2.0, 0.0) {
+        match layout.hit_test(origin_x as f32 + 2.0, origin_y as f32) {
             SidebarPanelHit::ToolbarButton(id) => assert_eq!(id.as_str(), "refine"),
             other => panic!("expected ToolbarButton, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn click_in_header_resolves_to_toolbar_button() {
+        click_in_header_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md):
+    /// the same header-click round trip must hold when the panel isn't
+    /// painted at the screen origin.
+    #[test]
+    fn click_in_header_resolves_to_toolbar_button_at_nonzero_origin() {
+        click_in_header_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/spinner.rs
+++ b/quadraui/src/tui/spinner.rs
@@ -85,18 +85,36 @@ mod tests {
         }
     }
 
-    #[test]
-    fn glyph_paint_and_hit_round_trip() {
-        let area = Rect::new(0, 0, 30, 1);
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends"
+    // (quadraui#494). `tui_spinner_layout` bakes `area.x`/`area.y`
+    // straight into `spinner.layout`'s returned bounds (absolute
+    // frame), so the regression guard is a full paint+hit_test round
+    // trip re-run at a non-zero origin.
+    fn glyph_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 30, 1);
         let mut buf = Buffer::empty(area);
         let spinner = mk_spinner("Loading", 0);
         let layout = draw_spinner(&mut buf, area, &spinner, &Theme::default());
 
-        assert_eq!(cell_char(&buf, 0, 0), '⠋');
-        assert_eq!(cell_char(&buf, 2, 0), 'L');
+        assert_eq!(cell_char(&buf, origin_x, origin_y), '⠋');
+        assert_eq!(cell_char(&buf, origin_x + 2, origin_y), 'L');
 
-        let hit = layout.hit_test(0.5, 0.5, &spinner.id);
+        let hit = layout.hit_test(origin_x as f32 + 0.5, origin_y as f32 + 0.5, &spinner.id);
         assert_eq!(hit, SpinnerHit::Body(WidgetId::new("spin")));
+    }
+
+    #[test]
+    fn glyph_paint_and_hit_round_trip() {
+        glyph_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md):
+    /// the same glyph paint + hit_test round trip must hold when the
+    /// spinner isn't painted at the screen origin.
+    #[test]
+    fn glyph_paint_and_hit_round_trip_at_nonzero_origin() {
+        glyph_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/split.rs
+++ b/quadraui/src/tui/split.rs
@@ -89,46 +89,75 @@ mod tests {
         }
     }
 
-    #[test]
-    fn horizontal_paint_and_click_round_trip() {
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends"
+    // (quadraui#494). `tui_split_layout` bakes `area.x`/`area.y`
+    // straight into `split.layout`'s returned bounds (absolute frame),
+    // so the regression guard is a full paint+hit_test round trip
+    // re-run at a non-zero origin.
+
+    fn horizontal_round_trip_at(origin_x: u16, origin_y: u16) {
         // Use 41 cols so available=40, 0.5*40=20 → divider at x=20, integer.
-        let area = Rect::new(0, 0, 41, 10);
+        let area = Rect::new(origin_x, origin_y, 41, 10);
         let mut buf = Buffer::empty(area);
         let split = hsplit(0.5);
         let layout = draw_split(&mut buf, area, &split, &Theme::default());
 
         let div_x = layout.divider_bounds.x.round() as u16;
-        assert_eq!(cell_char(&buf, div_x, 0), '│');
+        assert_eq!(cell_char(&buf, div_x, origin_y), '│');
 
-        let hit = layout.hit_test(layout.divider_bounds.x + 0.5, 5.0);
+        let mid_y = origin_y as f32 + 5.0;
+        let hit = layout.hit_test(layout.divider_bounds.x + 0.5, mid_y);
         assert_eq!(hit, SplitHit::Divider(WidgetId::new("split")));
 
-        let hit_first = layout.hit_test(1.0, 5.0);
+        let hit_first = layout.hit_test(origin_x as f32 + 1.0, mid_y);
         assert_eq!(hit_first, SplitHit::FirstPane(WidgetId::new("split")));
 
-        let hit_second = layout.hit_test(layout.divider_bounds.x + 1.5, 5.0);
+        let hit_second = layout.hit_test(layout.divider_bounds.x + 1.5, mid_y);
         assert_eq!(hit_second, SplitHit::SecondPane(WidgetId::new("split")));
     }
 
     #[test]
-    fn vertical_paint_and_click_round_trip() {
+    fn horizontal_paint_and_click_round_trip() {
+        horizontal_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md).
+    #[test]
+    fn horizontal_paint_and_click_round_trip_at_nonzero_origin() {
+        horizontal_round_trip_at(7, 13);
+    }
+
+    fn vertical_round_trip_at(origin_x: u16, origin_y: u16) {
         // Use 21 rows so available=20, 0.5*20=10 → divider at y=10, integer.
-        let area = Rect::new(0, 0, 40, 21);
+        let area = Rect::new(origin_x, origin_y, 40, 21);
         let mut buf = Buffer::empty(area);
         let split = vsplit(0.5);
         let layout = draw_split(&mut buf, area, &split, &Theme::default());
 
         let div_y = layout.divider_bounds.y.round() as u16;
-        assert_eq!(cell_char(&buf, 0, div_y), '─');
+        assert_eq!(cell_char(&buf, origin_x, div_y), '─');
 
-        let hit = layout.hit_test(20.0, layout.divider_bounds.y + 0.5);
+        let mid_x = origin_x as f32 + 20.0;
+        let hit = layout.hit_test(mid_x, layout.divider_bounds.y + 0.5);
         assert_eq!(hit, SplitHit::Divider(WidgetId::new("split")));
 
-        let hit_first = layout.hit_test(20.0, 1.0);
+        let hit_first = layout.hit_test(mid_x, origin_y as f32 + 1.0);
         assert_eq!(hit_first, SplitHit::FirstPane(WidgetId::new("split")));
 
-        let hit_second = layout.hit_test(20.0, layout.divider_bounds.y + 1.5);
+        let hit_second = layout.hit_test(mid_x, layout.divider_bounds.y + 1.5);
         assert_eq!(hit_second, SplitHit::SecondPane(WidgetId::new("split")));
+    }
+
+    #[test]
+    fn vertical_paint_and_click_round_trip() {
+        vertical_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md).
+    #[test]
+    fn vertical_paint_and_click_round_trip_at_nonzero_origin() {
+        vertical_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/split_tree.rs
+++ b/quadraui/src/tui/split_tree.rs
@@ -93,34 +93,57 @@ mod tests {
         )
     }
 
-    #[test]
-    fn horizontal_paint_and_click_round_trip() {
-        // 41 cols so available=40, 0.5*40=20 -> divider at cell x=20.
-        let area = Rect::new(0, 0, 41, 10);
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends"
+    // (quadraui#494). `tui_split_tree_layout` bakes `area.x`/`area.y`
+    // straight into `tree.layout`'s returned bounds (absolute frame),
+    // so the regression guard is a full paint+hit_test round trip
+    // re-run at a non-zero origin.
+    fn horizontal_round_trip_at(origin_x: u16, origin_y: u16) {
+        // 41 cols so available=40, 0.5*40=20 -> divider at cell x=origin_x+20.
+        let area = Rect::new(origin_x, origin_y, 41, 10);
         let mut buf = Buffer::empty(area);
         let tree = two_pane(SplitDirection::Horizontal, 0.5);
         let layout = draw_split_tree(&mut buf, area, &tree, &Theme::default());
 
         let d = &layout.dividers[0];
         let cell = d.cell_position();
-        assert_eq!(cell_char(&buf, cell, 0), '│');
+        assert_eq!(cell_char(&buf, cell, origin_y), '│');
 
+        let cross_cell = origin_y + 5;
         // hit_test_divider_cell at the exact painted cell resolves the
         // same split_index the paint loop used.
-        assert_eq!(layout.hit_test_divider_cell(cell, 5), Some(d.split_index));
+        assert_eq!(
+            layout.hit_test_divider_cell(cell, cross_cell),
+            Some(d.split_index)
+        );
 
         // Leaf hit-test resolves panes on either side of the divider.
         assert_eq!(
-            layout.hit_test_leaf(Point { x: 1.0, y: 5.0 }),
+            layout.hit_test_leaf(Point {
+                x: origin_x as f32 + 1.0,
+                y: cross_cell as f32
+            }),
             Some(&wid("a"))
         );
         assert_eq!(
             layout.hit_test_leaf(Point {
                 x: cell as f32 + 2.0,
-                y: 5.0
+                y: cross_cell as f32
             }),
             Some(&wid("b"))
         );
+    }
+
+    #[test]
+    fn horizontal_paint_and_click_round_trip() {
+        horizontal_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md).
+    #[test]
+    fn horizontal_paint_and_click_round_trip_at_nonzero_origin() {
+        horizontal_round_trip_at(7, 13);
     }
 
     #[test]
@@ -196,34 +219,53 @@ mod tests {
         assert_eq!(layout.leaves.len(), 3);
     }
 
-    #[test]
-    fn hit_test_agrees_with_actually_painted_cell_for_fractional_ratio() {
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends"
+    // (quadraui#494). This is a genuine paint→hit_test round trip (it
+    // reads the actually-painted column back out of the buffer), so it
+    // gets the same non-zero-origin treatment as the other round trips
+    // in this file.
+    fn fractional_ratio_round_trip_at(origin_x: u16, origin_y: u16) {
         // A ratio chosen so the divider position is NOT cell-aligned —
         // this is the vimcode #452 regression case: paint must truncate
         // (`as u16`) the same way `SplitTreeDivider::cell_position()`
         // does, not round — otherwise a click on the visually-painted
         // divider misses.
-        let area = Rect::new(0, 0, 101, 10); // available = 100
+        let area = Rect::new(origin_x, origin_y, 101, 10); // available = 100
         let mut buf = Buffer::empty(area);
-        let tree = two_pane(SplitDirection::Horizontal, 0.207); // position = 20.7
+        let tree = two_pane(SplitDirection::Horizontal, 0.207); // position = origin_x + 20.7
         let layout = draw_split_tree(&mut buf, area, &tree, &Theme::default());
-        assert!((layout.dividers[0].position - 20.7).abs() < 0.01);
+        assert!((layout.dividers[0].position - (origin_x as f32 + 20.7)).abs() < 0.01);
 
+        let cross_row = origin_y + 5;
         // Find the column the divider glyph actually painted at —
         // don't assume a formula, read the buffer.
-        let painted_col = (0..area.width)
-            .find(|&x| cell_char(&buf, x, 5) == '│')
+        let painted_col = (area.x..area.x + area.width)
+            .find(|&x| cell_char(&buf, x, cross_row) == '│')
             .expect("divider glyph should have painted somewhere");
 
         // hit_test_divider_cell at the ACTUAL painted column must
         // resolve to this divider — proving paint and hit-test agree
         // on the same float -> cell conversion.
         assert_eq!(
-            layout.hit_test_divider_cell(painted_col, 5),
+            layout.hit_test_divider_cell(painted_col, cross_row),
             Some(layout.dividers[0].split_index),
             "painted at column {painted_col} but hit_test_divider_cell disagrees \
              (paint and click used different float->cell conversions)"
         );
+    }
+
+    #[test]
+    fn hit_test_agrees_with_actually_painted_cell_for_fractional_ratio() {
+        fractional_ratio_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md):
+    /// the #452 paint/hit-test agreement must also hold when the tree
+    /// isn't painted at the screen origin.
+    #[test]
+    fn hit_test_agrees_with_actually_painted_cell_for_fractional_ratio_at_nonzero_origin() {
+        fractional_ratio_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/status_bar.rs
+++ b/quadraui/src/tui/status_bar.rs
@@ -272,8 +272,15 @@ mod tests {
         assert!(result.hit_regions.is_empty());
     }
 
-    #[test]
-    fn returns_hit_regions_for_action_segments() {
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends" (quadraui#494).
+    // `hit_regions` are bar-local by construction (`bar.layout` only takes
+    // width/height, never `area.x`/`area.y`), but `draw_status_bar` paints
+    // each segment's text at `area.x + vs.bounds.x` — so the only way to
+    // prove painting is correct at a non-zero origin is a full round trip:
+    // lay out, paint, and check the glyph lands at the *absolute* screen
+    // position while the returned hit region stays bar-local.
+    fn round_trip_at(origin_x: u16, origin_y: u16) {
         // Bar with an action_id'd segment in the middle of the left half.
         let bar = StatusBar {
             id: WidgetId::new("test-bar"),
@@ -298,10 +305,10 @@ mod tests {
         let layout = bar.layout(20.0, 1.0, 0.0, |seg| {
             StatusSegmentMeasure::new(seg.text.chars().count() as f32)
         });
-        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 20, origin_y + 1));
         let result = draw_status_bar(
             &mut buf,
-            Rect::new(0, 0, 20, 1),
+            Rect::new(origin_x, origin_y, 20, 1),
             &bar,
             &layout,
             &Theme::default(),
@@ -316,10 +323,34 @@ mod tests {
             StatusBarHit::Segment(id) => assert_eq!(id.as_str(), "middle-action"),
             other => panic!("expected Segment, got {:?}", other),
         }
-        // Region starts after "AAA" (x=3.0) and is 4 cells wide ("BBBB").
+        // Region starts after "AAA" (x=3.0) and is 4 cells wide ("BBBB") —
+        // bar-local, independent of `origin_x`/`origin_y`.
         let r = &result.hit_regions[0].0;
         assert_eq!(r.x, 3.0);
         assert_eq!(r.width, 4.0);
+
+        // Painting must land at the *absolute* screen position
+        // (area.x + bounds.x, area.y), not at the bar-local coordinates.
+        let painted_x = origin_x + r.x as u16;
+        assert_eq!(
+            cell_char(&buf, painted_x, origin_y),
+            'B',
+            "segment text should paint at area.x ({origin_x}) + bounds.x ({}), area.y ({origin_y})",
+            r.x
+        );
+    }
+
+    #[test]
+    fn returns_hit_regions_for_action_segments() {
+        round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md): the
+    /// same hit-region + paint round trip must hold when the bar isn't
+    /// painted at the screen origin.
+    #[test]
+    fn returns_hit_regions_for_action_segments_at_nonzero_origin() {
+        round_trip_at(7, 13);
     }
 
     fn make_clickable_bar() -> StatusBar {

--- a/quadraui/src/tui/text_display.rs
+++ b/quadraui/src/tui/text_display.rs
@@ -317,9 +317,15 @@ mod tests {
         assert_eq!(cell_char(&buf, 0, 0), ' ');
     }
 
-    #[test]
-    fn scrollbar_thumb_paint_and_click_round_trip() {
-        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 5));
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends" (quadraui#494).
+    // `tui_text_display_layout` is local-frame (it only takes `body`
+    // width/height, never `area.x`/`area.y`), but `draw_text_display`
+    // paints each row at `body.y + vis.bounds.y` (and the scrollbar gutter
+    // at `body.x`/`body.y`) — untested at a non-zero `area.y`/`area.x`
+    // until now.
+    fn scrollbar_thumb_round_trip_at(origin_x: u16, origin_y: u16) {
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 20, origin_y + 5));
         let display = TextDisplay {
             id: WidgetId::new("td"),
             lines: (0..20).map(|i| line(&format!("line{i}"))).collect(),
@@ -332,15 +338,17 @@ mod tests {
         };
         draw_text_display(
             &mut buf,
-            Rect::new(0, 0, 20, 5),
+            Rect::new(origin_x, origin_y, 20, 5),
             &display,
             &Theme::default(),
         );
 
-        // Scrollbar gutter at column 19. Thumb should be at top (scroll_offset=0).
-        assert_eq!(cell_char(&buf, 19, 0), '█');
+        // Scrollbar gutter at the last column of the area. Thumb should be
+        // at top (scroll_offset=0).
+        assert_eq!(cell_char(&buf, origin_x + 19, origin_y), '█');
 
-        // Use layout for hit-test.
+        // Use layout for hit-test — layout is local-frame (0,0-based), so
+        // the hit_test coordinates are NOT shifted by origin_x/origin_y.
         let layout = display
             .layout_with_scrollbar(20.0, 5.0, 1.0, 1.0, |_| TextDisplayLineMeasure::new(1.0));
         let thumb = layout.thumb_bounds.expect("thumb bounds present");
@@ -349,6 +357,19 @@ mod tests {
             hit,
             crate::primitives::text_display::TextDisplayHit::ScrollbarThumb
         );
+    }
+
+    #[test]
+    fn scrollbar_thumb_paint_and_click_round_trip() {
+        scrollbar_thumb_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md): the
+    /// same scrollbar paint + hit_test round trip must hold when the
+    /// display isn't painted at the screen origin.
+    #[test]
+    fn scrollbar_thumb_paint_and_click_round_trip_at_nonzero_origin() {
+        scrollbar_thumb_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/text_input.rs
+++ b/quadraui/src/tui/text_input.rs
@@ -113,3 +113,76 @@ pub fn draw_text_input(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::Point;
+    use crate::primitives::text_input::TextInputHit;
+    use crate::types::WidgetId;
+
+    fn cell_char(buf: &Buffer, x: u16, y: u16) -> char {
+        buf[(x, y)].symbol().chars().next().unwrap_or(' ')
+    }
+
+    fn mk_input(lines: Vec<&str>) -> TextInput {
+        TextInput {
+            id: WidgetId::new("ti"),
+            lines: lines.into_iter().map(String::from).collect(),
+            cursor_line: 0,
+            cursor_col: 0,
+            placeholder: None,
+            scroll_offset: 0,
+            scroll_col: 0,
+            has_focus: true,
+        }
+    }
+
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends" (quadraui#494).
+    // `tui_text_input_layout` bakes `rect.x`/`rect.y` straight into
+    // `ti.layout`'s returned bounds (absolute frame: `TextInput::layout`
+    // computes `content_x = rect.x + border + pad_x`), so the regression
+    // guard is a full paint+hit_test round trip re-run at a non-zero
+    // origin. There was no existing `#[cfg(test)] mod tests` in this file
+    // at all before quadraui#494, hence this doubles as the origin-(0,0)
+    // baseline test too.
+    fn paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let rect = Rect::new(origin_x, origin_y, 10, 4);
+        let mut buf = Buffer::empty(rect);
+        let ti = mk_input(vec!["hello"]);
+        let layout = draw_text_input(&mut buf, rect, &ti, &Theme::default());
+
+        // Border top-left corner paints at the absolute origin.
+        assert_eq!(cell_char(&buf, origin_x, origin_y), '┌');
+
+        // Content starts after the 1-cell border + 1-char horizontal
+        // padding, at the absolute screen position.
+        let content_x = origin_x + 2;
+        let content_y = origin_y + 1;
+        assert_eq!(cell_char(&buf, content_x, content_y), 'h');
+
+        // hit_test: a click at the first content cell (absolute coords)
+        // should resolve to the (only) visible line.
+        let p = Point::new(content_x as f32 + 0.5, content_y as f32 + 0.5);
+        let hit = layout
+            .hit_regions
+            .iter()
+            .find(|(r, _)| r.contains(p))
+            .map(|(_, h)| h.clone());
+        assert_eq!(hit, Some(TextInputHit::Line { line_idx: 0 }));
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        paint_and_click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md): the
+    /// same paint + hit_test round trip must hold when the input isn't
+    /// painted at the screen origin.
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        paint_and_click_round_trip_at(7, 13);
+    }
+}

--- a/quadraui/src/tui/toast.rs
+++ b/quadraui/src/tui/toast.rs
@@ -37,14 +37,18 @@ fn severity_bg(severity: ToastSeverity, theme: &Theme) -> crate::types::Color {
 }
 
 /// Compute the TUI cell-unit layout for a [`ToastStack`] without painting.
-pub fn tui_toast_stack_layout(
-    stack: &ToastStack,
-    viewport_width: f32,
-    viewport_height: f32,
-) -> ToastStackLayout {
+///
+/// `area`'s origin is baked into the returned bounds (absolute buffer
+/// coordinates, matching `tui_menu_bar_layout` / `tui_panel_layout`) —
+/// hosts call `layout.hit_test(x, y)` with raw click coordinates, no
+/// localisation needed.
+pub fn tui_toast_stack_layout(stack: &ToastStack, area: Rect) -> ToastStackLayout {
+    let viewport_width = area.width as f32;
     stack.layout(
+        area.x as f32,
+        area.y as f32,
         viewport_width,
-        viewport_height,
+        area.height as f32,
         TUI_TOAST_MARGIN,
         TUI_TOAST_GAP,
         |i| {
@@ -72,7 +76,7 @@ pub fn draw_toast_stack(
     stack: &ToastStack,
     theme: &Theme,
 ) -> ToastStackLayout {
-    let layout = tui_toast_stack_layout(stack, area.width as f32, area.height as f32);
+    let layout = tui_toast_stack_layout(stack, area);
 
     for vt in &layout.visible_toasts {
         let toast = &stack.toasts[vt.toast_idx];
@@ -192,10 +196,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn single_toast_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 60, 20);
-        let mut buf = Buffer::empty(area);
+    /// Shared body for `single_toast_paint_and_click_round_trip`, run at
+    /// both the origin and a non-zero `area` origin (quadraui#494 /
+    /// LESSONS.md "Layout helpers must return coords in the same frame
+    /// across backends"). `tui_toast_stack_layout` bakes `area.x`/`area.y`
+    /// straight into the returned bounds (absolute frame, matching
+    /// `tui_menu_bar_layout`/`tui_panel_layout`), so both the painted
+    /// glyph position AND the `hit_test` coordinates must shift together
+    /// with the origin.
+    fn single_toast_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 60, 20);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 60, origin_y + 20));
         let stack = stack_br(vec![info_toast("t1", "Hello world")]);
         let layout = draw_toast_stack(&mut buf, area, &stack, &Theme::default());
 
@@ -213,9 +224,23 @@ mod tests {
     }
 
     #[test]
-    fn dismiss_glyph_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 60, 20);
-        let mut buf = Buffer::empty(area);
+    fn single_toast_paint_and_click_round_trip() {
+        single_toast_paint_and_click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494): same round trip,
+    /// painted at a shifted `area` origin.
+    #[test]
+    fn single_toast_paint_and_click_round_trip_at_nonzero_origin() {
+        single_toast_paint_and_click_round_trip_at(7, 13);
+    }
+
+    /// Shared body for `dismiss_glyph_paint_and_click_round_trip` —
+    /// see [`single_toast_paint_and_click_round_trip_at`] for the
+    /// quadraui#494 non-zero-origin rationale.
+    fn dismiss_glyph_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 60, 20);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 60, origin_y + 20));
         let stack = stack_br(vec![info_toast("t1", "Test")]);
         let layout = draw_toast_stack(&mut buf, area, &stack, &Theme::default());
 
@@ -230,9 +255,21 @@ mod tests {
     }
 
     #[test]
-    fn action_button_paint_and_click_round_trip() {
-        let area = Rect::new(0, 0, 60, 20);
-        let mut buf = Buffer::empty(area);
+    fn dismiss_glyph_paint_and_click_round_trip() {
+        dismiss_glyph_paint_and_click_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn dismiss_glyph_paint_and_click_round_trip_at_nonzero_origin() {
+        dismiss_glyph_paint_and_click_round_trip_at(7, 13);
+    }
+
+    /// Shared body for `action_button_paint_and_click_round_trip` —
+    /// see [`single_toast_paint_and_click_round_trip_at`] for the
+    /// quadraui#494 non-zero-origin rationale.
+    fn action_button_paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 60, 20);
+        let mut buf = Buffer::empty(Rect::new(0, 0, origin_x + 60, origin_y + 20));
         let mut toast = info_toast("t1", "Error occurred");
         toast.action = Some(ToastAction {
             id: WidgetId::new("retry"),
@@ -249,6 +286,16 @@ mod tests {
 
         let hit = layout.hit_test(ax as f32 + 0.5, ay as f32 + 0.5);
         assert_eq!(hit, ToastHit::Action(WidgetId::new("retry")));
+    }
+
+    #[test]
+    fn action_button_paint_and_click_round_trip() {
+        action_button_paint_and_click_round_trip_at(0, 0);
+    }
+
+    #[test]
+    fn action_button_paint_and_click_round_trip_at_nonzero_origin() {
+        action_button_paint_and_click_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/toolbar.rs
+++ b/quadraui/src/tui/toolbar.rs
@@ -272,9 +272,14 @@ mod tests {
         assert_eq!(cell_char(&buf, 1, 0), ' ');
     }
 
-    #[test]
-    fn click_round_trip_through_layout() {
-        let area = Rect::new(0, 0, 40, 1);
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends" (quadraui#494).
+    // `tui_toolbar_layout` bakes `area.x`/`area.y` straight into
+    // `bar.layout`'s returned bounds (absolute frame), so the regression
+    // guard is a full paint+hit_test round trip re-run at a non-zero
+    // origin.
+    fn click_round_trip_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 40, 1);
         let mut buf = Buffer::empty(area);
         let bar = Toolbar {
             id: WidgetId::new("tb"),
@@ -285,6 +290,14 @@ mod tests {
         let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         // Click inside the first button.
         let b = layout.visible_items[0].bounds;
+        assert_eq!(
+            b.x, origin_x as f32,
+            "bounds should be absolute (area.x baked in)"
+        );
+        assert_eq!(
+            b.y, origin_y as f32,
+            "bounds should be absolute (area.y baked in)"
+        );
         let hit = layout.hit_test(b.x + 1.0, b.y);
         match hit {
             ToolbarHit::Button(id) => assert_eq!(id.as_str(), "a"),
@@ -297,6 +310,19 @@ mod tests {
             ToolbarHit::Button(id) => assert_eq!(id.as_str(), "b"),
             _ => panic!("expected button-b hit"),
         }
+    }
+
+    #[test]
+    fn click_round_trip_through_layout() {
+        click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md): the
+    /// same click round trip must hold when the toolbar isn't painted at
+    /// the screen origin.
+    #[test]
+    fn click_round_trip_through_layout_at_nonzero_origin() {
+        click_round_trip_at(7, 13);
     }
 
     #[test]

--- a/quadraui/src/tui/tree.rs
+++ b/quadraui/src/tui/tree.rs
@@ -484,9 +484,14 @@ mod tests {
     /// Accepts both `Row(idx)` and `Chevron(idx)` as valid hits — the
     /// test verifies row-position consistency, not whether the click
     /// landed on the chevron or the body.
-    #[test]
-    fn clicks_land_on_painted_row() {
-        let area = Rect::new(0, 0, 30, 8);
+    // Parametrized over the area's origin — LESSONS.md "Layout helpers
+    // must return coords in the same frame across backends" (quadraui#494).
+    // This harness already subtracts `area.y` before calling `hit_test`
+    // (tree-local coords), but every pre-existing call site used
+    // `Rect::new(0, 0, ...)`, so the subtraction was never exercised with
+    // a non-zero value. Re-run at a non-zero origin to close that gap.
+    fn clicks_land_on_painted_row_at(origin_x: u16, origin_y: u16) {
+        let area = Rect::new(origin_x, origin_y, 30, 8);
         let mut buf = Buffer::empty(area);
         let tree = long_tree(5);
         let layout = paint_then_layout(&mut buf, area, &tree, &Theme::default(), false);
@@ -517,6 +522,20 @@ mod tests {
                 visible.row_idx, needle, painted_y, hit_idx
             );
         }
+    }
+
+    #[test]
+    fn clicks_land_on_painted_row() {
+        clicks_land_on_painted_row_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (quadraui#494 / LESSONS.md): the
+    /// same paint + hit_test round trip must hold when the tree isn't
+    /// painted at the screen origin — exercises the `local_y = painted_y
+    /// - area.y` subtraction with a non-zero `area.y` for the first time.
+    #[test]
+    fn clicks_land_on_painted_row_at_nonzero_origin() {
+        clicks_land_on_painted_row_at(7, 13);
     }
 
     /// Click below the last visible row returns Empty.

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -10,7 +10,7 @@
 #![cfg(feature = "tui")]
 
 use quadraui::tui::testing::{driver_with_shell, TuiDriver};
-use quadraui::{ButtonMask, NamedKey, Point, Reaction, UiEvent};
+use quadraui::{Backend, ButtonMask, NamedKey, Point, Reaction, UiEvent};
 
 #[path = "../examples/common/shell_app.rs"]
 mod shell_app_ex;
@@ -1608,9 +1608,11 @@ fn full_chrome_right_edge_click_requests_window_resize() {
     let config = FullChromeDemo::config();
     let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
 
-    // x=99 is the last column (the right border); y=15 sits well below the
-    // 2-row title bar and above the bottom-panel resize grip.
-    driver.click(99.0, 15.0);
+    // Right border = the last column, whatever the driver's width; mid
+    // height sits well below the 2-row title bar and above the
+    // bottom-panel resize grip regardless of the driver's height.
+    let viewport = driver.backend().viewport();
+    driver.click(viewport.width - 0.5, viewport.height / 2.0);
     assert!(
         driver.screen_contains("Edge resize (no window) (East)"),
         "clicking the right border should call begin_window_resize(East), \
@@ -1627,9 +1629,10 @@ fn full_chrome_bottom_right_corner_click_requests_window_resize() {
     let config = FullChromeDemo::config();
     let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
 
-    // (99, 29) is the last valid cell in a 100x30 grid — the bottom-right
-    // corner, nowhere near the title bar.
-    driver.click(99.0, 29.0);
+    // The last valid cell of the driver's grid — the bottom-right corner,
+    // nowhere near the title bar — whatever the driver's dimensions.
+    let viewport = driver.backend().viewport();
+    driver.click(viewport.width - 0.5, viewport.height - 0.5);
     assert!(
         driver.screen_contains("Edge resize (no window) (SouthEast)"),
         "clicking the bottom-right corner should call \
@@ -1673,13 +1676,14 @@ fn full_chrome_title_bar_wins_over_window_edge_at_top_corner() {
 fn full_chrome_mouse_moved_over_edge_does_not_crash() {
     let config = FullChromeDemo::config();
     let mut driver = driver_with_shell(FullChromeDemo::new(), config, 100, 30);
+    let viewport = driver.backend().viewport();
 
     // Hover with no button held (a plain move, not a drag) over the right
     // border, then back over plain main-content — both must return
     // `Continue` (a cursor hint never triggers a repaint) and leave the
     // rest of the screen exactly as it was.
     let reaction = driver.dispatch(UiEvent::MouseMoved {
-        position: Point::new(99.0, 15.0),
+        position: Point::new(viewport.width - 0.5, viewport.height / 2.0),
         buttons: ButtonMask::default(),
     });
     assert_eq!(
@@ -1697,7 +1701,7 @@ fn full_chrome_mouse_moved_over_edge_does_not_crash() {
     );
 
     let reaction = driver.dispatch(UiEvent::MouseMoved {
-        position: Point::new(50.0, 15.0),
+        position: Point::new(viewport.width / 2.0, viewport.height / 2.0),
         buttons: ButtonMask::default(),
     });
     assert_eq!(
@@ -1751,8 +1755,9 @@ fn shell_menu_dropdown_item_over_activity_bar_activates() {
         driver.screen()
     );
 
-    // Click at the item's row, at x=1 — inside the activity bar strip.
-    driver.click(1.0, item_y);
+    // Click at the item's own painted position — already confirmed above
+    // (`item_x < 3.0`) to land inside the activity bar strip.
+    driver.click(item_x, item_y);
     assert!(
         driver.screen_contains("activated: new"),
         "clicking the dropdown item over the activity bar should activate it \
@@ -1772,29 +1777,33 @@ fn shell_menu_dropdown_item_over_activity_bar_activates() {
 /// hit-testing unconditionally, only when a modal is actually open under the
 /// cursor.
 ///
-/// This scans down the activity bar column for the row that actually
-/// toggles the (already-active) Explorer panel rather than asserting a
-/// specific row: `AppShell`'s cached click-region for an activity item is
-/// not guaranteed to be pixel-identical to the row its icon glyph paints on
-/// (padding/margins are an internal layout detail, unrelated to #411), so
-/// pinning an exact coordinate here would make this test fragile to changes
-/// in that unrelated geometry. What #411 cares about — and what this test
-/// asserts — is that *some* position within the activity bar's column still
-/// reaches shell chrome and toggles it, proving the fix didn't disable
-/// chrome hit-testing altogether.
+/// Locates the click target instead of guessing a row: `ShellMenuDemo`'s
+/// first panel (Explorer) is active by default, and
+/// `tui::activity_bar::draw_activity_bar` paints its left-edge accent glyph
+/// (`'▎'`) at exactly the row `AppShell`'s cached hit-region reports for
+/// that item — see that module's `icons_still_paint_at_the_absolute_row`
+/// and `hit_regions_are_bar_relative_not_absolute` tests. `'▎'` is unique
+/// to that one call site (nothing else in the TUI backend paints it), so
+/// `find` unambiguously locates the active item's row without a brute-force
+/// scan.
 #[test]
 fn shell_menu_activity_bar_click_still_switches_panel_when_no_modal_open() {
-    let toggled = (0..20).map(|i| 1.0 + i as f32 * 0.5).any(|y| {
-        let mut probe = driver_with_shell(ShellMenuDemo::new(), ShellMenuDemo::config(), 100, 30);
-        probe.click(1.0, y);
-        probe.screen_contains("Sidebar hidden")
+    let mut driver = driver_with_shell(ShellMenuDemo::new(), ShellMenuDemo::config(), 100, 30);
+
+    let (x, y) = driver.find("▎").unwrap_or_else(|| {
+        panic!(
+            "Explorer (active by default) should paint its accent bar:\n{}",
+            driver.screen()
+        )
     });
+    driver.click(x, y);
 
     assert!(
-        toggled,
-        "no click within the activity bar column toggled the sidebar — a \
-         plain chrome click with no modal open should still be handled by \
-         shell chrome (AppShellEvent::SidebarHidden)"
+        driver.screen_contains("Sidebar hidden"),
+        "clicking the active panel's activity-bar row with no modal open \
+         should still be handled by shell chrome \
+         (AppShellEvent::SidebarHidden):\n{}",
+        driver.screen()
     );
 }
 


### PR DESCRIPTION
Closes #494

Automated PR opened by coordinator for review of issue #494.