### PR TITLE
ci(quadraui): #581 run the tui job on windows-latest as a non-blocking matrix leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,51 @@ jobs:
             --base "${{ github.event.pull_request.base.sha }}"
 
   tui:
-    name: tui (build, test, clippy)
-    runs-on: ubuntu-latest
+    name: tui (build, test, clippy) — ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # The Windows leg starts NON-BLOCKING and that is the whole point of the
+    # rollout: `win = []` has no deps, so `cargo check --features win` already
+    # type-checks on Linux — what has never run anywhere is the *portable
+    # core* (ratatui / arboard / unicode-width / portable-pty→ConPTY) on a
+    # real Windows host. Turning that on as a hard gate would red this repo on
+    # its first run, and quadraui is the most-depended-on repo in the fleet
+    # (kubeui-gtk in-tree, coord-tui and vimcode downstream, both gated by the
+    # `downstream` job below) — so a Windows-only warning would block two
+    # consumers on something neither of them touched. Same argument
+    # rust-toolchain.toml makes for pinning the compiler, one platform over.
+    #
+    # Flipping this to blocking IS the milestone. Do it in its own commit,
+    # once the leg has been green for a few runs — don't quietly widen the
+    # matrix and leave a permanently-yellow column nobody reads.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    strategy:
+      # One platform failing must not cancel the other — seeing both columns
+      # is the entire reason this is a matrix rather than two hardcoded jobs.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
+      # MUST precede actions/checkout. GitHub's Windows image ships
+      # `core.autocrlf=true`, which rewrites every LF to CRLF as the working
+      # tree is written — that alone is enough to red `cargo fmt --check` and
+      # any test asserting on "\n", and nothing downstream can undo it once
+      # the files are on disk. `core.longpaths` is the same class of problem:
+      # cargo's hashed `target/` directories routinely exceed the legacy
+      # 260-char MAX_PATH, and the failure surfaces as an unrelated-looking
+      # I/O error deep in a build script.
+      - name: Configure git for Windows (line endings + long paths)
+        if: runner.os == 'Windows'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --system core.longpaths true
       - uses: actions/checkout@v4
       # Toolchain is pinned in rust-toolchain.toml (see its header comment
       # for why); rustup's own override resolution honors that file
-      # regardless of what this action installs as its "default".
+      # regardless of what this action installs as its "default". On Windows
+      # this resolves the `x86_64-pc-windows-msvc` host triple, which is the
+      # one the eventual `win` backend needs anyway — `windows-rs` + Direct2D
+      # are MSVC-ABI, not GNU.
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -98,13 +136,28 @@ jobs:
       # log, and uploads it as an artifact. For a backend that doesn't exist
       # yet (Windows, macOS) that artifact IS the implementation checklist,
       # so it must survive the run even when everything passed.
+      #
+      # Under the OS matrix this now produces two artifacts of the same
+      # *scenario* corpus run on two different hosts. That is not redundant:
+      # `TuiBackend` renders to ratatui's TestBackend, but the scenarios
+      # exercise the portable core underneath it (layout, text measurement,
+      # unicode width, event translation), and that core is exactly where a
+      # Windows-only divergence would hide.
       - name: Conformance matrix (tui)
         run: cargo test -p quadraui --features tui --test conformance -- --nocapture
       - name: Upload conformance matrix (tui)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: conformance-matrix-tui
+          # Suffixed per matrix leg because upload-artifact@v4 ERRORS on a
+          # duplicate artifact name instead of merging into it (a deliberate
+          # v3→v4 behaviour change). A bare "conformance-matrix-tui" here
+          # would fail whichever leg finished second — and, because that
+          # failure lands in the *upload* step rather than the test step, it
+          # would read as a CI plumbing flake rather than the naming bug it
+          # is. The ubuntu leg's artifact is renamed too; keeping the old
+          # name on one leg and suffixing the other is worse than either.
+          name: conformance-matrix-tui-${{ matrix.os }}
           path: target/conformance-matrix.txt
           if-no-files-found: warn
 

--- a/quadraui/tests/githooks_worktree.rs
+++ b/quadraui/tests/githooks_worktree.rs
@@ -14,6 +14,28 @@
 //! checked out into the new worktree), in-worktree checkouts never run the
 //! hook, and "nothing happened" looks identical to "nothing happened because
 //! the condition was false". See #512.
+//!
+//! ── Unix-only, deliberately and visibly (#581) ─────────────────────────
+//!
+//! The whole file is `cfg(unix)`. `.githooks/post-checkout` is a POSIX shell
+//! script whose entire job is creating **symlinks**, and these tests assert on
+//! `fs::symlink_metadata(..).file_type().is_symlink()` and on mode `100755`.
+//! None of that has meaning on Windows, where the equivalent mechanism is an
+//! NTFS **junction** and symlink creation needs Developer Mode or elevation.
+//!
+//! This is a recorded gap, not a dismissal: Windows worktree junctions are
+//! called out in quadraui#580 (and in claude-coordinator's CP-7). When that
+//! lands, the right move is a junction-aware `symlink_target` plus a
+//! `cfg(windows)` sibling of this suite — NOT deleting this gate.
+//!
+//! Gating the *whole file* rather than only the five tests that failed on
+//! `windows-latest` is the point. `worktree_add_git_status_is_empty` PASSED
+//! there — because the hook never fired, so `git status` was trivially clean.
+//! That is exactly the false pass the paragraph above warns about, arriving
+//! by a route #512 didn't anticipate: not an uncommitted `.githooks/`, but a
+//! platform where the hook cannot do anything in the first place. A green
+//! result from it on Windows is misinformation, so it does not get to run.
+#![cfg(unix)]
 
 use std::collections::HashMap;
 use std::fs;


