### PR TITLE
#471: StyledText::visible_width still counts chars — the #206 unicode-width fix never reached 14 layout consumers

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -15,12 +15,10 @@ publish = false
 terminal = ["dep:portable-pty", "dep:vt100"]
 
 # Public TUI rasterisers in `quadraui::tui`. Pulls in ratatui.
-tui = ["dep:ratatui", "dep:arboard", "dep:unicode-width"]
+tui = ["dep:ratatui", "dep:arboard"]
 
 # Public GTK rasterisers in `quadraui::gtk`. Pulls in gtk4 + pangocairo.
-# `unicode-width` is needed for wide-char (CJK/emoji) cell-width detection
-# in the terminal rasteriser (#439).
-gtk = ["dep:gtk4", "dep:pangocairo", "dep:arboard", "dep:unicode-width"]
+gtk = ["dep:gtk4", "dep:pangocairo", "dep:arboard"]
 
 # Public Win-GUI rasterisers in `quadraui::win`. No deps yet — the
 # feature gate exists so the module compiles and the Backend impl is
@@ -53,14 +51,15 @@ gtk4 = { version = "0.7", features = ["v4_10"], optional = true }
 pangocairo = { version = "0.18", optional = true }
 # Optional — pulled in by the `tui` feature.
 ratatui = { version = "0.30", optional = true }
-# Optional — pulled in by the `tui` and `gtk` features for wide-char
-# (CJK/emoji) cell-width detection. Kept at the loosest bound quadraui
-# itself actually needs ("0.2", i.e. >=0.2.0) rather than pinned to
-# whatever patch version happened to resolve at bump time — see
-# vendor/vt100-0.16.2-patched/README-PATCH.md (#452) for why a tighter
-# bound here would NOT have prevented that conflict anyway (vt100's own
-# manifest is the binding constraint, not this line).
-unicode-width = { version = "0.2", optional = true }
+# Unconditional (not feature-gated): `StyledText::visible_width` in the
+# core `types` module needs real cell-width measurement, not just
+# `tui`/`gtk`'s rasterisers — see #471. Kept at the loosest bound
+# quadraui itself actually needs ("0.2", i.e. >=0.2.0) rather than
+# pinned to whatever patch version happened to resolve at bump time —
+# see vendor/vt100-0.16.2-patched/README-PATCH.md (#452) for why a
+# tighter bound here would NOT have prevented that conflict anyway
+# (vt100's own manifest is the binding constraint, not this line).
+unicode-width = "0.2"
 # Optional — pulled in by `tui` and `gtk` for system clipboard access.
 arboard = { version = "3", optional = true }
 # Optional — pulled in by the `terminal` feature.

--- a/quadraui/src/text_util.rs
+++ b/quadraui/src/text_util.rs
@@ -30,6 +30,16 @@
 //! `compose/tree_controller.rs`); they're unified here so every
 //! caller — in-crate and, eventually, downstream — gets the same
 //! panic-free behaviour.
+//!
+//! [`char_cell_width`] and [`display_width`] measure real terminal
+//! display width (CJK/emoji count double, combining marks count zero) —
+//! see issue #471, which found `StyledText::visible_width`
+//! (`crate::types`) still counting `chars()` years after #206 fixed the
+//! equivalent terminal-cell logic, because that fix landed only in the
+//! `tui`-feature-gated `tui::text` module while `types` is core and
+//! unconditionally compiled. These live here instead so core code can
+//! use them without depending on `tui`/`gtk`; `tui::text` re-exports the
+//! same two functions for API stability.
 
 /// Snap `byte_idx` to the nearest UTF-8 char boundary in `s` at or
 /// before `byte_idx`, clamping `byte_idx` to `s.len()` first.
