### PR TITLE
ci(quadraui): #598 trigger macos.yml on macOS-touching PRs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,23 +6,45 @@ name: macOS
 # being all-Linux (precision / elitebook / dellserver) — worth stating
 # plainly since that blocker doesn't apply here.
 #
-# NOT wired to push/pull_request. `lib.rs` gates `mod macos` on
-# `target_os = "macos"`, so this job would be red on arrival: #484 reports
-# `MacBackend` missing 7 trait methods plus degenerate rasterisers.
-# claude-coordinator#581 already tried `continue-on-error: true` on a
-# red-on-arrival platform leg (see ci.yml's windows-latest leg in the `tui`
-# job) and that only gets you halfway: it keeps the *workflow run* green,
-# but the *job's own check* still reports `failure`, and `coord`'s merge
-# gate reads per-check conclusions — so a permanently-red macOS check would
-# still block `coord merge` on every quadraui PR regardless of
-# continue-on-error. Manual/scheduled instead of blocking sidesteps that
-# entirely: no check is posted to PRs at all until #484 lands. At that
-# point this job (or its build/test steps, folded back into ci.yml's normal
-# triggers) should move onto `push`/`pull_request` — matching the
-# windows-latest rollout precedent: land non-blocking, flip to blocking
-# once green, in its own commit.
+# Wired to `pull_request` ONLY through a path filter (#598). The original
+# #483 posture was schedule/manual-only, for a sound reason: `lib.rs` gates
+# `mod macos` on `target_os = "macos"`, so this job is red on arrival (#484
+# reports `MacBackend` missing 7 trait methods plus degenerate rasterisers),
+# and a permanently-red check would block `coord merge` on EVERY quadraui
+# PR. claude-coordinator#581 established that `continue-on-error: true`
+# does not rescue that: it keeps the *workflow run* green, but the *job's
+# own check* still reports `failure`, and coord's merge gate reads
+# per-check conclusions.
+#
+# What that posture could not do is let #484 ever be verified. The fleet
+# (precision / elitebook / dellserver) is all Linux and advertises no
+# `macos` capability, and because the gate above is on `target_os` rather
+# than the feature alone, `cargo check -p quadraui --features macos` on
+# Linux exits 0 having compiled NONE of `src/macos/` — measured, 22s, a
+# green result that proves nothing. Nor can the round-trip tests #484
+# mandates run: `macos/headless.rs::BitmapSurface` is inside the same gated
+# module. So every gate a worker passes through would report success while
+# proving nothing, and the old header's "move onto push/pull_request once
+# #484 lands" was circular — #484 cannot land without this signal.
+#
+# The path filter resolves both at once, and is load-bearing:
+#
+#   * A PR touching nothing under `quadraui/src/macos/**` gets NO macOS
+#     check — not a passing one, not a failing one, none at all. Unrelated
+#     work is untouched, exactly as #483 intended.
+#   * A PR touching macOS gets a real macos-latest build + test, where a
+#     red check is CORRECT: it is #484's progress bar and should hold the
+#     merge until the backend actually compiles.
+#
+# Do NOT add `continue-on-error` here, and do NOT "restore" the
+# schedule-only trigger — that re-creates the circularity above.
 on:
   workflow_dispatch: {}
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "quadraui/src/macos/**"
+      - ".github/workflows/macos.yml"
   schedule:
     # Mondays 06:00 UTC. Arbitrary but deliberate: frequent enough that a
     # regression in `src/macos` (193 tests, only ever run here) doesn't sit


### PR DESCRIPTION
Closes #598. Prerequisite for #484. Refs #479.

## ⚠ The macOS check on THIS PR is expected to be RED — that is the point

This PR edits `.github/workflows/macos.yml`, which is inside its own new paths filter, so it triggers the macOS job. That job fails today because `MacBackend` is missing 7 trait methods (#484). **The red check is the demonstration that the trigger works**, and its log is a precise, current list of what #484 must implement.

All `ci.yml` checks should be green as usual. Merge past the red macOS check deliberately — do not "fix" it by weakening the trigger.

## The circularity this resolves

#483 put this workflow on `workflow_dispatch` + weekly cron only, for a sound reason its header records: the job is red on arrival, and a permanently-red check blocks `coord merge` on **every** quadraui PR — which `continue-on-error` does *not* fix, because coord's gate reads per-check conclusions rather than the workflow run's (claude-coordinator#581).

That header then says the job should move onto `push`/`pull_request` *once #484 lands*. **But #484 cannot be verified without this signal**, so that condition was unreachable.

Measured on `develop`: `lib.rs:108` gates the module on `target_os = "macos"`, not the feature alone, and the fleet (precision / elitebook / dellserver) is all Linux with no `macos` capability. So `cargo check -p quadraui --features macos` on Linux **exits 0 in ~22s having compiled none of `src/macos/`** — a green result proving nothing. The round-trip tests #484 mandates can't run either: `macos/headless.rs::BitmapSurface` is in the same gated module.

Without this, a worker on #484 would write several hundred uncompilable lines and collect a green `cargo check`, a green Test verdict (`--features tui`), and a review from an agent that also can't compile it — every gate reporting success while proving nothing.

## Why the path filter is load-bearing

It threads #483's needle rather than undoing it:

- A PR touching nothing under `quadraui/src/macos/**` gets **no macOS check at all** — not passing, not failing, absent. Unrelated work unaffected, exactly as #483 intended.
- A PR touching macOS gets a real `macos-latest` build + test, where red is correct: it's #484's progress bar and should hold the merge until the backend compiles.

No `continue-on-error` — on a macOS-touching PR, blocking is the intent, and #581 showed non-blocking would make the check decorative while still reporting failure.

## Scope

Trigger only. `workflow_dispatch` and the weekly cron are unchanged; the job's steps, toolchain and `ci.yml` are untouched. Folding the macOS lane back into `ci.yml` stays a #484 follow-up.

## Verification

YAML parses; triggers are `workflow_dispatch` + `pull_request` (branches `main`/`develop`, paths `quadraui/src/macos/**` and the workflow itself) + the unchanged cron; `runs-on: macos-latest`; no `continue-on-error`; all 5 steps intact. The header comment is rewritten to record the circularity so the next reader doesn't restore the schedule-only trigger.