### PR TITLE
#542: cross_backend_parity asserts logical state only — a backend that silently drops chrome (borders, titles, scrollbars) passes; needs a structural tier

### DIFF
--- a/quadraui/docs/TUI_CONSUMER_TOUR.md
+++ b/quadraui/docs/TUI_CONSUMER_TOUR.md
@@ -50,6 +50,18 @@ Pick the **hover popup → Tooltip** pair. Smallest complete loop.
     — **the core contract**: given a world + a measurement, return
     fully-resolved coordinates. No backend code here, no painting.
 
+  > **#542 contract change:** `TooltipMeasure::new(width, height)`'s
+  > `height` is the tooltip's **total box height, border chrome
+  > included** — not a content-line count. On TUI, once
+  > `height >= 3`, [`crate::tui::draw_tooltip`](../src/tui/tooltip.rs)
+  > strokes a full 4-sided box (matching GTK, which has always stroked
+  > one) and only `height - 2` rows remain for content. A caller built
+  > against the pre-#542 contract that measures exactly its
+  > content-line count (as this tour's own §"How an engine state gets
+  > adapted" example historically did) needs `+ 2` added to `height`,
+  > or its last two content lines are silently dropped once it's 3+
+  > rows tall. See `TooltipMeasure`'s doc comment for the full contract.
+
 ### How an engine state gets adapted into it
 
 - [`src/render.rs::hover_popup_to_quadraui_tooltip`](../../src/render.rs) —

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -2030,6 +2030,11 @@ impl Backend for GtkBackend {
             self.current_char_width,
             &self.current_theme,
         );
+        // #542: register the tooltip's own surface — see the matching
+        // comment on `TuiBackend::draw_tooltip`. GTK already painted a
+        // full 4-sided box here before TUI did (#541); this just makes
+        // that box observable to a structural-parity assertion.
+        self.register_zone(tooltip.id.clone(), layout_arg.bounds);
     }
 
     fn draw_context_menu(

--- a/quadraui/src/primitives/tooltip.rs
+++ b/quadraui/src/primitives/tooltip.rs
@@ -72,7 +72,35 @@ pub enum TooltipEvent {
 
 // ── D6 Layout API ───────────────────────────────────────────────────────────
 
-/// Measurement for a `Tooltip` — the content's natural size.
+/// Measurement for a `Tooltip` — the **total box size** the caller wants
+/// reserved on screen, in the active backend's own units (character cells
+/// on TUI, pixels on GTK).
+///
+/// # Contract (#542)
+///
+/// `height` is the whole tooltip box, border chrome included — not just
+/// the content. `Tooltip::layout` passes it straight through to
+/// [`TooltipLayout::bounds`], and that is what a backend's `draw_tooltip`
+/// paints into. Concretely, on TUI:
+///
+/// - When `height >= 3` (and `width >= 2`), [`crate::tui::draw_tooltip`]
+///   strokes a full 4-sided box — one row each for the top and bottom
+///   border — leaving only `height - 2` rows for content. GTK has always
+///   stroked a full box the same way, but pays for it in sub-cell pixels
+///   rather than whole rows, so it needs no equivalent padding.
+/// - Below that (`height < 3`), TUI falls back to side-bars-only chrome
+///   (`│` on the first/last column, no top/bottom rule) and all `height`
+///   rows are usable for content.
+///
+/// **Callers that want *N* content lines visible on TUI once a bordered
+/// box is drawn must pass `height >= N + 2`**, not `N`. This is a
+/// behaviour change from before #542, when TUI drew no vertical chrome at
+/// all and `height` meant exactly "content rows" on every backend; a
+/// caller written against that older contract that still passes a bare
+/// content-line count will silently lose its last two lines once its
+/// tooltip is 3+ rows tall. See the #542 review discussion for the
+/// concrete downstream call sites this bit (`vimcode`'s hover-popup and
+/// diff-peek tooltip builders) — those need a matching `+ 2` migration.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TooltipMeasure {
     pub width: f32,
@@ -80,6 +108,10 @@ pub struct TooltipMeasure {
 }
 
 impl TooltipMeasure {
+    /// `height` is the total box height (border rows included on
+    /// backends that reserve whole rows for chrome) — see the
+    /// contract note on [`TooltipMeasure`] itself before passing a bare
+    /// content-line count.
     pub fn new(width: f32, height: f32) -> Self {
         Self { width, height }
     }
@@ -133,7 +165,12 @@ impl Tooltip {
     /// - `anchor` — bounds of the element being described.
     /// - `viewport` — bounds of the parent surface; tooltip is clamped
     ///   to stay inside these.
-    /// - `measure` — content width/height.
+    /// - `measure` — total box width/height (border chrome included, not
+    ///   just content) — see the contract note on [`TooltipMeasure`].
+    ///   `measure.height` is copied verbatim into the returned
+    ///   [`TooltipLayout::bounds`], which is exactly what a backend's
+    ///   `draw_tooltip` uses to decide how many rows it has for both
+    ///   border and content.
     /// - `margin` — gap between the anchor and the tooltip along the
     ///   placement axis.
     ///

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1247,7 +1247,15 @@ impl Backend for TuiBackend {
         // tooltip was drawn at all, not just infer it from text presence —
         // `screen_has("Keybindings")` stayed true on both backends through
         // #541 even though only one of them drew the chrome around it.
-        self.register_zone(tooltip.id.clone(), layout.bounds);
+        //
+        // Register `tooltip_painted_bounds`, not the raw float
+        // `layout.bounds` — `draw_tooltip` rounds to whole cells before
+        // painting, and registering the unrounded rect would report a
+        // surface that doesn't match what was actually drawn (#542 review).
+        self.register_zone(
+            tooltip.id.clone(),
+            crate::tui::tooltip_painted_bounds(layout),
+        );
     }
 
     fn draw_context_menu(

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1242,6 +1242,12 @@ impl Backend for TuiBackend {
             .current_frame_mut()
             .expect("TuiBackend::draw_tooltip called outside enter_frame_scope");
         crate::tui::draw_tooltip(frame.buffer_mut(), tooltip, layout, &theme);
+        // #542: register the tooltip's own surface so a structural-parity
+        // observer (`ConformanceDriver::inventory().zones()`) can see the
+        // tooltip was drawn at all, not just infer it from text presence —
+        // `screen_has("Keybindings")` stayed true on both backends through
+        // #541 even though only one of them drew the chrome around it.
+        self.register_zone(tooltip.id.clone(), layout.bounds);
     }
 
     fn draw_context_menu(

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -103,7 +103,7 @@ pub use text_display::{draw_text_display, tui_text_display_layout};
 pub use text_input::{draw_text_input, tui_text_input_layout};
 pub use toast::{draw_toast_stack, tui_toast_stack_layout};
 pub use toolbar::{draw_toolbar, tui_toolbar_layout};
-pub use tooltip::draw_tooltip;
+pub use tooltip::{draw_tooltip, painted_bounds as tooltip_painted_bounds};
 pub use tree::{draw_tree, tui_tree_layout};
 
 /// Convert a `quadraui::Color` to the ratatui palette colour used by

--- a/quadraui/src/tui/tooltip.rs
+++ b/quadraui/src/tui/tooltip.rs
@@ -17,10 +17,17 @@
 //! and diff peek). Otherwise `tooltip.text` is split on `\n` and each
 //! line is rendered plain (LSP hover popup path). Lines that exceed the
 //! box width or the available content rows are truncated.
+//!
+//! `layout.bounds.height` is the *total* box height, not a content-row
+//! count — see the contract note on [`crate::TooltipMeasure`]. Callers
+//! that want `N` content lines visible once a bordered box is drawn
+//! (`height >= 3`) must measure `N + 2`, or their last two lines are
+//! silently dropped by [`draw_tooltip`]'s `.take(content_rows)`.
 
 use ratatui::buffer::Buffer;
 
 use super::{ratatui_color, set_cell};
+use crate::event::Rect as QRect;
 use crate::primitives::tooltip::{Tooltip, TooltipLayout};
 use crate::theme::Theme;
 use crate::types::Color;
@@ -29,15 +36,36 @@ fn qc(c: Color) -> ratatui::style::Color {
     ratatui_color(c)
 }
 
+/// The whole-cell bounds [`draw_tooltip`] actually paints into —
+/// `layout.bounds` rounded to integer terminal columns/rows exactly the
+/// way `draw_tooltip` does internally.
+///
+/// Backends must register *this* (not the raw float `layout.bounds`) as
+/// the tooltip's zone via `Backend::register_zone`. Registering the
+/// unrounded bounds would let a structural-parity observer see a surface
+/// that doesn't match the cells actually painted — a latent precision
+/// mismatch (#542 review) that today's 0.35 ratio tolerance in the
+/// structural-parity acceptance slice happens to absorb, but which should
+/// stay aligned regardless.
+pub fn painted_bounds(layout: &TooltipLayout) -> QRect {
+    QRect::new(
+        layout.bounds.x.round(),
+        layout.bounds.y.round(),
+        layout.bounds.width.round(),
+        layout.bounds.height.round(),
+    )
+}
+
 /// Draw a [`Tooltip`] into `layout.bounds` on `buf`.
 ///
 /// Per-tooltip `tooltip.fg` / `tooltip.bg` overrides win over the
 /// theme defaults. The frame border always uses [`Theme::hover_border`].
 pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout, theme: &Theme) {
-    let x = layout.bounds.x.round() as u16;
-    let y = layout.bounds.y.round() as u16;
-    let w = layout.bounds.width.round() as u16;
-    let h = layout.bounds.height.round() as u16;
+    let painted = painted_bounds(layout);
+    let x = painted.x as u16;
+    let y = painted.y as u16;
+    let w = painted.width as u16;
+    let h = painted.height as u16;
     if w == 0 || h == 0 {
         return;
     }
@@ -55,7 +83,11 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
     // A full box costs one row for the top border and one for the
     // bottom, leaving `h - 2` for content; below that there's no room
     // for both border rows and any content, so keep the legacy
-    // side-bars-only chrome instead of rendering an empty box.
+    // side-bars-only chrome instead of rendering an empty box. `w >= 2`
+    // is a separate, narrower guard: `paint_border_row`'s `col == 0` and
+    // `col == w - 1` branches pick the left/right corner glyph, and at
+    // `w < 2` those two indices collide (`w - 1 == 0`), so the `col == 0`
+    // arm would win and every corner would render as a left corner.
     let has_horizontal_border = h >= 3 && w >= 2;
     let content_row0: u16 = if has_horizontal_border { 1 } else { 0 };
     let content_rows: u16 = if has_horizontal_border { h - 2 } else { h };
@@ -145,6 +177,17 @@ mod tests {
 
     fn cell_char(buf: &Buffer, x: u16, y: u16) -> char {
         buf[(x, y)].symbol().chars().next().unwrap_or(' ')
+    }
+
+    /// #542 review (non-blocking): the zone a backend registers for a
+    /// tooltip must match the cells `draw_tooltip` actually painted, not
+    /// the raw float layout bounds — otherwise a structural-parity
+    /// observer sees a surface offset from what's really on screen.
+    #[test]
+    fn painted_bounds_rounds_like_draw_tooltip_does() {
+        let layout = make_layout(0.4, 1.6, 9.6, 2.5);
+        let painted = painted_bounds(&layout);
+        assert_eq!(painted, QRect::new(0.0, 2.0, 10.0, 3.0));
     }
 
     #[test]

--- a/quadraui/src/tui/tooltip.rs
+++ b/quadraui/src/tui/tooltip.rs
@@ -1,14 +1,22 @@
 //! TUI rasteriser for [`crate::Tooltip`].
 //!
-//! Renders the popup with **side-bar borders only** (`│` on the first
-//! and last columns, no top/bottom border) — matches the visual style
-//! used by the LSP hover popup, signature help, and diff peek.
+//! Renders a full box — `┌─┐`/`└─┘` top and bottom border rows plus `│`
+//! side borders on every row — whenever the measured height leaves room
+//! for both border rows and at least one content row (`height >= 3`).
+//! This matches `quadraui::gtk::draw_tooltip`, which has always stroked a
+//! full rectangle; before this, TUI painted side bars only, so the same
+//! primitive produced materially different chrome on the two backends
+//! while `screen_has("Keybindings")` stayed `true` on both — the #541
+//! divergence #542's structural-parity tier exists to catch. A tooltip
+//! too short for that (`height < 3`, e.g. a single content row with no
+//! vertical padding measured in) falls back to the original side-bars-only
+//! chrome rather than rendering zero usable content rows.
 //!
 //! When `tooltip.styled_lines` is `Some`, each entry renders as one
 //! row of styled spans (multi-line styled path used by signature help
 //! and diff peek). Otherwise `tooltip.text` is split on `\n` and each
 //! line is rendered plain (LSP hover popup path). Lines that exceed the
-//! box width are truncated.
+//! box width or the available content rows are truncated.
 
 use ratatui::buffer::Buffer;
 
@@ -44,6 +52,39 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
         .unwrap_or_else(|| ratatui_color(theme.hover_bg));
     let border = ratatui_color(theme.hover_border);
 
+    // A full box costs one row for the top border and one for the
+    // bottom, leaving `h - 2` for content; below that there's no room
+    // for both border rows and any content, so keep the legacy
+    // side-bars-only chrome instead of rendering an empty box.
+    let has_horizontal_border = h >= 3 && w >= 2;
+    let content_row0: u16 = if has_horizontal_border { 1 } else { 0 };
+    let content_rows: u16 = if has_horizontal_border { h - 2 } else { h };
+
+    if has_horizontal_border {
+        let paint_border_row = |buf: &mut Buffer, row: u16, top: bool| {
+            for col in 0..w {
+                let ch = if col == 0 {
+                    if top {
+                        '┌'
+                    } else {
+                        '└'
+                    }
+                } else if col == w - 1 {
+                    if top {
+                        '┐'
+                    } else {
+                        '┘'
+                    }
+                } else {
+                    '─'
+                };
+                set_cell(buf, x + col, row, ch, border, bg);
+            }
+        };
+        paint_border_row(buf, y, true);
+        paint_border_row(buf, y + h - 1, false);
+    }
+
     let paint_row_background = |buf: &mut Buffer, row: u16| {
         for col in 0..w {
             let ch = if col == 0 || col == w - 1 { '│' } else { ' ' };
@@ -53,8 +94,8 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
     };
 
     if let Some(ref styled_lines) = tooltip.styled_lines {
-        for (i, styled) in styled_lines.iter().enumerate().take(h as usize) {
-            let row = y + i as u16;
+        for (i, styled) in styled_lines.iter().enumerate().take(content_rows as usize) {
+            let row = y + content_row0 + i as u16;
             paint_row_background(buf, row);
             let mut col_off: u16 = 2; // skip border + 1 pad
             for span in &styled.spans {
@@ -74,8 +115,8 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
     }
 
     let lines: Vec<&str> = tooltip.text.lines().collect();
-    for (i, text_line) in lines.iter().enumerate().take(h as usize) {
-        let row = y + i as u16;
+    for (i, text_line) in lines.iter().enumerate().take(content_rows as usize) {
+        let row = y + content_row0 + i as u16;
         paint_row_background(buf, row);
         for (j, ch) in text_line.chars().enumerate() {
             let col = x + 2 + j as u16;
@@ -125,6 +166,39 @@ mod tests {
         assert_eq!(cell_char(&buf, 9, 0), '│');
         // Text starts at col 2.
         let row: String = (2..7).map(|x| cell_char(&buf, x, 0)).collect();
+        assert_eq!(row, "hello");
+    }
+
+    /// #541/#542: once there's room for both border rows (`height >= 3`),
+    /// the box must be closed on every side — not just left/right — so a
+    /// structural-parity observer sees the same chrome shape GTK has
+    /// always drawn.
+    #[test]
+    fn paints_a_full_box_when_height_allows_it() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
+        let tt = Tooltip {
+            id: WidgetId::new("hover"),
+            text: "hello".into(),
+            styled_lines: None,
+            placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
+            fg: None,
+            bg: None,
+        };
+        let layout = make_layout(0.0, 0.0, 10.0, 3.0);
+        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+
+        // Top row: corners + a solid horizontal rule.
+        assert_eq!(cell_char(&buf, 0, 0), '┌');
+        assert_eq!(cell_char(&buf, 9, 0), '┐');
+        assert_eq!(cell_char(&buf, 4, 0), '─');
+        // Bottom row: corners + a solid horizontal rule.
+        assert_eq!(cell_char(&buf, 0, 2), '└');
+        assert_eq!(cell_char(&buf, 9, 2), '┘');
+        assert_eq!(cell_char(&buf, 4, 2), '─');
+        // Content moved down one row, side borders unchanged.
+        assert_eq!(cell_char(&buf, 0, 1), '│');
+        assert_eq!(cell_char(&buf, 9, 1), '│');
+        let row: String = (2..7).map(|x| cell_char(&buf, x, 1)).collect();
         assert_eq!(row, "hello");
     }
 


### PR DESCRIPTION
Closes #542

Automated PR opened by coordinator for review of issue #542.