@@ -99,6 +109,37 @@ pub fn safe_slice(s: &str, lo: usize, hi: usize) -> &str {
     let lo = snap_to_char_boundary(s, lo);
     let hi = snap_to_char_boundary(s, hi);
     &s[lo..hi]
+}
+
+/// Terminal cell width of a single character (0, 1, or 2).
+///
+/// Uses the `unicode-width` crate's UAX#11 tables directly, with no
+/// codepoint-range overrides. Private-Use-Area codepoints — including
+/// both Nerd Font PUA blocks (BMP `U+E000`–`U+F8FF` and Supplementary-A
+/// `U+F0000`–`U+FFFFD`) — measure as width 1, matching `unicode-width`
+/// and `Nerd Font Mono` (the terminal-recommended, single-cell variant).
+/// Non-Mono Nerd Font variants are genuinely double-width, but that is a
+/// font/theme property, not something derivable from the codepoint
+/// alone; if double-width PUA glyphs ever need supporting, it must come
+/// in as an explicit input (theme/config/probe), not a range guess here.
+/// See issue #545.
+///
+/// Lives here (rather than `tui::text`) so core types like
+/// [`crate::types::StyledText`] can measure real display width without
+/// depending on the `tui` or `gtk` features — see #471.
+/// [`crate::tui::char_cell_width`] re-exports this same function; it
+/// is not a separate implementation.
+pub fn char_cell_width(c: char) -> u16 {
+    unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) as u16
+}
+
+/// Terminal display width of `s` in cells: the sum of each character's
+/// [`char_cell_width`].
+///
+/// Not the same as `s.chars().count()` (CJK/emoji count double) or
+/// `s.len()` (UTF-8 byte length).
+pub fn display_width(s: &str) -> usize {
+    s.chars().map(|c| char_cell_width(c) as usize).sum()
 }
 
 /// Case-sensitive subsequence fuzzy match with a relevance score and