### PR DESCRIPTION
Closes #581. Refs #580 (W-0 of the Win-GUI plan; the only item there not blocked on #19).

Runs the existing `tui` job on `windows-latest` as well as `ubuntu-latest`, so the
**portable core** — ratatui, arboard, unicode-width, and via `terminal` portable-pty +
vt100, plus the layout / text-measurement / event-translation code underneath them —
gets Windows coverage. None of it had ever been built or tested on a Windows host.

No Direct2D code is involved. `win = []` has no dependencies, so `cargo check
--features win` already type-checks on Linux; this is about the layer the eventual
backend will sit on top of, covered *before* that work starts rather than tangled up
with it.

## What the first run actually found

The Windows build **succeeded**, and **1588 of 1593 tests passed**. Every failure was
in one file, `quadraui/tests/githooks_worktree.rs`, which drives
`.githooks/post-checkout` — a POSIX shell script whose entire job is creating symlinks
— and asserts on `symlink_metadata()` and mode `100755`. The Windows equivalent is an
NTFS junction, and creating symlinks there needs Developer Mode or elevation.

The second commit gates that file to `cfg(unix)`, with the gap recorded in-file and
pointed at #580 rather than silently compiled away.

**Gating the whole file rather than only the five visible failures is deliberate.**
`worktree_add_git_status_is_empty` *passed* on Windows — because the hook never fired,
so `git status --porcelain` was trivially clean. That is precisely the false pass the
file's own module doc warns about ("nothing happened" vs "nothing happened because the
condition was false", #512), arriving by a route #512 didn't anticipate: not an
uncommitted `.githooks/`, but a platform where the hook cannot act at all. A green
result from it on Windows is misinformation, so it doesn't get to run.

Still unknown after that first run: the job stops at the first failing step, so
**Clippy, the ConPTY pty smoke, and the conformance matrix were all skipped** on
Windows and have never executed there. This PR's re-run is the first time they will.

## Not a cosmetic matrix widening

Four details are load-bearing, and each is commented inline at the point it matters:

- **The Windows leg is non-blocking at the workflow level** (`continue-on-error` scoped
  to that leg) — see the precise scope of that claim below. `RUSTFLAGS: "-D warnings"`
  is workflow-level, and the `downstream` job gates coord-tui and vimcode, so a Windows
  leg going red on a platform-specific warning would otherwise block two consumers on
  something neither touched. Making it fully gating is W-7 in #580, deliberately a
  separate commit once the leg has been green for a while.
- **`fail-fast: false`** so one platform's failure doesn't cancel the other's column.
- **git config runs before `actions/checkout`.** The Windows runner image ships
  `core.autocrlf=true`, which rewrites LF→CRLF as the working tree is written — enough
  on its own to red `cargo fmt --check` and any `"\n"` assertion, and unfixable once
  the files are on disk. `core.longpaths` covers cargo's hashed `target/` paths against
  the legacy 260-char `MAX_PATH`.
- **Per-leg artifact names.** `upload-artifact@v4` errors on a duplicate artifact name
  rather than merging (a v3→v4 change), so a bare `conformance-matrix-tui` would fail
  whichever leg finished second — in the upload step, where it reads as plumbing flake
  rather than a naming bug. Both legs are suffixed; renaming only one would be worse.

## What "non-blocking" does and does not mean

Worth stating precisely, because the first revision of this description overstated it.

Job-level `continue-on-error` makes the **workflow run** conclude `success` while the
individual **check** still reports `conclusion=failure`. Verified on the first run here:
run conclusion `success`, job conclusion `failure`.

That distinction matters for this repo specifically. `coord`'s merge gate evaluates
*per-check* conclusions (`failed_checks` in `coord/ci_store.py` filters on
`c.conclusion`, not the run rollup), so a red Windows leg **does** block `coord merge`
even though GitHub considers the run green. `continue-on-error` buys a green run and a
green branch state; it does not buy a mergeable PR under this fleet's tooling.

Which is the other reason the `cfg(unix)` gate is the right fix rather than leaving the
leg red as a marker: a permanently-red check here is not a passive annotation, it is a
merge block on every future PR.

## Verification

- `cargo test -p quadraui --features tui --test githooks_worktree` on Linux: **7 passed,
  0 failed** — the gate changes nothing on the platform where the suite is meaningful.
- `cargo fmt --all --check`: clean.
- YAML parses; the job expands as intended (`runs-on`, both matrix legs, per-leg
  `continue-on-error`, git config ordered before checkout).
- `actionlint` was not available locally, so workflow semantics rest on the actual run.

Ubuntu leg behaviour is unchanged — same steps, same commands, only the artifact name
gains its `-ubuntu-latest` suffix.
