### PR TITLE
#584: ChartKind::Bar renders only series[0] and silently drops the rest — no stacked or grouped multi-series bars

### DIFF
--- a/quadraui/examples/common/chart_app.rs
+++ b/quadraui/examples/common/chart_app.rs
@@ -117,7 +117,7 @@ impl ChartApp {
                 },
                 Series {
                     label: "Failed".into(),
-                    data: vec![10.0, 8.0, 35.0, 20.0, 5.0],
+                    data: vec![10.0, 0.0, 35.0, 20.0, 5.0],
                     color: Some(Color::rgb(255, 100, 100)),
                     fill: false,
                 },
@@ -126,12 +126,14 @@ impl ChartApp {
             y_label: None,
             // Auto-derived: the ceiling is the largest column total in
             // stacked mode and the largest single value when grouped.
-            // Deliberately no zero anywhere in this dataset — stacked
-            // composition is proportionally correct by default
-            // regardless (`Chart::effective_y_range` anchors a
-            // multi-series stack's floor at 0.0, not at the smallest
-            // raw value), so this no longer needs a lucky zero to look
-            // right (#584 review).
+            // The `Failed` series' zero at index 1 is here to exercise
+            // the "zero series doesn't shift/clip the rest" case (see
+            // `tests/tui_example_driver.rs`'s stacked-bar test) — it is
+            // no longer *required* for correct proportions the way it
+            // was pre-fix: `Chart::effective_y_range` now anchors a
+            // multi-series stack's floor at 0.0 regardless of whether
+            // any raw value in the chart happens to be exactly 0.0
+            // (#584 review).
             y_range: None,
             x_range: None,
             show_legend: true,

--- a/quadraui/examples/common/chart_app.rs
+++ b/quadraui/examples/common/chart_app.rs
@@ -117,7 +117,7 @@ impl ChartApp {
                 },
                 Series {
                     label: "Failed".into(),
-                    data: vec![10.0, 0.0, 35.0, 20.0, 5.0],
+                    data: vec![10.0, 8.0, 35.0, 20.0, 5.0],
                     color: Some(Color::rgb(255, 100, 100)),
                     fill: false,
                 },
@@ -126,8 +126,12 @@ impl ChartApp {
             y_label: None,
             // Auto-derived: the ceiling is the largest column total in
             // stacked mode and the largest single value when grouped.
-            // The `Failed` series' zero at index 1 keeps the floor at
-            // 0.0, so stacked segments are exactly proportional.
+            // Deliberately no zero anywhere in this dataset — stacked
+            // composition is proportionally correct by default
+            // regardless (`Chart::effective_y_range` anchors a
+            // multi-series stack's floor at 0.0, not at the smallest
+            // raw value), so this no longer needs a lucky zero to look
+            // right (#584 review).
             y_range: None,
             x_range: None,
             show_legend: true,

--- a/quadraui/examples/common/chart_app.rs
+++ b/quadraui/examples/common/chart_app.rs
@@ -1,12 +1,15 @@
 //! Backend-agnostic app code for the chart example
 //! ([`tui_chart`] / [`gtk_chart`]).
 //!
-//! Demonstrates all three chart kinds: sparkline, line, and bar.
+//! Demonstrates all four chart kinds: sparkline, line, stacked bar and
+//! grouped bar. The two bar views share one three-series dataset, so
+//! switching between them shows the same data composed (stacked) vs.
+//! compared (grouped) — see quadraui#584.
 //!
 //! Controls:
-//! - space       add a data point to the sparkline
-//! - 1 / 2 / 3  switch view to sparkline / line / bar
-//! - q / Esc     quit
+//! - space           add a data point to the sparkline
+//! - 1 / 2 / 3 / 4   switch view to sparkline / line / stacked bar / grouped bar
+//! - q / Esc         quit
 
 use quadraui::{
     AppLogic, Backend, Chart, ChartKind, Color, Key, NamedKey, Reaction, Rect, Series, StatusBar,
@@ -92,21 +95,42 @@ impl ChartApp {
         }
     }
 
-    fn bar_chart(&self) -> Chart {
+    /// Three-series bar chart. `kind` picks stacked ([`ChartKind::Bar`])
+    /// or side-by-side ([`ChartKind::BarGrouped`]) composition of the
+    /// same data.
+    fn bar_chart(&self, kind: ChartKind) -> Chart {
         Chart {
             id: WidgetId::new("bar"),
-            kind: ChartKind::Bar,
-            series: vec![Series {
-                label: "Requests".into(),
-                data: vec![120.0, 230.0, 180.0, 310.0, 95.0],
-                color: Some(Color::rgb(80, 220, 120)),
-                fill: false,
-            }],
+            kind,
+            series: vec![
+                Series {
+                    label: "OK".into(),
+                    data: vec![120.0, 230.0, 180.0, 310.0, 95.0],
+                    color: Some(Color::rgb(80, 220, 120)),
+                    fill: false,
+                },
+                Series {
+                    label: "Slow".into(),
+                    data: vec![40.0, 60.0, 25.0, 70.0, 15.0],
+                    color: Some(Color::rgb(220, 180, 60)),
+                    fill: false,
+                },
+                Series {
+                    label: "Failed".into(),
+                    data: vec![10.0, 0.0, 35.0, 20.0, 5.0],
+                    color: Some(Color::rgb(255, 100, 100)),
+                    fill: false,
+                },
+            ],
             x_label: Some("Endpoint".into()),
             y_label: None,
+            // Auto-derived: the ceiling is the largest column total in
+            // stacked mode and the largest single value when grouped.
+            // The `Failed` series' zero at index 1 keeps the floor at
+            // 0.0, so stacked segments are exactly proportional.
             y_range: None,
             x_range: None,
-            show_legend: false,
+            show_legend: true,
             y_ticks: None,
             x_ticks: None,
             show_grid: false,
@@ -114,10 +138,14 @@ impl ChartApp {
     }
 
     fn status_bar(&self) -> StatusBar {
+        // `ChartKind` is `#[non_exhaustive]`, so a consumer match needs
+        // a wildcard arm — future kinds stay additive (quadraui#584).
         let kind_label = match self.active_kind {
             ChartKind::Sparkline => "Sparkline",
             ChartKind::Line => "Line",
-            ChartKind::Bar => "Bar",
+            ChartKind::Bar => "Bar (stacked)",
+            ChartKind::BarGrouped => "Bar (grouped)",
+            _ => "Chart",
         };
         StatusBar {
             id: WidgetId::new("status"),
@@ -129,7 +157,7 @@ impl ChartApp {
                 action_id: None,
             }],
             right_segments: vec![StatusBarSegment {
-                text: " 1/2/3=kind space=add q=quit ".into(),
+                text: " 1/2/3/4=kind space=add q=quit ".into(),
                 fg: Color::rgb(220, 220, 220),
                 bg: Color::rgb(40, 80, 120),
                 bold: false,
@@ -169,9 +197,10 @@ impl AppLogic for ChartApp {
             ChartKind::Line => {
                 let _ = backend.draw_chart(chart_rect, &self.line_chart(), hp, cx);
             }
-            ChartKind::Bar => {
-                let _ = backend.draw_chart(chart_rect, &self.bar_chart(), hp, cx);
+            kind @ (ChartKind::Bar | ChartKind::BarGrouped) => {
+                let _ = backend.draw_chart(chart_rect, &self.bar_chart(kind), hp, cx);
             }
+            _ => {}
         }
 
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
@@ -221,6 +250,13 @@ impl AppLogic for ChartApp {
                 self.active_kind = ChartKind::Bar;
                 Reaction::Redraw
             }
+            UiEvent::KeyPressed {
+                key: Key::Char('4'),
+                ..
+            } => {
+                self.active_kind = ChartKind::BarGrouped;
+                Reaction::Redraw
+            }
             UiEvent::MouseMoved { position, .. } => {
                 let viewport = backend.viewport();
                 let lh = backend.line_height();
@@ -231,7 +267,7 @@ impl AppLogic for ChartApp {
                 let chart = match self.active_kind {
                     ChartKind::Sparkline => self.sparkline(),
                     ChartKind::Line => self.line_chart(),
-                    ChartKind::Bar => self.bar_chart(),
+                    kind => self.bar_chart(kind),
                 };
                 let layout = backend.chart_layout(chart_rect, &chart);
                 let snap = backend.line_height() * 2.0;

--- a/quadraui/src/gtk/chart.rs
+++ b/quadraui/src/gtk/chart.rs
@@ -1,8 +1,11 @@
 //! GTK rasteriser for [`crate::Chart`].
 //!
 //! Sparklines render as Cairo polylines. Line charts use Cairo paths
-//! with optional area fill. Bar charts use Cairo rectangles. Axis
-//! labels and legends use Pango.
+//! with optional area fill. Bar charts use Cairo rectangles — one per
+//! series segment, stacked ([`ChartKind::Bar`]) or side by side
+//! ([`ChartKind::BarGrouped`]) from the shared
+//! [`Chart::bar_column_spans`] geometry (#584). Axis labels and legends
+//! use Pango.
 
 use gtk4::cairo::Context;
 use gtk4::pango;
@@ -64,7 +67,9 @@ pub fn draw_chart(
     match chart.kind {
         ChartKind::Sparkline => paint_sparkline(cr, &layout, chart, theme),
         ChartKind::Line => paint_line(cr, pango_layout, &layout, chart, theme),
-        ChartKind::Bar => paint_bar(cr, pango_layout, &layout, chart, theme),
+        ChartKind::Bar | ChartKind::BarGrouped => {
+            paint_bar(cr, pango_layout, &layout, chart, theme)
+        }
     }
 
     if let Some(data_x) = crosshair_x {
@@ -266,38 +271,41 @@ fn paint_bar(
         return;
     }
 
-    if let Some(s) = chart.series.first() {
-        if s.data.is_empty() {
-            return;
-        }
-        let (y_min, y_max) = chart.effective_y_range();
-        let range = y_max - y_min;
-        let n = s.data.len();
-        let bar_w = pw / n as f64;
-        let gap = (bar_w * 0.15).max(1.0);
-        let effective_bar_w = (bar_w - gap).max(1.0);
-        let color = series_color(chart, 0);
+    let n = chart.max_data_len();
+    if n > 0 {
+        let slot_w = pw / n as f64;
+        let gap = (slot_w * 0.15).max(1.0);
+        let bar_w = (slot_w - gap).max(1.0);
+        let stacked = chart.kind.is_stacked_bar();
+        let series_count = chart.series.len().max(1) as f64;
+        let baseline = py + ph;
 
-        for (i, &val) in s.data.iter().enumerate() {
-            let norm = if range > 0.0 {
-                ((val - y_min) / range).clamp(0.0, 1.0)
-            } else {
-                0.5
-            };
-            let bar_h = norm * ph;
-            let bx = px + i as f64 * bar_w + gap / 2.0;
-            let by = py + ph - bar_h;
-
-            set_source(cr, color);
-            cr.rectangle(bx, by, effective_bar_w, bar_h);
-            cr.fill().ok();
+        for i in 0..n {
+            let slot_x = px + i as f64 * slot_w + gap / 2.0;
+            for (si, bottom, top) in chart.bar_column_spans(i) {
+                // Stacked segments span the slot; grouped series split it.
+                let (bx, seg_w) = if stacked {
+                    (slot_x, bar_w)
+                } else {
+                    let sub_w = (bar_w / series_count).max(1.0);
+                    (slot_x + si as f64 * sub_w, sub_w)
+                };
+                let seg_h = (top - bottom) * ph;
+                if seg_h <= 0.0 {
+                    continue;
+                }
+                let by = baseline - top * ph;
+                set_source(cr, series_color(chart, si));
+                cr.rectangle(bx, by, seg_w, seg_h);
+                cr.fill().ok();
+            }
         }
 
         // Bottom axis.
         set_source(cr, theme.muted_fg);
         cr.set_line_width(1.0);
-        cr.move_to(px, py + ph);
-        cr.line_to(px + pw, py + ph);
+        cr.move_to(px, baseline);
+        cr.line_to(px + pw, baseline);
         cr.stroke().ok();
     }
 

--- a/quadraui/src/gtk/chart.rs
+++ b/quadraui/src/gtk/chart.rs
@@ -4,7 +4,7 @@
 //! with optional area fill. Bar charts use Cairo rectangles — one per
 //! series segment, stacked ([`ChartKind::Bar`]) or side by side
 //! ([`ChartKind::BarGrouped`]) from the shared
-//! [`Chart::bar_column_spans`] geometry (#584). Axis labels and legends
+//! [`Chart::bar_column_spans_all`] geometry (#584). Axis labels and legends
 //! use Pango.
 
 use gtk4::cairo::Context;
@@ -280,9 +280,9 @@ fn paint_bar(
         let series_count = chart.series.len().max(1) as f64;
         let baseline = py + ph;
 
-        for i in 0..n {
+        for (i, column) in chart.bar_column_spans_all().into_iter().enumerate() {
             let slot_x = px + i as f64 * slot_w + gap / 2.0;
-            for (si, bottom, top) in chart.bar_column_spans(i) {
+            for (si, bottom, top) in column {
                 // Stacked segments span the slot; grouped series split it.
                 let (bx, seg_w) = if stacked {
                     (slot_x, bar_w)

--- a/quadraui/src/gtk/chart.rs
+++ b/quadraui/src/gtk/chart.rs
@@ -480,3 +480,185 @@ fn paint_hover_marker_gtk(
         }
     }
 }
+
+// Headless paint tests for the stacked/grouped bar geometry (#584 review —
+// GTK had no chart coverage at all). Uses a Cairo `ImageSurface` and reads
+// back pixel data directly, mirroring the pattern in `gtk::terminal`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::chart::Series;
+    use crate::types::WidgetId;
+    use pangocairo::cairo::{Format, ImageSurface};
+
+    const W: i32 = 30;
+    const H: i32 = 30;
+
+    /// Read an RGB triple from an ARgb32 surface at pixel (x, y).
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    fn series(label: &str, data: Vec<f64>) -> Series {
+        Series {
+            label: label.into(),
+            data,
+            color: None,
+            fill: false,
+        }
+    }
+
+    fn bar_chart(kind: ChartKind, series: Vec<Series>, y_range: (f64, f64)) -> Chart {
+        Chart {
+            id: WidgetId::new("chart"),
+            kind,
+            series,
+            x_label: None,
+            y_label: None,
+            y_range: Some(y_range),
+            x_range: None,
+            show_legend: false,
+            y_ticks: Some(0),
+            x_ticks: Some(0),
+            show_grid: false,
+        }
+    }
+
+    fn paint(chart: &Chart) -> ImageSurface {
+        let surface = ImageSurface::create(Format::ARgb32, W, H).expect("create ImageSurface");
+        {
+            let cr = Context::new(&surface).expect("Context::new");
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            let theme = Theme::default();
+            draw_chart(
+                &cr,
+                &pango_layout,
+                0.0,
+                0.0,
+                W as f64,
+                H as f64,
+                chart,
+                &theme,
+                12.0,
+                8.0,
+                None,
+                None,
+            );
+        }
+        surface
+    }
+
+    #[test]
+    fn stacked_bar_paints_each_series_in_its_own_color() {
+        // Three equal-value series stacked in a single column, with an
+        // explicit y_range so the geometry is exact: (0, 1/3), (1/3, 2/3),
+        // (2/3, 1) bottom to top.
+        let chart = bar_chart(
+            ChartKind::Bar,
+            vec![
+                series("a", vec![1.0]),
+                series("b", vec![1.0]),
+                series("c", vec![1.0]),
+            ],
+            (0.0, 3.0),
+        );
+        let mut s = paint(&chart);
+        s.flush();
+        let stride = s.stride() as usize;
+        let data = s.data().expect("surface data");
+
+        // slot_w = 30, gap = 4.5, bar_w = 25.5, slot_x = 2.25 → mid-x ≈ 15.
+        let mid_x = 15;
+        let bottom_y = 25; // mid of series 0's span (screen bottom third)
+        let mid_y = 15; // mid of series 1's span
+        let top_y = 5; // mid of series 2's span (screen top third)
+
+        assert_eq!(
+            pixel(&data, stride, mid_x, bottom_y),
+            (SERIES_COLORS[0].r, SERIES_COLORS[0].g, SERIES_COLORS[0].b),
+            "bottom segment should be series 0's colour"
+        );
+        assert_eq!(
+            pixel(&data, stride, mid_x, mid_y),
+            (SERIES_COLORS[1].r, SERIES_COLORS[1].g, SERIES_COLORS[1].b),
+            "middle segment should be series 1's colour"
+        );
+        assert_eq!(
+            pixel(&data, stride, mid_x, top_y),
+            (SERIES_COLORS[2].r, SERIES_COLORS[2].g, SERIES_COLORS[2].b),
+            "top segment should be series 2's colour"
+        );
+    }
+
+    #[test]
+    fn stacked_bar_all_zero_series_does_not_shift_the_others() {
+        // series[1] and series[3] are all-zero; series[0] and series[2]
+        // must still occupy exactly half the stack each, with no gap or
+        // shift introduced by the zero-height segments between them.
+        let chart = bar_chart(
+            ChartKind::Bar,
+            vec![
+                series("a", vec![1.0]),
+                series("zero1", vec![0.0]),
+                series("b", vec![1.0]),
+                series("zero2", vec![0.0]),
+            ],
+            (0.0, 2.0),
+        );
+        let mut s = paint(&chart);
+        s.flush();
+        let stride = s.stride() as usize;
+        let data = s.data().expect("surface data");
+
+        let mid_x = 15;
+        // Bottom half (series 0) mid ≈ y 22-23; top half (series 2) mid ≈ y 7-8.
+        assert_eq!(
+            pixel(&data, stride, mid_x, 22),
+            (SERIES_COLORS[0].r, SERIES_COLORS[0].g, SERIES_COLORS[0].b),
+            "bottom half should stay series 0's colour, unshifted by the zero series"
+        );
+        assert_eq!(
+            pixel(&data, stride, mid_x, 8),
+            (SERIES_COLORS[2].r, SERIES_COLORS[2].g, SERIES_COLORS[2].b),
+            "top half should be series 2's colour, immediately above series 0"
+        );
+    }
+
+    #[test]
+    fn grouped_bar_paints_series_side_by_side() {
+        let chart = bar_chart(
+            ChartKind::BarGrouped,
+            vec![
+                series("a", vec![1.0]),
+                series("b", vec![2.0]),
+                series("c", vec![3.0]),
+            ],
+            (0.0, 3.0),
+        );
+        let mut s = paint(&chart);
+        s.flush();
+        let stride = s.stride() as usize;
+        let data = s.data().expect("surface data");
+
+        // All three sub-bars reach down to a shared row near the baseline
+        // (every grouped span starts at the floor), so one horizontal
+        // probe row distinguishes them purely by x position.
+        let probe_y = 27;
+        assert_eq!(
+            pixel(&data, stride, 6, probe_y),
+            (SERIES_COLORS[0].r, SERIES_COLORS[0].g, SERIES_COLORS[0].b),
+            "leftmost sub-bar should be series 0"
+        );
+        assert_eq!(
+            pixel(&data, stride, 15, probe_y),
+            (SERIES_COLORS[1].r, SERIES_COLORS[1].g, SERIES_COLORS[1].b),
+            "middle sub-bar should be series 1"
+        );
+        assert_eq!(
+            pixel(&data, stride, 23, probe_y),
+            (SERIES_COLORS[2].r, SERIES_COLORS[2].g, SERIES_COLORS[2].b),
+            "rightmost sub-bar should be series 2"
+        );
+    }
+}

--- a/quadraui/src/macos/chart.rs
+++ b/quadraui/src/macos/chart.rs
@@ -5,7 +5,9 @@
 //! - **Sparkline** — single-series polyline (1.5pt) inside the plot area.
 //! - **Line** — multi-series polyline with optional area fill at 20%
 //!   alpha.
-//! - **Bar** — vertical rectangles per data point.
+//! - **Bar** — vertical rectangles per series segment, stacked
+//!   ([`ChartKind::Bar`]) or side by side ([`ChartKind::BarGrouped`])
+//!   from the shared [`Chart::bar_column_spans`] geometry (#584).
 //!
 //! Hover marker and crosshair overlays are honoured. Axis labels,
 //! ticks, grid, and legend chrome use Core Text.
@@ -85,7 +87,7 @@ pub unsafe fn draw_chart(
     match chart.kind {
         ChartKind::Sparkline => paint_sparkline(ctx, &layout, chart, theme),
         ChartKind::Line => paint_line(ctx, font, &layout, chart, theme),
-        ChartKind::Bar => paint_bar(ctx, font, &layout, chart, theme),
+        ChartKind::Bar | ChartKind::BarGrouped => paint_bar(ctx, font, &layout, chart, theme),
     }
 
     if let Some(data_x) = crosshair_x {
@@ -236,37 +238,43 @@ unsafe fn paint_bar(
         theme.background,
     );
 
-    let Some(series) = chart.series.first() else {
-        return;
-    };
-    if series.data.is_empty() {
-        return;
-    }
-    let (y_min, y_max) = chart.effective_y_range();
-    let range = y_max - y_min;
-    let pw = pa.width as f64;
-    let ph = pa.height as f64;
-    let px = pa.x as f64;
-    let py = pa.y as f64;
-    let n = series.data.len() as f64;
-    // Slot-based positioning: each bar gets a full slot of width
-    // `pw / n`, with a 15% gap split between left/right edges.
-    let slot_w = pw / n;
-    let gap = (slot_w * 0.15).max(1.0);
-    let effective_bar_w = (slot_w - gap).max(1.0);
-    let baseline = py + ph;
-    let color = series_color(chart, 0);
-    for (i, &val) in series.data.iter().enumerate() {
-        let norm = if range > 0.0 {
-            ((val - y_min) / range).clamp(0.0, 1.0)
-        } else {
-            0.5
-        };
-        let bar_h = norm * ph;
-        let bx = px + i as f64 * slot_w + gap / 2.0;
-        let by = baseline - bar_h;
-        if bar_h > 0.0 {
-            fill_rect(ctx, bx, by, effective_bar_w, bar_h, color);
+    let n = chart.max_data_len();
+    if n > 0 {
+        let pw = pa.width as f64;
+        let ph = pa.height as f64;
+        let px = pa.x as f64;
+        let py = pa.y as f64;
+        // Slot-based positioning: each x-position gets a full slot of
+        // width `pw / n`, with a 15% gap split between left/right edges.
+        // Multi-series charts stack inside that slot (`ChartKind::Bar`)
+        // or split it side by side (`ChartKind::BarGrouped`) — #584.
+        let slot_w = pw / n as f64;
+        let gap = (slot_w * 0.15).max(1.0);
+        let effective_bar_w = (slot_w - gap).max(1.0);
+        let stacked = chart.kind.is_stacked_bar();
+        let series_count = chart.series.len().max(1) as f64;
+        let baseline = py + ph;
+        for i in 0..n {
+            let slot_x = px + i as f64 * slot_w + gap / 2.0;
+            for (si, bottom, top) in chart.bar_column_spans(i) {
+                let (bx, seg_w) = if stacked {
+                    (slot_x, effective_bar_w)
+                } else {
+                    let sub_w = (effective_bar_w / series_count).max(1.0);
+                    (slot_x + si as f64 * sub_w, sub_w)
+                };
+                let seg_h = (top - bottom) * ph;
+                if seg_h > 0.0 {
+                    fill_rect(
+                        ctx,
+                        bx,
+                        baseline - top * ph,
+                        seg_w,
+                        seg_h,
+                        series_color(chart, si),
+                    );
+                }
+            }
         }
     }
 

--- a/quadraui/src/macos/chart.rs
+++ b/quadraui/src/macos/chart.rs
@@ -7,7 +7,7 @@
 //!   alpha.
 //! - **Bar** — vertical rectangles per series segment, stacked
 //!   ([`ChartKind::Bar`]) or side by side ([`ChartKind::BarGrouped`])
-//!   from the shared [`Chart::bar_column_spans`] geometry (#584).
+//!   from the shared [`Chart::bar_column_spans_all`] geometry (#584).
 //!
 //! Hover marker and crosshair overlays are honoured. Axis labels,
 //! ticks, grid, and legend chrome use Core Text.
@@ -254,9 +254,9 @@ unsafe fn paint_bar(
         let stacked = chart.kind.is_stacked_bar();
         let series_count = chart.series.len().max(1) as f64;
         let baseline = py + ph;
-        for i in 0..n {
+        for (i, column) in chart.bar_column_spans_all().into_iter().enumerate() {
             let slot_x = px + i as f64 * slot_w + gap / 2.0;
-            for (si, bottom, top) in chart.bar_column_spans(i) {
+            for (si, bottom, top) in column {
                 let (bx, seg_w) = if stacked {
                     (slot_x, effective_bar_w)
                 } else {

--- a/quadraui/src/macos/chart.rs
+++ b/quadraui/src/macos/chart.rs
@@ -614,4 +614,138 @@ mod tests {
         // Marker is the series colour, solid — blue should dominate.
         assert!(b > r);
     }
+
+    // ── Multi-series bars (#584 review — macOS had no bar coverage) ──────
+    //
+    // Mirrors `gtk::chart`'s headless bar tests, computed against this
+    // file's fixed W×H (200×120) surface and `paint_bar`'s own geometry
+    // (single column ⇒ `slot_w = pw`, `gap = slot_w * 0.15`).
+
+    fn bar_series(label: &str, data: Vec<f64>) -> Series {
+        Series {
+            label: label.into(),
+            data,
+            color: None,
+            fill: false,
+        }
+    }
+
+    fn sample_bar_chart(kind: ChartKind, series: Vec<Series>, y_range: (f64, f64)) -> Chart {
+        Chart {
+            id: WidgetId::new("ch"),
+            kind,
+            series,
+            x_label: None,
+            y_label: None,
+            y_range: Some(y_range),
+            x_range: None,
+            show_legend: false,
+            y_ticks: Some(0),
+            x_ticks: Some(0),
+            show_grid: false,
+        }
+    }
+
+    #[test]
+    fn stacked_bar_paints_each_series_in_its_own_color() {
+        // Three equal-value series stacked in a single column: spans are
+        // (0, 1/3), (1/3, 2/3), (2/3, 1) bottom to top.
+        let chart = sample_bar_chart(
+            ChartKind::Bar,
+            vec![
+                bar_series("a", vec![1.0]),
+                bar_series("b", vec![1.0]),
+                bar_series("c", vec![1.0]),
+            ],
+            (0.0, 3.0),
+        );
+        let (surface, _layout) = paint_via_backend(&chart, None);
+
+        // slot_w = pw = 200, gap = 30, bar_w = 170, slot_x = 15 → mid-x = 100.
+        let mid_x = 100;
+        let (r0, g0, b0, _) = surface.pixel(mid_x, 100); // bottom third → series 0
+        assert_eq!(
+            (r0, g0, b0),
+            (SERIES_COLORS[0].r, SERIES_COLORS[0].g, SERIES_COLORS[0].b)
+        );
+        let (r1, g1, b1, _) = surface.pixel(mid_x, 60); // middle third → series 1
+        assert_eq!(
+            (r1, g1, b1),
+            (SERIES_COLORS[1].r, SERIES_COLORS[1].g, SERIES_COLORS[1].b)
+        );
+        let (r2, g2, b2, _) = surface.pixel(mid_x, 20); // top third → series 2
+        assert_eq!(
+            (r2, g2, b2),
+            (SERIES_COLORS[2].r, SERIES_COLORS[2].g, SERIES_COLORS[2].b)
+        );
+    }
+
+    #[test]
+    fn stacked_bar_all_zero_series_does_not_shift_the_others() {
+        // series[1] and series[3] are all-zero; series[0] and series[2]
+        // must still occupy exactly half the stack each, adjacent with no
+        // gap introduced by the zero-height segments between them.
+        let chart = sample_bar_chart(
+            ChartKind::Bar,
+            vec![
+                bar_series("a", vec![1.0]),
+                bar_series("zero1", vec![0.0]),
+                bar_series("b", vec![1.0]),
+                bar_series("zero2", vec![0.0]),
+            ],
+            (0.0, 2.0),
+        );
+        let (surface, _layout) = paint_via_backend(&chart, None);
+
+        let mid_x = 100;
+        let (r0, g0, b0, _) = surface.pixel(mid_x, 90); // bottom half → series 0
+        assert_eq!(
+            (r0, g0, b0),
+            (SERIES_COLORS[0].r, SERIES_COLORS[0].g, SERIES_COLORS[0].b),
+            "bottom half should stay series 0's colour, unshifted by the zero series"
+        );
+        let (r2, g2, b2, _) = surface.pixel(mid_x, 30); // top half → series 2
+        assert_eq!(
+            (r2, g2, b2),
+            (SERIES_COLORS[2].r, SERIES_COLORS[2].g, SERIES_COLORS[2].b),
+            "top half should be series 2's colour, immediately above series 0"
+        );
+    }
+
+    #[test]
+    fn grouped_bar_paints_series_side_by_side() {
+        let chart = sample_bar_chart(
+            ChartKind::BarGrouped,
+            vec![
+                bar_series("a", vec![1.0]),
+                bar_series("b", vec![2.0]),
+                bar_series("c", vec![3.0]),
+            ],
+            (0.0, 3.0),
+        );
+        let (surface, _layout) = paint_via_backend(&chart, None);
+
+        // All three sub-bars reach down to a shared row near the baseline
+        // (every grouped span starts at the floor), so one horizontal
+        // probe row distinguishes them purely by x position.
+        let probe_y = 100;
+        let (r0, g0, b0, _) = surface.pixel(43, probe_y);
+        assert_eq!(
+            (r0, g0, b0),
+            (SERIES_COLORS[0].r, SERIES_COLORS[0].g, SERIES_COLORS[0].b),
+            "leftmost sub-bar should be series 0"
+        );
+        let (r1, g1, b1, _) = surface.pixel(100, probe_y);
+        assert_eq!(
+            (r1, g1, b1),
+            (SERIES_COLORS[1].r, SERIES_COLORS[1].g, SERIES_COLORS[1].b),
+            "middle sub-bar should be series 1"
+        );
+        let (r2, g2, b2, _) = surface.pixel(157, probe_y);
+        assert_eq!(
+            (r2, g2, b2),
+            (SERIES_COLORS[2].r, SERIES_COLORS[2].g, SERIES_COLORS[2].b),
+            "rightmost sub-bar should be series 2"
+        );
+    }
 }

--- a/quadraui/src/primitives/chart.rs
+++ b/quadraui/src/primitives/chart.rs
@@ -19,7 +19,8 @@
 //! and a stack never clips (#584).
 //!
 //! Every backend paints bars from the shared geometry helper
-//! [`Chart::bar_column_spans`], which itself derives from
+//! [`Chart::bar_column_spans_all`] (or [`Chart::bar_column_spans`] for
+//! a single column), which itself derives from
 //! [`Chart::effective_y_range`], so stacked and grouped layouts stay
 //! identical across TUI, GTK and macOS. [`Chart::column_totals`] is a
 //! separate, independently-useful helper (e.g. for labelling a stack's
@@ -84,7 +85,11 @@ pub enum ChartKind {
     /// An *explicit* `y_range` whose floor isn't `0.0` still skews every
     /// segment's proportion relative to the others, since the geometry
     /// has no way to know which value the caller intends as "empty";
-    /// pass `y_range: Some((0.0, …))` if you need one.
+    /// pass `y_range: Some((0.0, …))` if you need one. If the explicit
+    /// range excludes `0.0` altogether (e.g. `Some((-10.0, -2.0))`) the
+    /// stack's baseline lands on whichever plot edge is nearer zero and
+    /// segments are clipped to the range rather than vanishing, but the
+    /// proportions on screen are then the caller's to justify.
     Bar,
     /// Vertical bar chart whose series are drawn **side by side**
     /// within each x-position, for comparing magnitudes rather than
@@ -321,20 +326,58 @@ impl Chart {
     /// order. This is the one source of truth every backend's bar
     /// painter and [`Chart::layout`] share (#584).
     ///
-    /// - [`ChartKind::Bar`] — spans accumulate: each segment starts
-    ///   where the previous one ended, so an all-zero series occupies
-    ///   an empty span and does **not** shift the series above it.
-    /// - [`ChartKind::BarGrouped`] — every span starts at the floor;
-    ///   the caller lays the series out side by side horizontally.
+    /// - [`ChartKind::Bar`] with two or more series — spans accumulate:
+    ///   each segment covers the gap between the running total before
+    ///   and after that series, so an all-zero series occupies an empty
+    ///   span and does **not** shift the series above it. A negative
+    ///   value walks the stack back *down*, and its segment is returned
+    ///   bottom-first (`bottom <= top` always holds).
+    /// - [`ChartKind::Bar`] with a single series, and
+    ///   [`ChartKind::BarGrouped`] — every span starts at the plot
+    ///   floor. Grouped callers lay the series out side by side
+    ///   horizontally; a single-series stack has nothing to compose
+    ///   against, so it stays a plain bar chart (#584).
     ///
     /// Returns one entry per series (zero-height for missing data), so
     /// callers can index by series without re-checking lengths. Empty
     /// for non-bar kinds.
+    ///
+    /// This resolves [`Chart::effective_y_range`] on every call, which
+    /// for a stacked chart is itself an O(series × columns) scan. Paint
+    /// loops that walk every column should call
+    /// [`Chart::bar_column_spans_all`] instead, which resolves the range
+    /// once for the whole chart.
     pub fn bar_column_spans(&self, data_idx: usize) -> Vec<(usize, f64, f64)> {
         if !self.kind.is_bar() {
             return Vec::new();
         }
-        let (y_min, y_max) = self.effective_y_range();
+        self.bar_column_spans_in(data_idx, self.effective_y_range())
+    }
+
+    /// [`Chart::bar_column_spans`] for every column, outer index =
+    /// column, resolving the y-range once instead of once per column.
+    ///
+    /// Backends paint whole charts, so this is the form their paint
+    /// loops want: it turns the bar pass from O(columns² × series) into
+    /// O(columns × series). Empty for non-bar kinds.
+    pub fn bar_column_spans_all(&self) -> Vec<Vec<(usize, f64, f64)>> {
+        if !self.kind.is_bar() {
+            return Vec::new();
+        }
+        let y_range = self.effective_y_range();
+        (0..self.max_data_len())
+            .map(|di| self.bar_column_spans_in(di, y_range))
+            .collect()
+    }
+
+    /// Shared body of [`Chart::bar_column_spans`] and
+    /// [`Chart::bar_column_spans_all`], with the y-range already
+    /// resolved by the caller.
+    fn bar_column_spans_in(
+        &self,
+        data_idx: usize,
+        (y_min, y_max): (f64, f64),
+    ) -> Vec<(usize, f64, f64)> {
         let range = y_max - y_min;
         let norm = |v: f64| {
             if range > 0.0 {
@@ -345,20 +388,27 @@ impl Chart {
         };
 
         let mut spans = Vec::with_capacity(self.series.len());
-        if self.kind.is_stacked_bar() {
+        // Gated on `series.len() > 1` to match [`Chart::effective_y_range`]'s
+        // zero-anchoring exactly. A *single*-series `Bar` keeps the plain
+        // min/max-of-data range, so `norm(0.0)` there is not the plot floor —
+        // for all-negative data (`[-5, -3, -1]` → range `(-5, -1)`) it clamps
+        // to `1.0` and every bar would collapse to zero height. Single-series
+        // bars take the `else` branch and stay byte-identical to pre-#584.
+        if self.kind.is_stacked_bar() && self.series.len() > 1 {
+            // Each segment spans the gap between two consecutive cumulative
+            // levels, both mapped through `norm`. Deriving `bottom` from the
+            // *previous cumulative value* rather than carrying the previous
+            // `top` forward means a segment stays visible even when zero
+            // falls outside the range entirely (an explicit all-negative
+            // `y_range` used to collapse the whole stack to zero height), and
+            // `min`/`max` keeps `bottom <= top` when a negative value walks
+            // the stack back down.
             let mut cum = 0.0;
-            // `norm(0.0)` rather than a literal `0.0`: when the range
-            // floor isn't exactly `0.0` (e.g. an explicit non-zero
-            // `y_range`), the stack's true baseline is wherever zero
-            // maps to, not the bottom of the plot area.
-            let mut bottom = norm(0.0);
             for (si, s) in self.series.iter().enumerate() {
-                cum += s.data.get(data_idx).copied().unwrap_or(0.0);
-                // `max(bottom)` keeps spans monotonic if a negative
-                // value would otherwise invert the segment.
-                let top = norm(cum).max(bottom);
-                spans.push((si, bottom, top));
-                bottom = top;
+                let next = cum + s.data.get(data_idx).copied().unwrap_or(0.0);
+                let (a, b) = (norm(cum), norm(next));
+                spans.push((si, a.min(b), a.max(b)));
+                cum = next;
             }
         } else {
             for (si, s) in self.series.iter().enumerate() {
@@ -475,8 +525,8 @@ impl Chart {
                     let slot_w = if n == 0 { 0.0 } else { plot_w / n as f32 };
                     let series_count = self.series.len().max(1) as f32;
                     let stacked = self.kind.is_stacked_bar();
-                    for di in 0..n {
-                        for (si, bottom, top) in self.bar_column_spans(di) {
+                    for (di, column) in self.bar_column_spans_all().into_iter().enumerate() {
+                        for (si, bottom, top) in column {
                             let (sx, sy) = if stacked {
                                 let mid = (bottom + top) / 2.0;
                                 (
@@ -807,6 +857,71 @@ mod tests {
     }
 
     #[test]
+    fn single_series_bar_spans_rise_from_the_plot_floor_for_negative_data() {
+        // Regression for review round 2 on #584: `bar_column_spans`'
+        // stacked baseline used to be `norm(0.0)` for *any* `Bar` chart,
+        // but a single-series chart keeps the plain min/max auto-range,
+        // where 0.0 sits outside the data. Here the range is (-5, -1),
+        // so `norm(0.0)` clamped to 1.0 and every bar collapsed to zero
+        // height. Pre-#584 these rendered 0% / 50% / 100%.
+        let chart = bar_chart(ChartKind::Bar, vec![vec![-5.0, -3.0, -1.0]]);
+        assert_eq!(chart.effective_y_range(), (-5.0, -1.0));
+        for (di, expected_top) in [0.0, 0.5, 1.0].into_iter().enumerate() {
+            let spans = chart.bar_column_spans(di);
+            assert_eq!(spans.len(), 1);
+            assert!((spans[0].1 - 0.0).abs() < 1e-9, "col {di}: {spans:?}");
+            assert!(
+                (spans[0].2 - expected_top).abs() < 1e-9,
+                "col {di}: {spans:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn single_series_bar_spans_are_unshifted_for_mixed_sign_data() {
+        // Same root cause, milder symptom: with range (-2, 3) the old
+        // `norm(0.0)` baseline of 0.4 made the tallest bar span
+        // 40%–100% instead of the full plot height.
+        let chart = bar_chart(ChartKind::Bar, vec![vec![-2.0, 3.0]]);
+        assert_eq!(chart.effective_y_range(), (-2.0, 3.0));
+        assert_eq!(chart.bar_column_spans(0), vec![(0, 0.0, 0.0)]);
+        assert_eq!(chart.bar_column_spans(1), vec![(0, 0.0, 1.0)]);
+    }
+
+    #[test]
+    fn stacked_spans_stay_visible_when_an_explicit_range_excludes_zero() {
+        // Zero is above the whole range, so the stack's baseline clamps
+        // to the plot ceiling and the segments hang below it. Deriving
+        // each segment from consecutive cumulative levels keeps them
+        // visible; carrying `top` forward used to collapse every
+        // segment to zero height (review round 2, non-blocking note).
+        let mut chart = bar_chart(ChartKind::Bar, vec![vec![-3.0], vec![-4.0]]);
+        chart.y_range = Some((-10.0, -2.0));
+        let spans = chart.bar_column_spans(0);
+        // -3 maps to 0.875 and -7 to 0.375 over the 8-unit range.
+        assert!((spans[0].1 - 0.875).abs() < 1e-9, "spans: {spans:?}");
+        assert!((spans[0].2 - 1.0).abs() < 1e-9, "spans: {spans:?}");
+        assert!((spans[1].1 - 0.375).abs() < 1e-9, "spans: {spans:?}");
+        assert!((spans[1].2 - 0.875).abs() < 1e-9, "spans: {spans:?}");
+        assert!(spans.iter().all(|(_, b, t)| t > b), "spans: {spans:?}");
+    }
+
+    #[test]
+    fn stacked_span_of_a_negative_series_walks_the_stack_back_down() {
+        // 10 then -15 then +20 over the auto range (-5, 15): the middle
+        // series' segment spans downward from 10 to -5 and is still
+        // returned bottom-first.
+        let chart = bar_chart(ChartKind::Bar, vec![vec![10.0], vec![-15.0], vec![20.0]]);
+        assert_eq!(chart.effective_y_range(), (-5.0, 15.0));
+        let spans = chart.bar_column_spans(0);
+        assert_eq!(
+            spans,
+            vec![(0, 0.25, 0.75), (1, 0.0, 0.75), (2, 0.0, 1.0)],
+            "spans: {spans:?}"
+        );
+    }
+
+    #[test]
     fn stacked_spans_accumulate_bottom_up() {
         let mut chart = bar_chart(ChartKind::Bar, vec![vec![1.0], vec![1.0], vec![1.0]]);
         chart.y_range = Some((0.0, 3.0));
@@ -845,6 +960,22 @@ mod tests {
     fn bar_column_spans_empty_for_non_bar_kinds() {
         let chart = sparkline_chart(vec![1.0, 2.0]);
         assert!(chart.bar_column_spans(0).is_empty());
+        assert!(chart.bar_column_spans_all().is_empty());
+    }
+
+    #[test]
+    fn bar_column_spans_all_matches_the_per_column_helper() {
+        // The bulk form exists only to resolve the y-range once for the
+        // whole chart; it must agree with the single-column form column
+        // for column, for both bar kinds.
+        for kind in [ChartKind::Bar, ChartKind::BarGrouped] {
+            let chart = bar_chart(kind, vec![vec![1.0, 5.0, -2.0], vec![2.0, 0.0, 3.0]]);
+            let all = chart.bar_column_spans_all();
+            assert_eq!(all.len(), chart.max_data_len(), "{kind:?}");
+            for (di, column) in all.iter().enumerate() {
+                assert_eq!(*column, chart.bar_column_spans(di), "{kind:?} col {di}");
+            }
+        }
     }
 
     #[test]

--- a/quadraui/src/primitives/chart.rs
+++ b/quadraui/src/primitives/chart.rs
@@ -13,12 +13,17 @@
 //!
 //! Each [`Series`] carries a `Vec<f64>` of y-values evenly spaced along
 //! the x-axis. The y-range auto-derives from data when
-//! [`Chart::y_range`] is `None` — for stacked bars that ceiling is the
-//! largest *column total*, so a stack never clips (#584).
+//! [`Chart::y_range`] is `None` — for a multi-series stacked bar chart
+//! the range is anchored at `0.0` (widened to fit the tallest column
+//! total and any negative excursion), so segments stay proportional
+//! and a stack never clips (#584).
 //!
-//! Every backend paints bars from the shared geometry helpers
-//! [`Chart::bar_column_spans`] and [`Chart::column_totals`], so stacked
-//! and grouped layouts stay identical across TUI, GTK and macOS.
+//! Every backend paints bars from the shared geometry helper
+//! [`Chart::bar_column_spans`], which itself derives from
+//! [`Chart::effective_y_range`], so stacked and grouped layouts stay
+//! identical across TUI, GTK and macOS. [`Chart::column_totals`] is a
+//! separate, independently-useful helper (e.g. for labelling a stack's
+//! grand total) — it isn't on the geometry path itself.
 
 use crate::event::Rect;
 use crate::types::{Color, WidgetId};
@@ -73,11 +78,13 @@ pub enum ChartKind {
     /// total height is the column sum. A single-series chart is exactly
     /// a plain bar chart — stacking is a no-op there.
     ///
-    /// Segment heights are proportional to the values only when the
-    /// y-axis floor is `0.0`. With an auto-derived range the floor is
-    /// `min(data)`, so the *bottom* segment absorbs that offset (the
-    /// same baseline behaviour a single-series bar chart has always
-    /// had). Set `y_range: Some((0.0, …))` for exact proportions.
+    /// With two or more series and an auto-derived range (no explicit
+    /// `y_range`), the floor is anchored at `0.0` specifically so
+    /// segment proportions are correct — see [`Chart::effective_y_range`].
+    /// An *explicit* `y_range` whose floor isn't `0.0` still skews every
+    /// segment's proportion relative to the others, since the geometry
+    /// has no way to know which value the caller intends as "empty";
+    /// pass `y_range: Some((0.0, …))` if you need one.
     Bar,
     /// Vertical bar chart whose series are drawn **side by side**
     /// within each x-position, for comparing magnitudes rather than
@@ -86,6 +93,10 @@ pub enum ChartKind {
     /// Each slot is split into `series.len()` sub-bars. When a slot is
     /// too narrow to give every series at least one device unit, the
     /// trailing series are clipped — widen the chart or drop a series.
+    /// (The TUI backend clips exactly this way; GTK and macOS instead
+    /// floor each sub-bar to 1px and let them overlap rather than
+    /// dropping data — both are acceptable outcomes for a pathologically
+    /// narrow chart, but they render differently from each other.)
     BarGrouped,
 }
 
@@ -225,13 +236,44 @@ impl ChartLayout {
 impl Chart {
     /// Resolve the effective y-range from explicit range or data min/max.
     ///
-    /// For a stacked bar chart ([`ChartKind::Bar`]) the ceiling is the
-    /// largest **column total**, not the largest single value, so a
-    /// stack can never clip. Column totals equal the data itself for a
-    /// single-series chart, so single-series output is unaffected.
+    /// For a stacked bar chart ([`ChartKind::Bar`]) with more than one
+    /// series, the range is anchored so that segment proportions are
+    /// correct: the floor is `min(0.0, ...)` and the ceiling is
+    /// `max(0.0, ...)` over every *partial sum* reached while
+    /// accumulating each column (not just each column's final total),
+    /// so a stack can never clip and — critically — never has its
+    /// segments' relative proportions skewed by a nonzero floor (#584
+    /// review). Using raw individual values as the floor here would
+    /// under-draw the first series in every column by a constant
+    /// offset whenever the smallest single value anywhere is `> 0`.
+    ///
+    /// A single-series `Bar` chart has nothing to compose against, so
+    /// it keeps the plain min/max-of-data behaviour every other chart
+    /// kind uses — single-series output is unaffected by stacking.
     pub fn effective_y_range(&self) -> (f64, f64) {
         if let Some(range) = self.y_range {
             return range;
+        }
+        if self.kind.is_stacked_bar() && self.series.len() > 1 {
+            let mut min = 0.0_f64;
+            let mut max = 0.0_f64;
+            for data_idx in 0..self.max_data_len() {
+                let mut cum = 0.0;
+                for s in &self.series {
+                    cum += s.data.get(data_idx).copied().unwrap_or(0.0);
+                    if cum < min {
+                        min = cum;
+                    }
+                    if cum > max {
+                        max = cum;
+                    }
+                }
+            }
+            return if (max - min).abs() < f64::EPSILON {
+                (min - 1.0, max + 1.0)
+            } else {
+                (min, max)
+            };
         }
         let mut min = f64::INFINITY;
         let mut max = f64::NEG_INFINITY;
@@ -242,19 +284,6 @@ impl Chart {
                 }
                 if v > max {
                     max = v;
-                }
-            }
-        }
-        if self.kind.is_stacked_bar() {
-            // Stacks are painted to the column total; widen the range so
-            // the tallest one still fits (negative values likewise pull
-            // the floor down rather than clipping below the axis).
-            for total in self.column_totals() {
-                if total < min {
-                    min = total;
-                }
-                if total > max {
-                    max = total;
                 }
             }
         }
@@ -318,7 +347,11 @@ impl Chart {
         let mut spans = Vec::with_capacity(self.series.len());
         if self.kind.is_stacked_bar() {
             let mut cum = 0.0;
-            let mut bottom = 0.0;
+            // `norm(0.0)` rather than a literal `0.0`: when the range
+            // floor isn't exactly `0.0` (e.g. an explicit non-zero
+            // `y_range`), the stack's true baseline is wherever zero
+            // maps to, not the bottom of the plot area.
+            let mut bottom = norm(0.0);
             for (si, s) in self.series.iter().enumerate() {
                 cum += s.data.get(data_idx).copied().unwrap_or(0.0);
                 // `max(bottom)` keeps spans monotonic if a negative
@@ -730,6 +763,47 @@ mod tests {
         // data itself, so nothing about the auto-range moves.
         let chart = bar_chart(ChartKind::Bar, vec![vec![2.0, 5.0, 3.0]]);
         assert_eq!(chart.effective_y_range(), (2.0, 5.0));
+    }
+
+    #[test]
+    fn stacked_bar_floor_anchors_at_zero_when_min_value_is_nonzero() {
+        // Regression for the review finding on #584: two series, one
+        // point each, neither containing a literal 0.0 anywhere. The
+        // auto-derived floor must still be 0.0 (not 5.0, the smallest
+        // raw value in the chart) or the segments below render
+        // out-of-proportion to their true values.
+        let chart = bar_chart(ChartKind::Bar, vec![vec![10.0], vec![5.0]]);
+        assert_eq!(chart.effective_y_range(), (0.0, 15.0));
+
+        let spans = chart.bar_column_spans(0);
+        // A = 10 of 15 total → 2/3 of the stack; B = 5 of 15 → 1/3.
+        // Pre-fix this rendered as an exact 50/50 split instead.
+        assert!((spans[0].1 - 0.0).abs() < 1e-9);
+        assert!((spans[0].2 - 2.0 / 3.0).abs() < 1e-9, "A span: {spans:?}");
+        assert!((spans[1].1 - 2.0 / 3.0).abs() < 1e-9);
+        assert!((spans[1].2 - 1.0).abs() < 1e-9, "B span: {spans:?}");
+    }
+
+    #[test]
+    fn stacked_bar_floor_tracks_negative_partial_sums_not_just_totals() {
+        // A column total alone can hide a dip below zero mid-stack:
+        // 10 + (-15) + 20 sums to 15, but the running sum touches -5
+        // partway through. The floor must cover that dip.
+        let chart = bar_chart(ChartKind::Bar, vec![vec![10.0], vec![-15.0], vec![20.0]]);
+        assert_eq!(chart.effective_y_range(), (-5.0, 15.0));
+    }
+
+    #[test]
+    fn bar_column_spans_baseline_tracks_a_nonzero_explicit_floor() {
+        // With an explicit y_range whose floor isn't 0.0, the stack's
+        // baseline (where the bottom segment starts) must track
+        // wherever zero maps to under that range, not the plot's
+        // literal bottom edge.
+        let mut chart = bar_chart(ChartKind::Bar, vec![vec![10.0], vec![10.0]]);
+        chart.y_range = Some((-10.0, 30.0));
+        let spans = chart.bar_column_spans(0);
+        // norm(0.0) = (0 - -10) / 40 = 0.25.
+        assert!((spans[0].1 - 0.25).abs() < 1e-9, "spans: {spans:?}");
     }
 
     #[test]

--- a/quadraui/src/primitives/chart.rs
+++ b/quadraui/src/primitives/chart.rs
@@ -7,10 +7,18 @@
 //! - [`ChartKind::Line`] — multi-series line/area chart with optional
 //!   axis labels and legend. Set [`Series::fill`] for area charts.
 //! - [`ChartKind::Bar`] — vertical bar chart with category labels.
+//!   Multiple series **stack** within each x-position.
+//! - [`ChartKind::BarGrouped`] — the same data drawn **side by side**
+//!   within each x-position instead of stacked.
 //!
 //! Each [`Series`] carries a `Vec<f64>` of y-values evenly spaced along
 //! the x-axis. The y-range auto-derives from data when
-//! [`Chart::y_range`] is `None`.
+//! [`Chart::y_range`] is `None` — for stacked bars that ceiling is the
+//! largest *column total*, so a stack never clips (#584).
+//!
+//! Every backend paints bars from the shared geometry helpers
+//! [`Chart::bar_column_spans`] and [`Chart::column_totals`], so stacked
+//! and grouped layouts stay identical across TUI, GTK and macOS.
 
 use crate::event::Rect;
 use crate::types::{Color, WidgetId};
@@ -46,15 +54,53 @@ pub struct Chart {
 }
 
 /// Chart visualisation kind.
+///
+/// `#[non_exhaustive]`: per PRIMITIVE_RULES rule 8, a downstream `match`
+/// on this enum needs a wildcard arm so later kinds (#584 added
+/// [`ChartKind::BarGrouped`]) stay additive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ChartKind {
     /// Single-row inline chart (no axes, no labels).
     Sparkline,
     /// Multi-series line chart with axes. Per-series `fill` enables area fill.
     #[default]
     Line,
-    /// Vertical bar chart.
+    /// Vertical bar chart with category labels.
+    ///
+    /// Multiple series **stack**: each x-position paints one coloured
+    /// segment per series, bottom-up in `series` order, and the bar's
+    /// total height is the column sum. A single-series chart is exactly
+    /// a plain bar chart — stacking is a no-op there.
+    ///
+    /// Segment heights are proportional to the values only when the
+    /// y-axis floor is `0.0`. With an auto-derived range the floor is
+    /// `min(data)`, so the *bottom* segment absorbs that offset (the
+    /// same baseline behaviour a single-series bar chart has always
+    /// had). Set `y_range: Some((0.0, …))` for exact proportions.
     Bar,
+    /// Vertical bar chart whose series are drawn **side by side**
+    /// within each x-position, for comparing magnitudes rather than
+    /// composition. Use [`ChartKind::Bar`] to compare totals instead.
+    ///
+    /// Each slot is split into `series.len()` sub-bars. When a slot is
+    /// too narrow to give every series at least one device unit, the
+    /// trailing series are clipped — widen the chart or drop a series.
+    BarGrouped,
+}
+
+impl ChartKind {
+    /// True for every bar-family kind ([`ChartKind::Bar`],
+    /// [`ChartKind::BarGrouped`]).
+    pub fn is_bar(self) -> bool {
+        matches!(self, ChartKind::Bar | ChartKind::BarGrouped)
+    }
+
+    /// True when bar segments accumulate per x-position rather than
+    /// sitting side by side.
+    pub fn is_stacked_bar(self) -> bool {
+        matches!(self, ChartKind::Bar)
+    }
 }
 
 /// One data series in a chart.
@@ -178,6 +224,11 @@ impl ChartLayout {
 
 impl Chart {
     /// Resolve the effective y-range from explicit range or data min/max.
+    ///
+    /// For a stacked bar chart ([`ChartKind::Bar`]) the ceiling is the
+    /// largest **column total**, not the largest single value, so a
+    /// stack can never clip. Column totals equal the data itself for a
+    /// single-series chart, so single-series output is unaffected.
     pub fn effective_y_range(&self) -> (f64, f64) {
         if let Some(range) = self.y_range {
             return range;
@@ -194,6 +245,19 @@ impl Chart {
                 }
             }
         }
+        if self.kind.is_stacked_bar() {
+            // Stacks are painted to the column total; widen the range so
+            // the tallest one still fits (negative values likewise pull
+            // the floor down rather than clipping below the axis).
+            for total in self.column_totals() {
+                if total < min {
+                    min = total;
+                }
+                if total > max {
+                    max = total;
+                }
+            }
+        }
         if min > max {
             (0.0, 1.0)
         } else if (max - min).abs() < f64::EPSILON {
@@ -206,6 +270,70 @@ impl Chart {
     /// Maximum data length across all series.
     pub fn max_data_len(&self) -> usize {
         self.series.iter().map(|s| s.data.len()).max().unwrap_or(0)
+    }
+
+    /// Sum of every series' value at each x-position, i.e. the height a
+    /// stacked bar reaches. Series shorter than [`Chart::max_data_len`]
+    /// contribute `0.0` for the missing positions.
+    pub fn column_totals(&self) -> Vec<f64> {
+        (0..self.max_data_len())
+            .map(|i| {
+                self.series
+                    .iter()
+                    .map(|s| s.data.get(i).copied().unwrap_or(0.0))
+                    .sum()
+            })
+            .collect()
+    }
+
+    /// Vertical extent of every bar segment in the `data_idx` column,
+    /// as `(series_idx, bottom, top)` fractions of the plot height
+    /// measured **up from the plot floor**, in bottom-to-top paint
+    /// order. This is the one source of truth every backend's bar
+    /// painter and [`Chart::layout`] share (#584).
+    ///
+    /// - [`ChartKind::Bar`] — spans accumulate: each segment starts
+    ///   where the previous one ended, so an all-zero series occupies
+    ///   an empty span and does **not** shift the series above it.
+    /// - [`ChartKind::BarGrouped`] — every span starts at the floor;
+    ///   the caller lays the series out side by side horizontally.
+    ///
+    /// Returns one entry per series (zero-height for missing data), so
+    /// callers can index by series without re-checking lengths. Empty
+    /// for non-bar kinds.
+    pub fn bar_column_spans(&self, data_idx: usize) -> Vec<(usize, f64, f64)> {
+        if !self.kind.is_bar() {
+            return Vec::new();
+        }
+        let (y_min, y_max) = self.effective_y_range();
+        let range = y_max - y_min;
+        let norm = |v: f64| {
+            if range > 0.0 {
+                ((v - y_min) / range).clamp(0.0, 1.0)
+            } else {
+                0.5
+            }
+        };
+
+        let mut spans = Vec::with_capacity(self.series.len());
+        if self.kind.is_stacked_bar() {
+            let mut cum = 0.0;
+            let mut bottom = 0.0;
+            for (si, s) in self.series.iter().enumerate() {
+                cum += s.data.get(data_idx).copied().unwrap_or(0.0);
+                // `max(bottom)` keeps spans monotonic if a negative
+                // value would otherwise invert the segment.
+                let top = norm(cum).max(bottom);
+                spans.push((si, bottom, top));
+                bottom = top;
+            }
+        } else {
+            for (si, s) in self.series.iter().enumerate() {
+                let top = s.data.get(data_idx).map(|&v| norm(v)).unwrap_or(0.0);
+                spans.push((si, 0.0, top));
+            }
+        }
+        spans
     }
 
     /// Compute layout and hit regions.
@@ -247,7 +375,7 @@ impl Chart {
                     x_tick_positions: Vec::new(),
                 }
             }
-            ChartKind::Line | ChartKind::Bar => {
+            ChartKind::Line | ChartKind::Bar | ChartKind::BarGrouped => {
                 let (y_min, y_max) = self.effective_y_range();
                 let y_tick_count = self.y_ticks.unwrap_or(5);
                 let y_label_width = if y_tick_count > 0 || self.y_label.is_some() {
@@ -305,21 +433,50 @@ impl Chart {
 
                 let range = y_max - y_min;
                 let mut data_point_positions = Vec::new();
-                for (si, s) in self.series.iter().enumerate() {
-                    let n = s.data.len();
-                    for (di, &val) in s.data.iter().enumerate() {
-                        let norm = if range > 0.0 {
-                            ((val - y_min) / range).clamp(0.0, 1.0)
-                        } else {
-                            0.5
-                        };
-                        let sx = if n <= 1 {
-                            plot_x
-                        } else {
-                            plot_x + (di as f32 / (n - 1) as f32) * plot_w
-                        };
-                        let sy = plot_y + plot_h - norm as f32 * plot_h;
-                        data_point_positions.push((si, di, sx, sy));
+                if self.kind.is_bar() {
+                    // Bars own a slot, not a point: anchor each segment
+                    // at its own rectangle so `nearest_point` resolves
+                    // to the (series, index) under the cursor — which is
+                    // what a stacked-segment tooltip needs (#584).
+                    let n = self.max_data_len();
+                    let slot_w = if n == 0 { 0.0 } else { plot_w / n as f32 };
+                    let series_count = self.series.len().max(1) as f32;
+                    let stacked = self.kind.is_stacked_bar();
+                    for di in 0..n {
+                        for (si, bottom, top) in self.bar_column_spans(di) {
+                            let (sx, sy) = if stacked {
+                                let mid = (bottom + top) / 2.0;
+                                (
+                                    plot_x + slot_w * (di as f32 + 0.5),
+                                    plot_y + plot_h - mid as f32 * plot_h,
+                                )
+                            } else {
+                                let sub_w = slot_w / series_count;
+                                (
+                                    plot_x + slot_w * di as f32 + sub_w * (si as f32 + 0.5),
+                                    plot_y + plot_h - top as f32 * plot_h,
+                                )
+                            };
+                            data_point_positions.push((si, di, sx, sy));
+                        }
+                    }
+                } else {
+                    for (si, s) in self.series.iter().enumerate() {
+                        let n = s.data.len();
+                        for (di, &val) in s.data.iter().enumerate() {
+                            let norm = if range > 0.0 {
+                                ((val - y_min) / range).clamp(0.0, 1.0)
+                            } else {
+                                0.5
+                            };
+                            let sx = if n <= 1 {
+                                plot_x
+                            } else {
+                                plot_x + (di as f32 / (n - 1) as f32) * plot_w
+                            };
+                            let sy = plot_y + plot_h - norm as f32 * plot_h;
+                            data_point_positions.push((si, di, sx, sy));
+                        }
                     }
                 }
 
@@ -518,5 +675,169 @@ mod tests {
         let chart = sparkline_chart(vec![5.0, 5.0, 5.0]);
         let (lo, hi) = chart.effective_y_range();
         assert!(lo < 5.0 && hi > 5.0);
+    }
+
+    // ── Multi-series bars (#584) ────────────────────────────────────────
+
+    fn bar_chart(kind: ChartKind, data: Vec<Vec<f64>>) -> Chart {
+        Chart {
+            id: WidgetId::new("chart"),
+            kind,
+            series: data
+                .into_iter()
+                .enumerate()
+                .map(|(i, d)| Series {
+                    label: format!("S{i}"),
+                    data: d,
+                    color: None,
+                    fill: false,
+                })
+                .collect(),
+            x_label: None,
+            y_label: None,
+            y_range: None,
+            x_range: None,
+            show_legend: false,
+            y_ticks: None,
+            x_ticks: None,
+            show_grid: false,
+        }
+    }
+
+    #[test]
+    fn stacked_bar_y_ceiling_is_max_column_total() {
+        let chart = bar_chart(
+            ChartKind::Bar,
+            vec![vec![1.0, 5.0], vec![2.0, 1.0], vec![3.0, 0.0]],
+        );
+        // Column totals are 6 and 6; the max single value is 5.
+        assert_eq!(chart.column_totals(), vec![6.0, 6.0]);
+        assert_eq!(chart.effective_y_range(), (0.0, 6.0));
+    }
+
+    #[test]
+    fn grouped_bar_y_ceiling_is_max_single_value() {
+        let chart = bar_chart(
+            ChartKind::BarGrouped,
+            vec![vec![1.0, 5.0], vec![2.0, 1.0], vec![3.0, 0.0]],
+        );
+        assert_eq!(chart.effective_y_range(), (0.0, 5.0));
+    }
+
+    #[test]
+    fn single_series_bar_y_range_is_unchanged_by_stacking() {
+        // Pin the pre-#584 behaviour: one series' column totals are the
+        // data itself, so nothing about the auto-range moves.
+        let chart = bar_chart(ChartKind::Bar, vec![vec![2.0, 5.0, 3.0]]);
+        assert_eq!(chart.effective_y_range(), (2.0, 5.0));
+    }
+
+    #[test]
+    fn stacked_spans_accumulate_bottom_up() {
+        let mut chart = bar_chart(ChartKind::Bar, vec![vec![1.0], vec![1.0], vec![1.0]]);
+        chart.y_range = Some((0.0, 3.0));
+        let spans = chart.bar_column_spans(0);
+        assert_eq!(spans.len(), 3);
+        assert!((spans[0].1 - 0.0).abs() < 1e-9 && (spans[0].2 - 1.0 / 3.0).abs() < 1e-9);
+        assert!((spans[1].1 - 1.0 / 3.0).abs() < 1e-9 && (spans[1].2 - 2.0 / 3.0).abs() < 1e-9);
+        assert!((spans[2].1 - 2.0 / 3.0).abs() < 1e-9 && (spans[2].2 - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn stacked_all_zero_series_does_not_shift_the_others() {
+        let mut with_zeros = bar_chart(
+            ChartKind::Bar,
+            vec![vec![1.0], vec![0.0], vec![1.0], vec![0.0]],
+        );
+        with_zeros.y_range = Some((0.0, 2.0));
+        let spans = with_zeros.bar_column_spans(0);
+        // The zero series occupies an empty span at the boundary…
+        assert_eq!((spans[1].1, spans[1].2), (0.5, 0.5));
+        assert_eq!((spans[3].1, spans[3].2), (1.0, 1.0));
+        // …and the series above it keeps the span it would have had.
+        assert_eq!((spans[0].1, spans[0].2), (0.0, 0.5));
+        assert_eq!((spans[2].1, spans[2].2), (0.5, 1.0));
+    }
+
+    #[test]
+    fn grouped_spans_all_start_at_the_floor() {
+        let mut chart = bar_chart(ChartKind::BarGrouped, vec![vec![1.0], vec![2.0], vec![4.0]]);
+        chart.y_range = Some((0.0, 4.0));
+        let spans = chart.bar_column_spans(0);
+        assert_eq!(spans, vec![(0, 0.0, 0.25), (1, 0.0, 0.5), (2, 0.0, 1.0)]);
+    }
+
+    #[test]
+    fn bar_column_spans_empty_for_non_bar_kinds() {
+        let chart = sparkline_chart(vec![1.0, 2.0]);
+        assert!(chart.bar_column_spans(0).is_empty());
+    }
+
+    #[test]
+    fn stacked_bar_nearest_point_resolves_series_and_index() {
+        let mut chart = bar_chart(
+            ChartKind::Bar,
+            vec![vec![1.0, 1.0], vec![1.0, 1.0], vec![1.0, 1.0]],
+        );
+        chart.y_range = Some((0.0, 3.0));
+        let m = ChartMeasure {
+            width: 30.0,
+            height: 30.0,
+            char_width: 1.0,
+            line_height: 1.0,
+        };
+        let layout = chart.layout(0.0, 0.0, m);
+        // One anchor per (series, column), not one per column.
+        assert_eq!(layout.data_point_positions.len(), 6);
+
+        let pa = layout.plot_area;
+        let slot_w = pa.width / 2.0;
+        // Second column, top third of the stack → series 2, index 1.
+        let x = pa.x + slot_w * 1.5;
+        let y = pa.y + pa.height / 6.0;
+        assert_eq!(layout.nearest_point(x, y, slot_w), Some((2, 1)));
+        // Bottom third of the first column → series 0, index 0.
+        let y_bottom = pa.y + pa.height * 5.0 / 6.0;
+        assert_eq!(
+            layout.nearest_point(pa.x + slot_w * 0.5, y_bottom, slot_w),
+            Some((0, 0))
+        );
+    }
+
+    #[test]
+    fn grouped_bar_anchors_sit_side_by_side() {
+        let mut chart = bar_chart(ChartKind::BarGrouped, vec![vec![1.0], vec![2.0], vec![3.0]]);
+        chart.y_range = Some((0.0, 3.0));
+        let m = ChartMeasure {
+            width: 30.0,
+            height: 30.0,
+            char_width: 1.0,
+            line_height: 1.0,
+        };
+        let layout = chart.layout(0.0, 0.0, m);
+        let xs: Vec<f32> = layout.data_point_positions.iter().map(|p| p.2).collect();
+        assert_eq!(xs.len(), 3);
+        assert!(xs[0] < xs[1] && xs[1] < xs[2], "sub-bars advance: {xs:?}");
+        // Taller value → higher anchor (smaller screen y).
+        let ys: Vec<f32> = layout.data_point_positions.iter().map(|p| p.3).collect();
+        assert!(ys[0] > ys[1] && ys[1] > ys[2], "bar tops rise: {ys:?}");
+    }
+
+    #[test]
+    fn bar_kind_predicates() {
+        assert!(ChartKind::Bar.is_bar() && ChartKind::Bar.is_stacked_bar());
+        assert!(ChartKind::BarGrouped.is_bar() && !ChartKind::BarGrouped.is_stacked_bar());
+        assert!(!ChartKind::Line.is_bar() && !ChartKind::Sparkline.is_bar());
+    }
+
+    #[test]
+    fn bar_grouped_round_trips_through_serde() {
+        let json = serde_json::to_string(&ChartKind::BarGrouped).unwrap();
+        assert_eq!(json, "\"BarGrouped\"");
+        let back: ChartKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ChartKind::BarGrouped);
+        // Pre-#584 payloads still deserialize.
+        let old: ChartKind = serde_json::from_str("\"Bar\"").unwrap();
+        assert_eq!(old, ChartKind::Bar);
     }
 }

--- a/quadraui/src/tui/chart.rs
+++ b/quadraui/src/tui/chart.rs
@@ -299,14 +299,14 @@ fn paint_bar(buf: &mut Buffer, layout: &ChartLayout, chart: &Chart, theme: &Them
     // Row 0 of a bar is the row directly above the axis row.
     let base_row = (py + ph).saturating_sub(2);
 
-    for di in 0..n {
+    for (di, column) in chart.bar_column_spans_all().into_iter().enumerate() {
         let slot_x = di * slot_w;
         if slot_x >= pw as usize {
             break;
         }
         let slot_cells = slot_w.min(pw as usize - slot_x);
 
-        for (si, bottom, top) in chart.bar_column_spans(di) {
+        for (si, bottom, top) in column {
             // Stacked segments span the whole slot; grouped series each
             // take a sub-slot beside the previous one.
             let (cell_off, cell_w) = if stacked {
@@ -842,6 +842,33 @@ mod tests {
                 "2...████..",
                 "1...████..",
                 "1.────────",
+            ]
+        );
+    }
+
+    /// Review round 2 on #584: a single-series `Bar` whose data is all
+    /// negative auto-derives the range (-5, -1), where `norm(0.0)`
+    /// clamps to the plot *ceiling*. The stacked baseline used to be
+    /// applied here too, collapsing every bar to zero height — an empty
+    /// plot area. Bars must still rise from the floor at 0% / 50% / 100%.
+    #[test]
+    fn single_series_bar_with_negative_data_still_paints() {
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buf = Buffer::empty(area);
+        let chart = bar_chart_of(
+            ChartKind::Bar,
+            vec![series_of("B", vec![-5.0, -3.0, -1.0], Color::rgb(1, 2, 3))],
+            None,
+        );
+        let _ = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
+        assert_eq!(
+            grid(&buf, area),
+            vec![
+                "-1.....██.",
+                "-1.....██.",
+                "-2...████.",
+                "-3...████.",
+                "-4.───────",
             ]
         );
     }

--- a/quadraui/src/tui/chart.rs
+++ b/quadraui/src/tui/chart.rs
@@ -58,7 +58,7 @@ pub fn draw_chart(
     match chart.kind {
         ChartKind::Sparkline => paint_sparkline(buf, &layout, chart, theme),
         ChartKind::Line => paint_line(buf, &layout, chart, theme),
-        ChartKind::Bar => paint_bar(buf, &layout, chart, theme),
+        ChartKind::Bar | ChartKind::BarGrouped => paint_bar(buf, &layout, chart, theme),
     }
 
     if let Some(data_x) = crosshair_x {
@@ -279,41 +279,70 @@ fn paint_bar(buf: &mut Buffer, layout: &ChartLayout, chart: &Chart, theme: &Them
         }
     }
 
-    if let Some(s) = chart.series.first() {
-        if s.data.is_empty() {
-            return;
+    let n = chart.max_data_len();
+    if n == 0 {
+        // Nothing to plot: still paint the legend and axis labels so an
+        // empty bar chart reads as an empty chart, matching the GTK and
+        // macOS painters.
+        paint_legend(buf, layout, chart, theme);
+        paint_axis_labels(buf, layout, chart, theme);
+        return;
+    }
+
+    // Cell-quantised bar geometry. Slot width floors, exactly as the
+    // single-series painter always did, so single-series output is
+    // byte-identical to pre-#584.
+    let slot_w = ((pw as usize) / n).max(1);
+    let plot_h = ph.saturating_sub(1) as usize;
+    let stacked = chart.kind.is_stacked_bar();
+    let series_count = chart.series.len().max(1);
+    // Row 0 of a bar is the row directly above the axis row.
+    let base_row = (py + ph).saturating_sub(2);
+
+    for di in 0..n {
+        let slot_x = di * slot_w;
+        if slot_x >= pw as usize {
+            break;
         }
+        let slot_cells = slot_w.min(pw as usize - slot_x);
 
-        let (y_min, y_max) = chart.effective_y_range();
-        let range = y_max - y_min;
-        let n = s.data.len();
-        let bar_w = ((pw as usize) / n.max(1)).max(1);
-        let fg = ratatui_color(series_color(chart, 0));
-        let plot_h = ph.saturating_sub(1) as usize;
-
-        for (i, &val) in s.data.iter().enumerate() {
-            let norm = if range > 0.0 {
-                ((val - y_min) / range).clamp(0.0, 1.0)
+        for (si, bottom, top) in chart.bar_column_spans(di) {
+            // Stacked segments span the whole slot; grouped series each
+            // take a sub-slot beside the previous one.
+            let (cell_off, cell_w) = if stacked {
+                (0, slot_cells)
             } else {
-                0.5
+                let sub_w = (slot_cells / series_count).max(1);
+                let off = si * sub_w;
+                if off >= slot_cells {
+                    // Slot too narrow for the remaining series.
+                    break;
+                }
+                (off, sub_w.min(slot_cells - off))
             };
-            let fill_rows = (norm * plot_h as f64).round() as usize;
-            let bx = px + (i * bar_w) as u16;
 
-            for r in 0..fill_rows {
-                let by = py + ph - 2 - r as u16;
-                if by >= py {
-                    for c in 0..bar_w.min((pw as usize).saturating_sub(i * bar_w)) {
-                        set_cell(buf, bx + c as u16, by, '█', fg, bg);
-                    }
+            let row_bottom = (bottom * plot_h as f64).round() as usize;
+            let row_top = (top * plot_h as f64).round() as usize;
+            if row_top <= row_bottom || plot_h == 0 {
+                continue;
+            }
+
+            let fg = ratatui_color(series_color(chart, si));
+            for r in row_bottom..row_top.min(plot_h) {
+                let by = base_row.saturating_sub(r as u16);
+                if by < py {
+                    break;
+                }
+                for c in 0..cell_w {
+                    set_cell(buf, px + (slot_x + cell_off + c) as u16, by, '█', fg, bg);
                 }
             }
         }
+    }
 
-        // Bottom axis.
-        for col in px..px + pw {
-            set_cell(buf, col, py + ph - 1, '─', dim, bg);
-        }
+    // Bottom axis.
+    for col in px..px + pw {
+        set_cell(buf, col, py + ph - 1, '─', dim, bg);
     }
 
     paint_legend(buf, layout, chart, theme);
@@ -470,7 +499,26 @@ fn paint_hover_marker(
             };
             (px + (frac * (pw - 1) as f32).round() as u16, py)
         }
-        ChartKind::Line | ChartKind::Bar => {
+        ChartKind::Bar | ChartKind::BarGrouped => {
+            // Bars anchor on their own rectangle, so reuse the layout's
+            // per-segment positions rather than the line/braille math —
+            // the marker lands on the hovered stack segment (#584).
+            let pos = layout
+                .data_point_positions
+                .iter()
+                .find(|&&(s, d, _, _)| s == series_idx && d == data_idx);
+            let &(_, _, sx, sy) = match pos {
+                Some(p) => p,
+                None => return,
+            };
+            if pw == 0 || ph == 0 {
+                return;
+            }
+            let col = (sx.round() as u16).clamp(px, px + pw - 1);
+            let row = (sy.round() as u16).clamp(py, py + ph.saturating_sub(2));
+            (col, row)
+        }
+        ChartKind::Line => {
             let plot_cols = pw.saturating_sub(1) as usize;
             let plot_rows = ph.saturating_sub(1) as usize;
             if plot_cols == 0 || plot_rows == 0 {
@@ -725,6 +773,297 @@ mod tests {
     #[test]
     fn legend_paint_and_click_round_trip_at_nonzero_origin() {
         legend_paint_and_click_round_trip_at(7, 13);
+    }
+
+    // ── Multi-series bars (#584) ────────────────────────────────────────
+
+    fn series_of(label: &str, data: Vec<f64>, color: Color) -> Series {
+        Series {
+            label: label.into(),
+            data,
+            color: Some(color),
+            fill: false,
+        }
+    }
+
+    fn bar_chart_of(kind: ChartKind, series: Vec<Series>, y_range: Option<(f64, f64)>) -> Chart {
+        Chart {
+            id: WidgetId::new("c"),
+            kind,
+            series,
+            x_label: None,
+            y_label: None,
+            y_range,
+            x_range: None,
+            show_legend: false,
+            y_ticks: None,
+            x_ticks: None,
+            show_grid: false,
+        }
+    }
+
+    /// The painted grid as one string per row, `.` for blank cells.
+    fn grid(buf: &Buffer, area: Rect) -> Vec<String> {
+        (area.y..area.y + area.height)
+            .map(|y| {
+                (area.x..area.x + area.width)
+                    .map(|x| match cell_char(buf, x, y) {
+                        ' ' => '.',
+                        c => c,
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn fg_at(buf: &Buffer, x: u16, y: u16) -> ratatui::style::Color {
+        buf[(x, y)].fg
+    }
+
+    /// #584 is additive: a single-series `Bar` must paint exactly what
+    /// it painted before stacking existed. The grid below (y-tick
+    /// gutter on the left, bars floored at the auto-range minimum,
+    /// slot width `pw / n` floored) is the pre-#584 output, pinned.
+    #[test]
+    fn single_series_bar_grid_is_pinned() {
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buf = Buffer::empty(area);
+        let chart = bar_chart_of(
+            ChartKind::Bar,
+            vec![series_of("B", vec![1.0, 3.0, 2.0], Color::rgb(1, 2, 3))],
+            None,
+        );
+        let _ = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
+        assert_eq!(
+            grid(&buf, area),
+            vec![
+                "3...██....",
+                "2...██....",
+                "2...████..",
+                "1...████..",
+                "1.────────",
+            ]
+        );
+    }
+
+    #[test]
+    fn stacked_bar_paints_every_series_with_its_own_colour() {
+        // 3 series × 1.0 over an explicit 0..3 range ⇒ each owns two of
+        // the six plot rows, bottom-up in `series` order.
+        let (red, green, blue) = (
+            Color::rgb(255, 0, 0),
+            Color::rgb(0, 255, 0),
+            Color::rgb(0, 0, 255),
+        );
+        let area = Rect::new(0, 0, 12, 7);
+        let mut buf = Buffer::empty(area);
+        let chart = bar_chart_of(
+            ChartKind::Bar,
+            vec![
+                series_of("a", vec![1.0], red),
+                series_of("b", vec![1.0], green),
+                series_of("c", vec![1.0], blue),
+            ],
+            Some((0.0, 3.0)),
+        );
+        let layout = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
+        let px = layout.plot_area.x.round() as u16;
+        let py = layout.plot_area.y.round() as u16;
+        let ph = layout.plot_area.height.round() as u16;
+
+        // Six stacked rows above the axis row, two per series.
+        let expected = [
+            (py + ph - 2, red),
+            (py + ph - 3, red),
+            (py + ph - 4, green),
+            (py + ph - 5, green),
+            (py + ph - 6, blue),
+            (py + ph - 7, blue),
+        ];
+        for (row, color) in expected {
+            assert_eq!(
+                cell_char(&buf, px, row),
+                '█',
+                "row {row} of the stack should be filled:\n{:?}",
+                grid(&buf, area)
+            );
+            assert_eq!(
+                fg_at(&buf, px, row),
+                ratatui_color(color),
+                "row {row} should carry its own series colour:\n{:?}",
+                grid(&buf, area)
+            );
+        }
+    }
+
+    #[test]
+    fn stacked_bar_ceiling_is_the_column_total() {
+        // Auto-range: totals are 3.0, so the tallest stack fills the
+        // plot and no segment is clipped off the top.
+        let area = Rect::new(0, 0, 12, 7);
+        let mut buf = Buffer::empty(area);
+        let chart = bar_chart_of(
+            ChartKind::Bar,
+            vec![
+                series_of("a", vec![1.0], Color::rgb(255, 0, 0)),
+                series_of("b", vec![1.0], Color::rgb(0, 255, 0)),
+                series_of("c", vec![1.0, 0.0], Color::rgb(0, 0, 255)),
+            ],
+            None,
+        );
+        assert_eq!(chart.effective_y_range(), (0.0, 3.0));
+        let layout = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
+        let px = layout.plot_area.x.round() as u16;
+        let py = layout.plot_area.y.round() as u16;
+        // Topmost plot row of the first column is painted by series 2.
+        assert_eq!(cell_char(&buf, px, py), '█');
+        assert_eq!(fg_at(&buf, px, py), ratatui_color(Color::rgb(0, 0, 255)));
+    }
+
+    #[test]
+    fn stacked_bar_all_zero_series_does_not_shift_the_others() {
+        let (red, blue) = (Color::rgb(255, 0, 0), Color::rgb(0, 0, 255));
+        let area = Rect::new(0, 0, 12, 7);
+        let render = |series: Vec<Series>| {
+            let mut buf = Buffer::empty(area);
+            let chart = bar_chart_of(ChartKind::Bar, series, Some((0.0, 3.0)));
+            let _ = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
+            grid(&buf, area)
+        };
+
+        let without_zeros = render(vec![
+            series_of("a", vec![2.0, 1.0], red),
+            series_of("c", vec![1.0, 2.0], blue),
+        ]);
+        let with_zeros = render(vec![
+            series_of("a", vec![2.0, 1.0], red),
+            series_of("zero", vec![0.0, 0.0], Color::rgb(9, 9, 9)),
+            series_of("c", vec![1.0, 2.0], blue),
+        ]);
+        assert_eq!(
+            with_zeros, without_zeros,
+            "an all-zero series must occupy no rows and move nothing"
+        );
+    }
+
+    #[test]
+    fn grouped_bar_paints_series_side_by_side() {
+        let (red, green, blue) = (
+            Color::rgb(255, 0, 0),
+            Color::rgb(0, 255, 0),
+            Color::rgb(0, 0, 255),
+        );
+        // Plot is 12 wide → one 12-cell slot split into three 4-cell
+        // sub-bars, each with its own height.
+        let area = Rect::new(0, 0, 14, 7);
+        let mut buf = Buffer::empty(area);
+        let chart = bar_chart_of(
+            ChartKind::BarGrouped,
+            vec![
+                series_of("a", vec![1.0], red),
+                series_of("b", vec![2.0], green),
+                series_of("c", vec![3.0], blue),
+            ],
+            Some((0.0, 3.0)),
+        );
+        // Grouped mode keeps the single-value ceiling.
+        assert_eq!(chart.effective_y_range(), (0.0, 3.0));
+        let layout = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
+        let px = layout.plot_area.x.round() as u16;
+        let py = layout.plot_area.y.round() as u16;
+        let ph = layout.plot_area.height.round() as u16;
+        let pw = layout.plot_area.width.round() as u16;
+        let sub_w = pw / 3;
+
+        let bottom = py + ph - 2;
+        for (i, color) in [red, green, blue].into_iter().enumerate() {
+            let col = px + sub_w * i as u16;
+            assert_eq!(
+                fg_at(&buf, col, bottom),
+                ratatui_color(color),
+                "sub-bar {i} owns its own columns:\n{:?}",
+                grid(&buf, area)
+            );
+        }
+        // Heights rise 1 → 2 → 3 across the sub-bars: the shortest does
+        // not reach the row the tallest does.
+        let top = py;
+        assert_eq!(cell_char(&buf, px + sub_w * 2, top), '█');
+        assert_eq!(cell_char(&buf, px, top), ' ');
+    }
+
+    #[test]
+    fn bar_hover_marker_lands_on_the_hovered_stack_segment() {
+        let area = Rect::new(0, 0, 12, 7);
+        let chart = bar_chart_of(
+            ChartKind::Bar,
+            vec![
+                series_of("a", vec![1.0], Color::rgb(255, 0, 0)),
+                series_of("b", vec![1.0], Color::rgb(0, 255, 0)),
+                series_of("c", vec![1.0], Color::rgb(0, 0, 255)),
+            ],
+            Some((0.0, 3.0)),
+        );
+        let marker_row = |hovered: (usize, usize)| {
+            let mut buf = Buffer::empty(area);
+            let layout = draw_chart(
+                &mut buf,
+                area,
+                &chart,
+                &Theme::default(),
+                Some(hovered),
+                None,
+            );
+            let px = layout.plot_area.x.round() as u16;
+            let pw = layout.plot_area.width.round() as u16;
+            let py = layout.plot_area.y.round() as u16;
+            let ph = layout.plot_area.height.round() as u16;
+            let row = (py..py + ph)
+                .find(|&row| (px..px + pw).any(|col| cell_char(&buf, col, row) == '●'))
+                .unwrap_or_else(|| panic!("no hover marker painted:\n{:?}", grid(&buf, area)));
+            (row, py, ph)
+        };
+
+        // Six plot rows, two per segment: hovering the bottom series
+        // marks the bottom band, the top series the top band — not the
+        // one spot the braille/line math used to pick for every series.
+        let (bottom_row, py, ph) = marker_row((0, 0));
+        assert!(
+            bottom_row >= py + ph - 3,
+            "bottom segment marker at {bottom_row}, plot rows {py}..{}",
+            py + ph
+        );
+        let (top_row, py, ph) = marker_row((2, 0));
+        assert!(
+            top_row <= py + 1,
+            "top segment marker at {top_row}, plot rows {py}..{}",
+            py + ph
+        );
+    }
+
+    #[test]
+    fn multi_series_bar_legend_labels_every_series() {
+        let area = Rect::new(0, 0, 30, 8);
+        let mut buf = Buffer::empty(area);
+        let mut chart = bar_chart_of(
+            ChartKind::Bar,
+            vec![
+                series_of("OK", vec![1.0], Color::rgb(255, 0, 0)),
+                series_of("Slow", vec![1.0], Color::rgb(0, 255, 0)),
+                series_of("Fail", vec![1.0], Color::rgb(0, 0, 255)),
+            ],
+            Some((0.0, 3.0)),
+        );
+        chart.show_legend = true;
+        let layout = draw_chart(&mut buf, area, &chart, &Theme::default(), None, None);
+        let lb = layout.legend_bounds.expect("bar charts get a legend row");
+        let row: String = (lb.x.round() as u16..(lb.x + lb.width).round() as u16)
+            .map(|x| cell_char(&buf, x, lb.y.round() as u16))
+            .collect();
+        assert!(
+            row.contains("OK") && row.contains("Slow") && row.contains("Fail"),
+            "every bar series should be named in the legend: {row:?}"
+        );
     }
 
     #[test]

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -3261,6 +3261,142 @@ fn chart_switching_to_line_view_paints_axis_labels_and_gridlines() {
     );
 }
 
+// ─── ChartApp (issue #584): stacked vs grouped multi-series bars ──────────
+//
+// `ChartApp`'s bar views share one three-series dataset (`OK`, `Slow`,
+// `Failed`), so '3' and '4' paint the same numbers composed two different
+// ways. Before #584 the TUI bar painter rendered `series[0]` and silently
+// dropped the rest, which looked like a perfectly plausible chart — the
+// only way to catch that regression is to assert on the rendered grid,
+// not on "did a bar appear".
+//
+// `Failed` is `[10, 0, 35, 20, 5]`: its zero at index 1 is the
+// "one series is all zeros at this x" case, which must contribute no
+// rows and must not shift the segments below or above it.
+
+/// Height (in `█` rows) of every screen column, left to right.
+fn bar_column_heights(screen: &str) -> Vec<usize> {
+    let rows: Vec<&str> = screen.lines().collect();
+    let width = rows.iter().map(|r| r.chars().count()).max().unwrap_or(0);
+    (0..width)
+        .map(|col| {
+            rows.iter()
+                .filter(|row| row.chars().nth(col) == Some('█'))
+                .count()
+        })
+        .collect()
+}
+
+/// Column heights collapsed to one entry per run of equal-height
+/// columns — i.e. one entry per painted bar (stacked slots are painted
+/// full-slot-width; grouped sub-bars are narrower).
+fn bar_runs(screen: &str) -> Vec<usize> {
+    let mut runs: Vec<usize> = Vec::new();
+    for h in bar_column_heights(screen) {
+        if runs.last() != Some(&h) {
+            runs.push(h);
+        }
+    }
+    // Drop the leading/trailing empty gutter columns.
+    while runs.first() == Some(&0) {
+        runs.remove(0);
+    }
+    while runs.last() == Some(&0) {
+        runs.pop();
+    }
+    runs
+}
+
+#[test]
+fn chart_stacked_bar_view_paints_every_series_scaled_to_column_totals() {
+    let mut driver = TuiDriver::new(ChartApp::new(), 100, 30);
+    driver.type_char('3');
+    let screen = driver.screen();
+
+    assert!(
+        screen.contains("Bar (stacked)"),
+        "status bar should name the stacked view:\n{screen}"
+    );
+    for label in ["OK", "Slow", "Failed"] {
+        assert!(
+            screen.contains(label),
+            "legend should name every bar series, missing {label:?}:\n{screen}"
+        );
+    }
+
+    // One run per x-position: a stack is painted across the whole slot,
+    // so all of a slot's columns share a height.
+    let runs = bar_runs(&screen);
+    assert_eq!(
+        runs.len(),
+        5,
+        "expected one full-width stack per x-position, got {runs:?}:\n{screen}"
+    );
+
+    // Heights track the *column totals* (170, 290, 240, 400, 115), not
+    // `series[0]` (120, 230, 180, 310, 95) and not the tallest single
+    // value — the pre-#584 painter would have scaled to series[0] alone.
+    let tallest = *runs.iter().max().unwrap() as f64;
+    assert!(tallest > 0.0, "no bars painted:\n{screen}");
+    let expected = [170.0, 290.0, 240.0, 400.0, 115.0];
+    for (i, &total) in expected.iter().enumerate() {
+        let want = total / 400.0 * tallest;
+        let got = runs[i] as f64;
+        assert!(
+            (got - want).abs() <= 1.0,
+            "stack {i} is {got} rows, expected ~{want:.1} for a column total of {total} \
+             (all runs: {runs:?}):\n{screen}"
+        );
+    }
+    // Index 1 is the zeroed `Failed` value: its stack is exactly
+    // OK+Slow, so a zero series neither adds rows nor shifts the rest.
+    assert!(runs[1] > runs[2], "290 should out-top 240: {runs:?}");
+}
+
+#[test]
+fn chart_grouped_bar_view_paints_series_side_by_side() {
+    let mut driver = TuiDriver::new(ChartApp::new(), 100, 30);
+    driver.type_char('3');
+    let stacked = driver.screen();
+    driver.type_char('4');
+    let grouped = driver.screen();
+
+    assert!(
+        grouped.contains("Bar (grouped)"),
+        "status bar should name the grouped view:\n{grouped}"
+    );
+    for label in ["OK", "Slow", "Failed"] {
+        assert!(
+            grouped.contains(label),
+            "legend should name every bar series, missing {label:?}:\n{grouped}"
+        );
+    }
+
+    // Each x-position is now three narrower bars of independent height,
+    // so the grid carries many more distinct-height runs than the five
+    // full-width stacks.
+    let grouped_runs = bar_runs(&grouped);
+    assert!(
+        grouped_runs.len() >= 10,
+        "expected side-by-side sub-bars, got {grouped_runs:?}:\n{grouped}"
+    );
+
+    // A zero-valued sub-bar paints nothing while its neighbours stay put.
+    assert!(
+        grouped_runs.iter().any(|&h| h == 0),
+        "the zeroed `Failed` sub-bar should be empty, not shifted: {grouped_runs:?}\n{grouped}"
+    );
+
+    // Grouped bars are thirds of a slot scaled to the tallest single
+    // value, so they cover far less of the plot than the stacks do.
+    let stacked_cells: usize = bar_column_heights(&stacked).iter().sum();
+    let grouped_cells: usize = bar_column_heights(&grouped).iter().sum();
+    assert!(
+        grouped_cells > 0 && grouped_cells < stacked_cells,
+        "grouped ({grouped_cells}) should fill less than stacked ({stacked_cells})"
+    );
+}
+
 // ─── IndicatorsApp (issue #308): toggling cancellable paints/clears '×' ────
 //
 // `IndicatorsApp::handle`'s `'c'` arm flips `self.cancellable`, which


### PR DESCRIPTION
Closes #584

Automated PR opened by coordinator for review of issue #584.