@@ -378,6 +419,33 @@ mod tests {
     fn safe_slice_on_boundaries_matches_manual_slice() {
         let s = "héllo world";
         assert_eq!(safe_slice(s, 0, 3), &s[0..3]);
+    }
+
+    // ── char_cell_width / display_width ────────────────────────────────
+
+    #[test]
+    fn char_cell_width_ascii_is_one() {
+        assert_eq!(char_cell_width('a'), 1);
+        assert_eq!(char_cell_width(' '), 1);
+    }
+
+    #[test]
+    fn char_cell_width_cjk_is_two() {
+        assert_eq!(char_cell_width('日'), 2);
+        assert_eq!(char_cell_width('中'), 2);
+    }
+
+    #[test]
+    fn char_cell_width_combining_mark_is_zero() {
+        // U+0301 COMBINING ACUTE ACCENT.
+        assert_eq!(char_cell_width('\u{0301}'), 0);
+    }
+
+    #[test]
+    fn display_width_sums_mixed_ascii_and_cjk() {
+        assert_eq!(display_width("ab日本"), 2 + 2 + 2);
+        assert_eq!(display_width(""), 0);
+        assert_eq!(display_width("hello"), 5);
     }
 
     // ── fuzzy_score ─────────────────────────────────────────────────────

--- a/quadraui/src/tui/form.rs
+++ b/quadraui/src/tui/form.rs
@@ -1630,4 +1630,129 @@ mod tests {
         let back: FormEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(ev, back);
     }
+
+    // ── CJK label paint↔measure agreement (#471 fix iteration 1) ──────────
+    //
+    // Before this fix, `tui_form_layout` reserved `label.visible_width()`
+    // (display-width-aware) columns for the label, but `draw_form` painted
+    // it via the char-count-strided `draw_styled_text` — so a CJK label
+    // measured wider than it was actually painted, leaving a stray gap
+    // before the right-aligned value/controls that scales with how much
+    // non-ASCII content the label has. These tests pin that the *painted*
+    // label span and the *measured* `visible_width()` now agree, for both
+    // a right-aligned value field (`ReadOnly`) and an items-after-label
+    // field (`ToggleGroup`).
+
+    #[test]
+    fn readonly_field_cjk_label_paints_full_display_width_no_gap() {
+        // "日本語:" — display width 7 (2+2+2+1), char count 4. Before the
+        // fix, `draw_styled_text` would stop painting after 4 columns while
+        // `tui_form_layout`/the ReadOnly branch reserved 7, leaving 3
+        // stray background columns between the label and the value.
+        let f = Form {
+            id: WidgetId::new("info"),
+            fields: vec![FormField {
+                id: WidgetId::new("lang"),
+                label: label("日本語:"),
+                kind: FieldKind::ReadOnly {
+                    value: label("OK"),
+                },
+                disabled: false,
+                validation: None,
+                hint: label(""),
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        let area = Rect::new(0, 0, 30, 3);
+        let mut buf = Buffer::empty(area);
+        draw_form(&mut buf, area, &f, &Theme::default());
+
+        let label_visible_width = f.fields[0].label.visible_width();
+        assert_eq!(label_visible_width, 7);
+
+        // Label starts at col 1 (label_col) and must span exactly its
+        // `visible_width()` in painted columns — cols 1..=6 hold the three
+        // wide CJK glyphs (each followed by an empty continuation cell),
+        // col 7 holds ':', and col 8 (label_col + visible_width) is
+        // unpainted background, not a stray copy of ':' or the value.
+        assert_eq!(cell_char(&buf, 1, 0), '日');
+        assert_eq!(buf[(2u16, 0u16)].symbol(), "");
+        assert_eq!(cell_char(&buf, 3, 0), '本');
+        assert_eq!(buf[(4u16, 0u16)].symbol(), "");
+        assert_eq!(cell_char(&buf, 5, 0), '語');
+        assert_eq!(buf[(6u16, 0u16)].symbol(), "");
+        assert_eq!(cell_char(&buf, 7, 0), ':');
+        assert_eq!(
+            cell_char(&buf, 1 + label_visible_width as u16, 0),
+            ' ',
+            "no leftover glyph past the label's measured display width"
+        );
+
+        // The ReadOnly value ("OK", visible_width 2) is right-aligned via
+        // `area.width - (w + 2)` = 30 - 4 = 26, independent of the label —
+        // confirm it painted where that formula (which now agrees with the
+        // label's actual painted extent) says it should.
+        assert_eq!(cell_char(&buf, 26, 0), 'O');
+        assert_eq!(cell_char(&buf, 27, 0), 'K');
+    }
+
+    #[test]
+    fn toggle_group_cjk_label_items_start_flush_with_painted_label() {
+        // Same desync, but for the "items packed after the label" shape
+        // (`ToggleGroup`/`ButtonRow`/`SegmentedControl`): `tui_form_layout`
+        // computes `start_x = label.visible_width() + 2` for where the
+        // toggles begin. Before the fix, the label painted narrower than
+        // that (char count, not display width), so toggles started further
+        // right than the label's actual painted end — a CJK-content-
+        // dependent gap. Pin that the gap is now exactly the intended 1
+        // blank column (the `+2` reserves 2 cells past the label's last
+        // glyph column, and the layout's `start_x` is 0-based while
+        // painting's `label_col` is 1-based, so 1 of those 2 reserved
+        // cells is absorbed by that frame offset).
+        let f = Form {
+            id: WidgetId::new("opts"),
+            fields: vec![FormField {
+                id: WidgetId::new("toggles"),
+                label: label("中文:"),
+                kind: FieldKind::ToggleGroup {
+                    toggles: vec![ToggleGroupItem {
+                        id: WidgetId::new("a"),
+                        label: "A".into(),
+                        value: true,
+                    }],
+                },
+                disabled: false,
+                validation: None,
+                hint: label(""),
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+        let area = Rect::new(0, 0, 30, 3);
+        let mut buf = Buffer::empty(area);
+        draw_form(&mut buf, area, &f, &Theme::default());
+
+        let label_visible_width = f.fields[0].label.visible_width();
+        assert_eq!(label_visible_width, 5); // 2 + 2 + 1
+
+        // Label painted at cols 1..=5 ("中", "文", ':').
+        assert_eq!(cell_char(&buf, 1, 0), '中');
+        assert_eq!(buf[(2u16, 0u16)].symbol(), "");
+        assert_eq!(cell_char(&buf, 3, 0), '文');
+        assert_eq!(buf[(4u16, 0u16)].symbol(), "");
+        assert_eq!(cell_char(&buf, 5, 0), ':');
+
+        // The toggle item ("A") starts exactly 1 column past the label's
+        // last painted glyph — not drifted further right by the old
+        // char-count/display-width mismatch (which for this label would
+        // have painted only 3 columns wide, leaving a 3-column gap instead
+        // of 1).
+        let a_col = (1..30)
+            .find(|&x| cell_char(&buf, x, 0) == 'A')
+            .expect("toggle item 'A' must be painted");
+        assert_eq!(a_col, 1 + label_visible_width as u16 + 1);
+    }
 }

--- a/quadraui/src/tui/form.rs
+++ b/quadraui/src/tui/form.rs
@@ -1654,9 +1654,7 @@ mod tests {
             fields: vec![FormField {
                 id: WidgetId::new("lang"),
                 label: label("日本語:"),
-                kind: FieldKind::ReadOnly {
-                    value: label("OK"),
-                },
+                kind: FieldKind::ReadOnly { value: label("OK") },
                 disabled: false,
                 validation: None,
                 hint: label(""),

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -166,6 +166,12 @@ fn qc(c: Color) -> RatatuiColor {
 /// caller's `decoration` as a final colour override (e.g. `Muted` dims
 /// every span that didn't already specify its own `fg`). Used by the
 /// list / form / palette rasterisers.
+///
+/// Strides by each character's [`char_cell_width`] (via [`set_cell_wide`]
+/// for double-width glyphs) rather than one buffer column per `char`, so
+/// the painted extent agrees with [`StyledText::visible_width`] — see
+/// #471, where the two fell out of sync after `visible_width` became
+/// display-width-aware but this loop stayed char-count-strided.
 #[allow(clippy::too_many_arguments)]
 fn draw_styled_text(
     buf: &mut Buffer,
@@ -192,8 +198,13 @@ fn draw_styled_text(
             if col >= area.width as usize {
                 return col;
             }
-            set_cell(buf, area.x + col as u16, y, ch, span_fg, span_bg);
-            col += 1;
+            let w = char_cell_width(ch) as usize;
+            if w == 2 && col + 1 < area.width as usize {
+                set_cell_wide(buf, area.x + col as u16, y, ch, span_fg, span_bg);
+            } else {
+                set_cell(buf, area.x + col as u16, y, ch, span_fg, span_bg);
+            }
+            col += w;
         }
     }
     col
@@ -399,5 +410,50 @@ mod tests {
             None,
         );
         assert_eq!(buf[(6, 6)].symbol(), "中");
+    }
+
+    // Regression test for #471 (fix iteration 1): `StyledText::visible_width`
+    // became display-width-aware (CJK/emoji count double), but
+    // `draw_styled_text` kept striding one buffer column per `char` — so a
+    // CJK label's *painted* extent (half its measured width) no longer
+    // matched what layout code reserved for it via `visible_width()`,
+    // producing a gap between painted labels and the controls positioned
+    // after them. `draw_styled_text` now strides by `char_cell_width`
+    // (mirroring `set_cell_wide`'s callers elsewhere in this file), so its
+    // return value — the column layout code implicitly relies on matching
+    // `visible_width()` — agrees with `visible_width()` end-to-end.
+    #[test]
+    fn draw_styled_text_strides_by_display_width_for_cjk() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 3));
+        let area = Rect::new(0, 0, 20, 3);
+        let text = StyledText::plain("日本語");
+        assert_eq!(text.visible_width(), 6, "CJK: 3 chars, 2 cols each");
+
+        let end_col = draw_styled_text(
+            &mut buf,
+            area,
+            0,
+            1,
+            &text,
+            RatatuiColor::White,
+            RatatuiColor::Black,
+            Decoration::Normal,
+            RatatuiColor::Gray,
+        );
+
+        // The returned column matches `visible_width()`, not `chars().count()`
+        // (which would have returned 1 + 3 = 4).
+        assert_eq!(end_col, 1 + text.visible_width());
+
+        // Each wide glyph occupies two buffer cells: the glyph itself, then
+        // an empty continuation cell (mirrors `set_cell_wide`'s contract).
+        assert_eq!(buf[(1, 0)].symbol(), "日");
+        assert_eq!(buf[(2, 0)].symbol(), "");
+        assert_eq!(buf[(3, 0)].symbol(), "本");
+        assert_eq!(buf[(4, 0)].symbol(), "");
+        assert_eq!(buf[(5, 0)].symbol(), "語");
+        assert_eq!(buf[(6, 0)].symbol(), "");
+        // Nothing painted past the label's actual display width.
+        assert_eq!(buf[(7, 0)].symbol(), " ");
     }
 }

--- a/quadraui/src/tui/multi_section_view.rs
+++ b/quadraui/src/tui/multi_section_view.rs
@@ -14,12 +14,16 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect as TuiRect;
 
-use super::{draw_form, draw_list, draw_message_list, draw_tree, qc, ratatui_color, set_cell};
+use super::{
+    draw_form, draw_list, draw_message_list, draw_tree, qc, ratatui_color, set_cell,
+    set_cell_wide,
+};
 use crate::event::Rect as QRect;
 use crate::primitives::multi_section_view::{
     Axis, EmptyBody, LayoutMetrics, MultiSectionView, MultiSectionViewLayout, SectionAux,
     SectionBody, SectionHeader, SectionMeasure,
 };
+use crate::text_util::char_cell_width;
 use crate::theme::Theme;
 use crate::types::StyledText;
 
@@ -387,8 +391,13 @@ fn paint_text_lines(buf: &mut Buffer, area: TuiRect, lines: &[StyledText], theme
                 if x >= area.x + area.width {
                     break;
                 }
-                set_cell(buf, x, y, ch, span_fg, span_bg);
-                x += 1;
+                let w = char_cell_width(ch);
+                if w == 2 && x + 1 < area.x + area.width {
+                    set_cell_wide(buf, x, y, ch, span_fg, span_bg);
+                } else {
+                    set_cell(buf, x, y, ch, span_fg, span_bg);
+                }
+                x += w;
             }
         }
     }
@@ -443,8 +452,13 @@ fn paint_empty_body(buf: &mut Buffer, area: TuiRect, empty: &EmptyBody, theme: &
                 if x >= area.x + area.width {
                     break;
                 }
-                set_cell(buf, x, y, ch, span_fg, bg);
-                x += 1;
+                let w = char_cell_width(ch);
+                if w == 2 && x + 1 < area.x + area.width {
+                    set_cell_wide(buf, x, y, ch, span_fg, bg);
+                } else {
+                    set_cell(buf, x, y, ch, span_fg, bg);
+                }
+                x += w;
             }
         }
     }
@@ -2470,5 +2484,52 @@ mod tests {
             row.contains("[x]"),
             "toggle value=true should paint [x], got row: {row:?}"
         );
+    }
+
+    // Regression test for #471 (fix iteration 1): `paint_empty_body` centers
+    // the empty-state message using `line.visible_width()` (display-width-
+    // aware), but before the fix painted it via a char-count-strided loop —
+    // so a CJK/emoji message rendered narrower than the centering math
+    // assumed, landing left-of-center instead of centered. Pin that the
+    // painted extent of a CJK message now agrees with `visible_width()`
+    // exactly, so it lands with equal left/right margins.
+    #[test]
+    fn empty_body_centers_cjk_message_by_display_width_not_char_count() {
+        let area = TuiRect::new(0, 0, 20, 3);
+        let mut buf = Buffer::empty(area);
+        let empty = EmptyBody {
+            text: StyledText::plain("日本語"),
+            ..Default::default()
+        };
+        assert_eq!(empty.text.visible_width(), 6);
+
+        paint_empty_body(&mut buf, area, &empty, &Theme::default());
+
+        // total=1 line, start_y = 0 + (3 - 1) / 2 = 1.
+        let y = 1;
+        // x_start = 0 + (20 - 6) / 2 = 7.
+        assert_eq!(cell_char(&buf, 7, y), '日');
+        assert_eq!(buf[(8u16, y)].symbol(), "");
+        assert_eq!(cell_char(&buf, 9, y), '本');
+        assert_eq!(buf[(10u16, y)].symbol(), "");
+        assert_eq!(cell_char(&buf, 11, y), '語');
+        assert_eq!(buf[(12u16, y)].symbol(), "");
+
+        // Equal margins on both sides: nothing painted before col 7 or at/
+        // after col 13 (7 + visible_width) on the message row.
+        for x in 0..7 {
+            assert_eq!(
+                cell_char(&buf, x, y),
+                ' ',
+                "unexpected content left of center at col {x}"
+            );
+        }
+        for x in 13..20 {
+            assert_eq!(
+                cell_char(&buf, x, y),
+                ' ',
+                "unexpected content right of the CJK message's measured width at col {x}"
+            );
+        }
     }
 }

