### PR TITLE
#486: macOS runtime event parity: DoubleClick, WindowResized, accelerator matching, ClipboardPaste

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -92,6 +92,7 @@ objc2-foundation = { version = "0.2", optional = true, features = [
     "NSArray",
     "NSDate",
     "NSGeometry",
+    "NSNotification",
     "NSObject",
     "NSProcessInfo",
     "NSString",

--- a/quadraui/src/dispatch.rs
+++ b/quadraui/src/dispatch.rs
@@ -816,6 +816,69 @@ pub fn dispatch_click(
     }]
 }
 
+// ─── Double-click synthesis ────────────────────────────────────────────────
+//
+// Backend-agnostic: relocated here from `tui::events` (issue #486) so
+// `macos::run` can reuse it without pulling in the `tui` feature. TUI's
+// `TuiBackend` batches translated events and calls
+// [`DoubleClickDetector::process`] on the whole slice each poll; macOS
+// dispatches synchronously per `NSEvent`, so `macos::backend::MacBackend`
+// wraps a single event in a one-element array before calling `process`.
+
+use std::time::{Duration, Instant};
+
+const DOUBLE_CLICK_MS: u64 = 400;
+const DOUBLE_CLICK_RADIUS: f32 = 1.5;
+
+/// Detects double-clicks from repeated `MouseDown` events within a
+/// time window at the same position. Stateful — lives on the backend
+/// (`TuiBackend::double_click`, `MacBackend::double_click`).
+#[derive(Default)]
+pub struct DoubleClickDetector {
+    last_click_time: Option<Instant>,
+    last_click_pos: Point,
+    last_click_button: MouseButton,
+}
+
+impl DoubleClickDetector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process a batch of translated events. Replaces `MouseDown` with
+    /// `DoubleClick` when the same button clicks at the same position
+    /// within the time window.
+    pub fn process(&mut self, events: &mut [UiEvent]) {
+        let now = Instant::now();
+        for ev in events.iter_mut() {
+            if let UiEvent::MouseDown {
+                button, position, ..
+            } = ev
+            {
+                let is_double = self
+                    .last_click_time
+                    .map(|t| now.duration_since(t) < Duration::from_millis(DOUBLE_CLICK_MS))
+                    .unwrap_or(false)
+                    && *button == self.last_click_button
+                    && (position.x - self.last_click_pos.x).abs() <= DOUBLE_CLICK_RADIUS
+                    && (position.y - self.last_click_pos.y).abs() <= DOUBLE_CLICK_RADIUS;
+
+                if is_double {
+                    *ev = UiEvent::DoubleClick {
+                        widget: None,
+                        position: *position,
+                    };
+                    self.last_click_time = None;
+                } else {
+                    self.last_click_time = Some(now);
+                    self.last_click_pos = *position;
+                    self.last_click_button = *button;
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2202,5 +2265,64 @@ mod tests {
             assert_eq!(c_start, 5);
             assert_eq!(c_end, 25);
         }
+    }
+
+    // ── DoubleClickDetector tests ────────────────────────────────────
+
+    fn mouse_down(x: f32, y: f32) -> UiEvent {
+        UiEvent::MouseDown {
+            widget: None,
+            button: MouseButton::Left,
+            position: Point::new(x, y),
+            modifiers: Modifiers::default(),
+        }
+    }
+
+    #[test]
+    fn double_click_detected_on_same_position() {
+        let mut det = DoubleClickDetector::new();
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(matches!(events[0], UiEvent::MouseDown { .. }));
+
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(
+            matches!(events[0], UiEvent::DoubleClick { .. }),
+            "second click at same position should be DoubleClick"
+        );
+    }
+
+    #[test]
+    fn no_double_click_at_different_position() {
+        let mut det = DoubleClickDetector::new();
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+
+        let mut events = vec![mouse_down(20.0, 10.0)];
+        det.process(&mut events);
+        assert!(
+            matches!(events[0], UiEvent::MouseDown { .. }),
+            "click at different position should NOT be DoubleClick"
+        );
+    }
+
+    #[test]
+    fn triple_click_resets_to_single() {
+        let mut det = DoubleClickDetector::new();
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(matches!(events[0], UiEvent::DoubleClick { .. }));
+
+        // Third click at same position — resets to single (no triple-click).
+        let mut events = vec![mouse_down(5.0, 3.0)];
+        det.process(&mut events);
+        assert!(
+            matches!(events[0], UiEvent::MouseDown { .. }),
+            "third click should reset to MouseDown"
+        );
     }
 }

--- a/quadraui/src/dispatch.rs
+++ b/quadraui/src/dispatch.rs
@@ -828,21 +828,59 @@ pub fn dispatch_click(
 use std::time::{Duration, Instant};
 
 const DOUBLE_CLICK_MS: u64 = 400;
+/// Tuned for TUI's **character-cell** coordinate grid, where adjacent
+/// cells are a whole unit apart — a 1.5-cell tolerance comfortably
+/// covers "same cell" while rejecting "next cell over". Backends whose
+/// `MouseDown` positions are in a different unit (e.g. macOS's
+/// point-precision `NSEvent` coordinates) must not inherit this value;
+/// see [`DoubleClickDetector::with_radius`] and
+/// `quadraui/docs/LESSONS.md`'s "No hardcoded px / cell / DIP
+/// constants" rule — constants belong on the backend, not shared code.
 const DOUBLE_CLICK_RADIUS: f32 = 1.5;
 
 /// Detects double-clicks from repeated `MouseDown` events within a
 /// time window at the same position. Stateful — lives on the backend
 /// (`TuiBackend::double_click`, `MacBackend::double_click`).
-#[derive(Default)]
 pub struct DoubleClickDetector {
     last_click_time: Option<Instant>,
     last_click_pos: Point,
     last_click_button: MouseButton,
+    /// Position tolerance, in whatever unit the caller's `MouseDown`
+    /// positions use. Defaults to [`DOUBLE_CLICK_RADIUS`] (TUI's
+    /// character-cell tolerance) via [`Self::new`] /
+    /// [`Self::default`]; callers in a different coordinate system
+    /// should use [`Self::with_radius`] instead.
+    radius: f32,
+}
+
+impl Default for DoubleClickDetector {
+    fn default() -> Self {
+        Self {
+            last_click_time: None,
+            last_click_pos: Point::default(),
+            last_click_button: MouseButton::default(),
+            radius: DOUBLE_CLICK_RADIUS,
+        }
+    }
 }
 
 impl DoubleClickDetector {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Same detector, but with a caller-supplied position-tolerance
+    /// `radius` instead of [`DOUBLE_CLICK_RADIUS`]. Use this whenever
+    /// the consumer's `MouseDown` positions aren't TUI's character-cell
+    /// grid — e.g. `MacBackend` wraps native `NSEvent` coordinates,
+    /// which are point-precision, so a 1.5-point tolerance (the raw
+    /// cell-tuned constant) is far tighter than two real clicks can
+    /// reliably land within.
+    pub fn with_radius(radius: f32) -> Self {
+        Self {
+            radius,
+            ..Self::default()
+        }
     }
 
     /// Process a batch of translated events. Replaces `MouseDown` with
@@ -860,8 +898,8 @@ impl DoubleClickDetector {
                     .map(|t| now.duration_since(t) < Duration::from_millis(DOUBLE_CLICK_MS))
                     .unwrap_or(false)
                     && *button == self.last_click_button
-                    && (position.x - self.last_click_pos.x).abs() <= DOUBLE_CLICK_RADIUS
-                    && (position.y - self.last_click_pos.y).abs() <= DOUBLE_CLICK_RADIUS;
+                    && (position.x - self.last_click_pos.x).abs() <= self.radius
+                    && (position.y - self.last_click_pos.y).abs() <= self.radius;
 
                 if is_double {
                     *ev = UiEvent::DoubleClick {

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -21,11 +21,15 @@
 //!
 //! [`crate::macos::run`]'s responder methods translate `NSEvent` into
 //! [`UiEvent`] (via [`crate::macos::events`]) and dispatch the result
-//! through the app's [`crate::runner::AppLogic`] synchronously. The
-//! queue here exists for parity with [`Backend`] callers that prefer
-//! the poll API and for backend-side producers landing in later
-//! tickets (window resize notification observers, accelerator-match
-//! rewrites).
+//! through the app's [`crate::runner::AppLogic`] synchronously —
+//! including the accelerator-match / double-click-fold / paste-
+//! interception pre-processing `run`'s `handle` closure applies before
+//! `AppLogic::handle` sees the event (#486). The queue here exists for
+//! parity with [`Backend`] callers that prefer the poll API and for
+//! backend-side producers (native menu activations, context-menu
+//! results). `WindowResized` (from the `NSViewFrameDidChangeNotification`
+//! observer, #486) dispatches synchronously like mouse/keyboard events
+//! rather than going through the queue.
 
 use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
@@ -35,8 +39,9 @@ use std::time::Duration;
 use core_graphics::sys::CGContextRef;
 use core_text::font::CTFont;
 
+use crate::accelerator::{key_to_binding_name, parse_binding};
 use crate::backend::{Backend, EditorPaintResult};
-use crate::dispatch::DragState;
+use crate::dispatch::{DoubleClickDetector, DragState};
 use crate::event::{Rect, UiEvent, Viewport};
 use crate::modal_stack::ModalStack;
 use crate::primitives::activity_bar::ActivityBarRowHit;
@@ -71,8 +76,9 @@ use crate::primitives::tooltip::{Tooltip, TooltipLayout};
 use crate::primitives::tree::TreeViewLayout;
 use crate::types::WidgetId;
 use crate::{
-    Accelerator, AcceleratorId, ActivityBar, Form, ListView, Palette, PlatformServices, StatusBar,
-    TabBar, Terminal, TextDisplay, Theme, TreeView,
+    Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Form, Key, ListView, Modifiers,
+    Palette, ParsedBinding, PlatformServices, StatusBar, TabBar, Terminal, TextDisplay, Theme,
+    TreeView,
 };
 
 use super::services::MacPlatformServices;
@@ -83,11 +89,16 @@ use super::services::MacPlatformServices;
 /// - `viewport` — width × height in points, scale = `backingScaleFactor`.
 ///   Updated each frame from the active `QuadraView`'s bounds.
 /// - `modal_stack` — pushed by hosts on modal open, popped on close.
-/// - `accelerators` — registered keybindings. Match-and-dispatch wiring
-///   lands when first consumer needs it.
+/// - `accelerators` / `parsed_accelerators` — registered keybindings and
+///   their parsed form; [`Self::match_keypress`] resolves a native
+///   keypress against them (#486). [`run`][super::run]'s `handle`
+///   closure rewrites a matching `KeyPressed` into `Accelerator` before
+///   `AppLogic::handle` sees it.
+/// - `double_click` — folds a `MouseDown` into `DoubleClick` (#486); see
+///   [`Self::fold_double_click`].
 /// - `events` — adapter queue. [`run`][super::run]'s responder methods
-///   dispatch synchronously today; the queue is reserved for backend-
-///   side producers (window notifications, future timer ticks).
+///   dispatch synchronously today; the queue is used for backend-side
+///   producers (native menu activations, context-menu results).
 /// - `current_cg_ptr` — frame-scope pointer; non-null only inside
 ///   [`Self::enter_frame_scope`].
 /// - `current_font` / `current_line_height` / `current_char_width` —
@@ -98,6 +109,18 @@ pub struct MacBackend {
     modal_stack: ModalStack,
     drag_state: DragState,
     accelerators: HashMap<AcceleratorId, Accelerator>,
+    /// Parsed form of `accelerators`, kept in sync by
+    /// `register_accelerator` / `unregister_accelerator`. Mirrors
+    /// `TuiBackend::parsed_accelerators` / `GtkBackend::parsed_accelerators`
+    /// — a `Vec` rather than a map because match order matters (first
+    /// registered wins on an accidental duplicate binding).
+    parsed_accelerators: Vec<(ParsedBinding, AcceleratorId)>,
+    /// Folds a `MouseDown` `NSEvent` into `DoubleClick` when it lands
+    /// within the time/position window of the previous click (#486).
+    /// `macos::run` dispatches synchronously per `NSEvent`, so this
+    /// runs on one event at a time via `Self::fold_double_click`
+    /// rather than `TuiBackend`'s per-poll batch.
+    double_click: DoubleClickDetector,
     events: Rc<std::cell::RefCell<VecDeque<UiEvent>>>,
     services: MacPlatformServices,
     /// Type-erased `CGContextRef`; non-null only inside
@@ -140,6 +163,8 @@ impl MacBackend {
             modal_stack: ModalStack::new(),
             drag_state: DragState::new(),
             accelerators: HashMap::new(),
+            parsed_accelerators: Vec::new(),
+            double_click: DoubleClickDetector::new(),
             events: Rc::new(std::cell::RefCell::new(VecDeque::new())),
             services: MacPlatformServices::new(),
             current_cg_ptr: Cell::new(std::ptr::null()),
@@ -237,6 +262,40 @@ impl MacBackend {
     pub(crate) fn current_cg(&self) -> CGContextRef {
         self.current_cg_ptr.get() as CGContextRef
     }
+
+    // ── Accelerator matching (#486) ──────────────────────────────────
+
+    /// Look up a registered `Global`-scope accelerator for a
+    /// `(key, modifiers)` pair. Mirrors `TuiBackend::match_keypress` /
+    /// `GtkBackend::match_keypress` — non-Global entries are skipped
+    /// because this backend doesn't own focus/mode context the way a
+    /// scoped `KeyMap` resolver does.
+    pub(crate) fn match_keypress(&self, key: &Key, modifiers: Modifiers) -> Option<AcceleratorId> {
+        let key_name = key_to_binding_name(key);
+        for (parsed, id) in &self.parsed_accelerators {
+            if parsed.modifiers == modifiers && parsed.key == key_name {
+                if let Some(acc) = self.accelerators.get(id) {
+                    if matches!(acc.scope, AcceleratorScope::Global) {
+                        return Some(id.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    // ── Double-click folding (#486) ──────────────────────────────────
+
+    /// Fold a `MouseDown` into `DoubleClick` if it lands within the
+    /// detector's time/position window of the previous click. Every
+    /// other variant passes through unchanged. `macos::run` calls this
+    /// on each translated `NSEvent` before handing it to `AppLogic`.
+    pub(crate) fn fold_double_click(&mut self, ev: UiEvent) -> UiEvent {
+        let mut events = [ev];
+        self.double_click.process(&mut events);
+        let [ev] = events;
+        ev
+    }
 }
 
 impl Default for MacBackend {
@@ -281,17 +340,20 @@ impl Backend for MacBackend {
     }
 
     fn register_accelerator(&mut self, acc: &Accelerator) {
+        // Re-registration replaces the prior entry — both in the map and
+        // the parsed list, otherwise a stale binding would shadow the
+        // new one in `match_keypress`. Mirrors
+        // `TuiBackend::register_accelerator` / `GtkBackend`'s equivalent.
         self.accelerators.insert(acc.id.clone(), acc.clone());
-        // Match-and-dispatch wiring lands when the first consumer
-        // needs accelerators routed through the backend — until then
-        // accelerators are stored but never re-emitted as
-        // `UiEvent::Accelerator`. Apps that need accelerator dispatch
-        // today match `UiEvent::KeyPressed` against
-        // `crate::parse_key_binding` themselves.
+        self.parsed_accelerators.retain(|(_, id)| id != &acc.id);
+        if let Some(parsed) = parse_binding(&acc.binding) {
+            self.parsed_accelerators.push((parsed, acc.id.clone()));
+        }
     }
 
     fn unregister_accelerator(&mut self, id: &AcceleratorId) {
         self.accelerators.remove(id);
+        self.parsed_accelerators.retain(|(_, eid)| eid != id);
     }
 
     fn install_menu_bar(&mut self, bar: &crate::primitives::menu_bar::MenuBar) {
@@ -1765,6 +1827,137 @@ mod tests {
         assert!(b.accelerators.contains_key(&AcceleratorId::new("save")));
         b.unregister_accelerator(&AcceleratorId::new("save"));
         assert!(!b.accelerators.contains_key(&AcceleratorId::new("save")));
+    }
+
+    // ── Accelerator matching (#486) ──────────────────────────────────
+
+    #[test]
+    fn match_keypress_finds_registered_global_binding() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&acc("save", "<D-s>"));
+        let id = b.match_keypress(
+            &crate::Key::Char('s'),
+            Modifiers {
+                cmd: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(id, Some(AcceleratorId::new("save")));
+    }
+
+    #[test]
+    fn match_keypress_modifier_mismatch_no_match() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&acc("save", "<D-s>"));
+        // Same key, wrong modifiers (Ctrl instead of Cmd).
+        let id = b.match_keypress(
+            &crate::Key::Char('s'),
+            Modifiers {
+                ctrl: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(id, None);
+    }
+
+    #[test]
+    fn match_keypress_skips_non_global_scope() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&Accelerator {
+            id: AcceleratorId::new("find-in-tree"),
+            binding: KeyBinding::Literal("<D-f>".to_string()),
+            scope: AcceleratorScope::Mode("tree".into()),
+            label: None,
+        });
+        let id = b.match_keypress(
+            &crate::Key::Char('f'),
+            Modifiers {
+                cmd: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(id, None, "non-Global scope must not match here");
+    }
+
+    #[test]
+    fn match_keypress_unregister_removes_match() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&acc("save", "<D-s>"));
+        b.unregister_accelerator(&AcceleratorId::new("save"));
+        let id = b.match_keypress(
+            &crate::Key::Char('s'),
+            Modifiers {
+                cmd: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(id, None);
+    }
+
+    #[test]
+    fn match_keypress_re_register_replaces_binding() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&acc("save", "<D-s>"));
+        b.register_accelerator(&acc("save", "<D-S-s>")); // Cmd+Shift+S
+        assert!(b
+            .match_keypress(
+                &crate::Key::Char('s'),
+                Modifiers {
+                    cmd: true,
+                    ..Default::default()
+                }
+            )
+            .is_none());
+        assert_eq!(
+            b.match_keypress(
+                &crate::Key::Char('s'),
+                Modifiers {
+                    cmd: true,
+                    shift: true,
+                    ..Default::default()
+                }
+            ),
+            Some(AcceleratorId::new("save"))
+        );
+    }
+
+    // ── Double-click folding (#486) ──────────────────────────────────
+
+    fn mouse_down(x: f32, y: f32) -> UiEvent {
+        UiEvent::MouseDown {
+            widget: None,
+            button: crate::MouseButton::Left,
+            position: Point::new(x, y),
+            modifiers: Modifiers::default(),
+        }
+    }
+
+    #[test]
+    fn fold_double_click_second_click_same_position_becomes_double_click() {
+        let mut b = MacBackend::new();
+        let first = b.fold_double_click(mouse_down(5.0, 3.0));
+        assert!(matches!(first, UiEvent::MouseDown { .. }));
+
+        let second = b.fold_double_click(mouse_down(5.0, 3.0));
+        assert!(
+            matches!(second, UiEvent::DoubleClick { .. }),
+            "second click at the same position should fold to DoubleClick"
+        );
+    }
+
+    #[test]
+    fn fold_double_click_different_position_stays_mouse_down() {
+        let mut b = MacBackend::new();
+        let _ = b.fold_double_click(mouse_down(5.0, 3.0));
+        let second = b.fold_double_click(mouse_down(50.0, 30.0));
+        assert!(matches!(second, UiEvent::MouseDown { .. }));
+    }
+
+    #[test]
+    fn fold_double_click_passes_non_mouse_down_events_through() {
+        let mut b = MacBackend::new();
+        let ev = b.fold_double_click(UiEvent::WindowFocused(true));
+        assert_eq!(ev, UiEvent::WindowFocused(true));
     }
 
     #[test]

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -75,6 +75,7 @@ use crate::primitives::toast::{ToastStack, ToastStackLayout};
 use crate::primitives::tooltip::{Tooltip, TooltipLayout};
 use crate::primitives::tree::TreeViewLayout;
 use crate::types::WidgetId;
+use crate::KeyBinding;
 use crate::{
     Accelerator, AcceleratorId, AcceleratorScope, ActivityBar, Form, Key, ListView, Modifiers,
     Palette, ParsedBinding, PlatformServices, StatusBar, TabBar, Terminal, TextDisplay, Theme,
@@ -152,6 +153,52 @@ pub struct MacBackend {
     caret_blink_pause_until: std::rc::Rc<std::cell::Cell<std::time::Instant>>,
 }
 
+/// Position tolerance, in points, for [`MacBackend::fold_double_click`]'s
+/// [`DoubleClickDetector`].
+///
+/// `ns_mouse_down` (`macos/events.rs`) passes raw `NSEvent` `x`/`y`
+/// straight through — unlike TUI's whole character cells, these are
+/// point-precision, so the detector's default radius
+/// (`crate::dispatch::DOUBLE_CLICK_RADIUS`, 1.5 — tuned for TUI's
+/// integral cell grid) is far tighter than two real mouse/trackpad
+/// clicks can reliably land within. `4.0` points is a rough approximation
+/// of AppKit's own double-click hit region; it's a heuristic, not a
+/// measured constant, since there's no public API exposing the system's
+/// actual tolerance the way `NSEvent.clickCount` would sidestep this
+/// entirely (see the #486 review's non-blocking note — reading
+/// `clickCount` natively remains the more robust fix and should be
+/// revisited, ideally verified on real hardware).
+const MAC_DOUBLE_CLICK_RADIUS: f32 = 4.0;
+
+/// Translate a parsed universal [`KeyBinding`] to macOS's native Cmd
+/// idiom.
+///
+/// [`crate::accelerator::parse_binding`] is shared with `TuiBackend`, so
+/// its universal arms (`KeyBinding::Save`, `Copy`, `Paste`, …) resolve to
+/// a **Ctrl**-modifier `ParsedBinding` regardless of platform — correct
+/// for TUI, wrong for macOS. `menu_bar_install::accelerator_to_ns` (the
+/// native menu path) and `crate::accelerator::render_binding` (the
+/// display/tooltip path) both already render these as **Cmd** on macOS,
+/// so a `MacBackend::match_keypress` that compared the raw Ctrl
+/// `ParsedBinding` against a real Cmd keypress would never fire (#486
+/// review). Swap Ctrl for Cmd here so registration, native-menu
+/// resolution, and rendering all agree.
+///
+/// `KeyBinding::Literal` bindings are left untouched — the app author
+/// already chose the exact modifier they want (e.g. `<C-s>` for a
+/// deliberate Ctrl+S that coexists with the native Cmd+S), and
+/// `accelerator_to_ns`/`render_binding` don't rewrite literals either.
+fn macos_universal_binding_modifiers(
+    binding: &KeyBinding,
+    mut parsed: ParsedBinding,
+) -> ParsedBinding {
+    if !matches!(binding, KeyBinding::Literal(_)) && parsed.modifiers.ctrl {
+        parsed.modifiers.ctrl = false;
+        parsed.modifiers.cmd = true;
+    }
+    parsed
+}
+
 impl MacBackend {
     /// Construct a fresh `MacBackend` with a default viewport, empty
     /// event queue, default theme, and no font. The runner overwrites
@@ -164,7 +211,7 @@ impl MacBackend {
             drag_state: DragState::new(),
             accelerators: HashMap::new(),
             parsed_accelerators: Vec::new(),
-            double_click: DoubleClickDetector::new(),
+            double_click: DoubleClickDetector::with_radius(MAC_DOUBLE_CLICK_RADIUS),
             events: Rc::new(std::cell::RefCell::new(VecDeque::new())),
             services: MacPlatformServices::new(),
             current_cg_ptr: Cell::new(std::ptr::null()),
@@ -270,6 +317,14 @@ impl MacBackend {
     /// `GtkBackend::match_keypress` — non-Global entries are skipped
     /// because this backend doesn't own focus/mode context the way a
     /// scoped `KeyMap` resolver does.
+    ///
+    /// Native Cmd keypresses (`ns_modifier_flags_to_quadraui` maps a real
+    /// Cmd into `Modifiers { cmd: true, .. }`) compare directly against
+    /// `parsed_accelerators`, which already stores universal bindings
+    /// with Cmd instead of Ctrl — see
+    /// [`macos_universal_binding_modifiers`], applied once at
+    /// `register_accelerator` time so this lookup stays a plain
+    /// equality check.
     pub(crate) fn match_keypress(&self, key: &Key, modifiers: Modifiers) -> Option<AcceleratorId> {
         let key_name = key_to_binding_name(key);
         for (parsed, id) in &self.parsed_accelerators {
@@ -347,6 +402,7 @@ impl Backend for MacBackend {
         self.accelerators.insert(acc.id.clone(), acc.clone());
         self.parsed_accelerators.retain(|(_, id)| id != &acc.id);
         if let Some(parsed) = parse_binding(&acc.binding) {
+            let parsed = macos_universal_binding_modifiers(&acc.binding, parsed);
             self.parsed_accelerators.push((parsed, acc.id.clone()));
         }
     }
@@ -1918,6 +1974,110 @@ mod tests {
                 }
             ),
             Some(AcceleratorId::new("save"))
+        );
+    }
+
+    /// Regression test for the blocking review finding on this PR:
+    /// `parse_binding` (shared with `TuiBackend`) resolves every
+    /// universal `KeyBinding` variant to a **Ctrl** `ParsedBinding`
+    /// regardless of platform. `accelerator_to_ns` (native menu path)
+    /// and `render_binding` (display path) both already render these
+    /// as **Cmd** on macOS, so a real Cmd+S keypress — the one the UI
+    /// tells the user to press — must match a `KeyBinding::Save`
+    /// registration.
+    #[test]
+    fn match_keypress_universal_binding_matches_native_cmd_not_ctrl() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&Accelerator {
+            id: AcceleratorId::new("save"),
+            binding: KeyBinding::Save,
+            scope: AcceleratorScope::Global,
+            label: None,
+        });
+
+        // The advertised shortcut (⌘S, matching `accelerator_to_ns` /
+        // `render_binding`) must fire.
+        assert_eq!(
+            b.match_keypress(
+                &crate::Key::Char('s'),
+                Modifiers {
+                    cmd: true,
+                    ..Default::default()
+                },
+            ),
+            Some(AcceleratorId::new("save")),
+        );
+
+        // The raw literal Ctrl+S that `parse_binding` alone would
+        // produce must NOT fire — that's not what's on screen and not
+        // the native macOS idiom.
+        assert_eq!(
+            b.match_keypress(
+                &crate::Key::Char('s'),
+                Modifiers {
+                    ctrl: true,
+                    ..Default::default()
+                },
+            ),
+            None,
+        );
+    }
+
+    /// `KeyBinding::Redo` parses to `<C-S-z>` (Ctrl+Shift+Z) — verifies
+    /// the Ctrl→Cmd translation preserves the co-occurring Shift
+    /// modifier instead of clobbering it, matching
+    /// `accelerator_to_ns`'s `cmd() | shift()` for the same variant.
+    #[test]
+    fn match_keypress_universal_binding_preserves_shift_modifier() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&Accelerator {
+            id: AcceleratorId::new("redo"),
+            binding: KeyBinding::Redo,
+            scope: AcceleratorScope::Global,
+            label: None,
+        });
+
+        assert_eq!(
+            b.match_keypress(
+                &crate::Key::Char('z'),
+                Modifiers {
+                    cmd: true,
+                    shift: true,
+                    ..Default::default()
+                },
+            ),
+            Some(AcceleratorId::new("redo")),
+        );
+    }
+
+    /// `KeyBinding::Literal` bindings are an app author's deliberate,
+    /// exact choice (e.g. a literal Ctrl+S that coexists with the
+    /// native Cmd+S) — `accelerator_to_ns`/`render_binding` don't
+    /// rewrite literals either, so `match_keypress` must not.
+    #[test]
+    fn match_keypress_literal_binding_ctrl_is_not_translated_to_cmd() {
+        let mut b = MacBackend::new();
+        b.register_accelerator(&acc("literal-ctrl-s", "<C-s>"));
+
+        assert_eq!(
+            b.match_keypress(
+                &crate::Key::Char('s'),
+                Modifiers {
+                    ctrl: true,
+                    ..Default::default()
+                },
+            ),
+            Some(AcceleratorId::new("literal-ctrl-s")),
+        );
+        assert_eq!(
+            b.match_keypress(
+                &crate::Key::Char('s'),
+                Modifiers {
+                    cmd: true,
+                    ..Default::default()
+                },
+            ),
+            None,
         );
     }
 

--- a/quadraui/src/macos/events.rs
+++ b/quadraui/src/macos/events.rs
@@ -246,8 +246,9 @@ pub fn ns_keycode_to_named_key(key_code: u16) -> Option<NamedKey> {
 
 /// Build a [`UiEvent::WindowResized`] from a resize notification.
 /// `width` / `height` are window content size in points; `scale` is the
-/// `backingScaleFactor`. The observer wiring lands in #35; today this
-/// is reachable only via tests + future direct callers.
+/// `backingScaleFactor`. Called from `macos::run`'s
+/// `viewFrameDidChange:` observer (#486), which dispatches the result
+/// synchronously alongside mouse/keyboard events.
 pub fn ns_resize_to_uievent(width: f64, height: f64, scale: f32) -> UiEvent {
     UiEvent::WindowResized {
         viewport: crate::Viewport::new(width as f32, height as f32, scale),

--- a/quadraui/src/macos/run.rs
+++ b/quadraui/src/macos/run.rs
@@ -42,24 +42,29 @@ use objc2::msg_send;
 use objc2::msg_send_id;
 use objc2::mutability;
 use objc2::rc::Retained;
-use objc2::runtime::ProtocolObject;
+use objc2::runtime::{AnyObject, ProtocolObject};
+use objc2::sel;
 use objc2::ClassType;
 use objc2::DeclaredClass;
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSBackingStoreType,
-    NSEvent, NSGraphicsContext, NSView, NSWindow, NSWindowStyleMask,
+    NSEvent, NSGraphicsContext, NSView, NSViewFrameDidChangeNotification, NSWindow,
+    NSWindowStyleMask,
 };
 use objc2_foundation::{
-    MainThreadMarker, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString,
+    MainThreadMarker, NSNotification, NSNotificationCenter, NSObject, NSObjectProtocol, NSPoint,
+    NSRect, NSSize, NSString,
 };
 
 use super::backend::MacBackend;
-use super::events::{ns_key_to_uievent, ns_mouse_down, ns_mouse_moved, ns_mouse_up, ns_scroll};
+use super::events::{
+    ns_key_to_uievent, ns_mouse_down, ns_mouse_moved, ns_mouse_up, ns_resize_to_uievent, ns_scroll,
+};
 use super::text::make_font;
 use crate::backend::Backend;
 use crate::event::Viewport;
 use crate::runner::{AppLogic, Reaction};
-use crate::{ButtonMask, UiEvent};
+use crate::{ButtonMask, Key, Modifiers, UiEvent};
 
 /// Opaque stand-in for the C type `CGContext`. We only ever hold a
 /// `*mut OpaqueCGContext`, which we then cast to `core-graphics`'
@@ -317,6 +322,34 @@ declare_class!(
                 self.dispatch(ev);
             }
         }
+
+        // ── Window resize (#486) ─────────────────────────────────
+
+        /// Registered (in [`run`]) as the observer for
+        /// `NSViewFrameDidChangeNotification`, which fires whenever this
+        /// view's `frame` changes — live window resize, programmatic
+        /// resize, and the split-second the window first opens. Compares
+        /// against `last_viewport` (also updated here) so a notification
+        /// that doesn't actually change the size — AppKit can post one
+        /// on origin-only moves — doesn't spam `AppLogic::handle` with a
+        /// same-size `WindowResized`.
+        #[method(viewFrameDidChange:)]
+        fn view_frame_did_change(&self, _note: &NSNotification) {
+            let bounds = self.bounds();
+            let scale = self
+                .window()
+                .map(|w| w.backingScaleFactor())
+                .unwrap_or(1.0);
+            let ev = ns_resize_to_uievent(bounds.size.width, bounds.size.height, scale as f32);
+            let UiEvent::WindowResized { viewport } = ev else {
+                unreachable!("ns_resize_to_uievent always returns UiEvent::WindowResized");
+            };
+            if self.ivars().last_viewport.get() == viewport {
+                return;
+            }
+            self.ivars().last_viewport.set(viewport);
+            self.dispatch(ev);
+        }
     }
 );
 
@@ -495,7 +528,53 @@ pub fn run<A: AppLogic + 'static>(app: A) -> std::process::ExitCode {
                 caret_visible.set(true);
                 caret_pause.set(std::time::Instant::now() + std::time::Duration::from_millis(500));
             }
+
             let mut backend_mut = backend.borrow_mut();
+
+            // Double-click folding (#486): a `MouseDown` landing within
+            // the detector's time/position window of the previous click
+            // becomes `DoubleClick` before `AppLogic` ever sees it —
+            // mirrors GTK's `GestureClick` `n_press == 2` branch
+            // (`gtk::run`) and TUI's `DoubleClickDetector`.
+            let ev = backend_mut.fold_double_click(ev);
+
+            // Global accelerator dispatch (#486): mirrors the
+            // "Global accelerator dispatch" step in
+            // `gtk::run::dispatch_event`.
+            let ev = if let UiEvent::KeyPressed { key, modifiers, .. } = &ev {
+                match backend_mut.match_keypress(key, *modifiers) {
+                    Some(id) => UiEvent::Accelerator(id, *modifiers),
+                    None => ev,
+                }
+            } else {
+                ev
+            };
+
+            // Cmd-V interception (paste, #486): AppKit has no native
+            // paste signal on a bespoke `NSView`, so — like GTK's Ctrl-V
+            // interception in `gtk::run::dispatch_event` — the runner
+            // reads the system clipboard directly and delivers
+            // `ClipboardPaste` instead of forwarding the raw key press.
+            // Cmd (not Ctrl) is the Mac paste modifier.
+            if let UiEvent::KeyPressed {
+                key: Key::Char('v') | Key::Char('V'),
+                modifiers:
+                    Modifiers {
+                        cmd: true,
+                        shift: false,
+                        alt: false,
+                        ctrl: false,
+                    },
+                ..
+            } = &ev
+            {
+                if let Some(text) = backend_mut.services().clipboard().read_text() {
+                    let mut app_mut = app.borrow_mut();
+                    return app_mut.handle(UiEvent::ClipboardPaste(text), &mut *backend_mut);
+                }
+                return Reaction::Continue;
+            }
+
             let mut app_mut = app.borrow_mut();
             app_mut.handle(ev, &mut *backend_mut)
         })
@@ -530,6 +609,27 @@ pub fn run<A: AppLogic + 'static>(app: A) -> std::process::ExitCode {
     window.setAcceptsMouseMovedEvents(true);
     window.makeFirstResponder(Some(view.as_super()));
     window.makeKeyAndOrderFront(None);
+
+    // WindowResized wiring (#486): opt the view into frame-change
+    // notifications and observe them on itself via `viewFrameDidChange:`.
+    // SAFETY: `view` is a valid, retained `QuadraView` (an `NSObject`
+    // subclass) for the lifetime of the app; the observer registration
+    // and the object being observed share that lifetime, and
+    // `NSNotificationCenter` doesn't retain the observer, matching the
+    // `target`-registration pattern `menu_bar_install` uses for menu
+    // actions. The cast to `&AnyObject` is a no-op upcast through the
+    // Obj-C class chain (`QuadraView` → `NSView` → `NSResponder` →
+    // `NSObject`).
+    view.setPostsFrameChangedNotifications(true);
+    let view_obj: &AnyObject = unsafe { &*(&*view as *const QuadraView as *const AnyObject) };
+    unsafe {
+        NSNotificationCenter::defaultCenter().addObserver_selector_name_object(
+            view_obj,
+            sel!(viewFrameDidChange:),
+            Some(NSViewFrameDidChangeNotification),
+            Some(view_obj),
+        );
+    }
 
     // Drive the InlineInput caret blink (#188). The pair is held as
     // locals for the lifetime of the app — when this function

--- a/quadraui/src/macos/run.rs
+++ b/quadraui/src/macos/run.rs
@@ -57,9 +57,7 @@ use objc2_foundation::{
 };
 
 use super::backend::MacBackend;
-use super::events::{
-    ns_key_to_uievent, ns_mouse_down, ns_mouse_moved, ns_mouse_up, ns_resize_to_uievent, ns_scroll,
-};
+use super::events::{ns_key_to_uievent, ns_mouse_down, ns_mouse_moved, ns_mouse_up, ns_scroll};
 use super::text::make_font;
 use crate::backend::Backend;
 use crate::event::Viewport;
@@ -340,15 +338,16 @@ declare_class!(
                 .window()
                 .map(|w| w.backingScaleFactor())
                 .unwrap_or(1.0);
-            let ev = ns_resize_to_uievent(bounds.size.width, bounds.size.height, scale as f32);
-            let UiEvent::WindowResized { viewport } = ev else {
-                unreachable!("ns_resize_to_uievent always returns UiEvent::WindowResized");
-            };
+            let viewport = Viewport::new(
+                bounds.size.width as f32,
+                bounds.size.height as f32,
+                scale as f32,
+            );
             if self.ivars().last_viewport.get() == viewport {
                 return;
             }
             self.ivars().last_viewport.set(viewport);
-            self.dispatch(ev);
+            self.dispatch(UiEvent::WindowResized { viewport });
         }
     }
 );

--- a/quadraui/src/tui/events.rs
+++ b/quadraui/src/tui/events.rs
@@ -128,59 +128,12 @@ pub fn crossterm_mouse_to_uievent(event: MouseEvent) -> Option<UiEvent> {
 }
 
 // ── Double-click synthesis ───────────────────────────────────────────────
-
-use std::time::{Duration, Instant};
-
-const DOUBLE_CLICK_MS: u64 = 400;
-const DOUBLE_CLICK_RADIUS: f32 = 1.5;
-
-/// Detects double-clicks from repeated `MouseDown` events within a
-/// time window at the same position. Stateful — lives on `TuiBackend`.
-#[derive(Default)]
-pub struct DoubleClickDetector {
-    last_click_time: Option<Instant>,
-    last_click_pos: Point,
-    last_click_button: MouseButton,
-}
-
-impl DoubleClickDetector {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Process a batch of translated events. Replaces `MouseDown` with
-    /// `DoubleClick` when the same button clicks at the same position
-    /// within the time window.
-    pub fn process(&mut self, events: &mut [UiEvent]) {
-        let now = Instant::now();
-        for ev in events.iter_mut() {
-            if let UiEvent::MouseDown {
-                button, position, ..
-            } = ev
-            {
-                let is_double = self
-                    .last_click_time
-                    .map(|t| now.duration_since(t) < Duration::from_millis(DOUBLE_CLICK_MS))
-                    .unwrap_or(false)
-                    && *button == self.last_click_button
-                    && (position.x - self.last_click_pos.x).abs() <= DOUBLE_CLICK_RADIUS
-                    && (position.y - self.last_click_pos.y).abs() <= DOUBLE_CLICK_RADIUS;
-
-                if is_double {
-                    *ev = UiEvent::DoubleClick {
-                        widget: None,
-                        position: *position,
-                    };
-                    self.last_click_time = None;
-                } else {
-                    self.last_click_time = Some(now);
-                    self.last_click_pos = *position;
-                    self.last_click_button = *button;
-                }
-            }
-        }
-    }
-}
+//
+// Relocated to `crate::dispatch` (issue #486) so `macos::run` can reuse
+// the same detector without pulling in the `tui` feature. Re-exported
+// here so existing `super::events::DoubleClickDetector` references
+// (this module's own `TuiBackend` usage) keep working.
+pub use crate::dispatch::DoubleClickDetector;
 
 fn crossterm_keycode_to_key(code: KeyCode) -> Option<Key> {
     let named = match code {
@@ -721,62 +674,6 @@ mod tests {
         assert!(matches!(round.kind, MouseEventKind::ScrollUp));
     }
 
-    // ── DoubleClickDetector tests ────────────────────────────────────
-
-    fn mouse_down(x: f32, y: f32) -> UiEvent {
-        UiEvent::MouseDown {
-            widget: None,
-            button: MouseButton::Left,
-            position: Point::new(x, y),
-            modifiers: Modifiers::default(),
-        }
-    }
-
-    #[test]
-    fn double_click_detected_on_same_position() {
-        let mut det = DoubleClickDetector::new();
-        let mut events = vec![mouse_down(5.0, 3.0)];
-        det.process(&mut events);
-        assert!(matches!(events[0], UiEvent::MouseDown { .. }));
-
-        let mut events = vec![mouse_down(5.0, 3.0)];
-        det.process(&mut events);
-        assert!(
-            matches!(events[0], UiEvent::DoubleClick { .. }),
-            "second click at same position should be DoubleClick"
-        );
-    }
-
-    #[test]
-    fn no_double_click_at_different_position() {
-        let mut det = DoubleClickDetector::new();
-        let mut events = vec![mouse_down(5.0, 3.0)];
-        det.process(&mut events);
-
-        let mut events = vec![mouse_down(20.0, 10.0)];
-        det.process(&mut events);
-        assert!(
-            matches!(events[0], UiEvent::MouseDown { .. }),
-            "click at different position should NOT be DoubleClick"
-        );
-    }
-
-    #[test]
-    fn triple_click_resets_to_single() {
-        let mut det = DoubleClickDetector::new();
-        let mut events = vec![mouse_down(5.0, 3.0)];
-        det.process(&mut events);
-
-        let mut events = vec![mouse_down(5.0, 3.0)];
-        det.process(&mut events);
-        assert!(matches!(events[0], UiEvent::DoubleClick { .. }));
-
-        // Third click at same position — resets to single (no triple-click).
-        let mut events = vec![mouse_down(5.0, 3.0)];
-        det.process(&mut events);
-        assert!(
-            matches!(events[0], UiEvent::MouseDown { .. }),
-            "third click should reset to MouseDown"
-        );
-    }
+    // DoubleClickDetector tests moved to `crate::dispatch` alongside its
+    // new home (issue #486).
 }


### PR DESCRIPTION
Closes #486

Automated PR opened by coordinator for review of issue #486.