### PR TITLE
#490: FrameInventory: portable text-run + widget-zone paint inventory on every backend (aligned with #322)

### DIFF
--- a/quadraui/docs/TESTING.md
+++ b/quadraui/docs/TESTING.md
@@ -265,6 +265,68 @@ separate for now — only the cross-backend parity test currently uses
 the shared-body pattern; migrating the full per-example suites onto it
 is follow-up work, not required by #301.
 
+### `FrameInventory`: the portable paint-inventory contract (quadraui#490)
+
+Before #490, "what did you paint and where" was backend-specific and
+leaked platform types into test bodies: TUI drivers scanned the cell
+grid with `find`/`find_bounds`, GTK read a `(text, bounds)` map, macOS
+had nothing, and a test that wanted to relate two painted things
+("is X left of Y?", "is X inside the sidebar zone?") had no
+backend-neutral way to ask.
+
+[`quadraui::testing::FrameInventory`] (`quadraui/src/testing.rs`, no
+`tui`/`gtk`/`macos`/`win` feature gate) is that contract — the same
+shape `#322` proposes for quadraweb's id→rect map:
+
+```rust
+pub struct TextRun { pub text: String, pub bounds: Rect }
+pub struct ZoneRec { pub id: WidgetId, pub bounds: Rect }
+pub struct FrameInventory { pub text_runs: Vec<TextRun>, pub zones: Vec<ZoneRec> }
+```
+
+`ConformanceDriver::inventory()` returns one per frame. `text_runs` is
+recovered from each backend's existing paint output with no per-widget
+opt-in (TUI's wide-char-aware cell-grid scan; GTK's `painted_text` map,
+fed by every Pango draw via `gtk/painted_text.rs`'s choke point).
+`zones` is populated from [`Backend::register_zone`] calls made during
+render — currently `AppShell::render` registers one zone per
+activity-bar item (keyed by that panel's real `WidgetId`) plus one
+`app-shell:`-prefixed zone per shell-chrome region (`activity-bar`,
+`sidebar-header`, `sidebar-content`, `main-content`, `status-bar`,
+`command-line`, `divider`, `bottom-panel`, `title-bar`, `window`); other
+primitives haven't been wired to call `register_zone` yet and simply
+contribute no zone, never a wrong one.
+
+`FrameInventory` carries a small relational assertion vocabulary — the
+structural fix for CLAUDE.md's no-hardcoded-coordinates rule, since
+every one of these is computed on the `Rect`s the inventory already
+reports, in the backend's own units, so a shared test body never writes
+a coordinate itself:
+
+```rust
+let inv = driver.inventory();
+inv.screen_has("EXPLORER");             // any text run contains this substring
+inv.absent("SOURCE CONTROL");           // no text run does
+inv.count("Settings");                  // how many runs do
+inv.left_of("E", "EXPLORER");           // a's right edge <= b's left edge
+inv.above("EXPLORER", "content");       // a's bottom edge <= b's top edge
+inv.same_row("E", "S");                 // vertical ranges overlap
+inv.inside("content", &WidgetId::new("app-shell:sidebar-content"));
+```
+
+`left_of`/`above`/`inside` are proven to agree across `TuiDriver` and
+`GtkDriver` for the `AppShellDemo` shell_app fixture in
+`tests/cross_backend_parity.rs` — see
+`frame_inventory_relations_agree_tui_and_gtk`.
+
+**Backend checklist:** every backend driver that implements
+`ConformanceDriver` MUST implement `inventory()` and populate
+`text_runs` from its real paint output (not a stub). Populating `zones`
+is incremental (call `Backend::register_zone` from whichever composers/
+primitives you want zone-testable) but the field must exist on the wire
+from day one — declare it empty, never omit it, so callers never need a
+breaking change when a new zone source lands.
+
 ## Backend testability requirement
 
 Every backend MUST support headless paint-to-memory so tests don't
@@ -280,7 +342,10 @@ need a real display, terminal, window manager, or font server.
   same code paths as the live runner.
 - Windows (when implemented): `ID2D1Bitmap` as offscreen render target.
 
-New backends ship with their harness on day one.
+New backends ship with their harness on day one. Once a backend has a
+`ConformanceDriver` impl, it MUST also implement
+[`FrameInventory`](#frameinventory-the-portable-paint-inventory-contract-quadraui490) —
+see the backend checklist above.
 
 ## Live-app headless smoke (GD-5, quadraui#450)
 

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -163,6 +163,23 @@ pub trait Backend {
     /// override this to accumulate regions for the current frame.
     fn register_text_region(&mut self, _region: crate::dispatch::TextRegion) {}
 
+    /// Record one hit-testable widget zone painted during the current
+    /// frame — the `WidgetId`-keyed counterpart to
+    /// [`Self::register_text_region`], and the source
+    /// [`crate::testing::FrameInventory::zones`] reads from
+    /// (quadraui#490, `docs/SMELL_AUDIT_2026-07.md` §6.2/B3).
+    ///
+    /// Call once per zone during render (chrome composers like
+    /// [`crate::compose::app_shell::AppShell::render`] call this for
+    /// each `WidgetId`-bearing region they lay out — activity-bar items,
+    /// sidebar panels, the status bar, and so on). The registration is
+    /// cleared at the start of each frame by `begin_frame`, mirroring
+    /// `register_text_region`'s lifecycle.
+    ///
+    /// Default: no-op. `TuiBackend`/`GtkBackend` override this to
+    /// accumulate the current frame's zones for `ConformanceDriver::inventory`.
+    fn register_zone(&mut self, _id: WidgetId, _bounds: Rect) {}
+
     /// Cancel any in-progress text-selection drag without clearing the
     /// currently displayed selection highlight.
     ///

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -565,6 +565,44 @@ impl AppShell {
 
     // ── Render ───────────────────────────────────────────────────────
 
+    /// Register a `WidgetId`-keyed [`crate::Backend::register_zone`] entry
+    /// for every chrome region `layout` reports, so a
+    /// [`crate::testing::ConformanceDriver::inventory`] caller can assert
+    /// `inside`/`left_of`/`above` against shell-level zones without
+    /// hardcoding a coordinate (quadraui#490). Ids are stable,
+    /// `app-shell:`-prefixed strings — not the panel/content `WidgetId`s
+    /// consumers pick — since a shell has exactly one of each of these
+    /// regions per frame.
+    ///
+    /// Per-item zones (one per activity-bar entry, keyed by that panel's
+    /// own `WidgetId`) are registered separately in [`Self::render`],
+    /// right after `draw_activity_bar` returns the hit list — this
+    /// function only covers the coarser, one-per-frame chrome regions.
+    fn register_chrome_zones(backend: &mut dyn Backend, layout: &AppShellLayout) {
+        backend.register_zone(WidgetId::new("app-shell:window"), layout.window_bounds);
+        backend.register_zone(
+            WidgetId::new("app-shell:activity-bar"),
+            layout.activity_bar_bounds,
+        );
+        backend.register_zone(
+            WidgetId::new("app-shell:main-content"),
+            layout.main_content_bounds,
+        );
+        for (id, bounds) in [
+            ("app-shell:title-bar", layout.title_bar_bounds),
+            ("app-shell:sidebar-header", layout.sidebar_header_bounds),
+            ("app-shell:sidebar-content", layout.sidebar_content_bounds),
+            ("app-shell:divider", layout.divider_bounds),
+            ("app-shell:bottom-panel", layout.bottom_panel_bounds),
+            ("app-shell:command-line", layout.command_line_bounds),
+            ("app-shell:status-bar", layout.status_bar_bounds),
+        ] {
+            if let Some(bounds) = bounds {
+                backend.register_zone(WidgetId::new(id), bounds);
+            }
+        }
+    }
+
     /// Render shell chrome and return layout bounds for consumer content.
     ///
     /// Draws: activity bar, sidebar header, resize divider.
@@ -572,10 +610,25 @@ impl AppShell {
     pub fn render(&self, backend: &mut dyn Backend, area: Rect) -> AppShellLayout {
         let lh = backend.line_height();
         let layout = self.compute_layout(area, lh);
+        Self::register_chrome_zones(backend, &layout);
 
         let bar = self.build_activity_bar();
         let hits =
             backend.draw_activity_bar(layout.activity_bar_bounds, &bar, self.hovered_activity_idx);
+        // Register each activity-bar item's own zone (its real `WidgetId`,
+        // e.g. `panel:git`) *before* `hits` moves into the hover-hit cache
+        // below — this is the per-item provenance
+        // `docs/SMELL_AUDIT_2026-07.md` §6.2/B3 calls for, not just the
+        // whole-bar zone `register_chrome_zones` already recorded.
+        for hit in &hits {
+            let item_bounds = Rect::new(
+                layout.activity_bar_bounds.x,
+                layout.activity_bar_bounds.y + hit.y_start as f32,
+                layout.activity_bar_bounds.width,
+                (hit.y_end - hit.y_start) as f32,
+            );
+            backend.register_zone(hit.id.clone(), item_bounds);
+        }
         *self.cached_activity_hits.borrow_mut() = hits;
         *self.cached_activity_bar_bounds.borrow_mut() = Some(layout.activity_bar_bounds);
 

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -49,6 +49,7 @@ use gtk4::prelude::*;
 use crate::backend::{activity_bar_hits, tab_bar_layout_to_hits};
 use crate::dispatch::TextRegion;
 use crate::event::Point;
+use crate::testing::ZoneRec;
 use crate::types::WidgetId;
 use crate::{
     parse_key_binding, Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Backend,
@@ -161,6 +162,12 @@ pub struct GtkBackend {
     /// [`Backend::register_text_region`]. Cleared at the start of each
     /// frame by [`Self::begin_frame`]. Parallels `TuiBackend::text_regions`.
     pub(crate) text_regions: Vec<TextRegion>,
+    /// Widget zones registered during the current frame via
+    /// [`Backend::register_zone`]. Cleared at the start of each frame by
+    /// [`Self::begin_frame`]. Parallels `TuiBackend::zones`. Read by
+    /// [`super::testing::GtkDriver::inventory`] to populate
+    /// [`crate::testing::FrameInventory::zones`] (quadraui#490).
+    pub(crate) zones: Vec<ZoneRec>,
     /// The `(text, bounds)` map painted this frame — recorded by trait
     /// methods that already compute a label's on-surface rect (e.g.
     /// [`Self::draw_status_bar`]) so [`super::testing::GtkDriver::find`]
@@ -304,6 +311,7 @@ impl GtkBackend {
             editor_font_family: "Monospace".to_string(),
             editor_font_size_pt: 11.0,
             text_regions: Vec::new(),
+            zones: Vec::new(),
             painted_text: Vec::new(),
             painted_text_recording: false,
             active_selection: None,
@@ -1106,6 +1114,9 @@ impl Backend for GtkBackend {
         // Clear per-frame text regions so stale registrations from the
         // previous frame don't linger. Mirrors TuiBackend::begin_frame.
         self.text_regions.clear();
+        // Clear per-frame widget zones for the same reason. Same
+        // lifecycle as text_regions.
+        self.zones.clear();
         // Clear last frame's painted-text map — see `painted_text`'s docs.
         self.painted_text.clear();
         // Clear the focused activity bar — re-set by draw_activity_bar
@@ -1116,6 +1127,10 @@ impl Backend for GtkBackend {
 
     fn register_text_region(&mut self, region: TextRegion) {
         self.text_regions.push(region);
+    }
+
+    fn register_zone(&mut self, id: WidgetId, bounds: QRect) {
+        self.zones.push(ZoneRec { id, bounds });
     }
 
     fn end_frame(&mut self) {

--- a/quadraui/src/gtk/testing.rs
+++ b/quadraui/src/gtk/testing.rs
@@ -478,10 +478,12 @@ impl<A: AppLogic> ConformanceDriver for GtkDriver<A> {
                     bounds: p.bounds,
                 })
                 .collect(),
-            // Widget-zone recording (`ZoneRec`) is B3/`docs/SMELL_AUDIT_2026-07.md`
-            // §6.2 follow-up work — no `FrameHitMap`-sourced zone log exists
-            // yet on either backend.
-            zones: Vec::new(),
+            // Zones registered this frame via `Backend::register_zone` —
+            // currently the shell-chrome zones `AppShell::render` records
+            // (activity-bar items, sidebar header/content, status bar,
+            // ...). Primitives that don't yet call `register_zone`
+            // contribute no zone (quadraui#490).
+            zones: self.backend.zones.clone(),
         }
     }
 

--- a/quadraui/src/testing.rs
+++ b/quadraui/src/testing.rs
@@ -87,16 +87,19 @@ pub struct ZoneRec {
     pub bounds: Rect,
 }
 
-/// Semantic paint inventory for one rendered frame.
+/// Semantic paint inventory for one rendered frame — the cross-backend
+/// observable contract `docs/SMELL_AUDIT_2026-07.md` §6.2/B3 describes,
+/// aligned with quadraweb#322's id→rect map (quadraui#490).
 ///
-/// This is the minimal slice needed to back [`ConformanceDriver::inventory`]
-/// today: `text_runs` is populated from each backend's existing text
-/// search (TUI's cell-grid scan, GTK's `painted_text` map). `zones` is
-/// reserved for the widget-zone contract `docs/SMELL_AUDIT_2026-07.md`
-/// §6.2/B3 describes (`FrameHitMap` / layout-return provenance) and is
-/// empty until that recording lands — declared here so the field exists
-/// on the wire and callers don't need a breaking change when it's filled
-/// in.
+/// `text_runs` is populated from each backend's existing text search
+/// (TUI's cell-grid scan, GTK's `painted_text` map) — this covers every
+/// text-bearing primitive with no per-widget opt-in required. `zones` is
+/// populated from [`crate::Backend::register_zone`] calls made during the
+/// frame; coverage is incremental — currently the shell chrome
+/// [`crate::compose::app_shell::AppShell::render`] records (activity-bar
+/// items by their own `WidgetId`, plus one `app-shell:`-prefixed zone per
+/// chrome region) — so a primitive that hasn't been wired to call
+/// `register_zone` yet simply contributes no zone, not a wrong one.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct FrameInventory {
     pub text_runs: Vec<TextRun>,
@@ -110,6 +113,100 @@ impl FrameInventory {
 
     pub fn zones(&self) -> &[ZoneRec] {
         &self.zones
+    }
+
+    // ── Relational assertion vocabulary (quadraui#490) ──────────────────
+    //
+    // These are the "no hardcoded coordinates" assertions the issue calls
+    // for: every one of them is computed from `Rect`s this same
+    // `FrameInventory` already reports, in whichever unit the backend
+    // that produced it uses (cells for TUI, pixels for GTK) — a shared
+    // test body never writes a literal coordinate itself, it only ever
+    // names two painted things and asks how they relate.
+
+    /// True if any painted text run contains `needle`.
+    pub fn screen_has(&self, needle: &str) -> bool {
+        self.text_runs.iter().any(|r| r.text.contains(needle))
+    }
+
+    /// True if no painted text run contains `needle` — the negative
+    /// counterpart to [`Self::screen_has`], for asserting something was
+    /// *not* painted this frame (e.g. a closed panel's content).
+    pub fn absent(&self, needle: &str) -> bool {
+        !self.screen_has(needle)
+    }
+
+    /// Number of painted text runs containing `needle`. Useful for
+    /// asserting a repeated element's cardinality (e.g. "3 rows contain
+    /// this label") without caring where each instance landed.
+    pub fn count(&self, needle: &str) -> usize {
+        self.text_runs
+            .iter()
+            .filter(|r| r.text.contains(needle))
+            .count()
+    }
+
+    /// Bounds of the first text run containing `needle`, in this frame's
+    /// paint order. `None` if nothing painted matched.
+    fn locate(&self, needle: &str) -> Option<Rect> {
+        self.text_runs
+            .iter()
+            .find(|r| r.text.contains(needle))
+            .map(|r| r.bounds)
+    }
+
+    /// Bounds of the zone registered under `id` via
+    /// [`crate::Backend::register_zone`], if any.
+    fn zone_bounds(&self, id: &WidgetId) -> Option<Rect> {
+        self.zones.iter().find(|z| &z.id == id).map(|z| z.bounds)
+    }
+
+    /// True if `a`'s painted bounds lie entirely to the left of `b`'s —
+    /// `a`'s right edge at or before `b`'s left edge. Panics-free: if
+    /// either needle wasn't painted this frame, returns `false` (the
+    /// same "didn't happen" answer a missing needle gets everywhere else
+    /// in this vocabulary — callers that need to know *why* should pair
+    /// this with [`Self::screen_has`]).
+    pub fn left_of(&self, a: &str, b: &str) -> bool {
+        match (self.locate(a), self.locate(b)) {
+            (Some(ra), Some(rb)) => ra.x + ra.width <= rb.x,
+            _ => false,
+        }
+    }
+
+    /// True if `a`'s painted bounds lie entirely above `b`'s — `a`'s
+    /// bottom edge at or before `b`'s top edge.
+    pub fn above(&self, a: &str, b: &str) -> bool {
+        match (self.locate(a), self.locate(b)) {
+            (Some(ra), Some(rb)) => ra.y + ra.height <= rb.y,
+            _ => false,
+        }
+    }
+
+    /// True if `a` and `b`'s painted bounds vertically overlap — the
+    /// same logical text row, even across backends whose native units
+    /// (TUI cell rows vs GTK sub-pixel baselines) never line up on exact
+    /// equality.
+    pub fn same_row(&self, a: &str, b: &str) -> bool {
+        match (self.locate(a), self.locate(b)) {
+            (Some(ra), Some(rb)) => ra.y < rb.y + rb.height && rb.y < ra.y + ra.height,
+            _ => false,
+        }
+    }
+
+    /// True if `needle`'s painted bounds lie entirely within the zone
+    /// registered under `zone_id`. `false` if either the needle wasn't
+    /// painted or the zone wasn't registered this frame.
+    pub fn inside(&self, needle: &str, zone_id: &WidgetId) -> bool {
+        match (self.locate(needle), self.zone_bounds(zone_id)) {
+            (Some(r), Some(z)) => {
+                r.x >= z.x
+                    && r.y >= z.y
+                    && r.x + r.width <= z.x + z.width
+                    && r.y + r.height <= z.y + z.height
+            }
+            _ => false,
+        }
     }
 }
 
@@ -172,4 +269,118 @@ pub trait ConformanceDriver: Sized {
 
     /// Whether the app has returned [`crate::Reaction::Exit`].
     fn exited(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A small hand-built inventory: an activity-bar-style icon column
+    /// (`"E"`, `"S"`, `"G"` stacked at x=0..2) to the left of a sidebar
+    /// header/content pair (`"SOURCE CONTROL"` above `"content"` at
+    /// x=10..40), plus one registered zone around the sidebar content
+    /// run. Exercises the relational vocabulary with no backend at all —
+    /// the cross-backend agreement itself is proven separately in
+    /// `tests/cross_backend_parity.rs::frame_inventory_relations_agree_tui_and_gtk`.
+    fn fixture() -> FrameInventory {
+        FrameInventory {
+            text_runs: vec![
+                TextRun {
+                    text: "E".into(),
+                    bounds: Rect::new(0.0, 0.0, 1.0, 1.0),
+                },
+                TextRun {
+                    text: "S".into(),
+                    bounds: Rect::new(0.0, 1.0, 1.0, 1.0),
+                },
+                TextRun {
+                    text: "G".into(),
+                    bounds: Rect::new(0.0, 2.0, 1.0, 1.0),
+                },
+                TextRun {
+                    text: "SOURCE CONTROL".into(),
+                    bounds: Rect::new(10.0, 0.0, 14.0, 1.0),
+                },
+                TextRun {
+                    text: "content".into(),
+                    bounds: Rect::new(10.0, 1.0, 7.0, 1.0),
+                },
+            ],
+            zones: vec![ZoneRec {
+                id: WidgetId::new("sidebar-content"),
+                bounds: Rect::new(10.0, 1.0, 30.0, 1.0),
+            }],
+        }
+    }
+
+    #[test]
+    fn screen_has_and_absent() {
+        let inv = fixture();
+        assert!(inv.screen_has("SOURCE"));
+        assert!(inv.screen_has("CONTROL"));
+        assert!(inv.absent("git"));
+        assert!(!inv.screen_has("git"));
+    }
+
+    #[test]
+    fn count_matches_every_run_containing_needle() {
+        let inv = fixture();
+        // "S" appears in the "S" icon run and inside "SOURCE CONTROL".
+        assert_eq!(inv.count("S"), 2);
+        assert_eq!(inv.count("G"), 1);
+        assert_eq!(inv.count("nope"), 0);
+    }
+
+    #[test]
+    fn left_of_is_true_for_the_icon_column_vs_the_sidebar() {
+        let inv = fixture();
+        assert!(inv.left_of("G", "SOURCE CONTROL"));
+        assert!(inv.left_of("G", "content"));
+        assert!(!inv.left_of("SOURCE CONTROL", "G"), "reverse must not hold");
+    }
+
+    #[test]
+    fn above_is_true_for_header_vs_content() {
+        let inv = fixture();
+        assert!(inv.above("SOURCE CONTROL", "content"));
+        assert!(
+            !inv.above("content", "SOURCE CONTROL"),
+            "reverse must not hold"
+        );
+        // Same-column icons stack top to bottom too.
+        assert!(inv.above("E", "S"));
+        assert!(inv.above("S", "G"));
+    }
+
+    #[test]
+    fn same_row_true_for_overlapping_ranges_false_across_rows() {
+        let inv = fixture();
+        assert!(inv.same_row("E", "SOURCE CONTROL"));
+        assert!(inv.same_row("S", "content"));
+        assert!(!inv.same_row("E", "content"));
+    }
+
+    #[test]
+    fn inside_checks_containment_within_a_registered_zone() {
+        let inv = fixture();
+        let zone = WidgetId::new("sidebar-content");
+        assert!(inv.inside("content", &zone));
+        assert!(
+            !inv.inside("SOURCE CONTROL", &zone),
+            "the header run sits above the zone's y range, not inside it"
+        );
+        assert!(
+            !inv.inside("content", &WidgetId::new("no-such-zone")),
+            "an unregistered zone id must never report containment"
+        );
+    }
+
+    #[test]
+    fn relations_are_false_not_panicking_when_a_needle_never_painted() {
+        let inv = fixture();
+        assert!(!inv.left_of("nope", "G"));
+        assert!(!inv.above("G", "nope"));
+        assert!(!inv.same_row("nope", "G"));
+        assert!(!inv.inside("nope", &WidgetId::new("sidebar-content")));
+    }
 }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -48,6 +48,7 @@ use std::time::Duration;
 use crate::accelerator::{key_to_binding_name, parse_binding};
 use crate::backend::{activity_bar_hits, tab_bar_layout_to_hits};
 use crate::dispatch::TextRegion;
+use crate::testing::ZoneRec;
 use crate::{
     Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Backend, CommandLine, DragState,
     DragTarget, Form, ListView, MenuBar, ModalStack, Palette, ParsedBinding, PlatformServices,
@@ -120,6 +121,12 @@ pub struct TuiBackend {
     /// [`crate::Backend::register_text_region`]. Cleared at the start
     /// of each frame by [`Self::begin_frame`].
     text_regions: Vec<TextRegion>,
+    /// Widget zones registered during the current frame via
+    /// [`crate::Backend::register_zone`]. Cleared at the start of each
+    /// frame by [`Self::begin_frame`], mirroring `text_regions`. Read by
+    /// [`crate::tui::testing::TuiDriver::inventory`] to populate
+    /// [`crate::testing::FrameInventory::zones`] (quadraui#490).
+    zones: Vec<ZoneRec>,
     /// Finalised selection (may persist after mouse-up). `None` when
     /// no selection is active. Set by [`Self::set_active_text_selection`],
     /// cleared by [`Self::clear_text_selection`] or on a new
@@ -188,6 +195,7 @@ impl TuiBackend {
             nerd_fonts_enabled: true,
             double_click: super::events::DoubleClickDetector::new(),
             text_regions: Vec::new(),
+            zones: Vec::new(),
             active_selection: None,
             cached_selection_text: String::new(),
             last_text_region_id: None,
@@ -252,6 +260,14 @@ impl TuiBackend {
     /// `draw_*` invocations consume the stored theme.
     pub fn set_current_theme(&mut self, theme: crate::Theme) {
         self.current_theme = theme;
+    }
+
+    /// Widget zones registered via [`crate::Backend::register_zone`] during
+    /// the current frame. Read by
+    /// [`crate::tui::testing::TuiDriver::inventory`] to populate
+    /// [`crate::testing::FrameInventory::zones`] (quadraui#490).
+    pub(crate) fn zones(&self) -> &[ZoneRec] {
+        &self.zones
     }
 
     // ── Text selection ─────────────────────────────────────────────────────
@@ -709,6 +725,9 @@ impl Backend for TuiBackend {
         // Clear per-frame text regions so stale registrations from the
         // previous frame don't linger.
         self.text_regions.clear();
+        // Clear per-frame widget zones for the same reason. Same
+        // lifecycle as text_regions.
+        self.zones.clear();
         // Clear the focused activity bar — re-set by draw_activity_bar
         // during the render pass if still focused.
         self.focused_activity_bar = None;
@@ -721,6 +740,10 @@ impl Backend for TuiBackend {
 
     fn register_text_region(&mut self, region: TextRegion) {
         self.text_regions.push(region);
+    }
+
+    fn register_zone(&mut self, id: WidgetId, bounds: QRect) {
+        self.zones.push(ZoneRec { id, bounds });
     }
 
     fn cancel_text_selection_drag(&mut self) {

--- a/quadraui/src/tui/testing.rs
+++ b/quadraui/src/tui/testing.rs
@@ -475,10 +475,12 @@ impl<A: AppLogic> ConformanceDriver for TuiDriver<A> {
         }
         FrameInventory {
             text_runs,
-            // Widget-zone recording (`ZoneRec`) is B3/`docs/SMELL_AUDIT_2026-07.md`
-            // §6.2 follow-up work — no `FrameHitMap`-sourced zone log exists
-            // yet on either backend.
-            zones: Vec::new(),
+            // Zones registered this frame via `Backend::register_zone` —
+            // currently the shell-chrome zones `AppShell::render` records
+            // (activity-bar items, sidebar header/content, status bar,
+            // ...). Primitives that don't yet call `register_zone`
+            // contribute no zone (quadraui#490).
+            zones: self.backend.zones().to_vec(),
         }
     }
 

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -21,7 +21,7 @@
 use quadraui::gtk::testing::{driver_with_shell as gtk_driver_with_shell, GtkDriver};
 use quadraui::testing::{ConformanceDriver, LogicalViewport};
 use quadraui::tui::testing::{driver_with_shell as tui_driver_with_shell, TuiDriver};
-use quadraui::{AppLogic, DataTableLayout, NamedKey};
+use quadraui::{AppLogic, DataTableLayout, NamedKey, WidgetId};
 
 #[path = "../examples/common/pipeline_app.rs"]
 mod pipeline_app;
@@ -690,4 +690,60 @@ fn activity_hover_distinguishes_adjacent_rows_after_title_bar_reveal() {
         "three distinct rows must map to three distinct icons — got \
          {row0:?} {row1:?} {row2:?}"
     );
+}
+
+// ─── quadraui#490: FrameInventory relational vocabulary ────────────────────
+//
+// `left_of`/`above`/`inside` are the whole point of `FrameInventory` — a
+// shared test body asks how two painted things relate, in whichever units
+// the backend that produced them uses, and never writes a coordinate
+// itself. Proves the three hold identically for `AppShellDemo` (the
+// `shell_app` fixture) on both `TuiDriver` and `GtkDriver`, per #490's
+// acceptance bar.
+
+/// Switch to the Source Control panel (`p` is `AppShellDemo`'s
+/// jump-to-Source-Control binding — see its `handle` impl) and return the
+/// [`quadraui::testing::FrameInventory`] for the resulting frame.
+fn source_control_inventory<D: ConformanceDriver>(d: &mut D) -> quadraui::testing::FrameInventory {
+    d.type_char('p');
+    d.inventory()
+}
+
+#[test]
+fn frame_inventory_relations_agree_tui_and_gtk() {
+    let mut tui = tui_driver_with_shell(AppShellDemo::new(), AppShellDemo::config(), 100, 30);
+    let mut gtk = gtk_driver_with_shell(AppShellDemo::new(), AppShellDemo::config(), 800, 480);
+
+    let tui_inv = source_control_inventory(&mut tui);
+    let gtk_inv = source_control_inventory(&mut gtk);
+
+    let sidebar_content_zone = WidgetId::new("app-shell:sidebar-content");
+    let main_content_zone = WidgetId::new("app-shell:main-content");
+
+    for (name, inv) in [("TUI", &tui_inv), ("GTK", &gtk_inv)] {
+        assert!(
+            inv.screen_has("CONTROL"),
+            "{name}: sidebar header should read SOURCE CONTROL after 'p'"
+        );
+        assert!(
+            inv.left_of("G", "CONTROL"),
+            "{name}: the activity bar's Source Control icon ('G') must sit \
+             left of the sidebar header it activates"
+        );
+        assert!(
+            inv.above("CONTROL", "content"),
+            "{name}: the sidebar header must sit above the sidebar content \
+             row (' (sidebar content here) ')"
+        );
+        assert!(
+            inv.inside("content", &sidebar_content_zone),
+            "{name}: the sidebar content text must fall inside the \
+             registered app-shell:sidebar-content zone"
+        );
+        assert!(
+            !inv.inside("content", &main_content_zone),
+            "{name}: the sidebar content text must NOT fall inside the \
+             main-content zone — the two zones must not overlap"
+        );
+    }
 }


### PR DESCRIPTION
Closes #490

Automated PR opened by coordinator for review of issue #490.