--- a/quadraui/src/tui/multi_section_view.rs
+++ b/quadraui/src/tui/multi_section_view.rs
@@ -15,8 +15,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect as TuiRect;
 
 use super::{
-    draw_form, draw_list, draw_message_list, draw_tree, qc, ratatui_color, set_cell,
-    set_cell_wide,
+    draw_form, draw_list, draw_message_list, draw_tree, qc, ratatui_color, set_cell, set_cell_wide,
 };
 use crate::event::Rect as QRect;
 use crate::primitives::multi_section_view::{

--- a/quadraui/src/tui/text.rs
+++ b/quadraui/src/tui/text.rs
@@ -12,33 +12,30 @@
 //! and [`truncate_to_width_ellipsis`] clip a string to a column budget
 //! without ever splitting a codepoint or a double-width glyph's two
 //! columns.
+//!
+//! [`char_cell_width`] and [`display_width`] are re-exports of
+//! [`crate::text_util::char_cell_width`] /
+//! [`crate::text_util::display_width`], not separate implementations —
+//! they moved to that core (feature-independent) module in #471 so
+//! [`crate::types::StyledText::visible_width`] could use real cell-width
+//! measurement too, without pulling in the `tui` feature. They stay
+//! re-exported here for API stability (existing `quadraui::tui::*`
+//! callers, and the `unicode-width` PUA doc details below).
+//!
+//! Uses the `unicode-width` crate's UAX#11 tables directly, with no
+//! codepoint-range overrides. Private-Use-Area codepoints — including
+//! both Nerd Font PUA blocks (BMP `U+E000`–`U+F8FF` and Supplementary-A
+//! `U+F0000`–`U+FFFFD`) — measure as width 1, matching `unicode-width`
+//! and `Nerd Font Mono` (the terminal-recommended, single-cell variant).
+//! Non-Mono Nerd Font variants are genuinely double-width, but that is a
+//! font/theme property, not something derivable from the codepoint
+//! alone; if double-width PUA glyphs ever need supporting, it must come
+//! in as an explicit input (theme/config/probe), not a range guess here.
+//! See issue #545.
 
 use std::borrow::Cow;
 
-/// Terminal cell width of a single character (0, 1, or 2).
-///
-/// Uses the `unicode-width` crate's UAX#11 tables directly, with no
-/// codepoint-range overrides. Private-Use-Area codepoints — including
-/// both Nerd Font PUA blocks (BMP `U+E000`–`U+F8FF` and Supplementary-A
-/// `U+F0000`–`U+FFFFD`) — measure as width 1, matching `unicode-width`
-/// and `Nerd Font Mono` (the terminal-recommended, single-cell variant).
-/// Non-Mono Nerd Font variants are genuinely double-width, but that is a
-/// font/theme property, not something derivable from the codepoint
-/// alone; if double-width PUA glyphs ever need supporting, it must come
-/// in as an explicit input (theme/config/probe), not a range guess here.
-/// See issue #545.
-pub fn char_cell_width(c: char) -> u16 {
-    unicode_width::UnicodeWidthChar::width(c).unwrap_or(1) as u16
-}
-
-/// Terminal display width of `s` in cells: the sum of each character's
-/// [`char_cell_width`].
-///
-/// Not the same as `s.chars().count()` (CJK/emoji count double) or
-/// `s.len()` (UTF-8 byte length).
-pub fn display_width(s: &str) -> usize {
-    s.chars().map(|c| char_cell_width(c) as usize).sum()
-}
+pub use crate::text_util::{char_cell_width, display_width};
 
 /// Truncate `s` to at most `max_cols` display columns.
 ///

--- a/quadraui/src/tui/text.rs
+++ b/quadraui/src/tui/text.rs
@@ -20,18 +20,9 @@
 //! [`crate::types::StyledText::visible_width`] could use real cell-width
 //! measurement too, without pulling in the `tui` feature. They stay
 //! re-exported here for API stability (existing `quadraui::tui::*`
-//! callers, and the `unicode-width` PUA doc details below).
-//!
-//! Uses the `unicode-width` crate's UAX#11 tables directly, with no
-//! codepoint-range overrides. Private-Use-Area codepoints — including
-//! both Nerd Font PUA blocks (BMP `U+E000`–`U+F8FF` and Supplementary-A
-//! `U+F0000`–`U+FFFFD`) — measure as width 1, matching `unicode-width`
-//! and `Nerd Font Mono` (the terminal-recommended, single-cell variant).
-//! Non-Mono Nerd Font variants are genuinely double-width, but that is a
-//! font/theme property, not something derivable from the codepoint
-//! alone; if double-width PUA glyphs ever need supporting, it must come
-//! in as an explicit input (theme/config/probe), not a range guess here.
-//! See issue #545.
+//! callers). See [`crate::text_util::char_cell_width`]'s doc comment for
+//! the PUA / Nerd-Font-width measurement rationale (kept in one place,
+//! at the implementation, rather than duplicated here).
 
 use std::borrow::Cow;
 

--- a/quadraui/src/types.rs
+++ b/quadraui/src/types.rs
@@ -143,8 +143,21 @@ impl StyledText {
         }
     }
 
