### PR TITLE
#503: Public char-boundary text utils: fix 12+ UTF-8 slice panics in gtk/macos rasterisers + Color::from_hex; unify 7 private helpers

### DIFF
--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -44,6 +44,7 @@ use crate::{
     Backend, ButtonMask, Color, Key, MessageList, MessageRow, Modifiers, MouseButton, NamedKey,
     Rect, Scrollbar, Spinner, StyledText, TextInput, TextInputHit, UiEvent, WidgetId,
 };
+use crate::text_util::{next_char_boundary, prev_char_boundary, safe_prefix, snap_to_char_boundary};
 use serde::{Deserialize, Serialize};
 use std::cell::Cell;
 
@@ -1233,8 +1234,7 @@ fn wrap_spans(spans: &[StyledSpan], col_budget: usize) -> Vec<Vec<StyledSpan>> {
 
 /// Convert a byte offset in `text` to `(line, char_col)`.
 fn cursor_byte_to_line_col(text: &str, cursor: usize) -> (usize, usize) {
-    let cursor = cursor.min(text.len());
-    let before = &text[..cursor];
+    let before = safe_prefix(text, cursor);
     let line = before.bytes().filter(|&b| b == b'\n').count();
     let col_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
     let col = before[col_start..].chars().count();
@@ -1283,38 +1283,6 @@ fn line_col_to_byte(text: &str, target_line: usize, target_col: usize) -> usize 
 
     // Target line doesn't exist — clamp to end of text.
     text.len()
-}
-
-fn snap_to_char_boundary(s: &str, byte: usize) -> usize {
-    let byte = byte.min(s.len());
-    let mut i = byte;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
-}
-
-fn prev_char_boundary(s: &str, byte: usize) -> usize {
-    if byte == 0 {
-        return 0;
-    }
-    let mut i = byte - 1;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
-}
-
-fn next_char_boundary(s: &str, byte: usize) -> usize {
-    let byte = byte.min(s.len());
-    if byte >= s.len() {
-        return s.len();
-    }
-    let mut i = byte + 1;
-    while i < s.len() && !s.is_char_boundary(i) {
-        i += 1;
-    }
-    i
 }
 
 fn rect_contains(rect: Rect, x: f32, y: f32) -> bool {
@@ -2562,6 +2530,18 @@ mod tests {
     #[test]
     fn byte_to_line_col_multiline() {
         assert_eq!(cursor_byte_to_line_col("ab\ncd", 4), (1, 1));
+    }
+
+    /// Regression for issue #503: `cursor_byte_to_line_col` used to
+    /// clamp `cursor` with only `.min(text.len())`, not a char-boundary
+    /// snap — a cursor byte offset landing mid-multibyte-character
+    /// (here, inside "é") panicked `&text[..cursor]`.
+    #[test]
+    fn byte_to_line_col_multibyte_mid_char_offset_does_not_panic() {
+        let text = "héllo";
+        assert!(!text.is_char_boundary(2)); // inside the 2-byte 'é'
+        let (line, col) = cursor_byte_to_line_col(text, 2);
+        assert_eq!((line, col), (0, 1));
     }
 
     #[test]

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -38,13 +38,15 @@
 //! scroll direction before emitting [`crate::UiEvent::Scroll`].
 
 use crate::compose::markdown::render_markdown_to_styled;
+use crate::text_util::{
+    next_char_boundary, prev_char_boundary, safe_prefix, snap_to_char_boundary,
+};
 use crate::theme::Theme;
 use crate::types::StyledSpan;
 use crate::{
     Backend, ButtonMask, Color, Key, MessageList, MessageRow, Modifiers, MouseButton, NamedKey,
     Rect, Scrollbar, Spinner, StyledText, TextInput, TextInputHit, UiEvent, WidgetId,
 };
-use crate::text_util::{next_char_boundary, prev_char_boundary, safe_prefix, snap_to_char_boundary};
 use serde::{Deserialize, Serialize};
 use std::cell::Cell;
 

--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -872,7 +872,6 @@ impl TreeController {
     }
 }
 
-
 fn rect_contains(rect: Rect, x: f32, y: f32) -> bool {
     x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height
 }

--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -23,6 +23,7 @@
 //! sign convention: positive `delta.y` = scroll content up (decrease
 //! offset). Backends normalise their native direction before emitting.
 
+use crate::text_util::{next_char_boundary, prev_char_boundary, snap_to_char_boundary};
 use crate::{
     Backend, ButtonMask, Key, Modifiers, MouseButton, NamedKey, Point, Rect, Scrollbar,
     SelectionMode, TreePath, TreeRow, TreeRowEditState, TreeView, TreeViewHit, UiEvent, WidgetId,
@@ -871,37 +872,6 @@ impl TreeController {
     }
 }
 
-fn snap_to_char_boundary(s: &str, byte: usize) -> usize {
-    let byte = byte.min(s.len());
-    let mut i = byte;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
-}
-
-fn prev_char_boundary(s: &str, byte: usize) -> usize {
-    if byte == 0 {
-        return 0;
-    }
-    let mut i = byte - 1;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
-}
-
-fn next_char_boundary(s: &str, byte: usize) -> usize {
-    let byte = byte.min(s.len());
-    if byte >= s.len() {
-        return s.len();
-    }
-    let mut i = byte + 1;
-    while i < s.len() && !s.is_char_boundary(i) {
-        i += 1;
-    }
-    i
-}
 
 fn rect_contains(rect: Rect, x: f32, y: f32) -> bool {
     x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height

--- a/quadraui/src/gtk/command_line.rs
+++ b/quadraui/src/gtk/command_line.rs
@@ -42,12 +42,44 @@ pub fn draw_command_line(
     super::painted_text::show_layout(cr, layout);
 
     if let Some(offset) = cmd.cursor_offset {
-        let anchor = &cmd.text[..offset.min(cmd.text.len())];
+        let anchor = crate::text_util::safe_prefix(&cmd.text, offset);
         layout.set_text(anchor);
         let (text_w, _) = layout.pixel_size();
         let cursor_color = cairo_rgb(theme.cursor);
         cr.set_source_rgb(cursor_color.0, cursor_color.1, cursor_color.2);
         cr.rectangle(x + text_w as f64, y, 2.0, line_height);
         cr.fill().ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::WidgetId;
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    /// Regression for issue #503: typing `:éditer` (or any command
+    /// with a multibyte char left of the cursor) used to panic
+    /// `&cmd.text[..offset.min(cmd.text.len())]` when `cursor_offset`
+    /// landed mid-character.
+    #[test]
+    fn draw_command_line_with_multibyte_cursor_does_not_panic() {
+        let surface = ImageSurface::create(Format::ARgb32, 400, 30).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let pango_layout = pangocairo::functions::create_layout(&cr);
+        let theme = Theme::default();
+
+        // ":éditer" — byte 2 sits inside the 2-byte 'é' (starts at byte 1).
+        let text = ":éditer";
+        assert!(!text.is_char_boundary(2));
+        let cmd = CommandLine {
+            id: WidgetId::new("cmdline"),
+            text: text.into(),
+            cursor_offset: Some(2),
+            right_align: false,
+        };
+
+        // Must not panic.
+        draw_command_line(&cr, &pango_layout, &cmd, &theme, 0.0, 0.0, 400.0, 20.0);
     }
 }

--- a/quadraui/src/gtk/editor.rs
+++ b/quadraui/src/gtk/editor.rs
@@ -655,7 +655,12 @@ pub fn editor_col_at_x(
         + editor_layout.scroll_left as f64 * cell_width;
     let x_pango = (local_x.max(0.0) * pango::SCALE as f64).round() as i32;
     let (_inside, byte_index, _trailing) = pango_layout.xy_to_index(x_pango, 0);
-    let clamped = (byte_index.max(0) as usize).min(line.raw_text.len());
+    // Pango should only ever return a UTF-8 char-boundary-aligned index for
+    // valid input, but we don't fully control its internals across
+    // versions/locales — snap defensively rather than trust it blindly and
+    // risk a panic on a non-boundary `byte_index`.
+    let clamped =
+        crate::text_util::snap_to_char_boundary(&line.raw_text, byte_index.max(0) as usize);
     line.raw_text[..clamped].chars().count() + line.segment_col_offset
 }
 
@@ -1022,5 +1027,58 @@ mod tests {
             editor_layout.text_bounds.x,
         );
         assert_eq!(resolved, 12);
+    }
+
+    /// Regression for issue #503: `editor_col_at_x`'s `byte_index.min(len)`
+    /// clamp (fed by Pango's `xy_to_index`) wasn't snapped to a char
+    /// boundary, so a multibyte line (é / CJK / emoji) probed at an x
+    /// position landing mid-character used to panic
+    /// `line.raw_text[..clamped]`. Sweep the full width of a multibyte
+    /// line and confirm every probe resolves without panicking.
+    #[test]
+    fn editor_col_at_x_multibyte_line_does_not_panic() {
+        let pango_layout = headless_pango_layout();
+        let mut line = styled_line();
+        line.raw_text = "café 🎉 中文 done".into();
+        line.spans = Vec::new();
+
+        let editor = Editor {
+            id: "ed".into(),
+            rect: Rect::new(0.0, 0.0, 900.0, 60.0),
+            lines: vec![line.clone()],
+            cursor: None,
+            extra_cursors: Vec::new(),
+            selection: None,
+            extra_selections: Vec::new(),
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: 0,
+            total_lines: 1,
+            max_col: 30,
+            gutter_char_width: 4,
+            is_active: true,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: HashMap::new(),
+            code_action_lines: HashSet::new(),
+            bracket_match_positions: Vec::new(),
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: true,
+            lightbulb_glyph: '!',
+        };
+
+        let cell_width = 9.0_f32;
+        let viewport = Rect::new(0.0, 0.0, 900.0, 60.0);
+        let editor_layout = editor.layout(viewport, cell_width, 18.0);
+
+        // Sweep x from before the line start to well past its end —
+        // every probe must resolve without panicking.
+        let mut x = editor_layout.text_bounds.x - 5.0;
+        while x < editor_layout.text_bounds.x + 300.0 {
+            let _ = editor_col_at_x(&pango_layout, &line, &editor_layout, x);
+            x += 1.0;
+        }
     }
 }

--- a/quadraui/src/gtk/find_replace.rs
+++ b/quadraui/src/gtk/find_replace.rs
@@ -290,3 +290,55 @@ pub fn draw_find_replace(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::Rect as QRect;
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    fn sample_panel(query: &str, cursor: usize, sel_anchor: Option<usize>) -> FindReplacePanel {
+        let (hit_regions, _input_width) =
+            crate::primitives::find_replace::compute_hit_regions(50, false, "", 2, 2);
+        FindReplacePanel {
+            query: query.into(),
+            replacement: String::new(),
+            show_replace: false,
+            focus: 0,
+            cursor,
+            sel_anchor,
+            match_info: "1 of 3".into(),
+            case_sensitive: false,
+            whole_word: false,
+            use_regex: false,
+            preserve_case: false,
+            in_selection: false,
+            group_bounds: QRect::new(0.0, 0.0, 600.0, 200.0),
+            panel_width: 50,
+            replace_one_glyph: "R1".into(),
+            replace_all_glyph: "R*".into(),
+            hit_regions,
+        }
+    }
+
+    /// Regression for issue #503: `cursor`/`sel_anchor` are char
+    /// offsets into `query`, but a query containing multibyte
+    /// characters plus an out-of-range or boundary-adjacent offset must
+    /// still paint without panicking — the shared boundary-snap
+    /// helpers this issue introduces are also meant to make this class
+    /// of "byte-offset-shaped" field safe by construction elsewhere in
+    /// the crate.
+    #[test]
+    fn draw_find_replace_with_multibyte_query_does_not_panic() {
+        let surface = ImageSurface::create(Format::ARgb32, 600, 200).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let pango_layout = pangocairo::functions::create_layout(&cr);
+        let theme = Theme::default();
+
+        // "café🎉中文" with a selection spanning the emoji + CJK chars.
+        let panel = sample_panel("café🎉中文", 3, Some(6));
+
+        // Must not panic.
+        draw_find_replace(&cr, &pango_layout, &panel, &theme, 16.0, 8.0);
+    }
+}

--- a/quadraui/src/gtk/form.rs
+++ b/quadraui/src/gtk/form.rs
@@ -14,6 +14,7 @@ use gtk4::pango;
 
 use super::cairo_rgb;
 use crate::primitives::form::{FieldKind, Form, ValidationState};
+use crate::text_util::{safe_prefix, snap_to_char_boundary};
 use crate::theme::Theme;
 
 /// Draw a [`Form`] into `(x, y, w, h)` on `cr` using `layout` for text
@@ -160,8 +161,8 @@ pub fn draw_form(
                         let cur = cursor.unwrap();
                         let anchor = selection_anchor.unwrap();
                         let (lo, hi) = (cur.min(anchor), cur.max(anchor));
-                        let lo = crate::text_util::snap_to_char_boundary(shown, lo);
-                        let hi = crate::text_util::snap_to_char_boundary(shown, hi);
+                        let lo = snap_to_char_boundary(shown, lo);
+                        let hi = snap_to_char_boundary(shown, hi);
 
                         let prefix = &shown[..lo];
                         let sel_text = &shown[lo..hi];
@@ -213,7 +214,7 @@ pub fn draw_form(
                     super::painted_text::show_layout(cr, layout);
 
                     if let Some(cur) = cursor {
-                        let prefix = crate::text_util::safe_prefix(shown, *cur);
+                        let prefix = safe_prefix(shown, *cur);
                         layout.set_text(prefix);
                         let (prefix_w, _) = layout.pixel_size();
                         let cx = ix + 8.0 + prefix_w as f64;
@@ -407,7 +408,7 @@ pub fn draw_form(
                         // Cursor position: each original char maps to one
                         // mask char, so measure the masked prefix up to
                         // the byte-offset translated cursor.
-                        let char_pos = crate::text_util::safe_prefix(value, *cur).chars().count();
+                        let char_pos = safe_prefix(value, *cur).chars().count();
                         let mask_prefix: String = masked.chars().take(char_pos).collect();
                         layout.set_text(&mask_prefix);
                         let (prefix_w, _) = layout.pixel_size();
@@ -472,7 +473,7 @@ pub fn draw_form(
                     if let Some(cur) = cursor {
                         // Clamp cursor to first line length for display.
                         let clamped = (*cur).min(first_line.len());
-                        let prefix = crate::text_util::safe_prefix(shown, clamped);
+                        let prefix = safe_prefix(shown, clamped);
                         layout.set_text(prefix);
                         let (prefix_w, _) = layout.pixel_size();
                         let cx = ix + 8.0 + prefix_w as f64;
@@ -660,7 +661,17 @@ mod tests {
         let cr = Context::new(&surface).expect("Context::new");
         let pango_layout = pangocairo::functions::create_layout(&cr);
         let theme = Theme::default();
-        draw_form(&cr, &pango_layout, 0.0, 0.0, 320.0, 160.0, form, &theme, 14.0);
+        draw_form(
+            &cr,
+            &pango_layout,
+            0.0,
+            0.0,
+            320.0,
+            160.0,
+            form,
+            &theme,
+            14.0,
+        );
     }
 
     /// Regression for issue #503: `TextInput.cursor`/`selection_anchor`

--- a/quadraui/src/gtk/form.rs
+++ b/quadraui/src/gtk/form.rs
@@ -160,8 +160,8 @@ pub fn draw_form(
                         let cur = cursor.unwrap();
                         let anchor = selection_anchor.unwrap();
                         let (lo, hi) = (cur.min(anchor), cur.max(anchor));
-                        let lo = lo.min(shown.len());
-                        let hi = hi.min(shown.len());
+                        let lo = crate::text_util::snap_to_char_boundary(shown, lo);
+                        let hi = crate::text_util::snap_to_char_boundary(shown, hi);
 
                         let prefix = &shown[..lo];
                         let sel_text = &shown[lo..hi];
@@ -213,7 +213,7 @@ pub fn draw_form(
                     super::painted_text::show_layout(cr, layout);
 
                     if let Some(cur) = cursor {
-                        let prefix = &shown[..(*cur).min(shown.len())];
+                        let prefix = crate::text_util::safe_prefix(shown, *cur);
                         layout.set_text(prefix);
                         let (prefix_w, _) = layout.pixel_size();
                         let cx = ix + 8.0 + prefix_w as f64;
@@ -407,7 +407,7 @@ pub fn draw_form(
                         // Cursor position: each original char maps to one
                         // mask char, so measure the masked prefix up to
                         // the byte-offset translated cursor.
-                        let char_pos = value[..(*cur).min(value.len())].chars().count();
+                        let char_pos = crate::text_util::safe_prefix(value, *cur).chars().count();
                         let mask_prefix: String = masked.chars().take(char_pos).collect();
                         layout.set_text(&mask_prefix);
                         let (prefix_w, _) = layout.pixel_size();
@@ -472,7 +472,7 @@ pub fn draw_form(
                     if let Some(cur) = cursor {
                         // Clamp cursor to first line length for display.
                         let clamped = (*cur).min(first_line.len());
-                        let prefix = &shown[..clamped.min(shown.len())];
+                        let prefix = crate::text_util::safe_prefix(shown, clamped);
                         layout.set_text(prefix);
                         let (prefix_w, _) = layout.pixel_size();
                         let cx = ix + 8.0 + prefix_w as f64;
@@ -645,5 +645,118 @@ pub fn draw_settings_chrome(
         cr.set_source_rgb(accent.0, accent.1, accent.2);
         cr.rectangle(cur_x, search_y + 2.0, 1.5, line_height - 4.0);
         cr.fill().ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::form::{Form, FormField};
+    use crate::types::{StyledText, WidgetId};
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    fn paint(form: &Form) {
+        let surface = ImageSurface::create(Format::ARgb32, 320, 160).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let pango_layout = pangocairo::functions::create_layout(&cr);
+        let theme = Theme::default();
+        draw_form(&cr, &pango_layout, 0.0, 0.0, 320.0, 160.0, form, &theme, 14.0);
+    }
+
+    /// Regression for issue #503: `TextInput.cursor`/`selection_anchor`
+    /// are host-supplied byte offsets with no guarantee they land on a
+    /// char boundary — `&shown[lo..hi]` / `&shown[..cur]` used to panic
+    /// the moment a multibyte character sat inside the range.
+    #[test]
+    fn text_input_with_multibyte_cursor_and_selection_does_not_panic() {
+        // "café🎉" — byte 4 sits inside 'é' (starts at byte 3); byte 7
+        // sits inside the emoji (starts at byte 6).
+        let value = "café🎉";
+        assert!(!value.is_char_boundary(4));
+        assert!(!value.is_char_boundary(7));
+        let form = Form {
+            id: WidgetId::new("settings"),
+            fields: vec![FormField {
+                id: WidgetId::new("name"),
+                label: StyledText::plain("Name"),
+                kind: FieldKind::TextInput {
+                    value: value.into(),
+                    placeholder: String::new(),
+                    cursor: Some(4),
+                    selection_anchor: Some(7),
+                },
+                hint: StyledText::default(),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: Some(WidgetId::new("name")),
+            scroll_offset: 0,
+            has_focus: true,
+        };
+
+        // Must not panic.
+        paint(&form);
+    }
+
+    /// Regression for issue #503: same class of bug in the
+    /// `PasswordInput` byte-cursor-to-mask-char-position conversion.
+    #[test]
+    fn password_input_with_multibyte_cursor_does_not_panic() {
+        let value = "café🎉";
+        assert!(!value.is_char_boundary(4));
+        let form = Form {
+            id: WidgetId::new("settings"),
+            fields: vec![FormField {
+                id: WidgetId::new("pw"),
+                label: StyledText::plain("Password"),
+                kind: FieldKind::PasswordInput {
+                    value: value.into(),
+                    placeholder: String::new(),
+                    cursor: Some(4),
+                    mask_char: '*',
+                },
+                hint: StyledText::default(),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: Some(WidgetId::new("pw")),
+            scroll_offset: 0,
+            has_focus: true,
+        };
+
+        // Must not panic.
+        paint(&form);
+    }
+
+    /// Regression for issue #503: `TextArea` clamps `cursor` against
+    /// `first_line.len()` but the earlier code sliced `shown` (which may
+    /// be `first_line` or a differently-lengthed placeholder) without a
+    /// char-boundary snap.
+    #[test]
+    fn text_area_with_multibyte_cursor_does_not_panic() {
+        let value = "café🎉\nsecond line";
+        assert!(!value.is_char_boundary(4));
+        let form = Form {
+            id: WidgetId::new("settings"),
+            fields: vec![FormField {
+                id: WidgetId::new("notes"),
+                label: StyledText::plain("Notes"),
+                kind: FieldKind::TextArea {
+                    value: value.into(),
+                    placeholder: String::new(),
+                    cursor: Some(4),
+                    visible_rows: 3,
+                },
+                hint: StyledText::default(),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: Some(WidgetId::new("notes")),
+            scroll_offset: 0,
+            has_focus: true,
+        };
+
+        // Must not panic.
+        paint(&form);
     }
 }

--- a/quadraui/src/gtk/palette.rs
+++ b/quadraui/src/gtk/palette.rs
@@ -157,11 +157,7 @@ pub fn draw_palette(
         cr.move_to(query_text_x, query_y + (qh_px - qh as f64) / 2.0);
         super::painted_text::show_layout(cr, layout);
 
-        let cursor_prefix: &str = if palette.query_cursor >= palette.query.len() {
-            palette.query.as_str()
-        } else {
-            &palette.query[..palette.query_cursor]
-        };
+        let cursor_prefix: &str = crate::text_util::safe_prefix(&palette.query, palette.query_cursor);
         layout.set_text(cursor_prefix);
         let (cursor_prefix_w, _) = layout.pixel_size();
         let cursor_x = query_text_x + cursor_prefix_w as f64;
@@ -429,4 +425,61 @@ pub fn draw_palette(
     }
 
     cr.restore().ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::palette::PaletteMode;
+    use crate::types::WidgetId;
+    use pangocairo::cairo::{Context, Format, ImageSurface};
+
+    fn sample_palette(query: &str, query_cursor: usize) -> Palette {
+        Palette {
+            id: WidgetId::new("palette"),
+            title: "Commands".into(),
+            query: query.into(),
+            query_cursor,
+            items: Vec::new(),
+            selected_idx: 0,
+            scroll_offset: 0,
+            total_count: 0,
+            has_focus: true,
+            show_query: true,
+            create_label: None,
+            preview: None,
+            mode: PaletteMode::List,
+        }
+    }
+
+    /// Regression for issue #503: `query_cursor` is a host-supplied byte
+    /// offset (per the field doc above) with no guarantee it lands on a
+    /// char boundary — `&palette.query[..query_cursor]` used to panic
+    /// the moment a multibyte character sat left of the cursor.
+    #[test]
+    fn draw_palette_with_multibyte_cursor_does_not_panic() {
+        let surface = ImageSurface::create(Format::ARgb32, 300, 200).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let pango_layout = pangocairo::functions::create_layout(&cr);
+
+        // "café🎉" — byte 4 sits inside the 2-byte 'é' (starts at byte 3).
+        let query = "café🎉";
+        assert!(!query.is_char_boundary(4));
+        let palette = sample_palette(query, 4);
+        let theme = Theme::default();
+
+        // Must not panic.
+        draw_palette(
+            &cr,
+            &pango_layout,
+            0.0,
+            0.0,
+            300.0,
+            200.0,
+            &palette,
+            &theme,
+            18.0,
+            false,
+        );
+    }
 }

--- a/quadraui/src/gtk/palette.rs
+++ b/quadraui/src/gtk/palette.rs
@@ -14,6 +14,7 @@ use gtk4::pango;
 
 use super::cairo_rgb;
 use crate::primitives::palette::{Palette, PaletteItemMeasure, PaletteMode};
+use crate::text_util::safe_prefix;
 use crate::theme::Theme;
 
 /// Draw a [`Palette`] modal into `(x, y, w, h)` on `cr`.
@@ -157,7 +158,7 @@ pub fn draw_palette(
         cr.move_to(query_text_x, query_y + (qh_px - qh as f64) / 2.0);
         super::painted_text::show_layout(cr, layout);
 
-        let cursor_prefix: &str = crate::text_util::safe_prefix(&palette.query, palette.query_cursor);
+        let cursor_prefix: &str = safe_prefix(&palette.query, palette.query_cursor);
         layout.set_text(cursor_prefix);
         let (cursor_prefix_w, _) = layout.pixel_size();
         let cursor_x = query_text_x + cursor_prefix_w as f64;

--- a/quadraui/src/gtk/tree.rs
+++ b/quadraui/src/gtk/tree.rs
@@ -13,6 +13,7 @@ use gtk4::pango;
 use super::cairo_rgb;
 use crate::event::Rect as QRect;
 use crate::primitives::tree::{TreeRowEditState, TreeRowMeasure, TreeView, TreeViewLayout};
+use crate::text_util::{safe_prefix, snap_to_char_boundary};
 use crate::theme::Theme;
 use crate::types::Decoration;
 
@@ -305,8 +306,8 @@ fn paint_edit_input_gtk(
     // Selection highlight.
     if let Some(anchor) = edit.selection_anchor {
         if anchor != edit.cursor {
-            let lo = crate::text_util::snap_to_char_boundary(&edit.text, anchor.min(edit.cursor));
-            let hi = crate::text_util::snap_to_char_boundary(&edit.text, anchor.max(edit.cursor));
+            let lo = snap_to_char_boundary(&edit.text, anchor.min(edit.cursor));
+            let hi = snap_to_char_boundary(&edit.text, anchor.max(edit.cursor));
             let prefix = &edit.text[..lo];
             let sel_text = &edit.text[lo..hi];
             layout.set_text(prefix);
@@ -332,7 +333,7 @@ fn paint_edit_input_gtk(
     super::painted_text::show_layout(cr, layout);
 
     // Thin vertical caret bar.
-    let cursor_prefix = crate::text_util::safe_prefix(&edit.text, edit.cursor);
+    let cursor_prefix = safe_prefix(&edit.text, edit.cursor);
     layout.set_text(cursor_prefix);
     let (cx_off, _) = layout.pixel_size();
     let caret_x = text_x + cx_off as f64;

--- a/quadraui/src/gtk/tree.rs
+++ b/quadraui/src/gtk/tree.rs
@@ -305,8 +305,8 @@ fn paint_edit_input_gtk(
     // Selection highlight.
     if let Some(anchor) = edit.selection_anchor {
         if anchor != edit.cursor {
-            let lo = anchor.min(edit.cursor).min(edit.text.len());
-            let hi = anchor.max(edit.cursor).min(edit.text.len());
+            let lo = crate::text_util::snap_to_char_boundary(&edit.text, anchor.min(edit.cursor));
+            let hi = crate::text_util::snap_to_char_boundary(&edit.text, anchor.max(edit.cursor));
             let prefix = &edit.text[..lo];
             let sel_text = &edit.text[lo..hi];
             layout.set_text(prefix);
@@ -332,8 +332,7 @@ fn paint_edit_input_gtk(
     super::painted_text::show_layout(cr, layout);
 
     // Thin vertical caret bar.
-    let cursor_byte = edit.cursor.min(edit.text.len());
-    let cursor_prefix = &edit.text[..cursor_byte];
+    let cursor_prefix = crate::text_util::safe_prefix(&edit.text, edit.cursor);
     layout.set_text(cursor_prefix);
     let (cx_off, _) = layout.pixel_size();
     let caret_x = text_x + cx_off as f64;
@@ -690,6 +689,62 @@ mod tests {
         assert!(
             painted.is_some(),
             "editing row interior should contain painted pixels (caret + text)"
+        );
+    }
+
+    /// Regression for issue #503: an inline-rename cursor/selection byte
+    /// offset landing mid-multibyte-character used to panic
+    /// `&edit.text[..cursor]` (and the selection lo/hi slices) instead of
+    /// snapping to the nearest char boundary. Paints a row with a
+    /// multibyte name and a cursor position that sits inside a
+    /// multibyte character's byte range, plus an active selection whose
+    /// bounds also land mid-character.
+    #[test]
+    fn gtk_editing_row_with_multibyte_cursor_does_not_panic() {
+        // "café🎉中文" — cursor/selection offsets below are deliberately
+        // *not* char-boundary aligned; snap_to_char_boundary must rescue
+        // them before any `&text[..n]` slice happens.
+        let text = "café🎉中文";
+        // byte 4 is inside the 2-byte 'é' (starts at byte 3); byte 8 is
+        // inside the 4-byte emoji (starts at byte 6).
+        let mid_char_cursor = 4;
+        let mid_char_anchor = 8;
+        assert!(!text.is_char_boundary(mid_char_cursor));
+        assert!(!text.is_char_boundary(mid_char_anchor));
+
+        let tree = make_tree(vec![
+            leaf(0, "alpha"),
+            TreeRow {
+                path: vec![1],
+                indent: 0,
+                icon: None,
+                text: StyledText::plain("old-name".to_string()),
+                badge: None,
+                is_expanded: None,
+                decoration: Decoration::Normal,
+                edit: Some(TreeRowEditState {
+                    text: text.to_string(),
+                    cursor: mid_char_cursor,
+                    selection_anchor: Some(mid_char_anchor),
+                    placeholder: None,
+                }),
+            },
+            leaf(2, "gamma"),
+        ]);
+
+        // Must not panic.
+        let (mut surface, layout) = paint_then_layout(&tree);
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        let vis = &layout.visible_rows[1];
+        let bounds = vis.bounds;
+        let y_top = (bounds.y + 1.0).floor() as i32;
+        let y_bot = (bounds.y + bounds.height - 1.0).floor() as i32;
+        let painted = first_painted_in(&data, stride, (1, W - 1), (y_top, y_bot.min(H)));
+        assert!(
+            painted.is_some(),
+            "editing row with multibyte text should still paint (selection + caret + text)"
         );
     }
 

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -272,7 +272,10 @@ pub use primitives::tree::{
     TreeEvent, TreeRow, TreeRowEditState, TreeRowMeasure, TreeView, TreeViewHit, TreeViewLayout,
     VisibleTreeRow,
 };
-pub use text_util::{fuzzy_score, word_wrap};
+pub use text_util::{
+    fuzzy_score, next_char_boundary, prev_char_boundary, safe_prefix, safe_slice,
+    snap_to_char_boundary, word_wrap,
+};
 pub use theme::Theme;
 pub use types::{
     Badge, Color, Decoration, Icon, Modifiers, SelectionMode, StyledSpan, StyledText, TreePath,

--- a/quadraui/src/macos/editor.rs
+++ b/quadraui/src/macos/editor.rs
@@ -122,8 +122,8 @@ pub unsafe fn draw_editor(
         // raw run. Crude but produces correct colour at character
         // boundaries given the monospace baseline.
         for span in &line.spans {
-            let start = span.start_byte.min(line.raw_text.len());
-            let end = span.end_byte.min(line.raw_text.len());
+            let start = crate::text_util::snap_to_char_boundary(&line.raw_text, span.start_byte);
+            let end = crate::text_util::snap_to_char_boundary(&line.raw_text, span.end_byte);
             if start >= end {
                 continue;
             }
@@ -399,6 +399,41 @@ mod tests {
         let (r, g, b, _) = surface.pixel(px, py);
         // Span bg painted over editor bg.
         assert_eq!((r, g, b), (50, 100, 150));
+    }
+
+    /// Regression for issue #503: syntax-highlighting `StyledSpan`
+    /// byte offsets were only `.min(len)`-clamped, not snapped to a
+    /// char boundary — a span landing mid-multibyte-character (é / CJK
+    /// / emoji) used to panic `&line.raw_text[..start]` /
+    /// `[start..end]`. Also exercises a multibyte cursor column via
+    /// `char_byte_offset`.
+    #[test]
+    fn multibyte_span_and_cursor_do_not_panic() {
+        // "café🎉 beta" — byte 4 sits inside the 2-byte 'é' (starts at
+        // byte 3); byte 8 sits inside the 4-byte emoji (starts at byte 6).
+        let text = "café🎉 beta";
+        assert!(!text.is_char_boundary(4));
+        assert!(!text.is_char_boundary(8));
+
+        let mut line = one_line(text);
+        line.spans = vec![ESpan {
+            start_byte: 4,
+            end_byte: 8,
+            style: Style {
+                fg: Color::rgb(255, 255, 255),
+                bg: Some(Color::rgb(50, 100, 150)),
+                bold: false,
+                italic: false,
+                font_scale: 1.0,
+            },
+        }];
+        // Cursor column 3 lands on 'é' (a char index, not a byte
+        // offset) — `char_byte_offset` must resolve it to a boundary.
+        let mut editor = editor_with_cursor(text, CursorShape::Block, 3);
+        editor.lines = vec![line];
+
+        // Must not panic.
+        let _surface = paint_via_backend(&editor);
     }
 
     #[test]

--- a/quadraui/src/macos/editor.rs
+++ b/quadraui/src/macos/editor.rs
@@ -31,6 +31,7 @@ use core_text::font::CTFont;
 use super::text::{draw_text, measure_text};
 use crate::backend::EditorPaintResult;
 use crate::primitives::editor::{CursorShape, Editor};
+use crate::text_util::snap_to_char_boundary;
 use crate::theme::Theme;
 use crate::types::Color;
 
@@ -122,8 +123,8 @@ pub unsafe fn draw_editor(
         // raw run. Crude but produces correct colour at character
         // boundaries given the monospace baseline.
         for span in &line.spans {
-            let start = crate::text_util::snap_to_char_boundary(&line.raw_text, span.start_byte);
-            let end = crate::text_util::snap_to_char_boundary(&line.raw_text, span.end_byte);
+            let start = snap_to_char_boundary(&line.raw_text, span.start_byte);
+            let end = snap_to_char_boundary(&line.raw_text, span.end_byte);
             if start >= end {
                 continue;
             }

--- a/quadraui/src/macos/find_replace.rs
+++ b/quadraui/src/macos/find_replace.rs
@@ -382,6 +382,19 @@ mod tests {
         );
     }
 
+    /// Regression for issue #503: `cursor` is a char offset into
+    /// `query`; a multibyte query with a boundary-adjacent or
+    /// out-of-range cursor must still paint without panicking.
+    #[test]
+    fn panel_with_multibyte_query_does_not_panic() {
+        let mut panel = sample_panel();
+        panel.query = "café🎉中文".into();
+        panel.cursor = 3;
+
+        // Must not panic.
+        let _surface = paint_via_backend(&panel);
+    }
+
     #[test]
     fn hit_regions_present_for_basic_panel() {
         let panel = sample_panel();

--- a/quadraui/src/macos/form.rs
+++ b/quadraui/src/macos/form.rs
@@ -29,6 +29,7 @@ use crate::event::Rect as QRect;
 use crate::primitives::form::{
     FieldKind, Form, FormFieldMeasure, FormItemMeasure, FormLayout, ValidationState,
 };
+use crate::text_util::safe_prefix;
 use crate::theme::Theme;
 use crate::types::{Color, WidgetId};
 
@@ -286,7 +287,7 @@ pub unsafe fn draw_form(
                     // Caret — thin 1.5pt bar at the cursor's byte offset.
                     if let Some(cur) = cursor {
                         if is_focused {
-                            let prefix = crate::text_util::safe_prefix(shown, *cur);
+                            let prefix = safe_prefix(shown, *cur);
                             let (prefix_w, _) = measure_text(font, prefix);
                             let caret_x = ix + 8.0 + prefix_w;
                             fill_rect(
@@ -446,7 +447,7 @@ pub unsafe fn draw_form(
                         if is_focused {
                             // Each plaintext char maps to one mask char, so
                             // measure the masked prefix up to the byte-cursor.
-                            let char_pos = crate::text_util::safe_prefix(value, *cur).chars().count();
+                            let char_pos = safe_prefix(value, *cur).chars().count();
                             let mask_prefix: String = masked.chars().take(char_pos).collect();
                             let (prefix_w, _) = measure_text(font, &mask_prefix);
                             let caret_x = ix + 8.0 + prefix_w;

--- a/quadraui/src/macos/form.rs
+++ b/quadraui/src/macos/form.rs
@@ -286,8 +286,7 @@ pub unsafe fn draw_form(
                     // Caret — thin 1.5pt bar at the cursor's byte offset.
                     if let Some(cur) = cursor {
                         if is_focused {
-                            let prefix_byte = (*cur).min(shown.len());
-                            let prefix = &shown[..prefix_byte];
+                            let prefix = crate::text_util::safe_prefix(shown, *cur);
                             let (prefix_w, _) = measure_text(font, prefix);
                             let caret_x = ix + 8.0 + prefix_w;
                             fill_rect(
@@ -447,7 +446,7 @@ pub unsafe fn draw_form(
                         if is_focused {
                             // Each plaintext char maps to one mask char, so
                             // measure the masked prefix up to the byte-cursor.
-                            let char_pos = value[..(*cur).min(value.len())].chars().count();
+                            let char_pos = crate::text_util::safe_prefix(value, *cur).chars().count();
                             let mask_prefix: String = masked.chars().take(char_pos).collect();
                             let (prefix_w, _) = measure_text(font, &mask_prefix);
                             let caret_x = ix + 8.0 + prefix_w;
@@ -989,5 +988,68 @@ mod tests {
             saw_glyph,
             "PasswordInput row should paint masked glyphs (none found)",
         );
+    }
+
+    /// Regression for issue #503: `TextInput.cursor` is a host-supplied
+    /// byte offset with no guarantee it lands on a char boundary —
+    /// `&shown[..prefix_byte]` used to panic the moment a multibyte
+    /// character sat left of the cursor.
+    #[test]
+    fn text_input_with_multibyte_cursor_does_not_panic() {
+        // "café🎉" — byte 4 sits inside the 2-byte 'é' (starts at byte 3).
+        let value = "café🎉";
+        assert!(!value.is_char_boundary(4));
+        let form = Form {
+            id: WidgetId::new("settings"),
+            fields: vec![FormField {
+                id: WidgetId::new("name"),
+                label: StyledText::plain("Name"),
+                kind: FieldKind::TextInput {
+                    value: value.into(),
+                    placeholder: String::new(),
+                    cursor: Some(4),
+                    selection_anchor: None,
+                },
+                hint: StyledText::default(),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: Some(WidgetId::new("name")),
+            scroll_offset: 0,
+            has_focus: true,
+        };
+
+        // Must not panic.
+        let _ = paint_via_backend(&form);
+    }
+
+    /// Regression for issue #503: same class of bug in the
+    /// `PasswordInput` byte-cursor-to-mask-char-position conversion.
+    #[test]
+    fn password_input_with_multibyte_cursor_does_not_panic() {
+        let value = "café🎉";
+        assert!(!value.is_char_boundary(4));
+        let form = Form {
+            id: WidgetId::new("settings"),
+            fields: vec![FormField {
+                id: WidgetId::new("pw"),
+                label: StyledText::plain("Password"),
+                kind: FieldKind::PasswordInput {
+                    value: value.into(),
+                    placeholder: String::new(),
+                    cursor: Some(4),
+                    mask_char: '*',
+                },
+                hint: StyledText::default(),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: Some(WidgetId::new("pw")),
+            scroll_offset: 0,
+            has_focus: true,
+        };
+
+        // Must not panic.
+        let _ = paint_via_backend(&form);
     }
 }

--- a/quadraui/src/macos/palette.rs
+++ b/quadraui/src/macos/palette.rs
@@ -20,6 +20,7 @@ use core_text::font::CTFont;
 
 use super::text::{draw_text, measure_text};
 use crate::primitives::palette::{Palette, PaletteItemMeasure};
+use crate::text_util::safe_prefix;
 use crate::theme::Theme;
 use crate::types::Color;
 
@@ -140,7 +141,7 @@ pub unsafe fn draw_palette(
             query_y + (qb.height as f64 - qh) / 2.0,
             color_to_cg(theme.query_fg),
         );
-        let cursor_prefix: &str = crate::text_util::safe_prefix(&palette.query, palette.query_cursor);
+        let cursor_prefix: &str = safe_prefix(&palette.query, palette.query_cursor);
         let (cpw, _) = measure_text(font, cursor_prefix);
         let cursor_x = query_text_x + cpw;
         let cursor_w = (line_height * 0.45).max(2.0);

--- a/quadraui/src/macos/palette.rs
+++ b/quadraui/src/macos/palette.rs
@@ -140,11 +140,7 @@ pub unsafe fn draw_palette(
             query_y + (qb.height as f64 - qh) / 2.0,
             color_to_cg(theme.query_fg),
         );
-        let cursor_prefix: &str = if palette.query_cursor >= palette.query.len() {
-            palette.query.as_str()
-        } else {
-            &palette.query[..palette.query_cursor]
-        };
+        let cursor_prefix: &str = crate::text_util::safe_prefix(&palette.query, palette.query_cursor);
         let (cpw, _) = measure_text(font, cursor_prefix);
         let cursor_x = query_text_x + cpw;
         let cursor_w = (line_height * 0.45).max(2.0);
@@ -471,6 +467,22 @@ mod tests {
                 theme.selected_bg.b
             ),
         );
+    }
+
+    /// Regression for issue #503: `query_cursor` is a host-supplied byte
+    /// offset with no guarantee it lands on a char boundary —
+    /// `&palette.query[..query_cursor]` used to panic the moment a
+    /// multibyte character sat left of the cursor.
+    #[test]
+    fn draw_palette_with_multibyte_cursor_does_not_panic() {
+        let mut p = sample_palette();
+        // "café🎉" — byte 4 sits inside the 2-byte 'é' (starts at byte 3).
+        p.query = "café🎉".into();
+        assert!(!p.query.is_char_boundary(4));
+        p.query_cursor = 4;
+
+        // Must not panic.
+        let _surface = paint_via_backend(&p);
     }
 
     #[test]

--- a/quadraui/src/text_util.rs
+++ b/quadraui/src/text_util.rs
@@ -54,6 +54,7 @@ pub fn snap_to_char_boundary(s: &str, byte_idx: usize) -> usize {
 /// Intended for "move cursor left one char" style operations, where the
 /// caller then slices or indexes at the returned offset.
 pub fn prev_char_boundary(s: &str, byte_idx: usize) -> usize {
+    let byte_idx = byte_idx.min(s.len());
     if byte_idx == 0 {
         return 0;
     }
@@ -304,6 +305,14 @@ mod tests {
         let s = "héllo";
         // byte 2 is mid-'é'; prev boundary is the start of 'é' at byte 1.
         assert_eq!(prev_char_boundary(s, 2), 1);
+    }
+
+    #[test]
+    fn prev_char_boundary_clamps_past_end() {
+        let s = "héllo";
+        // Same clamp-then-walk-back behaviour as snap_to_char_boundary /
+        // next_char_boundary for an out-of-range byte_idx.
+        assert_eq!(prev_char_boundary(s, 999), prev_char_boundary(s, s.len()));
     }
 
     #[test]

--- a/quadraui/src/text_util.rs
+++ b/quadraui/src/text_util.rs
@@ -15,6 +15,90 @@
 //! See issue #474 ("Text-util gaps") for the audit that found three
 //! independent fuzzy matchers (two of them weaker ad-hoc versions) and a
 //! hard-break wrap living app-side while quadraui had no shared version.
+//!
+//! The boundary-snap helpers below ([`snap_to_char_boundary`],
+//! [`prev_char_boundary`], [`next_char_boundary`], [`safe_prefix`],
+//! [`safe_slice`]) close a related gap tracked by issue #503: GUI
+//! rasterisers (gtk, macos) receive byte-offset cursor/selection
+//! positions from host apps and consumers of this crate (see
+//! `primitives/palette.rs`'s `query_cursor` field) with no guarantee
+//! those offsets land on a UTF-8 char boundary — slicing a `String`
+//! directly at such an offset panics the paint pass the moment a
+//! multibyte character (é, CJK, emoji) sits left of the cursor. Before
+//! this module these existed as seven byte-identical private copies
+//! (`tui/editor.rs`, `compose/chat_controller.rs`,
+//! `compose/tree_controller.rs`); they're unified here so every
+//! caller — in-crate and, eventually, downstream — gets the same
+//! panic-free behaviour.
+
+/// Snap `byte_idx` to the nearest UTF-8 char boundary in `s` at or
+/// before `byte_idx`, clamping `byte_idx` to `s.len()` first.
+///
+/// Use this to make an arbitrary (possibly host-supplied, possibly
+/// stale) byte offset safe to slice with: `&s[..snap_to_char_boundary(s,
+/// byte_idx)]` never panics, regardless of where `byte_idx` originally
+/// pointed.
+pub fn snap_to_char_boundary(s: &str, byte_idx: usize) -> usize {
+    let byte_idx = byte_idx.min(s.len());
+    let mut i = byte_idx;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Return the byte offset of the char boundary immediately before
+/// `byte_idx` (i.e. the start of the previous character). Returns `0`
+/// if `byte_idx == 0`.
+///
+/// Intended for "move cursor left one char" style operations, where the
+/// caller then slices or indexes at the returned offset.
+pub fn prev_char_boundary(s: &str, byte_idx: usize) -> usize {
+    if byte_idx == 0 {
+        return 0;
+    }
+    let mut i = byte_idx - 1;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Return the byte offset of the char boundary immediately after
+/// `byte_idx` (i.e. the start of the next character), clamped to
+/// `s.len()`.
+///
+/// Intended for "move cursor right one char" style operations.
+pub fn next_char_boundary(s: &str, byte_idx: usize) -> usize {
+    let byte_idx = byte_idx.min(s.len());
+    if byte_idx >= s.len() {
+        return s.len();
+    }
+    let mut i = byte_idx + 1;
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
+}
+
+/// Return `&s[..byte_idx]`, with `byte_idx` snapped to the nearest char
+/// boundary at or before it — a panic-free replacement for `&s[..byte_idx]`
+/// when `byte_idx` isn't known to be char-boundary-aligned (e.g. a
+/// host-supplied cursor position).
+pub fn safe_prefix(s: &str, byte_idx: usize) -> &str {
+    &s[..snap_to_char_boundary(s, byte_idx)]
+}
+
+/// Return `&s[lo..hi]`, with both bounds snapped to char boundaries and
+/// swapped if `lo > hi` — a panic-free replacement for `&s[lo..hi]` when
+/// the bounds aren't known to be char-boundary-aligned or correctly
+/// ordered.
+pub fn safe_slice(s: &str, lo: usize, hi: usize) -> &str {
+    let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+    let lo = snap_to_char_boundary(s, lo);
+    let hi = snap_to_char_boundary(s, hi);
+    &s[lo..hi]
+}
 
 /// Case-sensitive subsequence fuzzy match with a relevance score and
 /// per-match byte positions.
@@ -166,6 +250,126 @@ pub fn word_wrap(text: &str, col_budget: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── snap_to_char_boundary / prev_char_boundary / next_char_boundary ──
+
+    #[test]
+    fn snap_to_char_boundary_already_on_boundary_is_noop() {
+        let s = "héllo";
+        assert_eq!(snap_to_char_boundary(s, 0), 0);
+        assert_eq!(snap_to_char_boundary(s, 1), 1);
+        // 'é' is 2 bytes starting at byte 1, boundary after it is byte 3.
+        assert_eq!(snap_to_char_boundary(s, 3), 3);
+    }
+
+    #[test]
+    fn snap_to_char_boundary_mid_char_walks_back() {
+        let s = "héllo";
+        // byte 2 is inside 'é' (bytes 1..3) — must walk back to 1.
+        assert_eq!(snap_to_char_boundary(s, 2), 1);
+    }
+
+    #[test]
+    fn snap_to_char_boundary_clamps_past_end() {
+        let s = "abc";
+        assert_eq!(snap_to_char_boundary(s, 100), 3);
+    }
+
+    #[test]
+    fn snap_to_char_boundary_cjk_and_emoji() {
+        let s = "中文🎉end";
+        // Every offset, however it lands mid-char, should snap to a valid
+        // boundary and never panic when used to slice.
+        for i in 0..=s.len() {
+            let snapped = snap_to_char_boundary(s, i);
+            assert!(s.is_char_boundary(snapped));
+            let _ = &s[..snapped]; // must not panic
+        }
+    }
+
+    #[test]
+    fn prev_char_boundary_at_zero_stays_zero() {
+        assert_eq!(prev_char_boundary("abc", 0), 0);
+    }
+
+    #[test]
+    fn prev_char_boundary_steps_back_one_multibyte_char() {
+        let s = "héllo";
+        // Cursor right after 'é' (byte 3) should move to right before it (byte 1).
+        assert_eq!(prev_char_boundary(s, 3), 1);
+    }
+
+    #[test]
+    fn prev_char_boundary_from_mid_char_lands_before_that_char() {
+        let s = "héllo";
+        // byte 2 is mid-'é'; prev boundary is the start of 'é' at byte 1.
+        assert_eq!(prev_char_boundary(s, 2), 1);
+    }
+
+    #[test]
+    fn next_char_boundary_at_end_stays_at_end() {
+        let s = "abc";
+        assert_eq!(next_char_boundary(s, 3), 3);
+        assert_eq!(next_char_boundary(s, 100), 3);
+    }
+
+    #[test]
+    fn next_char_boundary_steps_forward_one_multibyte_char() {
+        let s = "héllo";
+        // Cursor right before 'é' (byte 1) should move past it to byte 3.
+        assert_eq!(next_char_boundary(s, 1), 3);
+    }
+
+    #[test]
+    fn next_char_boundary_from_mid_char_lands_after_that_char() {
+        let s = "héllo";
+        assert_eq!(next_char_boundary(s, 2), 3);
+    }
+
+    // ── safe_prefix / safe_slice ───────────────────────────────────────
+
+    #[test]
+    fn safe_prefix_on_boundary_matches_manual_slice() {
+        let s = "héllo";
+        assert_eq!(safe_prefix(s, 3), &s[..3]);
+    }
+
+    #[test]
+    fn safe_prefix_mid_char_does_not_panic() {
+        let s = "héllo";
+        assert_eq!(safe_prefix(s, 2), "h");
+    }
+
+    #[test]
+    fn safe_prefix_past_end_returns_whole_string() {
+        let s = "héllo";
+        assert_eq!(safe_prefix(s, 999), s);
+    }
+
+    #[test]
+    fn safe_slice_mid_char_bounds_do_not_panic() {
+        let s = "中文🎉end";
+        // Arbitrary byte offsets landing inside multibyte chars must still
+        // produce a valid (possibly empty) slice, never panic.
+        for lo in 0..=s.len() {
+            for hi in 0..=s.len() {
+                let slice = safe_slice(s, lo, hi);
+                let _ = slice; // must not panic; content already validated by &str type
+            }
+        }
+    }
+
+    #[test]
+    fn safe_slice_swaps_reversed_bounds() {
+        let s = "abcdef";
+        assert_eq!(safe_slice(s, 4, 1), &s[1..4]);
+    }
+
+    #[test]
+    fn safe_slice_on_boundaries_matches_manual_slice() {
+        let s = "héllo world";
+        assert_eq!(safe_slice(s, 0, 3), &s[0..3]);
+    }
 
     // ── fuzzy_score ─────────────────────────────────────────────────────
 

--- a/quadraui/src/tui/command_line.rs
+++ b/quadraui/src/tui/command_line.rs
@@ -5,6 +5,7 @@ use ratatui::layout::Rect;
 
 use super::{ratatui_color, set_cell};
 use crate::primitives::command_line::CommandLine;
+use crate::text_util::safe_prefix;
 use crate::theme::Theme;
 
 pub fn draw_command_line(buf: &mut Buffer, area: Rect, cmd: &CommandLine, theme: &Theme) {
@@ -40,7 +41,7 @@ pub fn draw_command_line(buf: &mut Buffer, area: Rect, cmd: &CommandLine, theme:
     }
 
     if let Some(offset) = cmd.cursor_offset {
-        let cursor_col = cmd.text[..offset.min(cmd.text.len())].chars().count() as u16;
+        let cursor_col = safe_prefix(&cmd.text, offset).chars().count() as u16;
         let cx = area.x + cursor_col.min(area.width.saturating_sub(1));
         if cx < area.x + area.width {
             let cell = &mut buf[(cx, area.y)];
@@ -48,5 +49,34 @@ pub fn draw_command_line(buf: &mut Buffer, area: Rect, cmd: &CommandLine, theme:
             let old_bg = cell.bg;
             cell.set_fg(old_bg).set_bg(old_fg);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::WidgetId;
+
+    /// Regression for issue #503: `cursor_offset` is a host-supplied
+    /// byte offset with no guarantee it lands on a char boundary — the
+    /// pre-fix `cmd.text[..offset.min(cmd.text.len())]` slice panicked
+    /// the moment a multibyte character sat left of the cursor.
+    #[test]
+    fn draw_command_line_with_multibyte_cursor_does_not_panic() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
+        let theme = Theme::default();
+
+        // ":éditer" — byte 2 sits inside the 2-byte 'é' (starts at byte 1).
+        let text = ":éditer";
+        assert!(!text.is_char_boundary(2));
+        let cmd = CommandLine {
+            id: WidgetId::new("cmdline"),
+            text: text.into(),
+            cursor_offset: Some(2),
+            right_align: false,
+        };
+
+        // Must not panic.
+        draw_command_line(&mut buf, Rect::new(0, 0, 20, 1), &cmd, &theme);
     }
 }

--- a/quadraui/src/tui/editor.rs
+++ b/quadraui/src/tui/editor.rs
@@ -41,6 +41,7 @@ use crate::primitives::editor::{
     SelectionKind,
 };
 use crate::primitives::scrollbar::Scrollbar;
+use crate::text_util::snap_to_char_boundary;
 use crate::theme::Theme;
 use crate::types::Color;
 use ratatui::buffer::Buffer;
@@ -513,16 +514,12 @@ pub fn draw_editor(
 // ─── Private helpers ────────────────────────────────────────────────────
 
 /// Convert a UTF-8 byte offset into a character index. Returns the
-/// total char count if the offset is past the end. Walks back from
-/// `clamped` to find a char boundary so non-boundary inputs don't
-/// panic. Mirrors `vimcode::tui_main::byte_to_char_idx`.
+/// total char count if the offset is past the end. Snaps to the
+/// nearest char boundary at or before `byte_offset` (via
+/// [`snap_to_char_boundary`]) so non-boundary inputs don't panic.
+/// Mirrors `vimcode::tui_main::byte_to_char_idx`.
 fn byte_to_char_idx(text: &str, byte_offset: usize) -> usize {
-    let clamped = byte_offset.min(text.len());
-    let mut safe = clamped;
-    while safe > 0 && !text.is_char_boundary(safe) {
-        safe -= 1;
-    }
-    text[..safe].chars().count()
+    text[..snap_to_char_boundary(text, byte_offset)].chars().count()
 }
 
 /// Convert a character-index column into a visual column, expanding

--- a/quadraui/src/tui/editor.rs
+++ b/quadraui/src/tui/editor.rs
@@ -519,7 +519,9 @@ pub fn draw_editor(
 /// [`snap_to_char_boundary`]) so non-boundary inputs don't panic.
 /// Mirrors `vimcode::tui_main::byte_to_char_idx`.
 fn byte_to_char_idx(text: &str, byte_offset: usize) -> usize {
-    text[..snap_to_char_boundary(text, byte_offset)].chars().count()
+    text[..snap_to_char_boundary(text, byte_offset)]
+        .chars()
+        .count()
 }
 
 /// Convert a character-index column into a visual column, expanding

--- a/quadraui/src/types.rs
+++ b/quadraui/src/types.rs
@@ -33,6 +33,15 @@ impl Color {
     /// Parse `"#rrggbb"` or `"#rrggbbaa"`. Returns `None` on malformed input.
     pub fn from_hex(s: &str) -> Option<Self> {
         let s = s.strip_prefix('#')?;
+        // Every byte must be an ASCII hex digit before we index into `s` by
+        // byte offset below — this also guarantees `s` is all-ASCII, so
+        // `s.len()` (bytes) matches char count and every `&s[i..j]` slice
+        // below lands on a char boundary. A non-ASCII (or otherwise
+        // non-hex) input like "#\u{20ac}abc" is rejected here instead of
+        // panicking on the slice.
+        if !s.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
         let (r, g, b, a) = match s.len() {
             6 => (
                 u8::from_str_radix(&s[0..2], 16).ok()?,
@@ -298,5 +307,49 @@ impl Default for TreeStyle {
             chevron_expanded: "▾".into(),
             chevron_collapsed: "▸".into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_hex_parses_rgb() {
+        assert_eq!(Color::from_hex("#ff0080"), Some(Color::rgb(0xff, 0x00, 0x80)));
+    }
+
+    #[test]
+    fn from_hex_parses_rgba() {
+        assert_eq!(
+            Color::from_hex("#ff008040"),
+            Some(Color::rgba(0xff, 0x00, 0x80, 0x40))
+        );
+    }
+
+    #[test]
+    fn from_hex_rejects_missing_prefix() {
+        assert_eq!(Color::from_hex("ff0080"), None);
+    }
+
+    #[test]
+    fn from_hex_rejects_wrong_length() {
+        assert_eq!(Color::from_hex("#ff008"), None);
+    }
+
+    #[test]
+    fn from_hex_rejects_non_hex_ascii() {
+        assert_eq!(Color::from_hex("#zzzzzz"), None);
+    }
+
+    /// Regression for issue #503: a multibyte char inside the hex digits
+    /// used to make `s.len()` (byte length) satisfy the `6`/`8` length
+    /// check while `&s[0..2]` etc. sliced mid-character, panicking
+    /// instead of returning `None` as the doc comment promises.
+    #[test]
+    fn from_hex_multibyte_char_returns_none_instead_of_panicking() {
+        // "\u{20ac}abc" ('€' + "abc") is 3 + 3 = 6 bytes, matching the RGB
+        // length branch by byte count alone.
+        assert_eq!(Color::from_hex("#\u{20ac}abc"), None);
     }
 }

--- a/quadraui/src/types.rs
+++ b/quadraui/src/types.rs
@@ -316,7 +316,10 @@ mod tests {
 
     #[test]
     fn from_hex_parses_rgb() {
-        assert_eq!(Color::from_hex("#ff0080"), Some(Color::rgb(0xff, 0x00, 0x80)));
+        assert_eq!(
+            Color::from_hex("#ff0080"),
+            Some(Color::rgb(0xff, 0x00, 0x80))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #503

Automated PR opened by coordinator for review of issue #503.