### PR TITLE
#540: cargo check --features win STILL fails on develop after #537 — 6 dead-code errors in shell_adapter.rs, and no CI job builds the win feature at all

### DIFF
--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -134,6 +134,13 @@ pub mod modal_stack;
 // runners (in `quadraui::tui::run`, `quadraui::gtk::run`) drive against.
 // See `docs/BACKEND_SETUP_AUDIT.md` (#260) for design rationale.
 pub mod runner;
+// `ShellAdapter` is constructed only by the TUI/GTK shell runners
+// (`crate::tui::shell_runner`, `crate::gtk::shell_runner`); under `win` alone
+// (no runner exists yet) nothing builds one, so the whole module — struct,
+// impls, and its private helpers — goes dead-code under `-D warnings` (#540).
+// Gate the module on the features that actually consume it rather than
+// `#[allow(dead_code)]`-ing the individual items.
+#[cfg(any(feature = "tui", feature = "gtk"))]
 pub mod shell_adapter;
 
 pub use diff::compute_hunks;

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -334,6 +334,11 @@ pub enum ActivityBarEvent {
 /// This is `pub(crate)` because external consumers receive the already-normalised
 /// string from [`ActivityBarEvent::KeyPressed::key`] — they have no reason to call
 /// the conversion helper directly.
+///
+/// `cfg`-gated: only `crate::tui::backend` and `crate::gtk::run` call this
+/// today. Under `win` alone (no consumer yet) it goes dead-code under
+/// `-D warnings` (#540).
+#[cfg(any(feature = "tui", feature = "gtk"))]
 pub(crate) fn key_to_activity_bar_string(key: &crate::event::Key) -> String {
     use crate::event::{Key, NamedKey};
     match key {

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -184,6 +184,11 @@ impl<'a> ShellContext<'a> {
     /// Construct a [`ShellContext`] for one `ShellApp::handle` dispatch.
     /// Only called by [`crate::shell_adapter::ShellAdapter`]; downstream
     /// consumers receive an already-built context, they don't build one.
+    ///
+    /// `cfg`-gated with `ShellAdapter` itself (#540): under `win` alone
+    /// there is no caller, so this and `take_activity_focus_requested`
+    /// below go dead-code under `-D warnings`.
+    #[cfg(any(feature = "tui", feature = "gtk"))]
     pub(crate) fn new(
         active_panel_id: Option<&'a WidgetId>,
         sidebar_visible: bool,
@@ -254,6 +259,9 @@ impl<'a> ShellContext<'a> {
     /// Consume the pending focus request, if any. `pub(crate)` — only
     /// [`crate::shell_adapter::ShellAdapter::handle`] calls this, after
     /// `ShellApp::handle` returns.
+    ///
+    /// `cfg`-gated with `ShellAdapter` itself (#540); see [`Self::new`].
+    #[cfg(any(feature = "tui", feature = "gtk"))]
     pub(crate) fn take_activity_focus_requested(&self) -> bool {
         self.activity_focus_requested.replace(false)
     }


### PR DESCRIPTION
Closes #540

Automated PR opened by coordinator for review of issue #540.