+    /// Terminal display width of the concatenated span text, in cells.
+    ///
+    /// Sums each span's [`crate::text_util::display_width`] — CJK and
+    /// wide-emoji glyphs count as 2, combining marks count as 0, so this
+    /// is not the same as `chars().count()`. Before #471, this counted
+    /// `chars()` directly: the #206 unicode-width fix landed only in the
+    /// `tui`-feature-gated rasteriser cell logic and never reached this
+    /// core type, so every layout site measuring a `StyledText` with
+    /// non-ASCII content (TUI `Form`, `MultiSectionView`, GTK
+    /// `sidebar_system`) mis-measured by up to 2x.
     pub fn visible_width(&self) -> usize {
-        self.spans.iter().map(|s| s.text.chars().count()).sum()
+        self.spans
+            .iter()
+            .map(|s| crate::text_util::display_width(&s.text))
+            .sum()
     }
 }
 
@@ -354,5 +367,42 @@ mod tests {
         // "\u{20ac}abc" ('€' + "abc") is 3 + 3 = 6 bytes, matching the RGB
         // length branch by byte count alone.
         assert_eq!(Color::from_hex("#\u{20ac}abc"), None);
+    }
+
+    #[test]
+    fn visible_width_ascii_matches_char_count() {
+        assert_eq!(StyledText::plain("hello").visible_width(), 5);
+        assert_eq!(StyledText::plain("").visible_width(), 0);
+    }
+
+    /// Regression for issue #471: CJK/emoji glyphs occupy two terminal
+    /// cells each, so `visible_width` must not equal `chars().count()`
+    /// for them.
+    #[test]
+    fn visible_width_cjk_counts_double_width() {
+        let text = StyledText::plain("日本語");
+        assert_eq!(text.visible_width(), 6);
+        assert_ne!(text.visible_width(), text.spans[0].text.chars().count());
+    }
+
+    #[test]
+    fn visible_width_sums_across_spans() {
+        let text = StyledText {
+            spans: vec![
+                StyledSpan::plain("中"),
+                StyledSpan::plain("a"),
+                StyledSpan::plain("文"),
+            ],
+        };
+        // "中" (2) + "a" (1) + "文" (2) = 5, vs. a char count of 3.
+        assert_eq!(text.visible_width(), 5);
+    }
+
+    #[test]
+    fn visible_width_combining_mark_counts_zero() {
+        // "e" + U+0301 COMBINING ACUTE ACCENT renders as one visual
+        // column even though it is two `char`s.
+        let text = StyledText::plain("e\u{0301}");
+        assert_eq!(text.visible_width(), 1);
     }
 }


### PR DESCRIPTION
Closes #471

Automated PR opened by coordinator for review of issue #471.