### PR TITLE
#541: Tooltip has no border/title vocabulary — backends agree only by convention after #542, so a consumer cannot ask for a borderless popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Runnable from the workspace root with `cargo run --example <name> --features <ba
 | `tui_split_tree` / `gtk_split_tree` | `tui` / `gtk` | `SplitTree` 3-way nested split (`Split(H, Split(V, A, B), C)`); every divider draggable via `DragTarget::SplitDivider`. |
 | `tui_panel` / `gtk_panel` | `tui` / `gtk` | `Panel` with title bar, close/maximize actions, content area, collapse toggle. |
 | `tui_toast` / `gtk_toast` | `tui` / `gtk` | `ToastStack` with severity tints, dismiss, action buttons. |
+| `tui_tooltip` / `gtk_tooltip` | `tui` / `gtk` | `Tooltip` border vocabulary (#541): cycle `Sides` / `Full` / `None` chrome and toggle a title embedded in `Full`'s top border row. |
 | `tui_indicators` / `gtk_indicators` | `tui` / `gtk` | `ProgressBar` + `Spinner` demo — determinate/indeterminate, cancel. |
 | `tui_search_panel` / `gtk_search_panel` | `tui` / `gtk` | Search panel spike: `MultiSectionView` + `TreeView` composition for file-search results. |
 | `tui_form_groups` / `gtk_form_groups` | `tui` / `gtk` | `Form` with `ToggleGroup` + `ButtonRow` horizontal field kinds, plus `FocusRing` for Tab/Shift+Tab cycling. Mini search/replace panel shape. |

--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -112,6 +112,16 @@ crossterm = "0.29"
 tempfile = "3"
 
 [[example]]
+name = "tui_tooltip"
+path = "examples/tui_tooltip.rs"
+required-features = ["tui"]
+
+[[example]]
+name = "gtk_tooltip"
+path = "examples/gtk_tooltip.rs"
+required-features = ["gtk"]
+
+[[example]]
 name = "tui_demo"
 path = "examples/tui_demo.rs"
 required-features = ["tui"]

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -80,6 +80,7 @@ pub mod tab_group_demo;
 pub mod text_input_demo;
 pub mod toast_app;
 pub mod toolbar_app;
+pub mod tooltip_demo;
 
 pub use activity_nav::ActivityNavApp;
 pub use ai_transcript::AiTranscript;
@@ -124,3 +125,4 @@ pub use submenu_app::SubmenuApp;
 pub use tab_group_demo::TabGroupDemo;
 pub use toast_app::ToastApp;
 pub use toolbar_app::ToolbarApp;
+pub use tooltip_demo::TooltipDemo;

--- a/quadraui/examples/common/tooltip_demo.rs
+++ b/quadraui/examples/common/tooltip_demo.rs
@@ -1,0 +1,190 @@
+//! Backend-agnostic app code for the tooltip example
+//! ([`tui_tooltip`] / [`gtk_tooltip`]).
+//!
+//! Demonstrates `Tooltip`'s border/title vocabulary (#541): a consumer
+//! picks `border` (`Sides` bars-only, `Full` closed box, `None` no
+//! chrome) and an optional `title` embedded in `Full`'s top border row,
+//! instead of each backend hardcoding its own answer — the gap
+//! JDonaghy/vimcode#635 hit when its migrated help popup lost its border
+//! and title with no way to ask for them back. `TooltipDemo` cycles
+//! through the settings so a human (or a `TuiDriver` test) can see all
+//! three border modes and the title toggle render identically in shape
+//! on both backends.
+//!
+//! Controls:
+//! - 1/2/3   choose Sides / Full / None border
+//! - t       toggle a title (only visible when border is Full)
+//! - q / Esc quit
+
+use quadraui::{
+    AppLogic, Backend, Color, Key, NamedKey, Reaction, Rect, StatusBar, StatusBarSegment, Tooltip,
+    TooltipBorder, TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
+};
+
+const ANCHOR_TEXT: &str = "hover target";
+const TOOLTIP_TEXT: &str = "Tooltip content";
+const TOOLTIP_TITLE: &str = "Info";
+
+pub struct TooltipDemo {
+    border: TooltipBorder,
+    show_title: bool,
+}
+
+impl TooltipDemo {
+    pub fn new() -> Self {
+        Self {
+            border: TooltipBorder::Full,
+            show_title: true,
+        }
+    }
+
+    fn tooltip(&self) -> Tooltip {
+        let mut t = Tooltip::new(WidgetId::new("tooltip-demo:tip"), TOOLTIP_TEXT)
+            .with_placement(TooltipPlacement::Bottom)
+            .with_border(self.border);
+        if self.show_title && matches!(self.border, TooltipBorder::Full) {
+            t = t.with_title(TOOLTIP_TITLE);
+        }
+        t
+    }
+
+    /// `Full` needs a top and bottom border row on top of the one content
+    /// row; `Sides`/`None` reserve no border rows at all (see the
+    /// contract note on `TooltipMeasure`).
+    fn rows(&self) -> f32 {
+        match self.border {
+            TooltipBorder::Full => 3.0,
+            // `Sides`, `None`, and (defensively, since `TooltipBorder` is
+            // `#[non_exhaustive]`) any future variant all reserve no
+            // border rows.
+            _ => 1.0,
+        }
+    }
+
+    fn border_label(&self) -> &'static str {
+        match self.border {
+            TooltipBorder::Sides => "Sides",
+            TooltipBorder::Full => "Full",
+            TooltipBorder::None => "None",
+            // `TooltipBorder` is `#[non_exhaustive]`; a future variant
+            // shows up here rather than failing to build.
+            _ => "?",
+        }
+    }
+
+    fn status_bar(&self) -> StatusBar {
+        StatusBar {
+            id: WidgetId::new("status"),
+            left_segments: vec![StatusBarSegment {
+                text: format!(
+                    " border: {} | title: {} ",
+                    self.border_label(),
+                    self.show_title
+                ),
+                fg: Color::rgb(255, 255, 255),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+            right_segments: vec![StatusBarSegment {
+                text: " 1=Sides 2=Full 3=None t=title q=quit ".into(),
+                fg: Color::rgb(220, 220, 220),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+        }
+    }
+
+    fn anchor_bar(&self) -> StatusBar {
+        StatusBar {
+            id: WidgetId::new("anchor"),
+            left_segments: vec![StatusBarSegment {
+                text: format!(" {ANCHOR_TEXT} "),
+                fg: Color::rgb(220, 220, 220),
+                bg: Color::rgb(37, 37, 38),
+                bold: false,
+                action_id: None,
+            }],
+            right_segments: vec![],
+        }
+    }
+}
+
+impl Default for TooltipDemo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppLogic for TooltipDemo {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let viewport = backend.viewport();
+        let lh = backend.line_height();
+        let cw = backend.char_width();
+
+        // Anchor bar at the top — the element the tooltip "describes".
+        let anchor = Rect::new(0.0, 0.0, viewport.width, lh);
+        let _ = backend.draw_status_bar(anchor, &self.anchor_bar(), None, None);
+
+        // Status bar at the bottom shows the current border/title choice
+        // plus the key hint.
+        let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
+        let _ = backend.draw_status_bar(status_rect, &self.status_bar(), None, None);
+
+        // Tooltip renders between the two bars, below the anchor.
+        let clamp = Rect::new(0.0, lh, viewport.width, viewport.height - 2.0 * lh);
+        let tooltip = self.tooltip();
+        let measure = TooltipMeasure::new(
+            cw * (TOOLTIP_TEXT.chars().count() as f32 + 4.0),
+            lh * self.rows(),
+        );
+        let layout = tooltip.layout(anchor, clamp, measure, lh);
+        backend.draw_tooltip(&tooltip, &layout);
+    }
+
+    fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
+        match event {
+            UiEvent::KeyPressed {
+                key: Key::Char('q'),
+                ..
+            }
+            | UiEvent::KeyPressed {
+                key: Key::Named(NamedKey::Escape),
+                ..
+            } => Reaction::Exit,
+            UiEvent::KeyPressed {
+                key: Key::Char('1'),
+                ..
+            } => {
+                self.border = TooltipBorder::Sides;
+                Reaction::Redraw
+            }
+            UiEvent::KeyPressed {
+                key: Key::Char('2'),
+                ..
+            } => {
+                self.border = TooltipBorder::Full;
+                Reaction::Redraw
+            }
+            UiEvent::KeyPressed {
+                key: Key::Char('3'),
+                ..
+            } => {
+                self.border = TooltipBorder::None;
+                Reaction::Redraw
+            }
+            UiEvent::KeyPressed {
+                key: Key::Char('t'),
+                ..
+            } => {
+                self.show_title = !self.show_title;
+                Reaction::Redraw
+            }
+            UiEvent::WindowResized { .. } => Reaction::Redraw,
+            _ => Reaction::Continue,
+        }
+    }
+}

--- a/quadraui/examples/common/tooltip_demo.rs
+++ b/quadraui/examples/common/tooltip_demo.rs
@@ -1,9 +1,9 @@
 //! Backend-agnostic app code for the tooltip example
 //! ([`tui_tooltip`] / [`gtk_tooltip`]).
 //!
-//! Demonstrates `Tooltip`'s border/title vocabulary (#541): a consumer
-//! picks `border` (`Sides` bars-only, `Full` closed box, `None` no
-//! chrome) and an optional `title` embedded in `Full`'s top border row,
+//! Demonstrates the `TooltipChrome` border/title vocabulary (#541): a
+//! consumer picks `border` (`Sides` bars-only, `Full` closed box, `None`
+//! no chrome) and an optional `title` embedded in `Full`'s top border row,
 //! instead of each backend hardcoding its own answer — the gap
 //! JDonaghy/vimcode#635 hit when its migrated help popup lost its border
 //! and title with no way to ask for them back. `TooltipDemo` cycles
@@ -18,7 +18,7 @@
 
 use quadraui::{
     AppLogic, Backend, Color, Key, NamedKey, Reaction, Rect, StatusBar, StatusBarSegment, Tooltip,
-    TooltipBorder, TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
+    TooltipBorder, TooltipChrome, TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
 };
 
 const ANCHOR_TEXT: &str = "hover target";
@@ -136,13 +136,12 @@ impl AppLogic for TooltipDemo {
             cw * (TOOLTIP_TEXT.chars().count() as f32 + 4.0),
             lh * self.rows(),
         );
-        let mut layout = tooltip
-            .layout(anchor, clamp, measure, lh)
-            .with_border(self.border);
+        let layout = tooltip.layout(anchor, clamp, measure, lh);
+        let mut chrome = TooltipChrome::new(self.border);
         if self.show_title && matches!(self.border, TooltipBorder::Full) {
-            layout = layout.with_title(TOOLTIP_TITLE);
+            chrome = chrome.with_title(TOOLTIP_TITLE);
         }
-        backend.draw_tooltip(&tooltip, &layout);
+        backend.draw_tooltip_with_chrome(&tooltip, &layout, &chrome);
     }
 
     fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/examples/common/tooltip_demo.rs
+++ b/quadraui/examples/common/tooltip_demo.rs
@@ -39,13 +39,8 @@ impl TooltipDemo {
     }
 
     fn tooltip(&self) -> Tooltip {
-        let mut t = Tooltip::new(WidgetId::new("tooltip-demo:tip"), TOOLTIP_TEXT)
+        Tooltip::new(WidgetId::new("tooltip-demo:tip"), TOOLTIP_TEXT)
             .with_placement(TooltipPlacement::Bottom)
-            .with_border(self.border);
-        if self.show_title && matches!(self.border, TooltipBorder::Full) {
-            t = t.with_title(TOOLTIP_TITLE);
-        }
-        t
     }
 
     /// `Full` needs a top and bottom border row on top of the one content
@@ -141,7 +136,12 @@ impl AppLogic for TooltipDemo {
             cw * (TOOLTIP_TEXT.chars().count() as f32 + 4.0),
             lh * self.rows(),
         );
-        let layout = tooltip.layout(anchor, clamp, measure, lh);
+        let mut layout = tooltip
+            .layout(anchor, clamp, measure, lh)
+            .with_border(self.border);
+        if self.show_title && matches!(self.border, TooltipBorder::Full) {
+            layout = layout.with_title(TOOLTIP_TITLE);
+        }
         backend.draw_tooltip(&tooltip, &layout);
     }
 

--- a/quadraui/examples/gtk_tooltip.rs
+++ b/quadraui/examples/gtk_tooltip.rs
@@ -1,0 +1,17 @@
+//! Tooltip `AppLogic` + `quadraui::gtk::run` example.
+//!
+//! Cycle through `Tooltip`'s border vocabulary (#541): side bars, a
+//! closed box, or no chrome at all, plus a title embedded in the box's
+//! top border row. Press 1/2/3 for Sides/Full/None, `t` to toggle the
+//! title, `q` to quit.
+//!
+//! ```sh
+//! cargo run --example gtk_tooltip --features gtk
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::gtk::run(common::TooltipDemo::new())
+}

--- a/quadraui/examples/tui_tooltip.rs
+++ b/quadraui/examples/tui_tooltip.rs
@@ -1,0 +1,17 @@
+//! Tooltip `AppLogic` + `quadraui::tui::run` example.
+//!
+//! Cycle through `Tooltip`'s border vocabulary (#541): side bars, a
+//! closed box, or no chrome at all, plus a title embedded in the box's
+//! top border row. Press 1/2/3 for Sides/Full/None, `t` to toggle the
+//! title, `q` to quit.
+//!
+//! ```sh
+//! cargo run --example tui_tooltip --features tui
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::io::Result<()> {
+    quadraui::tui::run(common::TooltipDemo::new())
+}

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -47,7 +47,7 @@ use crate::primitives::text_display::TextDisplayLayout;
 use crate::primitives::text_input::{TextInput, TextInputLayout};
 use crate::primitives::toast::{ToastStack, ToastStackLayout};
 use crate::primitives::toolbar::{Toolbar, ToolbarLayout};
-use crate::primitives::tooltip::{Tooltip, TooltipLayout};
+use crate::primitives::tooltip::{Tooltip, TooltipChrome, TooltipLayout};
 use crate::primitives::tree::TreeViewLayout;
 use crate::types::WidgetId;
 use crate::{
@@ -882,11 +882,41 @@ pub trait Backend {
     /// hosts to route clicks without re-rendering.
     fn text_input_layout(&self, rect: Rect, ti: &TextInput) -> TextInputLayout;
 
-    /// Draw a [`Tooltip`] popup at its caller-resolved layout. The
+    /// Draw a [`Tooltip`] popup at its caller-resolved layout, with the
+    /// default chrome ([`crate::TooltipBorder::Full`], no title). The
     /// caller computes anchor + viewport + content measurement and
     /// asks `tooltip.layout(...)` for the bounds. Tooltips are
     /// non-interactive — no hit data returned.
+    ///
+    /// To ask for a different border, or for a title in the top rule,
+    /// call [`Backend::draw_tooltip_with_chrome`].
     fn draw_tooltip(&mut self, tooltip: &Tooltip, layout: &TooltipLayout);
+
+    /// Draw a [`Tooltip`] popup with an explicit [`TooltipChrome`]
+    /// request (#541): which border to stroke (`Sides` / `Full` /
+    /// `None`) and an optional title to embed in `Full`'s top rule.
+    ///
+    /// Added rather than folded into [`Backend::draw_tooltip`]'s
+    /// signature, and given a default body, so that #541 breaks no
+    /// existing `Backend` implementor and no existing call site — see
+    /// `primitives::tooltip`'s module doc.
+    ///
+    /// The default body **ignores `chrome`** and delegates to
+    /// `draw_tooltip`, i.e. renders `TooltipChrome::default()`. That is
+    /// the correct fallback for a backend that has no chrome vocabulary
+    /// of its own, but it does mean a `Sides`/`None`/title request is
+    /// silently dropped by any backend that hasn't overridden this.
+    /// The TUI, GTK and macOS backends all override it and honour the
+    /// request in full.
+    fn draw_tooltip_with_chrome(
+        &mut self,
+        tooltip: &Tooltip,
+        layout: &TooltipLayout,
+        chrome: &TooltipChrome,
+    ) {
+        let _ = chrome;
+        self.draw_tooltip(tooltip, layout);
+    }
 
     /// Draw a [`ContextMenu`] popup at its caller-resolved layout.
     /// Returns the per-clickable-item hit rectangles + their

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -2095,14 +2095,24 @@ impl Backend for GtkBackend {
     }
 
     fn draw_tooltip(&mut self, tooltip: &crate::Tooltip, layout_arg: &crate::TooltipLayout) {
+        self.draw_tooltip_with_chrome(tooltip, layout_arg, &crate::TooltipChrome::default());
+    }
+
+    fn draw_tooltip_with_chrome(
+        &mut self,
+        tooltip: &crate::Tooltip,
+        layout_arg: &crate::TooltipLayout,
+        chrome: &crate::TooltipChrome,
+    ) {
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_tooltip called outside enter_frame_scope");
-        crate::gtk::draw_tooltip(
+        crate::gtk::draw_tooltip_with_chrome(
             cr,
             pango_layout,
             tooltip,
             layout_arg,
+            chrome,
             self.current_line_height,
             self.current_char_width,
             &self.current_theme,

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -113,7 +113,7 @@ pub use text_display::{draw_text_display, gtk_text_display_layout};
 pub use text_input::{draw_text_input, gtk_text_input_layout};
 pub use toast::{draw_toast_stack, gtk_toast_stack_layout};
 pub use toolbar::{draw_toolbar, gtk_toolbar_layout};
-pub use tooltip::draw_tooltip;
+pub use tooltip::{draw_tooltip, draw_tooltip_with_chrome};
 pub use tree::{draw_tree, gtk_tree_layout};
 
 /// Convert a `quadraui::Color` (0-255 RGBA) into Cairo's normalised

--- a/quadraui/src/gtk/tooltip.rs
+++ b/quadraui/src/gtk/tooltip.rs
@@ -1,14 +1,27 @@
 //! GTK rasteriser for [`crate::Tooltip`].
 //!
 //! Cairo + Pango equivalent of `quadraui::tui::draw_tooltip`. Paints a
-//! rectangle (background + 1 px border) at the resolved bounds, then
-//! draws either the plain `text` or per-row `styled_lines`.
+//! background rectangle at the resolved bounds, then border chrome per
+//! `tooltip.border` (#541 — [`crate::TooltipBorder`]):
+//!
+//! - [`TooltipBorder::Full`] (the default) strokes a full 4-sided box —
+//!   GTK has always done this, unconditionally, before #541 gave it a
+//!   name. An optional `tooltip.title` is centred over the top edge,
+//!   punched through the stroke with a background-coloured backing
+//!   rectangle so it reads as embedded in the border rather than a
+//!   content row (matching the TUI rasteriser's top-row title).
+//! - [`TooltipBorder::Sides`] strokes two vertical lines at the left and
+//!   right edges only, no top/bottom — TUI's pre-#542 look, now
+//!   available on GTK by explicit request. No title (no top rule).
+//! - [`TooltipBorder::None`] strokes nothing.
+//!
+//! Then draws either the plain `text` or per-row `styled_lines`.
 
 use gtk4::cairo::Context;
 use gtk4::pango;
 
 use super::cairo_rgb;
-use crate::primitives::tooltip::{Tooltip, TooltipLayout};
+use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipLayout};
 use crate::theme::Theme;
 
 /// Draw a [`Tooltip`] at its resolved layout position.
@@ -16,6 +29,9 @@ use crate::theme::Theme;
 /// `padding_x` is the horizontal padding (in pixels) from the left
 /// border to the start of text — consumers typically pass the same
 /// `char_width` they used when computing the tooltip's measured width.
+/// Halved when `tooltip.border` is [`TooltipBorder::None`], since there
+/// is no border column to clear first — mirrors the TUI rasteriser's
+/// `text_col_offset` dropping from 2 (border + pad) to 1 (pad only).
 ///
 /// Per-tooltip `tooltip.fg` / `tooltip.bg` overrides win over the
 /// theme defaults. The frame border always uses [`Theme::hover_border`].
@@ -44,32 +60,82 @@ pub fn draw_tooltip(
         .unwrap_or_else(|| cairo_rgb(theme.hover_fg));
     let border = cairo_rgb(theme.hover_border);
 
+    let bx = bounds.x as f64;
+    let by = bounds.y as f64;
+    let bw = bounds.width as f64;
+    let bh = bounds.height as f64;
+
     cr.set_source_rgb(bg.0, bg.1, bg.2);
-    cr.rectangle(
-        bounds.x as f64,
-        bounds.y as f64,
-        bounds.width as f64,
-        bounds.height as f64,
-    );
+    cr.rectangle(bx, by, bw, bh);
     cr.fill().ok();
 
-    cr.set_source_rgb(border.0, border.1, border.2);
-    cr.set_line_width(1.0);
-    cr.rectangle(
-        bounds.x as f64,
-        bounds.y as f64,
-        bounds.width as f64,
-        bounds.height as f64,
-    );
-    cr.stroke().ok();
+    // Content normally starts 2px below the top edge; a title pushes
+    // that down further below, since its real font height (title_h) is
+    // typically much taller than the 1px border line it's centred on —
+    // without this, a title would visually collide with the first
+    // content row instead of sitting in its own space above it, the way
+    // the TUI rasteriser's dedicated title row never overlaps content.
+    let mut text_top = by + 2.0;
 
-    let text_x = bounds.x as f64 + padding_x;
-    let text_top = bounds.y as f64 + 2.0;
+    match tooltip.border {
+        TooltipBorder::Full => {
+            cr.set_source_rgb(border.0, border.1, border.2);
+            cr.set_line_width(1.0);
+            cr.rectangle(bx, by, bw, bh);
+            cr.stroke().ok();
+
+            if let Some(title) = tooltip
+                .title
+                .as_deref()
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+            {
+                layout.set_text(title);
+                layout.set_attributes(None);
+                let (title_w, title_h) = layout.pixel_size();
+                let (title_w, title_h) = (title_w as f64, title_h as f64);
+                let pad = 4.0;
+                let title_x = bx + ((bw - title_w) / 2.0).max(0.0);
+                let title_y = by - title_h / 2.0;
+
+                // Punch a background-coloured gap through the border
+                // stroke so the title reads as embedded in the top rule,
+                // not a content row sitting on top of it.
+                cr.set_source_rgb(bg.0, bg.1, bg.2);
+                cr.rectangle(title_x - pad, title_y, title_w + pad * 2.0, title_h);
+                cr.fill().ok();
+
+                cr.set_source_rgb(fg.0, fg.1, fg.2);
+                cr.move_to(title_x, title_y);
+                super::painted_text::show_layout(cr, layout);
+
+                text_top = text_top.max(title_y + title_h + 2.0);
+            }
+        }
+        TooltipBorder::Sides => {
+            cr.set_source_rgb(border.0, border.1, border.2);
+            cr.set_line_width(1.0);
+            cr.move_to(bx, by);
+            cr.line_to(bx, by + bh);
+            cr.stroke().ok();
+            cr.move_to(bx + bw, by);
+            cr.line_to(bx + bw, by + bh);
+            cr.stroke().ok();
+        }
+        TooltipBorder::None => {}
+    }
+
+    let text_padding_x = if matches!(tooltip.border, TooltipBorder::None) {
+        padding_x / 2.0
+    } else {
+        padding_x
+    };
+    let text_x = bx + text_padding_x;
 
     if let Some(ref styled_lines) = tooltip.styled_lines {
         for (i, styled) in styled_lines.iter().enumerate() {
             let row_y = text_top + i as f64 * line_height;
-            if row_y + line_height > bounds.y as f64 + bounds.height as f64 {
+            if row_y + line_height > by + bh {
                 break;
             }
             let mut x_off = text_x;
@@ -90,12 +156,241 @@ pub fn draw_tooltip(
     cr.set_source_rgb(fg.0, fg.1, fg.2);
     for (i, text_line) in tooltip.text.lines().enumerate() {
         let row_y = text_top + i as f64 * line_height;
-        if row_y + line_height > bounds.y as f64 + bounds.height as f64 {
+        if row_y + line_height > by + bh {
             break;
         }
         layout.set_text(text_line);
         layout.set_attributes(None);
         cr.move_to(text_x, row_y);
         super::painted_text::show_layout(cr, layout);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gtk4::cairo::{Context, Format, ImageSurface};
+
+    use super::*;
+    use crate::event::Rect as QRect;
+    use crate::primitives::tooltip::{ResolvedPlacement, Tooltip, TooltipPlacement};
+    use crate::types::WidgetId;
+
+    const W: i32 = 200;
+    const H: i32 = 80;
+    const LINE_H: f64 = 16.0;
+    const PAD_X: f64 = 8.0;
+
+    /// Same byte layout as `gtk/data_table.rs`'s test helper and
+    /// `GtkDriver::pixel`.
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    /// A pure-background reference pixel: bottom-right corner, a few
+    /// pixels in from both edges — clear of any border stroke (which
+    /// hugs the very edge) and of `sample_tooltip`'s short, top-aligned
+    /// "Hover hint" body text (which a dead-centre probe can land on,
+    /// since the box is only one line tall).
+    fn bg_reference(data: &[u8], stride: usize, bounds: QRect) -> (u8, u8, u8) {
+        pixel(
+            data,
+            stride,
+            (bounds.x + bounds.width) as i32 - 4,
+            (bounds.y + bounds.height) as i32 - 4,
+        )
+    }
+
+    fn sample_tooltip(border: TooltipBorder, title: Option<&str>) -> Tooltip {
+        Tooltip {
+            id: WidgetId::new("tip"),
+            text: "Hover hint".into(),
+            styled_lines: None,
+            placement: TooltipPlacement::Bottom,
+            border,
+            title: title.map(str::to_string),
+            fg: None,
+            bg: None,
+        }
+    }
+
+    /// Bounds pinned to whole pixels — `cr`'s 1px-wide strokes centre on
+    /// the path, so a whole-pixel origin keeps the edge probe and the
+    /// "clear of any stroke" probe from straddling the same anti-aliased
+    /// pixel row/column (same reasoning as
+    /// `macos::tooltip::tests::tooltip_border_paints_at_edge`).
+    fn sample_layout() -> TooltipLayout {
+        TooltipLayout {
+            bounds: QRect::new(20.0, 20.0, 120.0, 24.0),
+            resolved_placement: ResolvedPlacement::Bottom,
+        }
+    }
+
+    /// Paint `tooltip` at `layout.bounds` on a fresh surface and return
+    /// the raw pixel buffer alongside the stride.
+    fn paint(tooltip: &Tooltip, layout: &TooltipLayout) -> (Vec<u8>, usize) {
+        let mut surface = ImageSurface::create(Format::ARgb32, W, H).expect("create ImageSurface");
+        {
+            let cr = Context::new(&surface).expect("Context::new");
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            draw_tooltip(
+                &cr,
+                &pango_layout,
+                tooltip,
+                layout,
+                LINE_H,
+                PAD_X,
+                &Theme::default(),
+            );
+        }
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data").to_vec();
+        (data, stride)
+    }
+
+    #[test]
+    fn full_border_strokes_all_four_edges() {
+        let tooltip = sample_tooltip(TooltipBorder::Full, None);
+        let layout = sample_layout();
+        let (data, stride) = paint(&tooltip, &layout);
+        let b = layout.bounds;
+        let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
+
+        let inner = bg_reference(&data, stride, b);
+        for (name, edge) in [
+            ("top", pixel(&data, stride, bx + bw / 2, by)),
+            ("bottom", pixel(&data, stride, bx + bw / 2, by + bh - 1)),
+            ("left", pixel(&data, stride, bx, by + bh / 2)),
+            ("right", pixel(&data, stride, bx + bw - 1, by + bh / 2)),
+        ] {
+            assert_ne!(
+                edge, inner,
+                "TooltipBorder::Full: {name} edge should show border ink, distinct from the \
+                 interior background (edge={edge:?}, inner={inner:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn sides_border_only_strokes_left_and_right() {
+        let tooltip = sample_tooltip(TooltipBorder::Sides, None);
+        let layout = sample_layout();
+        let (data, stride) = paint(&tooltip, &layout);
+        let b = layout.bounds;
+        let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
+
+        let inner = bg_reference(&data, stride, b);
+        let top = pixel(&data, stride, bx + bw / 2, by);
+        let bottom = pixel(&data, stride, bx + bw / 2, by + bh - 1);
+        let left = pixel(&data, stride, bx, by + bh / 2);
+        let right = pixel(&data, stride, bx + bw - 1, by + bh / 2);
+
+        assert_eq!(
+            top, inner,
+            "TooltipBorder::Sides must not stroke the top edge — no top/bottom rule, \
+             regardless of box height (top={top:?}, inner={inner:?})"
+        );
+        assert_eq!(
+            bottom, inner,
+            "TooltipBorder::Sides must not stroke the bottom edge (bottom={bottom:?}, \
+             inner={inner:?})"
+        );
+        assert_ne!(
+            left, inner,
+            "TooltipBorder::Sides must still stroke the left edge (left={left:?}, \
+             inner={inner:?})"
+        );
+        assert_ne!(
+            right, inner,
+            "TooltipBorder::Sides must still stroke the right edge (right={right:?}, \
+             inner={inner:?})"
+        );
+    }
+
+    #[test]
+    fn none_border_strokes_nothing() {
+        let tooltip = sample_tooltip(TooltipBorder::None, None);
+        let layout = sample_layout();
+        let (data, stride) = paint(&tooltip, &layout);
+        let b = layout.bounds;
+        let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
+
+        let inner = bg_reference(&data, stride, b);
+        for (name, edge) in [
+            ("top", pixel(&data, stride, bx + bw / 2, by)),
+            ("bottom", pixel(&data, stride, bx + bw / 2, by + bh - 1)),
+            ("left", pixel(&data, stride, bx, by + bh / 2)),
+            ("right", pixel(&data, stride, bx + bw - 1, by + bh / 2)),
+        ] {
+            assert_eq!(
+                edge, inner,
+                "TooltipBorder::None must not stroke {name} — no chrome at all \
+                 (edge={edge:?}, inner={inner:?})"
+            );
+        }
+    }
+
+    /// #541 ask 2: a title punches a background-coloured gap through the
+    /// top stroke so it reads as embedded in the border, not a content
+    /// row. Scans the top edge rather than probing one fixed x — the
+    /// title is horizontally centred, so a single dead-centre sample can
+    /// land on a glyph's own ink instead of the cleared pad around it.
+    /// What the punch guarantees is: somewhere in the interior the top
+    /// edge reads as background (the gap), and near the corners it's
+    /// still the plain stroke (the punch is local to the title, not the
+    /// whole edge).
+    #[test]
+    fn full_border_title_punches_a_gap_but_leaves_the_rest_of_the_top_edge_stroked() {
+        let tooltip = sample_tooltip(TooltipBorder::Full, Some("Hi"));
+        let layout = sample_layout();
+        let (data, stride) = paint(&tooltip, &layout);
+        let b = layout.bounds;
+        let (bx, by, bw) = (b.x as i32, b.y as i32, b.width as i32);
+
+        let inner = bg_reference(&data, stride, b);
+        let margin = 3; // stay clear of the corner glyphs (┌/┐ equivalent stroke joins)
+        let interior: Vec<(u8, u8, u8)> = (bx + margin..bx + bw - margin)
+            .map(|x| pixel(&data, stride, x, by))
+            .collect();
+
+        assert!(
+            interior.contains(&inner),
+            "the title's short label + padding should punch at least one background-\
+             coloured pixel into the top edge somewhere in its interior (inner={inner:?}, \
+             top-edge interior samples={interior:?})"
+        );
+
+        let top_near_corner = pixel(&data, stride, bx + 1, by);
+        assert_ne!(
+            top_near_corner, inner,
+            "the top edge right at the corner should still show the plain border stroke, \
+             i.e. the punch must not swallow the whole edge \
+             (top_near_corner={top_near_corner:?}, inner={inner:?})"
+        );
+    }
+
+    #[test]
+    fn title_is_ignored_when_border_is_sides_or_none() {
+        // A title set on a non-`Full` tooltip has no top rule to embed
+        // into — both variants must render identically to their
+        // no-title counterparts (no stray top-edge ink from an attempted
+        // title punch/paint).
+        for border in [TooltipBorder::Sides, TooltipBorder::None] {
+            let with_title = sample_tooltip(border, Some("Ignored"));
+            let without_title = sample_tooltip(border, None);
+            let layout = sample_layout();
+            let (with_data, stride) = paint(&with_title, &layout);
+            let (without_data, _) = paint(&without_title, &layout);
+            let b = layout.bounds;
+            let (bx, by, bw) = (b.x as i32, b.y as i32, b.width as i32);
+            let top_with = pixel(&with_data, stride, bx + bw / 2, by);
+            let top_without = pixel(&without_data, stride, bx + bw / 2, by);
+            assert_eq!(
+                top_with, top_without,
+                "{border:?}: setting `title` must not change what's painted at the top \
+                 edge (top_with={top_with:?}, top_without={top_without:?})"
+            );
+        }
     }
 }

--- a/quadraui/src/gtk/tooltip.rs
+++ b/quadraui/src/gtk/tooltip.rs
@@ -2,11 +2,13 @@
 //!
 //! Cairo + Pango equivalent of `quadraui::tui::draw_tooltip`. Paints a
 //! background rectangle at the resolved bounds, then border chrome per
-//! `tooltip.border` (#541 — [`crate::TooltipBorder`]):
+//! `layout.border` (#541 — [`crate::TooltipBorder`]; see
+//! `primitives::tooltip`'s module doc for why it lives on
+//! [`TooltipLayout`] rather than on [`Tooltip`]):
 //!
 //! - [`TooltipBorder::Full`] (the default) strokes a full 4-sided box —
 //!   GTK has always done this, unconditionally, before #541 gave it a
-//!   name. An optional `tooltip.title` is centred over the top edge,
+//!   name. An optional `layout.title` is centred over the top edge,
 //!   punched through the stroke with a background-coloured backing
 //!   rectangle so it reads as embedded in the border rather than a
 //!   content row (matching the TUI rasteriser's top-row title).
@@ -29,7 +31,7 @@ use crate::theme::Theme;
 /// `padding_x` is the horizontal padding (in pixels) from the left
 /// border to the start of text — consumers typically pass the same
 /// `char_width` they used when computing the tooltip's measured width.
-/// Halved when `tooltip.border` is [`TooltipBorder::None`], since there
+/// Halved when `layout.border` is [`TooltipBorder::None`], since there
 /// is no border column to clear first — mirrors the TUI rasteriser's
 /// `text_col_offset` dropping from 2 (border + pad) to 1 (pad only).
 ///
@@ -77,14 +79,14 @@ pub fn draw_tooltip(
     // the TUI rasteriser's dedicated title row never overlaps content.
     let mut text_top = by + 2.0;
 
-    match tooltip.border {
+    match tooltip_layout.border {
         TooltipBorder::Full => {
             cr.set_source_rgb(border.0, border.1, border.2);
             cr.set_line_width(1.0);
             cr.rectangle(bx, by, bw, bh);
             cr.stroke().ok();
 
-            if let Some(title) = tooltip
+            if let Some(title) = tooltip_layout
                 .title
                 .as_deref()
                 .map(str::trim)
@@ -125,7 +127,7 @@ pub fn draw_tooltip(
         TooltipBorder::None => {}
     }
 
-    let text_padding_x = if matches!(tooltip.border, TooltipBorder::None) {
+    let text_padding_x = if matches!(tooltip_layout.border, TooltipBorder::None) {
         padding_x / 2.0
     } else {
         padding_x
@@ -201,14 +203,12 @@ mod tests {
         )
     }
 
-    fn sample_tooltip(border: TooltipBorder, title: Option<&str>) -> Tooltip {
+    fn sample_tooltip() -> Tooltip {
         Tooltip {
             id: WidgetId::new("tip"),
             text: "Hover hint".into(),
             styled_lines: None,
             placement: TooltipPlacement::Bottom,
-            border,
-            title: title.map(str::to_string),
             fg: None,
             bg: None,
         }
@@ -219,11 +219,17 @@ mod tests {
     /// "clear of any stroke" probe from straddling the same anti-aliased
     /// pixel row/column (same reasoning as
     /// `macos::tooltip::tests::tooltip_border_paints_at_edge`).
-    fn sample_layout() -> TooltipLayout {
-        TooltipLayout {
+    fn sample_layout(border: TooltipBorder, title: Option<&str>) -> TooltipLayout {
+        let mut layout = TooltipLayout {
             bounds: QRect::new(20.0, 20.0, 120.0, 24.0),
             resolved_placement: ResolvedPlacement::Bottom,
+            border,
+            title: None,
+        };
+        if let Some(t) = title {
+            layout = layout.with_title(t);
         }
+        layout
     }
 
     /// Paint `tooltip` at `layout.bounds` on a fresh surface and return
@@ -251,8 +257,8 @@ mod tests {
 
     #[test]
     fn full_border_strokes_all_four_edges() {
-        let tooltip = sample_tooltip(TooltipBorder::Full, None);
-        let layout = sample_layout();
+        let tooltip = sample_tooltip();
+        let layout = sample_layout(TooltipBorder::Full, None);
         let (data, stride) = paint(&tooltip, &layout);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
@@ -274,8 +280,8 @@ mod tests {
 
     #[test]
     fn sides_border_only_strokes_left_and_right() {
-        let tooltip = sample_tooltip(TooltipBorder::Sides, None);
-        let layout = sample_layout();
+        let tooltip = sample_tooltip();
+        let layout = sample_layout(TooltipBorder::Sides, None);
         let (data, stride) = paint(&tooltip, &layout);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
@@ -310,8 +316,8 @@ mod tests {
 
     #[test]
     fn none_border_strokes_nothing() {
-        let tooltip = sample_tooltip(TooltipBorder::None, None);
-        let layout = sample_layout();
+        let tooltip = sample_tooltip();
+        let layout = sample_layout(TooltipBorder::None, None);
         let (data, stride) = paint(&tooltip, &layout);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
@@ -342,8 +348,8 @@ mod tests {
     /// whole edge).
     #[test]
     fn full_border_title_punches_a_gap_but_leaves_the_rest_of_the_top_edge_stroked() {
-        let tooltip = sample_tooltip(TooltipBorder::Full, Some("Hi"));
-        let layout = sample_layout();
+        let tooltip = sample_tooltip();
+        let layout = sample_layout(TooltipBorder::Full, Some("Hi"));
         let (data, stride) = paint(&tooltip, &layout);
         let b = layout.bounds;
         let (bx, by, bw) = (b.x as i32, b.y as i32, b.width as i32);
@@ -377,12 +383,13 @@ mod tests {
         // no-title counterparts (no stray top-edge ink from an attempted
         // title punch/paint).
         for border in [TooltipBorder::Sides, TooltipBorder::None] {
-            let with_title = sample_tooltip(border, Some("Ignored"));
-            let without_title = sample_tooltip(border, None);
-            let layout = sample_layout();
-            let (with_data, stride) = paint(&with_title, &layout);
-            let (without_data, _) = paint(&without_title, &layout);
-            let b = layout.bounds;
+            let with_title = sample_tooltip();
+            let without_title = sample_tooltip();
+            let with_layout = sample_layout(border, Some("Ignored"));
+            let without_layout = sample_layout(border, None);
+            let (with_data, stride) = paint(&with_title, &with_layout);
+            let (without_data, _) = paint(&without_title, &without_layout);
+            let b = with_layout.bounds;
             let (bx, by, bw) = (b.x as i32, b.y as i32, b.width as i32);
             let top_with = pixel(&with_data, stride, bx + bw / 2, by);
             let top_without = pixel(&without_data, stride, bx + bw / 2, by);

--- a/quadraui/src/gtk/tooltip.rs
+++ b/quadraui/src/gtk/tooltip.rs
@@ -2,13 +2,16 @@
 //!
 //! Cairo + Pango equivalent of `quadraui::tui::draw_tooltip`. Paints a
 //! background rectangle at the resolved bounds, then border chrome per
-//! `layout.border` (#541 — [`crate::TooltipBorder`]; see
-//! `primitives::tooltip`'s module doc for why it lives on
-//! [`TooltipLayout`] rather than on [`Tooltip`]):
+//! the [`TooltipChrome`] argument (#541 — [`crate::TooltipBorder`]; see
+//! `primitives::tooltip`'s module doc for why the vocabulary is a
+//! sidecar value rather than a field on [`Tooltip`] or
+//! [`TooltipLayout`]). [`draw_tooltip`] keeps its pre-#541 signature and
+//! renders `TooltipChrome::default()`; [`draw_tooltip_with_chrome`]
+//! takes the request explicitly:
 //!
 //! - [`TooltipBorder::Full`] (the default) strokes a full 4-sided box —
 //!   GTK has always done this, unconditionally, before #541 gave it a
-//!   name. An optional `layout.title` is centred over the top edge,
+//!   name. An optional `chrome.title` is centred over the top edge,
 //!   punched through the stroke with a background-coloured backing
 //!   rectangle so it reads as embedded in the border rather than a
 //!   content row (matching the TUI rasteriser's top-row title).
@@ -23,26 +26,62 @@ use gtk4::cairo::Context;
 use gtk4::pango;
 
 use super::cairo_rgb;
-use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipLayout};
+use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipChrome, TooltipLayout};
 use crate::theme::Theme;
 
-/// Draw a [`Tooltip`] at its resolved layout position.
+/// Draw a [`Tooltip`] at its resolved layout position with the default
+/// chrome — a [`TooltipBorder::Full`] box, no title, i.e. exactly what
+/// this rasteriser drew before #541 added a choice.
 ///
 /// `padding_x` is the horizontal padding (in pixels) from the left
 /// border to the start of text — consumers typically pass the same
 /// `char_width` they used when computing the tooltip's measured width.
-/// Halved when `layout.border` is [`TooltipBorder::None`], since there
-/// is no border column to clear first — mirrors the TUI rasteriser's
-/// `text_col_offset` dropping from 2 (border + pad) to 1 (pad only).
 ///
 /// Per-tooltip `tooltip.fg` / `tooltip.bg` overrides win over the
 /// theme defaults. The frame border always uses [`Theme::hover_border`].
+///
+/// To ask for different chrome, call [`draw_tooltip_with_chrome`].
 #[allow(clippy::too_many_arguments)]
 pub fn draw_tooltip(
     cr: &Context,
     layout: &pango::Layout,
     tooltip: &Tooltip,
     tooltip_layout: &TooltipLayout,
+    line_height: f64,
+    padding_x: f64,
+    theme: &Theme,
+) {
+    draw_tooltip_with_chrome(
+        cr,
+        layout,
+        tooltip,
+        tooltip_layout,
+        &TooltipChrome::default(),
+        line_height,
+        padding_x,
+        theme,
+    );
+}
+
+/// Draw a [`Tooltip`] at its resolved layout position, with the border
+/// and optional title requested by `chrome` (#541).
+///
+/// `padding_x` is the horizontal padding (in pixels) from the left
+/// border to the start of text — consumers typically pass the same
+/// `char_width` they used when computing the tooltip's measured width.
+/// Halved when `chrome.border` is [`TooltipBorder::None`], since there
+/// is no border column to clear first — mirrors the TUI rasteriser's
+/// `text_col_offset` dropping from 2 (border + pad) to 1 (pad only).
+///
+/// Per-tooltip `tooltip.fg` / `tooltip.bg` overrides win over the
+/// theme defaults. The frame border always uses [`Theme::hover_border`].
+#[allow(clippy::too_many_arguments)]
+pub fn draw_tooltip_with_chrome(
+    cr: &Context,
+    layout: &pango::Layout,
+    tooltip: &Tooltip,
+    tooltip_layout: &TooltipLayout,
+    chrome: &TooltipChrome,
     line_height: f64,
     padding_x: f64,
     theme: &Theme,
@@ -79,14 +118,14 @@ pub fn draw_tooltip(
     // the TUI rasteriser's dedicated title row never overlaps content.
     let mut text_top = by + 2.0;
 
-    match tooltip_layout.border {
+    match chrome.border {
         TooltipBorder::Full => {
             cr.set_source_rgb(border.0, border.1, border.2);
             cr.set_line_width(1.0);
             cr.rectangle(bx, by, bw, bh);
             cr.stroke().ok();
 
-            if let Some(title) = tooltip_layout
+            if let Some(title) = chrome
                 .title
                 .as_deref()
                 .map(str::trim)
@@ -127,7 +166,7 @@ pub fn draw_tooltip(
         TooltipBorder::None => {}
     }
 
-    let text_padding_x = if matches!(tooltip_layout.border, TooltipBorder::None) {
+    let text_padding_x = if matches!(chrome.border, TooltipBorder::None) {
         padding_x / 2.0
     } else {
         padding_x
@@ -219,31 +258,35 @@ mod tests {
     /// "clear of any stroke" probe from straddling the same anti-aliased
     /// pixel row/column (same reasoning as
     /// `macos::tooltip::tests::tooltip_border_paints_at_edge`).
-    fn sample_layout(border: TooltipBorder, title: Option<&str>) -> TooltipLayout {
-        let mut layout = TooltipLayout {
+    fn sample_layout(border: TooltipBorder, title: Option<&str>) -> (TooltipLayout, TooltipChrome) {
+        let layout = TooltipLayout {
             bounds: QRect::new(20.0, 20.0, 120.0, 24.0),
             resolved_placement: ResolvedPlacement::Bottom,
-            border,
-            title: None,
         };
+        let mut chrome = TooltipChrome::new(border);
         if let Some(t) = title {
-            layout = layout.with_title(t);
+            chrome = chrome.with_title(t);
         }
-        layout
+        (layout, chrome)
     }
 
     /// Paint `tooltip` at `layout.bounds` on a fresh surface and return
     /// the raw pixel buffer alongside the stride.
-    fn paint(tooltip: &Tooltip, layout: &TooltipLayout) -> (Vec<u8>, usize) {
+    fn paint(
+        tooltip: &Tooltip,
+        layout: &TooltipLayout,
+        chrome: &TooltipChrome,
+    ) -> (Vec<u8>, usize) {
         let mut surface = ImageSurface::create(Format::ARgb32, W, H).expect("create ImageSurface");
         {
             let cr = Context::new(&surface).expect("Context::new");
             let pango_layout = pangocairo::functions::create_layout(&cr);
-            draw_tooltip(
+            draw_tooltip_with_chrome(
                 &cr,
                 &pango_layout,
                 tooltip,
                 layout,
+                chrome,
                 LINE_H,
                 PAD_X,
                 &Theme::default(),
@@ -258,8 +301,8 @@ mod tests {
     #[test]
     fn full_border_strokes_all_four_edges() {
         let tooltip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::Full, None);
-        let (data, stride) = paint(&tooltip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::Full, None);
+        let (data, stride) = paint(&tooltip, &layout, &chrome);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
 
@@ -281,8 +324,8 @@ mod tests {
     #[test]
     fn sides_border_only_strokes_left_and_right() {
         let tooltip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::Sides, None);
-        let (data, stride) = paint(&tooltip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::Sides, None);
+        let (data, stride) = paint(&tooltip, &layout, &chrome);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
 
@@ -317,8 +360,8 @@ mod tests {
     #[test]
     fn none_border_strokes_nothing() {
         let tooltip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::None, None);
-        let (data, stride) = paint(&tooltip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::None, None);
+        let (data, stride) = paint(&tooltip, &layout, &chrome);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as i32, b.y as i32, b.width as i32, b.height as i32);
 
@@ -349,8 +392,8 @@ mod tests {
     #[test]
     fn full_border_title_punches_a_gap_but_leaves_the_rest_of_the_top_edge_stroked() {
         let tooltip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::Full, Some("Hi"));
-        let (data, stride) = paint(&tooltip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::Full, Some("Hi"));
+        let (data, stride) = paint(&tooltip, &layout, &chrome);
         let b = layout.bounds;
         let (bx, by, bw) = (b.x as i32, b.y as i32, b.width as i32);
 
@@ -385,10 +428,10 @@ mod tests {
         for border in [TooltipBorder::Sides, TooltipBorder::None] {
             let with_title = sample_tooltip();
             let without_title = sample_tooltip();
-            let with_layout = sample_layout(border, Some("Ignored"));
-            let without_layout = sample_layout(border, None);
-            let (with_data, stride) = paint(&with_title, &with_layout);
-            let (without_data, _) = paint(&without_title, &without_layout);
+            let (with_layout, with_chrome) = sample_layout(border, Some("Ignored"));
+            let (without_layout, without_chrome) = sample_layout(border, None);
+            let (with_data, stride) = paint(&with_title, &with_layout, &with_chrome);
+            let (without_data, _) = paint(&without_title, &without_layout, &without_chrome);
             let b = with_layout.bounds;
             let (bx, by, bw) = (b.x as i32, b.y as i32, b.width as i32);
             let top_with = pixel(&with_data, stride, bx + bw / 2, by);

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -2131,6 +2131,45 @@ mod tests {
 
     // ── Tooltip primitive tests (D6 shape) ────────────────────────────
 
+    /// `Default` is the migration path #541 hands downstream consumers
+    /// (`Tooltip { id, text, ..Default::default() }`), so it has to agree
+    /// field-for-field with `Tooltip::new` — otherwise a consumer that
+    /// migrates by spreading silently gets different chrome than one that
+    /// migrates to the builder.
+    #[test]
+    fn tooltip_default_matches_new_on_every_optional_field() {
+        let d = Tooltip::default();
+        assert_eq!(d, Tooltip::new(WidgetId::new(""), ""));
+        assert_eq!(d.styled_lines, None);
+        assert_eq!(d.placement, TooltipPlacement::Bottom);
+        // `Full`, not `Sides`: the behaviour-preserving default for GTK and
+        // macOS, which have always stroked a closed box.
+        assert_eq!(d.border, TooltipBorder::Full);
+        assert_eq!(d.title, None);
+        assert_eq!(d.bg, None);
+        assert_eq!(d.fg, None);
+    }
+
+    /// The spread keeps the fields the consumer names and defaults the
+    /// rest — the property that makes the *next* added field a non-event
+    /// for anyone who migrated this way.
+    #[test]
+    fn tooltip_default_spread_preserves_named_fields() {
+        let t = Tooltip {
+            id: WidgetId::new("tip"),
+            text: "Hello".to_string(),
+            placement: TooltipPlacement::Top,
+            border: TooltipBorder::None,
+            ..Default::default()
+        };
+        assert_eq!(t.id, WidgetId::new("tip"));
+        assert_eq!(t.text, "Hello");
+        assert_eq!(t.placement, TooltipPlacement::Top);
+        assert_eq!(t.border, TooltipBorder::None);
+        assert_eq!(t.title, None);
+        assert_eq!(t.styled_lines, None);
+    }
+
     #[test]
     fn tooltip_layout_prefers_bottom_when_room() {
         let t = Tooltip {

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -272,8 +272,8 @@ pub use primitives::toolbar::{
     ToolbarLayout, VisibleToolbarItem,
 };
 pub use primitives::tooltip::{
-    ResolvedPlacement, Tooltip, TooltipBorder, TooltipEvent, TooltipHit, TooltipLayout,
-    TooltipMeasure, TooltipPlacement,
+    ResolvedPlacement, Tooltip, TooltipBorder, TooltipChrome, TooltipEvent, TooltipHit,
+    TooltipLayout, TooltipMeasure, TooltipPlacement,
 };
 pub use primitives::tree::{
     TreeEvent, TreeRow, TreeRowEditState, TreeRowMeasure, TreeView, TreeViewHit, TreeViewLayout,
@@ -2131,23 +2131,39 @@ mod tests {
 
     // ── Tooltip primitive tests (D6 shape) ────────────────────────────
 
-    /// #541: `TooltipLayout::with_border` / `with_title` are additive on
-    /// the value `Tooltip::layout` returns, not fields on `Tooltip`
-    /// itself — see `primitives::tooltip`'s module doc for why. Defaults
-    /// match what every backend drew unconditionally before #541
-    /// introduced a choice.
+    /// #541: the border/title vocabulary is a separate [`TooltipChrome`]
+    /// value passed alongside the tooltip and its layout — *not* a field
+    /// on `Tooltip` or on `TooltipLayout`, both of which consumers
+    /// construct with exhaustive literals (see `primitives::tooltip`'s
+    /// module doc). `TooltipChrome::default()` matches what every backend
+    /// drew unconditionally before #541 introduced a choice.
     #[test]
-    fn tooltip_layout_border_and_title_default_then_builder_overrides() {
-        let t = Tooltip::new(WidgetId::new("tip"), "Hello");
-        let anchor = Rect::new(0.0, 0.0, 10.0, 1.0);
-        let viewport = Rect::new(0.0, 0.0, 80.0, 24.0);
-        let layout = t.layout(anchor, viewport, TooltipMeasure::new(20.0, 3.0), 0.0);
-        assert_eq!(layout.border, TooltipBorder::Full);
-        assert_eq!(layout.title, None);
+    fn tooltip_chrome_defaults_to_full_then_builders_override() {
+        let chrome = TooltipChrome::default();
+        assert_eq!(chrome.border, TooltipBorder::Full);
+        assert_eq!(chrome.title, None);
 
-        let layout = layout.with_border(TooltipBorder::None).with_title("Hi");
-        assert_eq!(layout.border, TooltipBorder::None);
-        assert_eq!(layout.title.as_deref(), Some("Hi"));
+        let chrome = TooltipChrome::new(TooltipBorder::None).with_title("Hi");
+        assert_eq!(chrome.border, TooltipBorder::None);
+        assert_eq!(chrome.title.as_deref(), Some("Hi"));
+
+        let chrome = chrome.with_border(TooltipBorder::Sides);
+        assert_eq!(chrome.border, TooltipBorder::Sides);
+    }
+
+    /// #541 rule-8 guard: `TooltipLayout` must stay constructible from a
+    /// bare exhaustive literal, because downstream consumers that
+    /// position a popup themselves (rather than anchoring it via
+    /// `Tooltip::layout`) build one by hand. If a future change adds a
+    /// required field here, this test stops compiling — which is the
+    /// point: that would be an `E0063` break for every such call site.
+    #[test]
+    fn tooltip_layout_stays_exhaustively_constructible() {
+        let layout = TooltipLayout {
+            bounds: Rect::new(1.0, 2.0, 30.0, 4.0),
+            resolved_placement: ResolvedPlacement::Bottom,
+        };
+        assert_eq!(layout.bounds.width, 30.0);
     }
 
     #[test]

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -272,8 +272,8 @@ pub use primitives::toolbar::{
     ToolbarLayout, VisibleToolbarItem,
 };
 pub use primitives::tooltip::{
-    ResolvedPlacement, Tooltip, TooltipEvent, TooltipHit, TooltipLayout, TooltipMeasure,
-    TooltipPlacement,
+    ResolvedPlacement, Tooltip, TooltipBorder, TooltipEvent, TooltipHit, TooltipLayout,
+    TooltipMeasure, TooltipPlacement,
 };
 pub use primitives::tree::{
     TreeEvent, TreeRow, TreeRowEditState, TreeRowMeasure, TreeView, TreeViewHit, TreeViewLayout,
@@ -2138,6 +2138,8 @@ mod tests {
             text: "Hello".to_string(),
             placement: TooltipPlacement::Bottom,
             styled_lines: None,
+            border: TooltipBorder::default(),
+            title: None,
             bg: None,
             fg: None,
         };
@@ -2159,6 +2161,8 @@ mod tests {
             text: "Hello".to_string(),
             placement: TooltipPlacement::Bottom,
             styled_lines: None,
+            border: TooltipBorder::default(),
+            title: None,
             bg: None,
             fg: None,
         };
@@ -2181,6 +2185,8 @@ mod tests {
             text: "…".to_string(),
             placement: TooltipPlacement::Bottom,
             styled_lines: None,
+            border: TooltipBorder::default(),
+            title: None,
             bg: None,
             fg: None,
         };
@@ -2204,6 +2210,8 @@ mod tests {
             text: "Very wide".to_string(),
             placement: TooltipPlacement::Top,
             styled_lines: None,
+            border: TooltipBorder::default(),
+            title: None,
             bg: None,
             fg: None,
         };
@@ -2225,6 +2233,8 @@ mod tests {
             text: "Very tall".to_string(),
             placement: TooltipPlacement::Left,
             styled_lines: None,
+            border: TooltipBorder::default(),
+            title: None,
             bg: None,
             fg: None,
         };
@@ -2242,6 +2252,8 @@ mod tests {
             text: "Hover".to_string(),
             placement: TooltipPlacement::Right,
             styled_lines: None,
+            border: TooltipBorder::default(),
+            title: None,
             bg: None,
             fg: None,
         };

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -2131,43 +2131,23 @@ mod tests {
 
     // ── Tooltip primitive tests (D6 shape) ────────────────────────────
 
-    /// `Default` is the migration path #541 hands downstream consumers
-    /// (`Tooltip { id, text, ..Default::default() }`), so it has to agree
-    /// field-for-field with `Tooltip::new` — otherwise a consumer that
-    /// migrates by spreading silently gets different chrome than one that
-    /// migrates to the builder.
+    /// #541: `TooltipLayout::with_border` / `with_title` are additive on
+    /// the value `Tooltip::layout` returns, not fields on `Tooltip`
+    /// itself — see `primitives::tooltip`'s module doc for why. Defaults
+    /// match what every backend drew unconditionally before #541
+    /// introduced a choice.
     #[test]
-    fn tooltip_default_matches_new_on_every_optional_field() {
-        let d = Tooltip::default();
-        assert_eq!(d, Tooltip::new(WidgetId::new(""), ""));
-        assert_eq!(d.styled_lines, None);
-        assert_eq!(d.placement, TooltipPlacement::Bottom);
-        // `Full`, not `Sides`: the behaviour-preserving default for GTK and
-        // macOS, which have always stroked a closed box.
-        assert_eq!(d.border, TooltipBorder::Full);
-        assert_eq!(d.title, None);
-        assert_eq!(d.bg, None);
-        assert_eq!(d.fg, None);
-    }
+    fn tooltip_layout_border_and_title_default_then_builder_overrides() {
+        let t = Tooltip::new(WidgetId::new("tip"), "Hello");
+        let anchor = Rect::new(0.0, 0.0, 10.0, 1.0);
+        let viewport = Rect::new(0.0, 0.0, 80.0, 24.0);
+        let layout = t.layout(anchor, viewport, TooltipMeasure::new(20.0, 3.0), 0.0);
+        assert_eq!(layout.border, TooltipBorder::Full);
+        assert_eq!(layout.title, None);
 
-    /// The spread keeps the fields the consumer names and defaults the
-    /// rest — the property that makes the *next* added field a non-event
-    /// for anyone who migrated this way.
-    #[test]
-    fn tooltip_default_spread_preserves_named_fields() {
-        let t = Tooltip {
-            id: WidgetId::new("tip"),
-            text: "Hello".to_string(),
-            placement: TooltipPlacement::Top,
-            border: TooltipBorder::None,
-            ..Default::default()
-        };
-        assert_eq!(t.id, WidgetId::new("tip"));
-        assert_eq!(t.text, "Hello");
-        assert_eq!(t.placement, TooltipPlacement::Top);
-        assert_eq!(t.border, TooltipBorder::None);
-        assert_eq!(t.title, None);
-        assert_eq!(t.styled_lines, None);
+        let layout = layout.with_border(TooltipBorder::None).with_title("Hi");
+        assert_eq!(layout.border, TooltipBorder::None);
+        assert_eq!(layout.title.as_deref(), Some("Hi"));
     }
 
     #[test]
@@ -2177,8 +2157,6 @@ mod tests {
             text: "Hello".to_string(),
             placement: TooltipPlacement::Bottom,
             styled_lines: None,
-            border: TooltipBorder::default(),
-            title: None,
             bg: None,
             fg: None,
         };
@@ -2200,8 +2178,6 @@ mod tests {
             text: "Hello".to_string(),
             placement: TooltipPlacement::Bottom,
             styled_lines: None,
-            border: TooltipBorder::default(),
-            title: None,
             bg: None,
             fg: None,
         };
@@ -2224,8 +2200,6 @@ mod tests {
             text: "…".to_string(),
             placement: TooltipPlacement::Bottom,
             styled_lines: None,
-            border: TooltipBorder::default(),
-            title: None,
             bg: None,
             fg: None,
         };
@@ -2249,8 +2223,6 @@ mod tests {
             text: "Very wide".to_string(),
             placement: TooltipPlacement::Top,
             styled_lines: None,
-            border: TooltipBorder::default(),
-            title: None,
             bg: None,
             fg: None,
         };
@@ -2272,8 +2244,6 @@ mod tests {
             text: "Very tall".to_string(),
             placement: TooltipPlacement::Left,
             styled_lines: None,
-            border: TooltipBorder::default(),
-            title: None,
             bg: None,
             fg: None,
         };
@@ -2291,8 +2261,6 @@ mod tests {
             text: "Hover".to_string(),
             placement: TooltipPlacement::Right,
             styled_lines: None,
-            border: TooltipBorder::default(),
-            title: None,
             bg: None,
             fg: None,
         };

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -911,6 +911,15 @@ impl Backend for MacBackend {
         )
     }
     fn draw_tooltip(&mut self, tooltip: &Tooltip, layout: &TooltipLayout) {
+        self.draw_tooltip_with_chrome(tooltip, layout, &crate::TooltipChrome::default());
+    }
+
+    fn draw_tooltip_with_chrome(
+        &mut self,
+        tooltip: &Tooltip,
+        layout: &TooltipLayout,
+        chrome: &crate::TooltipChrome,
+    ) {
         let ctx = self.current_cg();
         debug_assert!(
             !ctx.is_null(),
@@ -925,11 +934,12 @@ impl Backend for MacBackend {
         let char_width = self.current_char_width;
         // SAFETY: ctx is non-null inside the frame scope.
         unsafe {
-            super::tooltip::draw_tooltip(
+            super::tooltip::draw_tooltip_with_chrome(
                 ctx,
                 font,
                 tooltip,
                 layout,
+                chrome,
                 line_height,
                 char_width,
                 &theme,

--- a/quadraui/src/macos/mod.rs
+++ b/quadraui/src/macos/mod.rs
@@ -103,5 +103,5 @@ pub use terminal::{draw_terminal_cells, draw_terminal_divider};
 pub use text_display::{draw_text_display, mac_text_display_layout};
 pub use toast::{draw_toast_stack, mac_toast_stack_layout};
 pub use toolbar::{draw_toolbar, mac_toolbar_layout};
-pub use tooltip::draw_tooltip;
+pub use tooltip::{draw_tooltip, draw_tooltip_with_chrome};
 pub use tree::{draw_tree, mac_tree_layout};

--- a/quadraui/src/macos/tooltip.rs
+++ b/quadraui/src/macos/tooltip.rs
@@ -1,22 +1,38 @@
 //! macOS rasteriser for [`crate::Tooltip`].
 //!
-//! Mirrors [`crate::gtk::tooltip::draw_tooltip`]: bordered rectangle
-//! at the tooltip's resolved bounds, then plain `text` or per-row
-//! `styled_lines`.
+//! Mirrors [`crate::gtk::tooltip::draw_tooltip`]: a filled background
+//! rectangle at the tooltip's resolved bounds, then border chrome per
+//! `tooltip.border` (#541 — [`crate::TooltipBorder`]):
+//!
+//! - [`TooltipBorder::Full`] (the default) strokes a full 4-sided box —
+//!   this backend has always done this, unconditionally, before #541
+//!   gave it a name (it was one of the three backends the original issue
+//!   flagged as "not verified in detail" beyond a `fill_rect` call —
+//!   confirmed here to be a `stroke_rect`, same as GTK). An optional
+//!   `tooltip.title` is centred over the top edge, punched through the
+//!   stroke with a background-coloured backing rectangle so it reads as
+//!   embedded in the border, mirroring the TUI and GTK rasterisers.
+//! - [`TooltipBorder::Sides`] strokes two vertical lines at the left and
+//!   right edges only, no top/bottom. No title (no top rule).
+//! - [`TooltipBorder::None`] strokes nothing.
+//!
+//! Then draws either the plain `text` or per-row `styled_lines`.
 
 use core_graphics::geometry::CGRect;
 use core_graphics::sys::CGContextRef;
 use core_text::font::CTFont;
 
 use super::text::{draw_text, measure_text};
-use crate::primitives::tooltip::{Tooltip, TooltipLayout};
+use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipLayout};
 use crate::theme::Theme;
 use crate::types::Color;
 
 /// Draw a [`Tooltip`] at its resolved layout position.
 ///
 /// `padding_x` is the horizontal padding from the left border to the
-/// start of text — consumers typically pass `char_width`.
+/// start of text — consumers typically pass `char_width`. Halved when
+/// `tooltip.border` is [`TooltipBorder::None`], since there is no border
+/// column to clear first — mirrors the TUI/GTK rasterisers.
 ///
 /// # Safety
 ///
@@ -41,32 +57,71 @@ pub unsafe fn draw_tooltip(
     let fg = tooltip.fg.unwrap_or(theme.hover_fg);
     let border = theme.hover_border;
 
-    fill_rect(
-        ctx,
-        bounds.x as f64,
-        bounds.y as f64,
-        bounds.width as f64,
-        bounds.height as f64,
-        bg,
-    );
+    let bx = bounds.x as f64;
+    let by = bounds.y as f64;
+    let bw = bounds.width as f64;
+    let bh = bounds.height as f64;
 
-    stroke_rect(
-        ctx,
-        bounds.x as f64,
-        bounds.y as f64,
-        bounds.width as f64,
-        bounds.height as f64,
-        border,
-        1.0,
-    );
+    fill_rect(ctx, bx, by, bw, bh, bg);
 
-    let text_x = bounds.x as f64 + padding_x;
-    let text_top = bounds.y as f64 + 2.0;
+    // Content normally starts 2pt below the top edge; a title pushes
+    // that down further, since its real font height (title_h) is
+    // typically much taller than the 1pt border line it's centred on —
+    // without this, a title would visually collide with the first
+    // content row instead of sitting in its own space above it, the way
+    // the TUI rasteriser's dedicated title row never overlaps content.
+    let mut text_top = by + 2.0;
+
+    match tooltip.border {
+        TooltipBorder::Full => {
+            stroke_rect(ctx, bx, by, bw, bh, border, 1.0);
+
+            if let Some(title) = tooltip
+                .title
+                .as_deref()
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+            {
+                let (title_w, title_h) = measure_text(font, title);
+                let pad = 4.0;
+                let title_x = bx + ((bw - title_w) / 2.0).max(0.0);
+                let title_y = by - title_h / 2.0;
+
+                // Punch a background-coloured gap through the border
+                // stroke so the title reads as embedded in the top rule,
+                // not a content row sitting on top of it — mirrors the
+                // GTK rasteriser.
+                fill_rect(
+                    ctx,
+                    title_x - pad,
+                    title_y,
+                    title_w + pad * 2.0,
+                    title_h,
+                    bg,
+                );
+                draw_text(ctx, font, title, title_x, title_y, color_to_cg(fg));
+
+                text_top = text_top.max(title_y + title_h + 2.0);
+            }
+        }
+        TooltipBorder::Sides => {
+            stroke_line(ctx, bx, by, bx, by + bh, border, 1.0);
+            stroke_line(ctx, bx + bw, by, bx + bw, by + bh, border, 1.0);
+        }
+        TooltipBorder::None => {}
+    }
+
+    let text_padding_x = if matches!(tooltip.border, TooltipBorder::None) {
+        padding_x / 2.0
+    } else {
+        padding_x
+    };
+    let text_x = bx + text_padding_x;
 
     if let Some(ref styled_lines) = tooltip.styled_lines {
         for (i, styled) in styled_lines.iter().enumerate() {
             let row_y = text_top + i as f64 * line_height;
-            if row_y + line_height > bounds.y as f64 + bounds.height as f64 {
+            if row_y + line_height > by + bh {
                 break;
             }
             let mut x_off = text_x;
@@ -82,7 +137,7 @@ pub unsafe fn draw_tooltip(
 
     for (i, text_line) in tooltip.text.lines().enumerate() {
         let row_y = text_top + i as f64 * line_height;
-        if row_y + line_height > bounds.y as f64 + bounds.height as f64 {
+        if row_y + line_height > by + bh {
             break;
         }
         draw_text(ctx, font, text_line, text_x, row_y, color_to_cg(fg));
@@ -121,6 +176,26 @@ unsafe fn stroke_rect(
     CGContextStrokeRect(ctx, CGRect::new(&CGPoint::new(x, y), &CGSize::new(w, h)));
 }
 
+/// Stroke a single line segment — used by [`TooltipBorder::Sides`] to
+/// paint the left/right edges without the top/bottom rules `stroke_rect`
+/// would also draw.
+unsafe fn stroke_line(
+    ctx: CGContextRef,
+    x0: f64,
+    y0: f64,
+    x1: f64,
+    y1: f64,
+    c: Color,
+    line_width: f64,
+) {
+    let (r, g, b, a) = color_to_cg(c);
+    CGContextSetRGBStrokeColor(ctx, r, g, b, a);
+    CGContextSetLineWidth(ctx, line_width);
+    CGContextMoveToPoint(ctx, x0, y0);
+    CGContextAddLineToPoint(ctx, x1, y1);
+    CGContextStrokePath(ctx);
+}
+
 extern "C" {
     fn CGContextSetRGBFillColor(
         c: CGContextRef,
@@ -139,6 +214,17 @@ extern "C" {
     fn CGContextSetLineWidth(c: CGContextRef, w: core_graphics::base::CGFloat);
     fn CGContextFillRect(c: CGContextRef, rect: CGRect);
     fn CGContextStrokeRect(c: CGContextRef, rect: CGRect);
+    fn CGContextMoveToPoint(
+        c: CGContextRef,
+        x: core_graphics::base::CGFloat,
+        y: core_graphics::base::CGFloat,
+    );
+    fn CGContextAddLineToPoint(
+        c: CGContextRef,
+        x: core_graphics::base::CGFloat,
+        y: core_graphics::base::CGFloat,
+    );
+    fn CGContextStrokePath(c: CGContextRef);
 }
 
 #[cfg(test)]
@@ -160,11 +246,17 @@ mod tests {
     }
 
     fn sample_tooltip() -> Tooltip {
+        sample_tooltip_with(TooltipBorder::default(), None)
+    }
+
+    fn sample_tooltip_with(border: TooltipBorder, title: Option<&str>) -> Tooltip {
         Tooltip {
             id: WidgetId::new("tip"),
             text: "Hover hint".into(),
             styled_lines: None,
             placement: TooltipPlacement::Bottom,
+            border,
+            title: title.map(str::to_string),
             fg: None,
             bg: None,
         }
@@ -262,5 +354,140 @@ mod tests {
         // Surface stays all-zero.
         let (r, g, b, _) = surface.pixel(10, 10);
         assert_eq!((r, g, b), (0, 0, 0));
+    }
+
+    // ── #541: explicit border vocabulary — same coverage as
+    // `gtk::tooltip::tests`, since ask 4 was to confirm this backend
+    // wasn't just a bare `fill_rect` call (it turned out to already be a
+    // `stroke_rect`, matching GTK) and to bring it up to the same
+    // vocabulary once confirmed.
+
+    /// A pure-background reference pixel: bottom-right corner, a few
+    /// pixels in from both edges — clear of any border stroke (which
+    /// hugs the very edge) and of `sample_tooltip`'s short, top-aligned
+    /// "Hover hint" body text.
+    fn bg_reference(surface: &BitmapSurface, bounds: QRect) -> (u8, u8, u8) {
+        let (r, g, b, _) = surface.pixel(
+            bounds.x as u32 + bounds.width as u32 - 4,
+            bounds.y as u32 + bounds.height as u32 - 4,
+        );
+        (r, g, b)
+    }
+
+    #[test]
+    fn sides_border_only_strokes_left_and_right() {
+        let tip = sample_tooltip_with(TooltipBorder::Sides, None);
+        let layout = sample_layout();
+        let surface = paint(&tip, &layout);
+        let b = layout.bounds;
+        let (bx, by, bw, bh) = (b.x as u32, b.y as u32, b.width as u32, b.height as u32);
+
+        let inner = bg_reference(&surface, b);
+        let (top_r, top_g, top_b, _) = surface.pixel(bx + bw / 2, by);
+        let (bottom_r, bottom_g, bottom_b, _) = surface.pixel(bx + bw / 2, by + bh - 1);
+        let (left_r, left_g, left_b, _) = surface.pixel(bx, by + bh / 2);
+        let (right_r, right_g, right_b, _) = surface.pixel(bx + bw - 1, by + bh / 2);
+
+        assert_eq!(
+            (top_r, top_g, top_b),
+            inner,
+            "TooltipBorder::Sides must not stroke the top edge — no top/bottom rule, \
+             regardless of box height"
+        );
+        assert_eq!(
+            (bottom_r, bottom_g, bottom_b),
+            inner,
+            "TooltipBorder::Sides must not stroke the bottom edge"
+        );
+        assert_ne!(
+            (left_r, left_g, left_b),
+            inner,
+            "TooltipBorder::Sides must still stroke the left edge"
+        );
+        assert_ne!(
+            (right_r, right_g, right_b),
+            inner,
+            "TooltipBorder::Sides must still stroke the right edge"
+        );
+    }
+
+    #[test]
+    fn none_border_strokes_nothing() {
+        let tip = sample_tooltip_with(TooltipBorder::None, None);
+        let layout = sample_layout();
+        let surface = paint(&tip, &layout);
+        let b = layout.bounds;
+        let (bx, by, bw, bh) = (b.x as u32, b.y as u32, b.width as u32, b.height as u32);
+
+        let inner = bg_reference(&surface, b);
+        for (name, (r, g, bl, _)) in [
+            ("top", surface.pixel(bx + bw / 2, by)),
+            ("bottom", surface.pixel(bx + bw / 2, by + bh - 1)),
+            ("left", surface.pixel(bx, by + bh / 2)),
+            ("right", surface.pixel(bx + bw - 1, by + bh / 2)),
+        ] {
+            assert_eq!(
+                (r, g, bl),
+                inner,
+                "TooltipBorder::None must not stroke {name} — no chrome at all"
+            );
+        }
+    }
+
+    /// #541 ask 2: a title punches a background-coloured gap through the
+    /// top stroke so it reads as embedded in the border, not a content
+    /// row. Scans the top edge rather than probing one fixed x — the
+    /// title is horizontally centred, so a single dead-centre sample can
+    /// land on a glyph's own ink instead of the cleared pad around it
+    /// (same reasoning as the GTK rasteriser's equivalent test).
+    #[test]
+    fn full_border_title_punches_a_gap_but_leaves_the_rest_of_the_top_edge_stroked() {
+        let tip = sample_tooltip_with(TooltipBorder::Full, Some("Hi"));
+        let layout = sample_layout();
+        let surface = paint(&tip, &layout);
+        let b = layout.bounds;
+        let (bx, by, bw) = (b.x as u32, b.y as u32, b.width as u32);
+
+        let inner = bg_reference(&surface, b);
+        let margin = 3u32;
+        let interior: Vec<(u8, u8, u8)> = (bx + margin..bx + bw - margin)
+            .map(|x| {
+                let (r, g, bl, _) = surface.pixel(x, by);
+                (r, g, bl)
+            })
+            .collect();
+
+        assert!(
+            interior.contains(&inner),
+            "the title's short label + padding should punch at least one background-\
+             coloured pixel into the top edge somewhere in its interior (inner={inner:?}, \
+             top-edge interior samples={interior:?})"
+        );
+
+        let (corner_r, corner_g, corner_b, _) = surface.pixel(bx + 1, by);
+        assert_ne!(
+            (corner_r, corner_g, corner_b),
+            inner,
+            "the top edge right at the corner should still show the plain border stroke"
+        );
+    }
+
+    #[test]
+    fn title_is_ignored_when_border_is_sides_or_none() {
+        for border in [TooltipBorder::Sides, TooltipBorder::None] {
+            let with_title = sample_tooltip_with(border, Some("Ignored"));
+            let without_title = sample_tooltip_with(border, None);
+            let layout = sample_layout();
+            let with_surface = paint(&with_title, &layout);
+            let without_surface = paint(&without_title, &layout);
+            let b = layout.bounds;
+            let (bx, by, bw) = (b.x as u32, b.y as u32, b.width as u32);
+            let top_with = with_surface.pixel(bx + bw / 2, by);
+            let top_without = without_surface.pixel(bx + bw / 2, by);
+            assert_eq!(
+                top_with, top_without,
+                "{border:?}: setting `title` must not change what's painted at the top edge"
+            );
+        }
     }
 }

--- a/quadraui/src/macos/tooltip.rs
+++ b/quadraui/src/macos/tooltip.rs
@@ -2,14 +2,16 @@
 //!
 //! Mirrors [`crate::gtk::tooltip::draw_tooltip`]: a filled background
 //! rectangle at the tooltip's resolved bounds, then border chrome per
-//! `tooltip.border` (#541 — [`crate::TooltipBorder`]):
+//! `layout.border` (#541 — [`crate::TooltipBorder`]; see
+//! `primitives::tooltip`'s module doc for why it lives on
+//! [`TooltipLayout`] rather than on [`Tooltip`]):
 //!
 //! - [`TooltipBorder::Full`] (the default) strokes a full 4-sided box —
 //!   this backend has always done this, unconditionally, before #541
 //!   gave it a name (it was one of the three backends the original issue
 //!   flagged as "not verified in detail" beyond a `fill_rect` call —
 //!   confirmed here to be a `stroke_rect`, same as GTK). An optional
-//!   `tooltip.title` is centred over the top edge, punched through the
+//!   `layout.title` is centred over the top edge, punched through the
 //!   stroke with a background-coloured backing rectangle so it reads as
 //!   embedded in the border, mirroring the TUI and GTK rasterisers.
 //! - [`TooltipBorder::Sides`] strokes two vertical lines at the left and
@@ -31,7 +33,7 @@ use crate::types::Color;
 ///
 /// `padding_x` is the horizontal padding from the left border to the
 /// start of text — consumers typically pass `char_width`. Halved when
-/// `tooltip.border` is [`TooltipBorder::None`], since there is no border
+/// `layout.border` is [`TooltipBorder::None`], since there is no border
 /// column to clear first — mirrors the TUI/GTK rasterisers.
 ///
 /// # Safety
@@ -72,11 +74,11 @@ pub unsafe fn draw_tooltip(
     // the TUI rasteriser's dedicated title row never overlaps content.
     let mut text_top = by + 2.0;
 
-    match tooltip.border {
+    match tooltip_layout.border {
         TooltipBorder::Full => {
             stroke_rect(ctx, bx, by, bw, bh, border, 1.0);
 
-            if let Some(title) = tooltip
+            if let Some(title) = tooltip_layout
                 .title
                 .as_deref()
                 .map(str::trim)
@@ -111,7 +113,7 @@ pub unsafe fn draw_tooltip(
         TooltipBorder::None => {}
     }
 
-    let text_padding_x = if matches!(tooltip.border, TooltipBorder::None) {
+    let text_padding_x = if matches!(tooltip_layout.border, TooltipBorder::None) {
         padding_x / 2.0
     } else {
         padding_x
@@ -246,27 +248,27 @@ mod tests {
     }
 
     fn sample_tooltip() -> Tooltip {
-        sample_tooltip_with(TooltipBorder::default(), None)
-    }
-
-    fn sample_tooltip_with(border: TooltipBorder, title: Option<&str>) -> Tooltip {
         Tooltip {
             id: WidgetId::new("tip"),
             text: "Hover hint".into(),
             styled_lines: None,
             placement: TooltipPlacement::Bottom,
-            border,
-            title: title.map(str::to_string),
             fg: None,
             bg: None,
         }
     }
 
-    fn sample_layout() -> TooltipLayout {
-        TooltipLayout {
+    fn sample_layout(border: TooltipBorder, title: Option<&str>) -> TooltipLayout {
+        let mut layout = TooltipLayout {
             bounds: QRect::new(10.0, 10.0, 120.0, 24.0),
             resolved_placement: ResolvedPlacement::Bottom,
+            border,
+            title: None,
+        };
+        if let Some(t) = title {
+            layout = layout.with_title(t);
         }
+        layout
     }
 
     fn paint(tip: &Tooltip, layout: &TooltipLayout) -> BitmapSurface {
@@ -285,7 +287,7 @@ mod tests {
     #[test]
     fn tooltip_paints_hover_bg() {
         let tip = sample_tooltip();
-        let layout = sample_layout();
+        let layout = sample_layout(TooltipBorder::default(), None);
         let surface = paint(&tip, &layout);
         let theme = Theme::default();
         // Probe near right edge of bounds — glyph-free zone.
@@ -303,7 +305,7 @@ mod tests {
     #[test]
     fn tooltip_border_paints_at_edge() {
         let tip = sample_tooltip();
-        let layout = sample_layout();
+        let layout = sample_layout(TooltipBorder::default(), None);
         let surface = paint(&tip, &layout);
         let theme = Theme::default();
         // The 1pt border stroke centres on the rect's top edge, so
@@ -333,7 +335,7 @@ mod tests {
     fn tooltip_with_custom_bg_overrides_theme() {
         let mut tip = sample_tooltip();
         tip.bg = Some(crate::types::Color::rgb(50, 100, 150));
-        let layout = sample_layout();
+        let layout = sample_layout(TooltipBorder::default(), None);
         let surface = paint(&tip, &layout);
         let bx = layout.bounds.x as u32;
         let by = layout.bounds.y as u32;
@@ -349,6 +351,8 @@ mod tests {
         let layout = TooltipLayout {
             bounds: QRect::new(10.0, 10.0, 0.0, 0.0),
             resolved_placement: ResolvedPlacement::Bottom,
+            border: TooltipBorder::default(),
+            title: None,
         };
         let surface = paint(&tip, &layout);
         // Surface stays all-zero.
@@ -376,8 +380,8 @@ mod tests {
 
     #[test]
     fn sides_border_only_strokes_left_and_right() {
-        let tip = sample_tooltip_with(TooltipBorder::Sides, None);
-        let layout = sample_layout();
+        let tip = sample_tooltip();
+        let layout = sample_layout(TooltipBorder::Sides, None);
         let surface = paint(&tip, &layout);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as u32, b.y as u32, b.width as u32, b.height as u32);
@@ -413,8 +417,8 @@ mod tests {
 
     #[test]
     fn none_border_strokes_nothing() {
-        let tip = sample_tooltip_with(TooltipBorder::None, None);
-        let layout = sample_layout();
+        let tip = sample_tooltip();
+        let layout = sample_layout(TooltipBorder::None, None);
         let surface = paint(&tip, &layout);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as u32, b.y as u32, b.width as u32, b.height as u32);
@@ -442,8 +446,8 @@ mod tests {
     /// (same reasoning as the GTK rasteriser's equivalent test).
     #[test]
     fn full_border_title_punches_a_gap_but_leaves_the_rest_of_the_top_edge_stroked() {
-        let tip = sample_tooltip_with(TooltipBorder::Full, Some("Hi"));
-        let layout = sample_layout();
+        let tip = sample_tooltip();
+        let layout = sample_layout(TooltipBorder::Full, Some("Hi"));
         let surface = paint(&tip, &layout);
         let b = layout.bounds;
         let (bx, by, bw) = (b.x as u32, b.y as u32, b.width as u32);
@@ -475,12 +479,13 @@ mod tests {
     #[test]
     fn title_is_ignored_when_border_is_sides_or_none() {
         for border in [TooltipBorder::Sides, TooltipBorder::None] {
-            let with_title = sample_tooltip_with(border, Some("Ignored"));
-            let without_title = sample_tooltip_with(border, None);
-            let layout = sample_layout();
-            let with_surface = paint(&with_title, &layout);
-            let without_surface = paint(&without_title, &layout);
-            let b = layout.bounds;
+            let with_title = sample_tooltip();
+            let without_title = sample_tooltip();
+            let with_layout = sample_layout(border, Some("Ignored"));
+            let without_layout = sample_layout(border, None);
+            let with_surface = paint(&with_title, &with_layout);
+            let without_surface = paint(&without_title, &without_layout);
+            let b = with_layout.bounds;
             let (bx, by, bw) = (b.x as u32, b.y as u32, b.width as u32);
             let top_with = with_surface.pixel(bx + bw / 2, by);
             let top_without = without_surface.pixel(bx + bw / 2, by);

--- a/quadraui/src/macos/tooltip.rs
+++ b/quadraui/src/macos/tooltip.rs
@@ -2,16 +2,19 @@
 //!
 //! Mirrors [`crate::gtk::tooltip::draw_tooltip`]: a filled background
 //! rectangle at the tooltip's resolved bounds, then border chrome per
-//! `layout.border` (#541 — [`crate::TooltipBorder`]; see
-//! `primitives::tooltip`'s module doc for why it lives on
-//! [`TooltipLayout`] rather than on [`Tooltip`]):
+//! the [`TooltipChrome`] argument (#541 — [`crate::TooltipBorder`]; see
+//! `primitives::tooltip`'s module doc for why the vocabulary is a
+//! sidecar value rather than a field on [`Tooltip`] or
+//! [`TooltipLayout`]). [`draw_tooltip`] keeps its pre-#541 signature and
+//! renders `TooltipChrome::default()`; [`draw_tooltip_with_chrome`]
+//! takes the request explicitly:
 //!
 //! - [`TooltipBorder::Full`] (the default) strokes a full 4-sided box —
 //!   this backend has always done this, unconditionally, before #541
 //!   gave it a name (it was one of the three backends the original issue
 //!   flagged as "not verified in detail" beyond a `fill_rect` call —
 //!   confirmed here to be a `stroke_rect`, same as GTK). An optional
-//!   `layout.title` is centred over the top edge, punched through the
+//!   `chrome.title` is centred over the top edge, punched through the
 //!   stroke with a background-coloured backing rectangle so it reads as
 //!   embedded in the border, mirroring the TUI and GTK rasterisers.
 //! - [`TooltipBorder::Sides`] strokes two vertical lines at the left and
@@ -25,16 +28,18 @@ use core_graphics::sys::CGContextRef;
 use core_text::font::CTFont;
 
 use super::text::{draw_text, measure_text};
-use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipLayout};
+use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipChrome, TooltipLayout};
 use crate::theme::Theme;
 use crate::types::Color;
 
-/// Draw a [`Tooltip`] at its resolved layout position.
+/// Draw a [`Tooltip`] at its resolved layout position with the default
+/// chrome — a [`TooltipBorder::Full`] box, no title, i.e. exactly what
+/// this rasteriser drew before #541 added a choice.
 ///
 /// `padding_x` is the horizontal padding from the left border to the
-/// start of text — consumers typically pass `char_width`. Halved when
-/// `layout.border` is [`TooltipBorder::None`], since there is no border
-/// column to clear first — mirrors the TUI/GTK rasterisers.
+/// start of text — consumers typically pass `char_width`.
+///
+/// To ask for different chrome, call [`draw_tooltip_with_chrome`].
 ///
 /// # Safety
 ///
@@ -46,6 +51,45 @@ pub unsafe fn draw_tooltip(
     font: &CTFont,
     tooltip: &Tooltip,
     tooltip_layout: &TooltipLayout,
+    line_height: f64,
+    padding_x: f64,
+    theme: &Theme,
+) {
+    // SAFETY: forwarded unchanged — `ctx` validity is the caller's
+    // contract, documented above and identical for both entry points.
+    unsafe {
+        draw_tooltip_with_chrome(
+            ctx,
+            font,
+            tooltip,
+            tooltip_layout,
+            &TooltipChrome::default(),
+            line_height,
+            padding_x,
+            theme,
+        );
+    }
+}
+
+/// Draw a [`Tooltip`] at its resolved layout position, with the border
+/// and optional title requested by `chrome` (#541).
+///
+/// `padding_x` is the horizontal padding from the left border to the
+/// start of text — consumers typically pass `char_width`. Halved when
+/// `chrome.border` is [`TooltipBorder::None`], since there is no border
+/// column to clear first — mirrors the TUI/GTK rasterisers.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_tooltip_with_chrome(
+    ctx: CGContextRef,
+    font: &CTFont,
+    tooltip: &Tooltip,
+    tooltip_layout: &TooltipLayout,
+    chrome: &TooltipChrome,
     line_height: f64,
     padding_x: f64,
     theme: &Theme,
@@ -74,11 +118,11 @@ pub unsafe fn draw_tooltip(
     // the TUI rasteriser's dedicated title row never overlaps content.
     let mut text_top = by + 2.0;
 
-    match tooltip_layout.border {
+    match chrome.border {
         TooltipBorder::Full => {
             stroke_rect(ctx, bx, by, bw, bh, border, 1.0);
 
-            if let Some(title) = tooltip_layout
+            if let Some(title) = chrome
                 .title
                 .as_deref()
                 .map(str::trim)
@@ -113,7 +157,7 @@ pub unsafe fn draw_tooltip(
         TooltipBorder::None => {}
     }
 
-    let text_padding_x = if matches!(tooltip_layout.border, TooltipBorder::None) {
+    let text_padding_x = if matches!(chrome.border, TooltipBorder::None) {
         padding_x / 2.0
     } else {
         padding_x
@@ -258,27 +302,26 @@ mod tests {
         }
     }
 
-    fn sample_layout(border: TooltipBorder, title: Option<&str>) -> TooltipLayout {
-        let mut layout = TooltipLayout {
+    fn sample_layout(border: TooltipBorder, title: Option<&str>) -> (TooltipLayout, TooltipChrome) {
+        let layout = TooltipLayout {
             bounds: QRect::new(10.0, 10.0, 120.0, 24.0),
             resolved_placement: ResolvedPlacement::Bottom,
-            border,
-            title: None,
         };
+        let mut chrome = TooltipChrome::new(border);
         if let Some(t) = title {
-            layout = layout.with_title(t);
+            chrome = chrome.with_title(t);
         }
-        layout
+        (layout, chrome)
     }
 
-    fn paint(tip: &Tooltip, layout: &TooltipLayout) -> BitmapSurface {
+    fn paint(tip: &Tooltip, layout: &TooltipLayout, chrome: &TooltipChrome) -> BitmapSurface {
         let surface = BitmapSurface::new(W, H);
         surface.fill(0.0, 0.0, 0.0, 0.0);
         let mut backend = MacBackend::new();
         backend.set_current_font(font());
         backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
         backend.enter_frame_scope(surface.context_ptr(), |b| {
-            b.draw_tooltip(tip, layout);
+            b.draw_tooltip_with_chrome(tip, layout, chrome);
         });
         backend.end_frame();
         surface
@@ -287,8 +330,8 @@ mod tests {
     #[test]
     fn tooltip_paints_hover_bg() {
         let tip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::default(), None);
-        let surface = paint(&tip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::default(), None);
+        let surface = paint(&tip, &layout, &chrome);
         let theme = Theme::default();
         // Probe near right edge of bounds — glyph-free zone.
         let bx = layout.bounds.x as u32;
@@ -305,8 +348,8 @@ mod tests {
     #[test]
     fn tooltip_border_paints_at_edge() {
         let tip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::default(), None);
-        let surface = paint(&tip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::default(), None);
+        let surface = paint(&tip, &layout, &chrome);
         let theme = Theme::default();
         // The 1pt border stroke centres on the rect's top edge, so
         // the edge pixel is anti-aliased ~50/50 between border ink
@@ -335,8 +378,8 @@ mod tests {
     fn tooltip_with_custom_bg_overrides_theme() {
         let mut tip = sample_tooltip();
         tip.bg = Some(crate::types::Color::rgb(50, 100, 150));
-        let layout = sample_layout(TooltipBorder::default(), None);
-        let surface = paint(&tip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::default(), None);
+        let surface = paint(&tip, &layout, &chrome);
         let bx = layout.bounds.x as u32;
         let by = layout.bounds.y as u32;
         let bw = layout.bounds.width as u32;
@@ -351,10 +394,8 @@ mod tests {
         let layout = TooltipLayout {
             bounds: QRect::new(10.0, 10.0, 0.0, 0.0),
             resolved_placement: ResolvedPlacement::Bottom,
-            border: TooltipBorder::default(),
-            title: None,
         };
-        let surface = paint(&tip, &layout);
+        let surface = paint(&tip, &layout, &TooltipChrome::default());
         // Surface stays all-zero.
         let (r, g, b, _) = surface.pixel(10, 10);
         assert_eq!((r, g, b), (0, 0, 0));
@@ -381,8 +422,8 @@ mod tests {
     #[test]
     fn sides_border_only_strokes_left_and_right() {
         let tip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::Sides, None);
-        let surface = paint(&tip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::Sides, None);
+        let surface = paint(&tip, &layout, &chrome);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as u32, b.y as u32, b.width as u32, b.height as u32);
 
@@ -418,8 +459,8 @@ mod tests {
     #[test]
     fn none_border_strokes_nothing() {
         let tip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::None, None);
-        let surface = paint(&tip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::None, None);
+        let surface = paint(&tip, &layout, &chrome);
         let b = layout.bounds;
         let (bx, by, bw, bh) = (b.x as u32, b.y as u32, b.width as u32, b.height as u32);
 
@@ -447,8 +488,8 @@ mod tests {
     #[test]
     fn full_border_title_punches_a_gap_but_leaves_the_rest_of_the_top_edge_stroked() {
         let tip = sample_tooltip();
-        let layout = sample_layout(TooltipBorder::Full, Some("Hi"));
-        let surface = paint(&tip, &layout);
+        let (layout, chrome) = sample_layout(TooltipBorder::Full, Some("Hi"));
+        let surface = paint(&tip, &layout, &chrome);
         let b = layout.bounds;
         let (bx, by, bw) = (b.x as u32, b.y as u32, b.width as u32);
 
@@ -481,10 +522,10 @@ mod tests {
         for border in [TooltipBorder::Sides, TooltipBorder::None] {
             let with_title = sample_tooltip();
             let without_title = sample_tooltip();
-            let with_layout = sample_layout(border, Some("Ignored"));
-            let without_layout = sample_layout(border, None);
-            let with_surface = paint(&with_title, &with_layout);
-            let without_surface = paint(&without_title, &without_layout);
+            let (with_layout, with_chrome) = sample_layout(border, Some("Ignored"));
+            let (without_layout, without_chrome) = sample_layout(border, None);
+            let with_surface = paint(&with_title, &with_layout, &with_chrome);
+            let without_surface = paint(&without_title, &without_layout, &without_chrome);
             let b = with_layout.bounds;
             let (bx, by, bw) = (b.x as u32, b.y as u32, b.width as u32);
             let top_with = with_surface.pixel(bx + bw / 2, by);

--- a/quadraui/src/primitives/tooltip.rs
+++ b/quadraui/src/primitives/tooltip.rs
@@ -14,6 +14,41 @@
 //! content. The primitive's `layout()` chooses x/y based on preferred
 //! placement, adjusting if it would overflow the viewport. Backends
 //! render a box with the content at the resolved position.
+//!
+//! ## Downstream impact (#541)
+//!
+//! `border: TooltipBorder` and `title: Option<String>` are **new required
+//! fields on a plain (all-`pub`, no `#[non_exhaustive]`) struct**, so any
+//! exhaustive `Tooltip { .. }` literal with no `..Default::default()`
+//! fails to compile the moment this lands on `develop` — there is no
+//! backwards-compatible way to add a field to that shape (see
+//! `CLAUDE.md`'s *Downstream consumers* section). `vimcode` constructs
+//! `Tooltip` this way at 7 call sites and needs a matching migration PR
+//! (adding `border: TooltipBorder::default(), title: None,` or switching
+//! to [`Tooltip::new`] + the `with_*` builder methods below):
+//!
+//! - `src/tui_main/panels.rs:810`
+//! - `src/render.rs:1151`, `src/render.rs:1490`, `src/render.rs:4285`
+//! - `src/gtk/draw.rs:1378`, `src/gtk/draw.rs:1667`, `src/gtk/draw.rs:1765`
+//!
+//! Per policy this needs a companion `vimcode` migration issue/PR opened
+//! and linked before or alongside merge — that is a `gh`/cross-repo action
+//! outside a Work dispatch's tool access and must be done by whoever lands
+//! this (see the PR discussion for #541).
+//!
+//! [`Tooltip::new`] plus the builder methods below are the *forward*
+//! mitigation: they give every future construction site (in-tree and
+//! downstream, once migrated) a path that survives additional optional
+//! fields without another exhaustive-literal break. [`TooltipBorder`] is
+//! `#[non_exhaustive]` for the same reason — it is brand new this PR, so
+//! marking it costs nothing today and buys the same protection for its
+//! own future variants. `Tooltip` itself is deliberately left exhaustive
+//! here rather than also marked `#[non_exhaustive]`: doing so would, on
+//! top of the break above, additionally force every in-tree sealed
+//! acceptance slice under `tests/acceptance/` (an external crate from the
+//! library's point of view, exactly like `vimcode`) onto the builder too —
+//! and workers may not edit those files (see `CLAUDE.md`). That
+//! migration is Gate A's to make independently, not this PR's.
 
 use crate::event::Rect;
 use crate::types::{Color, Modifiers, StyledText, WidgetId};
@@ -67,6 +102,13 @@ pub struct Tooltip {
 /// popup that migrated to `Backend::draw_tooltip` (JDonaghy/vimcode#635)
 /// silently lost its top/bottom border and title because there was no
 /// field to carry the request. This type is that field's vocabulary.
+///
+/// `#[non_exhaustive]`: brand new this PR, so marking it costs no
+/// consumer anything today, and it means a future fourth variant (e.g. a
+/// `Rounded` corner style) is additive instead of another breaking change
+/// like the one adding this whole type was (see the module doc's
+/// *Downstream impact* section).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum TooltipBorder {
     /// Vertical bars on the left/right edge only — no top or bottom rule,
@@ -203,6 +245,70 @@ impl TooltipLayout {
 }
 
 impl Tooltip {
+    /// Construct a `Tooltip` with just the two fields every consumer must
+    /// supply — `id` and `text` — and every other field at its
+    /// behaviour-preserving default (`styled_lines: None`, `placement:
+    /// Bottom`, `border: Full`, `title: None`, `bg: None`, `fg: None`).
+    ///
+    /// Prefer this (plus the `with_*` builder methods below) over a raw
+    /// `Tooltip { .. }` struct literal for any *new* call site: `Tooltip`
+    /// is a plain, all-`pub`-field struct with no `#[non_exhaustive]`
+    /// (see the module doc's *Downstream impact* section for why it
+    /// stays that way for now), so a raw literal is re-broken by the
+    /// next added field exactly the way `border`/`title` broke every
+    /// existing exhaustive literal in #541. Building through `new` +
+    /// `with_*` survives that.
+    pub fn new(id: WidgetId, text: impl Into<String>) -> Self {
+        Self {
+            id,
+            text: text.into(),
+            styled_lines: None,
+            placement: TooltipPlacement::default(),
+            border: TooltipBorder::default(),
+            title: None,
+            bg: None,
+            fg: None,
+        }
+    }
+
+    /// Set `styled_lines` (per-span-coloured multi-line content, in place
+    /// of `text`).
+    pub fn with_styled_lines(mut self, styled_lines: Vec<StyledText>) -> Self {
+        self.styled_lines = Some(styled_lines);
+        self
+    }
+
+    /// Set the preferred placement relative to the anchor.
+    pub fn with_placement(mut self, placement: TooltipPlacement) -> Self {
+        self.placement = placement;
+        self
+    }
+
+    /// Set the border chrome (#541).
+    pub fn with_border(mut self, border: TooltipBorder) -> Self {
+        self.border = border;
+        self
+    }
+
+    /// Set a title, centred into the top border row when `border` is
+    /// [`TooltipBorder::Full`] (#541). Ignored by `Sides` and `None`.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Override the background colour (theme default otherwise).
+    pub fn with_bg(mut self, bg: Color) -> Self {
+        self.bg = Some(bg);
+        self
+    }
+
+    /// Override the foreground colour (theme default otherwise).
+    pub fn with_fg(mut self, fg: Color) -> Self {
+        self.fg = Some(fg);
+        self
+    }
+
     /// Compute tooltip placement.
     ///
     /// # Arguments

--- a/quadraui/src/primitives/tooltip.rs
+++ b/quadraui/src/primitives/tooltip.rs
@@ -15,61 +15,43 @@
 //! placement, adjusting if it would overflow the viewport. Backends
 //! render a box with the content at the resolved position.
 //!
-//! ## Downstream impact (#541)
+//! ## Border/title vocabulary lives on the *layout*, not the tooltip (#541)
 //!
-//! `border: TooltipBorder` and `title: Option<String>` are **new required
-//! fields on a public struct consumers construct**, so per rule 8 of
-//! `quadraui/docs/PRIMITIVE_RULES.md` this is a breaking change: every
-//! *exhaustive* `Tooltip { .. }` literal in a consumer stops compiling the
-//! moment this lands on `develop`. There is no Rust shim that keeps an
-//! exhaustive literal compiling across an added field, so the break itself
-//! cannot be deprecated away — only made small and made final.
+//! [`TooltipBorder`] and an optional title are per-tooltip chrome a
+//! consumer can now ask for (`Sides` bars-only, `Full` closed box, `None`
+//! no chrome at all; an optional title centred into `Full`'s top border
+//! row) — see [`TooltipLayout::with_border`] / [`TooltipLayout::with_title`].
 //!
-//! **Made small.** [`Tooltip`] now implements [`Default`], so each affected
-//! site migrates by deleting the fields it was leaving at the default and
-//! adding one line:
+//! They are fields on [`TooltipLayout`] (the value [`Tooltip::layout`]
+//! returns), **not** new fields on [`Tooltip`] itself. `Tooltip` is a
+//! plain, non-`#[non_exhaustive]` struct that `tests/acceptance/`'s sealed
+//! slices — and, per rule 8 of `quadraui/docs/PRIMITIVE_RULES.md`,
+//! consumers outside this crate — construct with an *exhaustive* literal.
+//! Adding a required field to that struct would break every one of those
+//! literals the instant this landed on `develop`, with no Rust shim able
+//! to keep an exhaustive literal compiling across an added field (the
+//! problem the module doc here used to describe at length, before this
+//! design settled on not doing that). Routing the new vocabulary through
+//! `TooltipLayout` — a value callers already receive from `layout()`
+//! rather than hand-construct — sidesteps the break entirely: `Tooltip`'s
+//! field set is unchanged by #541, so every existing exhaustive
+//! `Tooltip { .. }` literal (in-tree and downstream) keeps compiling
+//! untouched, and the two sealed acceptance slices under
+//! `tests/acceptance/ms-11/` needed no edits for this issue.
+//!
+//! Usage:
 //!
 //! ```
-//! # use quadraui::{Tooltip, TooltipPlacement, WidgetId};
-//! let tip = Tooltip {
-//!     id: WidgetId::new("hover"),
-//!     text: "Hover hint".to_string(),
-//!     placement: TooltipPlacement::Top,
-//!     ..Default::default()
-//! };
-//! assert_eq!(tip.title, None);
+//! # use quadraui::{Tooltip, TooltipBorder, TooltipMeasure, WidgetId, Rect};
+//! let tip = Tooltip::new(WidgetId::new("hover"), "Hover hint");
+//! let anchor = Rect::new(0.0, 0.0, 10.0, 1.0);
+//! let viewport = Rect::new(0.0, 0.0, 80.0, 24.0);
+//! let measure = TooltipMeasure::new(20.0, 3.0);
+//! let layout = tip
+//!     .layout(anchor, viewport, measure, 0.0)
+//!     .with_border(TooltipBorder::Sides);
+//! assert_eq!(layout.border, TooltipBorder::Sides);
 //! ```
-//!
-//! **Made final.** That same `..Default::default()` spread is what makes
-//! the *next* added field a non-event: a literal written this way keeps
-//! compiling when the struct grows. [`Tooltip::new`] plus the `with_*`
-//! builder methods are the equivalent path for sites that would rather not
-//! name fields at all. This is why `Tooltip` stays a plain struct rather
-//! than gaining `#[non_exhaustive]`: `#[non_exhaustive]` would forbid
-//! struct-literal *and* functional-update syntax outside this crate
-//! entirely, forcing every consumer through the builder forever and
-//! deleting the cheap one-line escape hatch above, for no protection that
-//! `Default` + the spread does not already buy. ([`TooltipBorder`] *is*
-//! `#[non_exhaustive]` — different calculus: it is brand new this PR, so
-//! nothing matches on it yet and marking it costs no consumer anything.)
-//!
-//! `vimcode` constructs `Tooltip` exhaustively at 7 call sites, all of
-//! which need that one-line migration:
-//!
-//! - `src/tui_main/panels.rs:810`
-//! - `src/render.rs:1151`, `src/render.rs:1490`, `src/render.rs:4285`
-//! - `src/gtk/draw.rs:1378`, `src/gtk/draw.rs:1667`, `src/gtk/draw.rs:1765`
-//!
-//! Per rule 8's two-PR protocol that needs a companion `vimcode` migration
-//! issue/PR opened and linked before or alongside merge — a cross-repo
-//! `gh` action outside a Work dispatch's tool access, so it is the job of
-//! whoever lands this (see the PR discussion for #541). `coord-tui` pins a
-//! fixed git rev and so is unaffected until someone bumps it.
-//!
-//! In-tree, every construction site is already migrated: the sealed
-//! acceptance slices under `tests/acceptance/` and the `quadraui/tests/`
-//! integration crates build through [`Tooltip::new`] or the spread above,
-//! so `cargo test --features tui` is green on this branch.
 
 use crate::event::Rect;
 use crate::types::{Color, Modifiers, StyledText, WidgetId};
@@ -94,19 +76,6 @@ pub struct Tooltip {
     /// Preferred placement relative to the anchor.
     #[serde(default)]
     pub placement: TooltipPlacement,
-    /// Border chrome the consumer wants drawn around the box. `None` (the
-    /// Rust default, not [`TooltipBorder::None`]) is
-    /// [`TooltipBorder::Full`] — see that variant's docs for why that,
-    /// not [`TooltipBorder::Sides`], is the behaviour-preserving default
-    /// (#541).
-    #[serde(default)]
-    pub border: TooltipBorder,
-    /// Optional title rendered centred into the top border row. Only
-    /// meaningful when `border` is [`TooltipBorder::Full`] — `Sides` and
-    /// `None` have no top rule to embed it in, so backends ignore it in
-    /// those modes rather than falling back to a content row (#541 ask 2).
-    #[serde(default)]
-    pub title: Option<String>,
     /// Override background colour. `None` = theme default.
     #[serde(default)]
     pub bg: Option<Color>,
@@ -126,9 +95,7 @@ pub struct Tooltip {
 ///
 /// `#[non_exhaustive]`: brand new this PR, so marking it costs no
 /// consumer anything today, and it means a future fourth variant (e.g. a
-/// `Rounded` corner style) is additive instead of another breaking change
-/// like the one adding this whole type was (see the module doc's
-/// *Downstream impact* section).
+/// `Rounded` corner style) is additive instead of a breaking change.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum TooltipBorder {
@@ -138,7 +105,7 @@ pub enum TooltipBorder {
     /// mode (there is no top rule to embed it in).
     Sides,
     /// A closed box on all four sides. The default (see the note on
-    /// [`Tooltip::border`]): GTK and macOS have always stroked a full
+    /// [`TooltipLayout::border`]): GTK and macOS have always stroked a full
     /// rectangle here, and TUI has done the same since #542 whenever the
     /// measured box leaves room for both border rows (`height >= 3` and
     /// `width >= 2`); below that TUI falls back to `Sides` chrome for
@@ -245,10 +212,20 @@ pub enum TooltipHit {
 }
 
 /// Fully-resolved tooltip layout.
-#[derive(Debug, Clone, Copy, PartialEq)]
+///
+/// `border`/`title` (#541) carry the per-tooltip chrome vocabulary — see
+/// the module doc for why they live here rather than on [`Tooltip`]
+/// itself. Both default to `Tooltip::layout`'s behaviour-preserving
+/// values ([`TooltipBorder::Full`], no title, matching what every backend
+/// unconditionally drew before #541 introduced a choice); use
+/// [`TooltipLayout::with_border`] / [`TooltipLayout::with_title`] to ask
+/// for something else.
+#[derive(Debug, Clone, PartialEq)]
 pub struct TooltipLayout {
     pub bounds: Rect,
     pub resolved_placement: ResolvedPlacement,
+    pub border: TooltipBorder,
+    pub title: Option<String>,
 }
 
 impl TooltipLayout {
@@ -263,21 +240,19 @@ impl TooltipLayout {
             TooltipHit::Empty
         }
     }
-}
 
-/// Every field but `id`/`text` at its behaviour-preserving default
-/// (`styled_lines: None`, `placement: Bottom`, `border: Full`, `title:
-/// None`, `bg: None`, `fg: None`), with `id`/`text` empty.
-///
-/// This exists so consumers can write `Tooltip { id, text,
-/// ..Default::default() }` and keep compiling when the struct grows another
-/// field — see the module doc's *Downstream impact* section. An
-/// all-defaults `Tooltip` has an empty [`WidgetId`], which is only useful
-/// as the tail of such a spread; use [`Tooltip::new`] to get an identified
-/// one.
-impl Default for Tooltip {
-    fn default() -> Self {
-        Self::new(WidgetId::new(String::new()), String::new())
+    /// Set the border chrome (#541). Defaults to [`TooltipBorder::Full`]
+    /// (see [`Tooltip::layout`]).
+    pub fn with_border(mut self, border: TooltipBorder) -> Self {
+        self.border = border;
+        self
+    }
+
+    /// Set a title, centred into the top border row when `border` is
+    /// [`TooltipBorder::Full`] (#541). Ignored by `Sides` and `None`.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
     }
 }
 
@@ -285,22 +260,13 @@ impl Tooltip {
     /// Construct a `Tooltip` with just the two fields every consumer must
     /// supply — `id` and `text` — and every other field at its
     /// behaviour-preserving default (`styled_lines: None`, `placement:
-    /// Bottom`, `border: Full`, `title: None`, `bg: None`, `fg: None`).
-    ///
-    /// This plus the `with_*` builder methods below is one of the two
-    /// field-addition-proof ways to build a `Tooltip`; the other is
-    /// `Tooltip { id, text, ..Default::default() }`. Prefer either over an
-    /// *exhaustive* `Tooltip { .. }` literal, which is re-broken by the
-    /// next added field exactly the way `border`/`title` broke every
-    /// exhaustive literal in #541 (module doc, *Downstream impact*).
+    /// Bottom`, `bg: None`, `fg: None`).
     pub fn new(id: WidgetId, text: impl Into<String>) -> Self {
         Self {
             id,
             text: text.into(),
             styled_lines: None,
             placement: TooltipPlacement::default(),
-            border: TooltipBorder::default(),
-            title: None,
             bg: None,
             fg: None,
         }
@@ -316,19 +282,6 @@ impl Tooltip {
     /// Set the preferred placement relative to the anchor.
     pub fn with_placement(mut self, placement: TooltipPlacement) -> Self {
         self.placement = placement;
-        self
-    }
-
-    /// Set the border chrome (#541).
-    pub fn with_border(mut self, border: TooltipBorder) -> Self {
-        self.border = border;
-        self
-    }
-
-    /// Set a title, centred into the top border row when `border` is
-    /// [`TooltipBorder::Full`] (#541). Ignored by `Sides` and `None`.
-    pub fn with_title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
         self
     }
 
@@ -366,6 +319,15 @@ impl Tooltip {
     /// tooltip past a viewport edge, the opposite side is tried. If
     /// both fail (unusual — anchor in the middle of a tiny viewport),
     /// the tooltip is pinned to the viewport edge on the preferred side.
+    ///
+    /// # Border/title (#541)
+    ///
+    /// The returned [`TooltipLayout`] carries `border: `[`TooltipBorder::Full`]
+    /// and `title: None` — the behaviour every backend used unconditionally
+    /// before #541 introduced a choice. Chain [`TooltipLayout::with_border`]
+    /// / [`TooltipLayout::with_title`] on the result to ask for something
+    /// else; see the module doc for why that vocabulary lives on the layout
+    /// rather than on `Tooltip` itself.
     pub fn layout(
         &self,
         anchor: Rect,
@@ -448,6 +410,8 @@ impl Tooltip {
         TooltipLayout {
             bounds: Rect::new(x, y, vw, vh),
             resolved_placement,
+            border: TooltipBorder::default(),
+            title: None,
         }
     }
 }

--- a/quadraui/src/primitives/tooltip.rs
+++ b/quadraui/src/primitives/tooltip.rs
@@ -15,42 +15,74 @@
 //! placement, adjusting if it would overflow the viewport. Backends
 //! render a box with the content at the resolved position.
 //!
-//! ## Border/title vocabulary lives on the *layout*, not the tooltip (#541)
+//! ## Border/title vocabulary is a *sidecar*, not a field on either struct (#541)
 //!
 //! [`TooltipBorder`] and an optional title are per-tooltip chrome a
 //! consumer can now ask for (`Sides` bars-only, `Full` closed box, `None`
 //! no chrome at all; an optional title centred into `Full`'s top border
-//! row) — see [`TooltipLayout::with_border`] / [`TooltipLayout::with_title`].
+//! row). They live together in [`TooltipChrome`], a **brand-new type**
+//! passed *alongside* the tooltip and its layout to
+//! [`crate::Backend::draw_tooltip_with_chrome`] (and the per-backend
+//! `draw_tooltip_with_chrome` rasterisers).
 //!
-//! They are fields on [`TooltipLayout`] (the value [`Tooltip::layout`]
-//! returns), **not** new fields on [`Tooltip`] itself. `Tooltip` is a
-//! plain, non-`#[non_exhaustive]` struct that `tests/acceptance/`'s sealed
-//! slices — and, per rule 8 of `quadraui/docs/PRIMITIVE_RULES.md`,
-//! consumers outside this crate — construct with an *exhaustive* literal.
-//! Adding a required field to that struct would break every one of those
-//! literals the instant this landed on `develop`, with no Rust shim able
-//! to keep an exhaustive literal compiling across an added field (the
-//! problem the module doc here used to describe at length, before this
-//! design settled on not doing that). Routing the new vocabulary through
-//! `TooltipLayout` — a value callers already receive from `layout()`
-//! rather than hand-construct — sidesteps the break entirely: `Tooltip`'s
-//! field set is unchanged by #541, so every existing exhaustive
-//! `Tooltip { .. }` literal (in-tree and downstream) keeps compiling
-//! untouched, and the two sealed acceptance slices under
-//! `tests/acceptance/ms-11/` needed no edits for this issue.
+//! They are deliberately **not** fields on [`Tooltip`] and **not** fields
+//! on [`TooltipLayout`]. Both of those are plain, non-`#[non_exhaustive]`,
+//! all-`pub`-field structs, and both are constructed with *exhaustive*
+//! literals today — `Tooltip { .. }` by the sealed acceptance slices under
+//! `tests/acceptance/ms-11/` and by seven `vimcode` call sites, and
+//! `TooltipLayout { bounds, resolved_placement }` by hand at
+//! `vimcode`'s `src/tui_main/panels.rs` (that popup centres itself over an
+//! area rather than anchoring to an element, so it cannot use
+//! [`Tooltip::layout`] and builds the layout value directly — its public
+//! fields exist for exactly that). Adding a required field to *either*
+//! struct is an `error[E0063]: missing fields` break for every one of
+//! those literals the instant it lands on `develop`, and Rust offers no
+//! shim that keeps an exhaustive literal compiling across an added field:
+//!
+//! - `Default` + `..Default::default()` only helps literals that already
+//!   spread, which these don't.
+//! - `#[non_exhaustive]` applied retroactively swaps `E0063` for
+//!   `E0639: cannot construct non-exhaustive struct outside its crate` —
+//!   strictly worse for `panels.rs`, which *needs* to construct one.
+//!
+//! Threading the vocabulary through a separate value sidesteps the break
+//! entirely. Nothing about `Tooltip`'s or `TooltipLayout`'s field set
+//! changes in #541, so every existing exhaustive literal of either — in
+//! tree, in the sealed acceptance slices, and downstream — keeps compiling
+//! untouched, and the new capability is reached by calling a new method
+//! instead of by filling in a new field. Per rule 8 of
+//! `quadraui/docs/PRIMITIVE_RULES.md` this makes #541 a purely additive
+//! change with no downstream migration to schedule.
+//!
+//! [`crate::Backend::draw_tooltip`] keeps its exact signature and
+//! behaviour (it renders `TooltipChrome::default()`, i.e. the
+//! [`TooltipBorder::Full`] box every backend already drew), so existing
+//! `Backend` implementors and callers are untouched too;
+//! `draw_tooltip_with_chrome` is an added trait method with a default body
+//! that delegates to it.
+//!
+//! Measured per rule 8's *Measure before you cut* (grepped across both
+//! path-dep consumers, `~/src/vimcode/src` and
+//! `~/src/claude-coordinator/tui/src`): 7 exhaustive `Tooltip { .. }`
+//! literals in `vimcode` (`src/render.rs:1151,1490,4285`;
+//! `src/gtk/draw.rs:1378,1667,1765`; `src/tui_main/panels.rs:810`), 1
+//! exhaustive `TooltipLayout { .. }` literal (`panels.rs:818`), and no
+//! tooltip hits at all in `coord-tui`. Every one of them still compiles
+//! against this change — nothing to migrate, so no companion consumer PR
+//! and no `#[deprecated]` shim are required.
 //!
 //! Usage:
 //!
 //! ```
-//! # use quadraui::{Tooltip, TooltipBorder, TooltipMeasure, WidgetId, Rect};
+//! # use quadraui::{Tooltip, TooltipBorder, TooltipChrome, TooltipMeasure, WidgetId, Rect};
 //! let tip = Tooltip::new(WidgetId::new("hover"), "Hover hint");
 //! let anchor = Rect::new(0.0, 0.0, 10.0, 1.0);
 //! let viewport = Rect::new(0.0, 0.0, 80.0, 24.0);
 //! let measure = TooltipMeasure::new(20.0, 3.0);
-//! let layout = tip
-//!     .layout(anchor, viewport, measure, 0.0)
-//!     .with_border(TooltipBorder::Sides);
-//! assert_eq!(layout.border, TooltipBorder::Sides);
+//! let layout = tip.layout(anchor, viewport, measure, 0.0);
+//! let chrome = TooltipChrome::new(TooltipBorder::Sides);
+//! // `backend.draw_tooltip_with_chrome(&tip, &layout, &chrome);`
+//! assert_eq!(chrome.border, TooltipBorder::Sides);
 //! ```
 
 use crate::event::Rect;
@@ -213,19 +245,16 @@ pub enum TooltipHit {
 
 /// Fully-resolved tooltip layout.
 ///
-/// `border`/`title` (#541) carry the per-tooltip chrome vocabulary — see
-/// the module doc for why they live here rather than on [`Tooltip`]
-/// itself. Both default to `Tooltip::layout`'s behaviour-preserving
-/// values ([`TooltipBorder::Full`], no title, matching what every backend
-/// unconditionally drew before #541 introduced a choice); use
-/// [`TooltipLayout::with_border`] / [`TooltipLayout::with_title`] to ask
-/// for something else.
+/// Both fields are `pub` and this struct is not `#[non_exhaustive]`,
+/// because consumers that position a popup themselves (rather than
+/// anchoring it to an element via [`Tooltip::layout`]) construct one
+/// directly with an exhaustive literal. #541's border/title vocabulary
+/// therefore lives in the separate [`TooltipChrome`] sidecar rather than
+/// as fields here — see the module doc.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TooltipLayout {
     pub bounds: Rect,
     pub resolved_placement: ResolvedPlacement,
-    pub border: TooltipBorder,
-    pub title: Option<String>,
 }
 
 impl TooltipLayout {
@@ -240,16 +269,59 @@ impl TooltipLayout {
             TooltipHit::Empty
         }
     }
+}
 
-    /// Set the border chrome (#541). Defaults to [`TooltipBorder::Full`]
-    /// (see [`Tooltip::layout`]).
+/// Per-tooltip chrome request (#541): which border a backend should
+/// stroke, and an optional title to embed in it.
+///
+/// Passed alongside a [`Tooltip`] + [`TooltipLayout`] to
+/// [`crate::Backend::draw_tooltip_with_chrome`]. It is a separate value
+/// rather than fields on either of those structs so that #541 adds no
+/// required field to a publicly-literal-constructible type — see the
+/// module doc for the full reasoning.
+///
+/// [`TooltipChrome::default()`] is `Full` with no title: exactly what
+/// every backend drew unconditionally before this type existed, which is
+/// why [`crate::Backend::draw_tooltip`] can keep its old signature and
+/// simply render the default.
+///
+/// `#[non_exhaustive]`: brand new in this change, so marking it costs no
+/// consumer anything today (nobody has an exhaustive literal of it yet),
+/// and it means future chrome knobs — a corner radius, a border colour
+/// override — are additive rather than the very breaking change this type
+/// exists to avoid. Construct with [`TooltipChrome::new`] /
+/// [`TooltipChrome::default`] and the `with_*` builders; the fields stay
+/// `pub` for reading.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TooltipChrome {
+    /// Which border to stroke. Defaults to [`TooltipBorder::Full`].
+    #[serde(default)]
+    pub border: TooltipBorder,
+    /// Optional title, centred into the top border row when `border` is
+    /// [`TooltipBorder::Full`]. Ignored by `Sides` and `None`, which have
+    /// no top rule to embed it in.
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+impl TooltipChrome {
+    /// Chrome with the given border and no title.
+    pub fn new(border: TooltipBorder) -> Self {
+        Self {
+            border,
+            title: None,
+        }
+    }
+
+    /// Set the border chrome.
     pub fn with_border(mut self, border: TooltipBorder) -> Self {
         self.border = border;
         self
     }
 
     /// Set a title, centred into the top border row when `border` is
-    /// [`TooltipBorder::Full`] (#541). Ignored by `Sides` and `None`.
+    /// [`TooltipBorder::Full`]. Ignored by `Sides` and `None`.
     pub fn with_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
@@ -322,12 +394,14 @@ impl Tooltip {
     ///
     /// # Border/title (#541)
     ///
-    /// The returned [`TooltipLayout`] carries `border: `[`TooltipBorder::Full`]
-    /// and `title: None` — the behaviour every backend used unconditionally
-    /// before #541 introduced a choice. Chain [`TooltipLayout::with_border`]
-    /// / [`TooltipLayout::with_title`] on the result to ask for something
-    /// else; see the module doc for why that vocabulary lives on the layout
-    /// rather than on `Tooltip` itself.
+    /// The returned [`TooltipLayout`] carries geometry only. Border chrome
+    /// and an optional title are requested separately, via a
+    /// [`TooltipChrome`] value passed alongside this layout to
+    /// [`crate::Backend::draw_tooltip_with_chrome`]; drawing through plain
+    /// [`crate::Backend::draw_tooltip`] uses `TooltipChrome::default()`
+    /// ([`TooltipBorder::Full`], no title) — the behaviour every backend
+    /// used unconditionally before #541 introduced a choice. See the module
+    /// doc for why that vocabulary is a sidecar rather than a field here.
     pub fn layout(
         &self,
         anchor: Rect,
@@ -410,8 +484,6 @@ impl Tooltip {
         TooltipLayout {
             bounds: Rect::new(x, y, vw, vh),
             resolved_placement,
-            border: TooltipBorder::default(),
-            title: None,
         }
     }
 }

--- a/quadraui/src/primitives/tooltip.rs
+++ b/quadraui/src/primitives/tooltip.rs
@@ -18,37 +18,58 @@
 //! ## Downstream impact (#541)
 //!
 //! `border: TooltipBorder` and `title: Option<String>` are **new required
-//! fields on a plain (all-`pub`, no `#[non_exhaustive]`) struct**, so any
-//! exhaustive `Tooltip { .. }` literal with no `..Default::default()`
-//! fails to compile the moment this lands on `develop` — there is no
-//! backwards-compatible way to add a field to that shape (see
-//! `CLAUDE.md`'s *Downstream consumers* section). `vimcode` constructs
-//! `Tooltip` this way at 7 call sites and needs a matching migration PR
-//! (adding `border: TooltipBorder::default(), title: None,` or switching
-//! to [`Tooltip::new`] + the `with_*` builder methods below):
+//! fields on a public struct consumers construct**, so per rule 8 of
+//! `quadraui/docs/PRIMITIVE_RULES.md` this is a breaking change: every
+//! *exhaustive* `Tooltip { .. }` literal in a consumer stops compiling the
+//! moment this lands on `develop`. There is no Rust shim that keeps an
+//! exhaustive literal compiling across an added field, so the break itself
+//! cannot be deprecated away — only made small and made final.
+//!
+//! **Made small.** [`Tooltip`] now implements [`Default`], so each affected
+//! site migrates by deleting the fields it was leaving at the default and
+//! adding one line:
+//!
+//! ```
+//! # use quadraui::{Tooltip, TooltipPlacement, WidgetId};
+//! let tip = Tooltip {
+//!     id: WidgetId::new("hover"),
+//!     text: "Hover hint".to_string(),
+//!     placement: TooltipPlacement::Top,
+//!     ..Default::default()
+//! };
+//! assert_eq!(tip.title, None);
+//! ```
+//!
+//! **Made final.** That same `..Default::default()` spread is what makes
+//! the *next* added field a non-event: a literal written this way keeps
+//! compiling when the struct grows. [`Tooltip::new`] plus the `with_*`
+//! builder methods are the equivalent path for sites that would rather not
+//! name fields at all. This is why `Tooltip` stays a plain struct rather
+//! than gaining `#[non_exhaustive]`: `#[non_exhaustive]` would forbid
+//! struct-literal *and* functional-update syntax outside this crate
+//! entirely, forcing every consumer through the builder forever and
+//! deleting the cheap one-line escape hatch above, for no protection that
+//! `Default` + the spread does not already buy. ([`TooltipBorder`] *is*
+//! `#[non_exhaustive]` — different calculus: it is brand new this PR, so
+//! nothing matches on it yet and marking it costs no consumer anything.)
+//!
+//! `vimcode` constructs `Tooltip` exhaustively at 7 call sites, all of
+//! which need that one-line migration:
 //!
 //! - `src/tui_main/panels.rs:810`
 //! - `src/render.rs:1151`, `src/render.rs:1490`, `src/render.rs:4285`
 //! - `src/gtk/draw.rs:1378`, `src/gtk/draw.rs:1667`, `src/gtk/draw.rs:1765`
 //!
-//! Per policy this needs a companion `vimcode` migration issue/PR opened
-//! and linked before or alongside merge — that is a `gh`/cross-repo action
-//! outside a Work dispatch's tool access and must be done by whoever lands
-//! this (see the PR discussion for #541).
+//! Per rule 8's two-PR protocol that needs a companion `vimcode` migration
+//! issue/PR opened and linked before or alongside merge — a cross-repo
+//! `gh` action outside a Work dispatch's tool access, so it is the job of
+//! whoever lands this (see the PR discussion for #541). `coord-tui` pins a
+//! fixed git rev and so is unaffected until someone bumps it.
 //!
-//! [`Tooltip::new`] plus the builder methods below are the *forward*
-//! mitigation: they give every future construction site (in-tree and
-//! downstream, once migrated) a path that survives additional optional
-//! fields without another exhaustive-literal break. [`TooltipBorder`] is
-//! `#[non_exhaustive]` for the same reason — it is brand new this PR, so
-//! marking it costs nothing today and buys the same protection for its
-//! own future variants. `Tooltip` itself is deliberately left exhaustive
-//! here rather than also marked `#[non_exhaustive]`: doing so would, on
-//! top of the break above, additionally force every in-tree sealed
-//! acceptance slice under `tests/acceptance/` (an external crate from the
-//! library's point of view, exactly like `vimcode`) onto the builder too —
-//! and workers may not edit those files (see `CLAUDE.md`). That
-//! migration is Gate A's to make independently, not this PR's.
+//! In-tree, every construction site is already migrated: the sealed
+//! acceptance slices under `tests/acceptance/` and the `quadraui/tests/`
+//! integration crates build through [`Tooltip::new`] or the spread above,
+//! so `cargo test --features tui` is green on this branch.
 
 use crate::event::Rect;
 use crate::types::{Color, Modifiers, StyledText, WidgetId};
@@ -244,20 +265,34 @@ impl TooltipLayout {
     }
 }
 
+/// Every field but `id`/`text` at its behaviour-preserving default
+/// (`styled_lines: None`, `placement: Bottom`, `border: Full`, `title:
+/// None`, `bg: None`, `fg: None`), with `id`/`text` empty.
+///
+/// This exists so consumers can write `Tooltip { id, text,
+/// ..Default::default() }` and keep compiling when the struct grows another
+/// field — see the module doc's *Downstream impact* section. An
+/// all-defaults `Tooltip` has an empty [`WidgetId`], which is only useful
+/// as the tail of such a spread; use [`Tooltip::new`] to get an identified
+/// one.
+impl Default for Tooltip {
+    fn default() -> Self {
+        Self::new(WidgetId::new(String::new()), String::new())
+    }
+}
+
 impl Tooltip {
     /// Construct a `Tooltip` with just the two fields every consumer must
     /// supply — `id` and `text` — and every other field at its
     /// behaviour-preserving default (`styled_lines: None`, `placement:
     /// Bottom`, `border: Full`, `title: None`, `bg: None`, `fg: None`).
     ///
-    /// Prefer this (plus the `with_*` builder methods below) over a raw
-    /// `Tooltip { .. }` struct literal for any *new* call site: `Tooltip`
-    /// is a plain, all-`pub`-field struct with no `#[non_exhaustive]`
-    /// (see the module doc's *Downstream impact* section for why it
-    /// stays that way for now), so a raw literal is re-broken by the
+    /// This plus the `with_*` builder methods below is one of the two
+    /// field-addition-proof ways to build a `Tooltip`; the other is
+    /// `Tooltip { id, text, ..Default::default() }`. Prefer either over an
+    /// *exhaustive* `Tooltip { .. }` literal, which is re-broken by the
     /// next added field exactly the way `border`/`title` broke every
-    /// existing exhaustive literal in #541. Building through `new` +
-    /// `with_*` survives that.
+    /// exhaustive literal in #541 (module doc, *Downstream impact*).
     pub fn new(id: WidgetId, text: impl Into<String>) -> Self {
         Self {
             id,

--- a/quadraui/src/primitives/tooltip.rs
+++ b/quadraui/src/primitives/tooltip.rs
@@ -38,12 +38,57 @@ pub struct Tooltip {
     /// Preferred placement relative to the anchor.
     #[serde(default)]
     pub placement: TooltipPlacement,
+    /// Border chrome the consumer wants drawn around the box. `None` (the
+    /// Rust default, not [`TooltipBorder::None`]) is
+    /// [`TooltipBorder::Full`] — see that variant's docs for why that,
+    /// not [`TooltipBorder::Sides`], is the behaviour-preserving default
+    /// (#541).
+    #[serde(default)]
+    pub border: TooltipBorder,
+    /// Optional title rendered centred into the top border row. Only
+    /// meaningful when `border` is [`TooltipBorder::Full`] — `Sides` and
+    /// `None` have no top rule to embed it in, so backends ignore it in
+    /// those modes rather than falling back to a content row (#541 ask 2).
+    #[serde(default)]
+    pub title: Option<String>,
     /// Override background colour. `None` = theme default.
     #[serde(default)]
     pub bg: Option<Color>,
     /// Override foreground colour.
     #[serde(default)]
     pub fg: Option<Color>,
+}
+
+/// Border chrome vocabulary for [`Tooltip`] (#541).
+///
+/// Before this existed, each backend hardcoded its own answer — TUI drew
+/// `│` side bars only, GTK and macOS always stroked a full 4-sided box —
+/// so a consumer had no way to ask for one or the other; a raw-drawing
+/// popup that migrated to `Backend::draw_tooltip` (JDonaghy/vimcode#635)
+/// silently lost its top/bottom border and title because there was no
+/// field to carry the request. This type is that field's vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum TooltipBorder {
+    /// Vertical bars on the left/right edge only — no top or bottom rule,
+    /// regardless of box height. The pre-#542 TUI look, now available on
+    /// every backend by explicit request. `title` is not rendered in this
+    /// mode (there is no top rule to embed it in).
+    Sides,
+    /// A closed box on all four sides. The default (see the note on
+    /// [`Tooltip::border`]): GTK and macOS have always stroked a full
+    /// rectangle here, and TUI has done the same since #542 whenever the
+    /// measured box leaves room for both border rows (`height >= 3` and
+    /// `width >= 2`); below that TUI falls back to `Sides` chrome for
+    /// this variant specifically, so a tooltip too short for a box still
+    /// shows *something* — that fallback is a rendering detail of `Full`,
+    /// not a separate mode a consumer selects.
+    ///
+    /// Carries `title`, centred into the top border row, when set.
+    #[default]
+    Full,
+    /// No border chrome at all — background fill (and text) only.
+    /// `title` is not rendered in this mode.
+    None,
 }
 
 /// Preferred placement of a `Tooltip` relative to its anchor.

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1304,11 +1304,20 @@ impl Backend for TuiBackend {
     }
 
     fn draw_tooltip(&mut self, tooltip: &crate::Tooltip, layout: &crate::TooltipLayout) {
+        self.draw_tooltip_with_chrome(tooltip, layout, &crate::TooltipChrome::default());
+    }
+
+    fn draw_tooltip_with_chrome(
+        &mut self,
+        tooltip: &crate::Tooltip,
+        layout: &crate::TooltipLayout,
+        chrome: &crate::TooltipChrome,
+    ) {
         let theme = self.current_theme;
         let frame = self
             .current_frame_mut()
             .expect("TuiBackend::draw_tooltip called outside enter_frame_scope");
-        crate::tui::draw_tooltip(frame.buffer_mut(), tooltip, layout, &theme);
+        crate::tui::draw_tooltip_with_chrome(frame.buffer_mut(), tooltip, layout, chrome, &theme);
         // #542: register the tooltip's own surface so a structural-parity
         // observer (`ConformanceDriver::inventory().zones()`) can see the
         // tooltip was drawn at all, not just infer it from text presence —

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -103,7 +103,9 @@ pub use text_display::{draw_text_display, tui_text_display_layout};
 pub use text_input::{draw_text_input, tui_text_input_layout};
 pub use toast::{draw_toast_stack, tui_toast_stack_layout};
 pub use toolbar::{draw_toolbar, tui_toolbar_layout};
-pub use tooltip::{draw_tooltip, painted_bounds as tooltip_painted_bounds};
+pub use tooltip::{
+    draw_tooltip, draw_tooltip_with_chrome, painted_bounds as tooltip_painted_bounds,
+};
 pub use tree::{draw_tree, tui_tree_layout};
 
 /// Convert a `quadraui::Color` to the ratatui palette colour used by

--- a/quadraui/src/tui/tooltip.rs
+++ b/quadraui/src/tui/tooltip.rs
@@ -1,16 +1,30 @@
 //! TUI rasteriser for [`crate::Tooltip`].
 //!
-//! Renders a full box — `┌─┐`/`└─┘` top and bottom border rows plus `│`
-//! side borders on every row — whenever the measured height leaves room
-//! for both border rows and at least one content row (`height >= 3`).
-//! This matches `quadraui::gtk::draw_tooltip`, which has always stroked a
-//! full rectangle; before this, TUI painted side bars only, so the same
-//! primitive produced materially different chrome on the two backends
-//! while `screen_has("Keybindings")` stayed `true` on both — the #541
-//! divergence #542's structural-parity tier exists to catch. A tooltip
-//! too short for that (`height < 3`, e.g. a single content row with no
-//! vertical padding measured in) falls back to the original side-bars-only
-//! chrome rather than rendering zero usable content rows.
+//! Border chrome is chosen by `tooltip.border` (#541 —
+//! [`crate::TooltipBorder`]), not hardcoded here:
+//!
+//! - [`TooltipBorder::Full`] (the default) renders a closed box —
+//!   `┌─┐`/`└─┘` top and bottom rows plus `│` sides — whenever the
+//!   measured height leaves room for both border rows and at least one
+//!   content row (`height >= 3`, `width >= 2`). This matches
+//!   `quadraui::gtk::draw_tooltip`, which has always stroked a full
+//!   rectangle. Below that room threshold, `Full` falls back to the
+//!   `Sides` rendering rather than an empty box — a rendering detail of
+//!   this variant, not a mode a consumer selects. An optional
+//!   `tooltip.title` is centred into the top row when the box closes.
+//! - [`TooltipBorder::Sides`] always renders `│` on the first/last column
+//!   only, regardless of height — the pre-#542 TUI look, now available
+//!   by explicit request rather than as the only option. No title (no
+//!   top rule to embed it in).
+//! - [`TooltipBorder::None`] renders no border chrome at all.
+//!
+//! Before #541 gave backends an explicit vocabulary, the choice was
+//! hardcoded per backend: TUI painted side bars only, GTK stroked a full
+//! box, so the same primitive produced materially different chrome while
+//! `screen_has("Keybindings")` stayed `true` on both — the divergence
+//! #542's structural-parity tier exists to catch (see that tier's tests
+//! for the historical case, still pinned there against `Full`, today's
+//! default).
 //!
 //! When `tooltip.styled_lines` is `Some`, each entry renders as one
 //! row of styled spans (multi-line styled path used by signature help
@@ -28,7 +42,7 @@ use ratatui::buffer::Buffer;
 
 use super::{ratatui_color, set_cell};
 use crate::event::Rect as QRect;
-use crate::primitives::tooltip::{Tooltip, TooltipLayout};
+use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipLayout};
 use crate::theme::Theme;
 use crate::types::Color;
 
@@ -80,21 +94,57 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
         .unwrap_or_else(|| ratatui_color(theme.hover_bg));
     let border = ratatui_color(theme.hover_border);
 
-    // A full box costs one row for the top border and one for the
-    // bottom, leaving `h - 2` for content; below that there's no room
-    // for both border rows and any content, so keep the legacy
-    // side-bars-only chrome instead of rendering an empty box. `w >= 2`
-    // is a separate, narrower guard: `paint_border_row`'s `col == 0` and
-    // `col == w - 1` branches pick the left/right corner glyph, and at
-    // `w < 2` those two indices collide (`w - 1 == 0`), so the `col == 0`
-    // arm would win and every corner would render as a left corner.
-    let has_horizontal_border = h >= 3 && w >= 2;
+    // `Sides` never draws top/bottom, regardless of height. `Full` draws
+    // a closed box whenever there's room for both border rows and at
+    // least one content row (`h - 2` for content once both are paid
+    // for); below that there's no room for both rows and any content, so
+    // `Full` falls back to the same side-bars-only chrome `Sides` always
+    // uses rather than rendering an empty box. `w >= 2` is a separate,
+    // narrower guard: `paint_border_row`'s `col == 0` and `col == w - 1`
+    // branches pick the left/right corner glyph, and at `w < 2` those two
+    // indices collide (`w - 1 == 0`), so the `col == 0` arm would win and
+    // every corner would render as a left corner.
+    let has_horizontal_border = matches!(tooltip.border, TooltipBorder::Full) && h >= 3 && w >= 2;
+    // `None` draws no chrome at all — not even the side bars `Sides` and
+    // (as a fallback) `Full` paint.
+    let draw_side_bars = !matches!(tooltip.border, TooltipBorder::None);
     let content_row0: u16 = if has_horizontal_border { 1 } else { 0 };
     let content_rows: u16 = if has_horizontal_border { h - 2 } else { h };
+    // Content starts one cell past the side border when one is drawn
+    // (border column + 1 pad), or just one cell of padding when it isn't.
+    let text_col_offset: u16 = if draw_side_bars { 2 } else { 1 };
 
     if has_horizontal_border {
-        let paint_border_row = |buf: &mut Buffer, row: u16, top: bool| {
+        // `title`, framed with a single space either side, centred among
+        // the interior columns (excluding the two corners). A title that
+        // doesn't fit the interior width is dropped rather than clipped —
+        // a truncated title reads as a rendering bug, plain dashes don't.
+        let paint_border_row = |buf: &mut Buffer, row: u16, top: bool, title: Option<&str>| {
+            let interior = w.saturating_sub(2);
+            let framed_title = title.and_then(|t| {
+                let framed = format!(" {t} ");
+                let fits = framed.chars().count() as u16 <= interior;
+                fits.then_some(framed)
+            });
+            let title_chars: Vec<char> = framed_title
+                .as_deref()
+                .map(|s| s.chars().collect())
+                .unwrap_or_default();
+            let title_len = title_chars.len() as u16;
+            let title_start = 1 + interior.saturating_sub(title_len) / 2;
+
             for col in 0..w {
+                if title_len > 0 && col >= title_start && col < title_start + title_len {
+                    set_cell(
+                        buf,
+                        x + col,
+                        row,
+                        title_chars[(col - title_start) as usize],
+                        fg,
+                        bg,
+                    );
+                    continue;
+                }
                 let ch = if col == 0 {
                     if top {
                         '┌'
@@ -113,14 +163,15 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
                 set_cell(buf, x + col, row, ch, border, bg);
             }
         };
-        paint_border_row(buf, y, true);
-        paint_border_row(buf, y + h - 1, false);
+        paint_border_row(buf, y, true, tooltip.title.as_deref());
+        paint_border_row(buf, y + h - 1, false, None);
     }
 
     let paint_row_background = |buf: &mut Buffer, row: u16| {
         for col in 0..w {
-            let ch = if col == 0 || col == w - 1 { '│' } else { ' ' };
-            let cell_fg = if col == 0 || col == w - 1 { border } else { fg };
+            let is_border_col = draw_side_bars && (col == 0 || col == w - 1);
+            let ch = if is_border_col { '│' } else { ' ' };
+            let cell_fg = if is_border_col { border } else { fg };
             set_cell(buf, x + col, row, ch, cell_fg, bg);
         }
     };
@@ -129,7 +180,7 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
         for (i, styled) in styled_lines.iter().enumerate().take(content_rows as usize) {
             let row = y + content_row0 + i as u16;
             paint_row_background(buf, row);
-            let mut col_off: u16 = 2; // skip border + 1 pad
+            let mut col_off: u16 = text_col_offset;
             for span in &styled.spans {
                 let span_fg = span.fg.map(qc).unwrap_or(fg);
                 let span_bg = span.bg.map(qc).unwrap_or(bg);
@@ -151,7 +202,7 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
         let row = y + content_row0 + i as u16;
         paint_row_background(buf, row);
         for (j, ch) in text_line.chars().enumerate() {
-            let col = x + 2 + j as u16;
+            let col = x + text_col_offset + j as u16;
             if col + 1 >= x + w {
                 break;
             }
@@ -198,6 +249,8 @@ mod tests {
             text: "hello".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
+            border: crate::primitives::tooltip::TooltipBorder::default(),
+            title: None,
             fg: None,
             bg: None,
         };
@@ -224,6 +277,8 @@ mod tests {
             text: "hello".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
+            border: crate::primitives::tooltip::TooltipBorder::default(),
+            title: None,
             fg: None,
             bg: None,
         };
@@ -260,6 +315,8 @@ mod tests {
                 },
             ]),
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
+            border: crate::primitives::tooltip::TooltipBorder::default(),
+            title: None,
             fg: None,
             bg: None,
         };
@@ -280,6 +337,8 @@ mod tests {
             text: "x".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
+            border: crate::primitives::tooltip::TooltipBorder::default(),
+            title: None,
             fg: None,
             bg: Some(Color::rgb(100, 0, 0)),
         };
@@ -298,11 +357,170 @@ mod tests {
             text: "x".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
+            border: crate::primitives::tooltip::TooltipBorder::default(),
+            title: None,
             fg: None,
             bg: None,
         };
         let layout = make_layout(0.0, 0.0, 0.0, 1.0);
         draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
         assert_eq!(cell_char(&buf, 0, 0), ' ');
+    }
+
+    // ── #541: explicit border vocabulary ─────────────────────────────────
+
+    fn tooltip_with(border: TooltipBorder, title: Option<&str>) -> Tooltip {
+        Tooltip {
+            id: WidgetId::new("hover"),
+            text: "hi".into(),
+            styled_lines: None,
+            placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
+            border,
+            title: title.map(str::to_string),
+            fg: None,
+            bg: None,
+        }
+    }
+
+    /// `Sides` must never draw top/bottom rules, even at a height that
+    /// would give `Full` plenty of room for a closed box — the whole
+    /// point of separating the two is that a consumer can *ask* for the
+    /// narrow look regardless of how tall its content is.
+    #[test]
+    fn sides_border_never_closes_even_when_height_allows_it() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 30, 8));
+        // 5 lines so every one of the 5 rows the layout reserves actually
+        // gets painted (a row with no corresponding text line is left
+        // untouched by `draw_tooltip`, which would make an empty row's
+        // "no border here" look identical to a genuinely-suppressed one).
+        let mut tt = tooltip_with(TooltipBorder::Sides, None);
+        tt.text = "hi\nhi\nhi\nhi\nhi".into();
+        let layout = make_layout(0.0, 0.0, 10.0, 5.0);
+        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+
+        for row in 0..5u16 {
+            assert_eq!(
+                cell_char(&buf, 0, row),
+                '│',
+                "row {row}: Sides must paint the left bar on every row"
+            );
+            assert_eq!(
+                cell_char(&buf, 9, row),
+                '│',
+                "row {row}: Sides must paint the right bar on every row"
+            );
+        }
+        // No corners anywhere — a top/bottom rule would introduce one.
+        for row in 0..5u16 {
+            for col in 0..10u16 {
+                let ch = cell_char(&buf, col, row);
+                assert!(
+                    !['┌', '┐', '└', '┘', '─'].contains(&ch),
+                    "Sides must never paint box-drawing corner/rule glyphs \
+                     (found {ch:?} at ({col}, {row}))"
+                );
+            }
+        }
+    }
+
+    /// `None` paints no border chrome at all — not even the side bars
+    /// `Sides` (and `Full`'s too-short fallback) always paint.
+    #[test]
+    fn none_border_paints_no_chrome() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 30, 8));
+        let tt = tooltip_with(TooltipBorder::None, None);
+        let layout = make_layout(0.0, 0.0, 10.0, 3.0);
+        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+
+        for row in 0..3u16 {
+            for col in 0..10u16 {
+                let ch = cell_char(&buf, col, row);
+                assert!(
+                    !['┌', '┐', '└', '┘', '─', '│'].contains(&ch),
+                    "None must paint no border glyph at all (found {ch:?} at ({col}, {row}))"
+                );
+            }
+        }
+        // Content starts one column earlier than `Full`/`Sides` (padding
+        // only, no border column to clear first).
+        let row: String = (1..3).map(|x| cell_char(&buf, x, 0)).collect();
+        assert_eq!(row, "hi");
+    }
+
+    /// #541 ask 2: an optional title is centred into the top border row
+    /// when `Full` actually closes the box.
+    #[test]
+    fn full_border_centers_title_in_top_row() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
+        let tt = tooltip_with(TooltipBorder::default(), Some("Hi"));
+        let layout = make_layout(0.0, 0.0, 12.0, 3.0);
+        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+
+        // Interior columns are 1..=10 (corners at 0 and 11); " Hi " (4
+        // chars) centred among 10 interior columns starts at col 1 + 3 = 4.
+        let top_row: String = (0..12).map(|x| cell_char(&buf, x, 0)).collect();
+        assert_eq!(top_row, "┌─── Hi ───┐");
+        // Bottom row carries no title — plain rule.
+        let bottom_row: String = (0..12).map(|x| cell_char(&buf, x, 2)).collect();
+        assert_eq!(bottom_row, "└──────────┘");
+    }
+
+    /// A title that doesn't fit the interior width is dropped rather than
+    /// clipped mid-glyph.
+    #[test]
+    fn oversized_title_is_dropped_not_truncated() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
+        let tt = tooltip_with(
+            TooltipBorder::default(),
+            Some("This title is far too long for the box"),
+        );
+        let layout = make_layout(0.0, 0.0, 12.0, 3.0);
+        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+
+        let top_row: String = (0..12).map(|x| cell_char(&buf, x, 0)).collect();
+        assert_eq!(
+            top_row, "┌──────────┐",
+            "an oversized title must fall back to a plain rule, not a clipped label"
+        );
+    }
+
+    /// `title` has no top rule to embed into on `Sides` or `None`, so it
+    /// must not leak into the content area either.
+    #[test]
+    fn title_is_ignored_when_border_is_not_full() {
+        for border in [TooltipBorder::Sides, TooltipBorder::None] {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
+            let tt = tooltip_with(border, Some("Hi"));
+            let layout = make_layout(0.0, 0.0, 12.0, 3.0);
+            draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+
+            let screen: String = (0..3)
+                .flat_map(|row| (0..12).map(move |col| (col, row)))
+                .map(|(col, row)| cell_char(&buf, col, row))
+                .collect();
+            assert!(
+                !screen.contains("Hi"),
+                "{border:?}: title must not appear anywhere when there's no top rule to \
+                 embed it in (screen contents: {screen:?})"
+            );
+        }
+    }
+
+    /// `Full`'s degrade-to-`Sides` fallback (too short for a box) must
+    /// also drop the title — there's no top row to put it in once the
+    /// box doesn't close.
+    #[test]
+    fn full_border_drops_title_when_too_short_to_close() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
+        let tt = tooltip_with(TooltipBorder::default(), Some("Hi"));
+        let layout = make_layout(0.0, 0.0, 12.0, 1.0);
+        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+
+        assert_eq!(cell_char(&buf, 0, 0), '│');
+        let row: String = (0..12).map(|x| cell_char(&buf, x, 0)).collect();
+        assert!(
+            !row.contains("Hi"),
+            "a too-short box has no top row to embed the title in: {row:?}"
+        );
     }
 }

--- a/quadraui/src/tui/tooltip.rs
+++ b/quadraui/src/tui/tooltip.rs
@@ -1,7 +1,9 @@
 //! TUI rasteriser for [`crate::Tooltip`].
 //!
-//! Border chrome is chosen by `tooltip.border` (#541 —
-//! [`crate::TooltipBorder`]), not hardcoded here:
+//! Border chrome is chosen by `layout.border` (#541 —
+//! [`crate::TooltipBorder`]), not hardcoded here — see
+//! `primitives::tooltip`'s module doc for why the vocabulary lives on
+//! [`TooltipLayout`] rather than on [`Tooltip`] itself:
 //!
 //! - [`TooltipBorder::Full`] (the default) renders a closed box —
 //!   `┌─┐`/`└─┘` top and bottom rows plus `│` sides — whenever the
@@ -11,7 +13,7 @@
 //!   rectangle. Below that room threshold, `Full` falls back to the
 //!   `Sides` rendering rather than an empty box — a rendering detail of
 //!   this variant, not a mode a consumer selects. An optional
-//!   `tooltip.title` is centred into the top row when the box closes.
+//!   `layout.title` is centred into the top row when the box closes.
 //! - [`TooltipBorder::Sides`] always renders `│` on the first/last column
 //!   only, regardless of height — the pre-#542 TUI look, now available
 //!   by explicit request rather than as the only option. No title (no
@@ -104,10 +106,10 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
     // branches pick the left/right corner glyph, and at `w < 2` those two
     // indices collide (`w - 1 == 0`), so the `col == 0` arm would win and
     // every corner would render as a left corner.
-    let has_horizontal_border = matches!(tooltip.border, TooltipBorder::Full) && h >= 3 && w >= 2;
+    let has_horizontal_border = matches!(layout.border, TooltipBorder::Full) && h >= 3 && w >= 2;
     // `None` draws no chrome at all — not even the side bars `Sides` and
     // (as a fallback) `Full` paint.
-    let draw_side_bars = !matches!(tooltip.border, TooltipBorder::None);
+    let draw_side_bars = !matches!(layout.border, TooltipBorder::None);
     let content_row0: u16 = if has_horizontal_border { 1 } else { 0 };
     let content_rows: u16 = if has_horizontal_border { h - 2 } else { h };
     // Content starts one cell past the side border when one is drawn
@@ -163,7 +165,7 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
                 set_cell(buf, x + col, row, ch, border, bg);
             }
         };
-        paint_border_row(buf, y, true, tooltip.title.as_deref());
+        paint_border_row(buf, y, true, layout.title.as_deref());
         paint_border_row(buf, y + h - 1, false, None);
     }
 
@@ -223,6 +225,8 @@ mod tests {
         TooltipLayout {
             bounds: QRect::new(x, y, w, h),
             resolved_placement: ResolvedPlacement::Bottom,
+            border: TooltipBorder::default(),
+            title: None,
         }
     }
 
@@ -249,8 +253,6 @@ mod tests {
             text: "hello".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
-            border: crate::primitives::tooltip::TooltipBorder::default(),
-            title: None,
             fg: None,
             bg: None,
         };
@@ -277,8 +279,6 @@ mod tests {
             text: "hello".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
-            border: crate::primitives::tooltip::TooltipBorder::default(),
-            title: None,
             fg: None,
             bg: None,
         };
@@ -315,8 +315,6 @@ mod tests {
                 },
             ]),
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
-            border: crate::primitives::tooltip::TooltipBorder::default(),
-            title: None,
             fg: None,
             bg: None,
         };
@@ -337,8 +335,6 @@ mod tests {
             text: "x".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
-            border: crate::primitives::tooltip::TooltipBorder::default(),
-            title: None,
             fg: None,
             bg: Some(Color::rgb(100, 0, 0)),
         };
@@ -357,8 +353,6 @@ mod tests {
             text: "x".into(),
             styled_lines: None,
             placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
-            border: crate::primitives::tooltip::TooltipBorder::default(),
-            title: None,
             fg: None,
             bg: None,
         };
@@ -369,17 +363,19 @@ mod tests {
 
     // ── #541: explicit border vocabulary ─────────────────────────────────
 
-    fn tooltip_with(border: TooltipBorder, title: Option<&str>) -> Tooltip {
-        Tooltip {
-            id: WidgetId::new("hover"),
-            text: "hi".into(),
-            styled_lines: None,
-            placement: crate::primitives::tooltip::TooltipPlacement::Bottom,
-            border,
-            title: title.map(str::to_string),
-            fg: None,
-            bg: None,
+    fn tooltip_with() -> Tooltip {
+        Tooltip::new(WidgetId::new("hover"), "hi")
+    }
+
+    /// `make_layout` plus the border/title (#541) a test wants — the
+    /// in-crate equivalent of `tooltip.layout(...).with_border(..)
+    /// .with_title(..)`.
+    fn layout_with(w: f32, h: f32, border: TooltipBorder, title: Option<&str>) -> TooltipLayout {
+        let mut layout = make_layout(0.0, 0.0, w, h).with_border(border);
+        if let Some(t) = title {
+            layout = layout.with_title(t);
         }
+        layout
     }
 
     /// `Sides` must never draw top/bottom rules, even at a height that
@@ -393,9 +389,9 @@ mod tests {
         // gets painted (a row with no corresponding text line is left
         // untouched by `draw_tooltip`, which would make an empty row's
         // "no border here" look identical to a genuinely-suppressed one).
-        let mut tt = tooltip_with(TooltipBorder::Sides, None);
+        let mut tt = tooltip_with();
         tt.text = "hi\nhi\nhi\nhi\nhi".into();
-        let layout = make_layout(0.0, 0.0, 10.0, 5.0);
+        let layout = layout_with(10.0, 5.0, TooltipBorder::Sides, None);
         draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
 
         for row in 0..5u16 {
@@ -428,8 +424,8 @@ mod tests {
     #[test]
     fn none_border_paints_no_chrome() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 8));
-        let tt = tooltip_with(TooltipBorder::None, None);
-        let layout = make_layout(0.0, 0.0, 10.0, 3.0);
+        let tt = tooltip_with();
+        let layout = layout_with(10.0, 3.0, TooltipBorder::None, None);
         draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
 
         for row in 0..3u16 {
@@ -452,8 +448,8 @@ mod tests {
     #[test]
     fn full_border_centers_title_in_top_row() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
-        let tt = tooltip_with(TooltipBorder::default(), Some("Hi"));
-        let layout = make_layout(0.0, 0.0, 12.0, 3.0);
+        let tt = tooltip_with();
+        let layout = layout_with(12.0, 3.0, TooltipBorder::default(), Some("Hi"));
         draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
 
         // Interior columns are 1..=10 (corners at 0 and 11); " Hi " (4
@@ -470,11 +466,13 @@ mod tests {
     #[test]
     fn oversized_title_is_dropped_not_truncated() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
-        let tt = tooltip_with(
+        let tt = tooltip_with();
+        let layout = layout_with(
+            12.0,
+            3.0,
             TooltipBorder::default(),
             Some("This title is far too long for the box"),
         );
-        let layout = make_layout(0.0, 0.0, 12.0, 3.0);
         draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
 
         let top_row: String = (0..12).map(|x| cell_char(&buf, x, 0)).collect();
@@ -490,8 +488,8 @@ mod tests {
     fn title_is_ignored_when_border_is_not_full() {
         for border in [TooltipBorder::Sides, TooltipBorder::None] {
             let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
-            let tt = tooltip_with(border, Some("Hi"));
-            let layout = make_layout(0.0, 0.0, 12.0, 3.0);
+            let tt = tooltip_with();
+            let layout = layout_with(12.0, 3.0, border, Some("Hi"));
             draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
 
             let screen: String = (0..3)
@@ -512,8 +510,8 @@ mod tests {
     #[test]
     fn full_border_drops_title_when_too_short_to_close() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
-        let tt = tooltip_with(TooltipBorder::default(), Some("Hi"));
-        let layout = make_layout(0.0, 0.0, 12.0, 1.0);
+        let tt = tooltip_with();
+        let layout = layout_with(12.0, 1.0, TooltipBorder::default(), Some("Hi"));
         draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
 
         assert_eq!(cell_char(&buf, 0, 0), '│');

--- a/quadraui/src/tui/tooltip.rs
+++ b/quadraui/src/tui/tooltip.rs
@@ -1,9 +1,12 @@
 //! TUI rasteriser for [`crate::Tooltip`].
 //!
-//! Border chrome is chosen by `layout.border` (#541 —
+//! Border chrome is chosen by the [`TooltipChrome`] argument (#541 —
 //! [`crate::TooltipBorder`]), not hardcoded here — see
-//! `primitives::tooltip`'s module doc for why the vocabulary lives on
-//! [`TooltipLayout`] rather than on [`Tooltip`] itself:
+//! `primitives::tooltip`'s module doc for why the vocabulary is a
+//! sidecar value rather than a field on [`Tooltip`] or [`TooltipLayout`].
+//! [`draw_tooltip`] keeps its pre-#541 signature and renders
+//! `TooltipChrome::default()`; [`draw_tooltip_with_chrome`] takes the
+//! request explicitly:
 //!
 //! - [`TooltipBorder::Full`] (the default) renders a closed box —
 //!   `┌─┐`/`└─┘` top and bottom rows plus `│` sides — whenever the
@@ -13,7 +16,7 @@
 //!   rectangle. Below that room threshold, `Full` falls back to the
 //!   `Sides` rendering rather than an empty box — a rendering detail of
 //!   this variant, not a mode a consumer selects. An optional
-//!   `layout.title` is centred into the top row when the box closes.
+//!   `chrome.title` is centred into the top row when the box closes.
 //! - [`TooltipBorder::Sides`] always renders `│` on the first/last column
 //!   only, regardless of height — the pre-#542 TUI look, now available
 //!   by explicit request rather than as the only option. No title (no
@@ -44,7 +47,7 @@ use ratatui::buffer::Buffer;
 
 use super::{ratatui_color, set_cell};
 use crate::event::Rect as QRect;
-use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipLayout};
+use crate::primitives::tooltip::{Tooltip, TooltipBorder, TooltipChrome, TooltipLayout};
 use crate::theme::Theme;
 use crate::types::Color;
 
@@ -72,11 +75,30 @@ pub fn painted_bounds(layout: &TooltipLayout) -> QRect {
     )
 }
 
-/// Draw a [`Tooltip`] into `layout.bounds` on `buf`.
+/// Draw a [`Tooltip`] into `layout.bounds` on `buf` with the default
+/// chrome — a [`TooltipBorder::Full`] box, no title, i.e. exactly what
+/// this rasteriser drew before #541 added a choice.
 ///
 /// Per-tooltip `tooltip.fg` / `tooltip.bg` overrides win over the
 /// theme defaults. The frame border always uses [`Theme::hover_border`].
+///
+/// To ask for different chrome, call [`draw_tooltip_with_chrome`].
 pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout, theme: &Theme) {
+    draw_tooltip_with_chrome(buf, tooltip, layout, &TooltipChrome::default(), theme);
+}
+
+/// Draw a [`Tooltip`] into `layout.bounds` on `buf`, with the border and
+/// optional title requested by `chrome` (#541).
+///
+/// Per-tooltip `tooltip.fg` / `tooltip.bg` overrides win over the
+/// theme defaults. The frame border always uses [`Theme::hover_border`].
+pub fn draw_tooltip_with_chrome(
+    buf: &mut Buffer,
+    tooltip: &Tooltip,
+    layout: &TooltipLayout,
+    chrome: &TooltipChrome,
+    theme: &Theme,
+) {
     let painted = painted_bounds(layout);
     let x = painted.x as u16;
     let y = painted.y as u16;
@@ -106,10 +128,10 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
     // branches pick the left/right corner glyph, and at `w < 2` those two
     // indices collide (`w - 1 == 0`), so the `col == 0` arm would win and
     // every corner would render as a left corner.
-    let has_horizontal_border = matches!(layout.border, TooltipBorder::Full) && h >= 3 && w >= 2;
+    let has_horizontal_border = matches!(chrome.border, TooltipBorder::Full) && h >= 3 && w >= 2;
     // `None` draws no chrome at all — not even the side bars `Sides` and
     // (as a fallback) `Full` paint.
-    let draw_side_bars = !matches!(layout.border, TooltipBorder::None);
+    let draw_side_bars = !matches!(chrome.border, TooltipBorder::None);
     let content_row0: u16 = if has_horizontal_border { 1 } else { 0 };
     let content_rows: u16 = if has_horizontal_border { h - 2 } else { h };
     // Content starts one cell past the side border when one is drawn
@@ -133,6 +155,15 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
                 .map(|s| s.chars().collect())
                 .unwrap_or_default();
             let title_len = title_chars.len() as u16;
+            // Integer divide rounds down, so when `interior - title_len` is
+            // odd the title sits one column left of dead-centre (the extra
+            // column goes to the right). Deliberate and stable rather than
+            // arbitrary: cells are indivisible, so *some* side gets the odd
+            // column, and biasing left matches how the rest of this crate
+            // centres odd remainders (`tui::panel`'s title bar, `tui::
+            // dialog`'s buttons). Flagged as a cosmetic nit in the #541
+            // review; documented rather than "fixed", since rounding the
+            // other way is equally off-centre.
             let title_start = 1 + interior.saturating_sub(title_len) / 2;
 
             for col in 0..w {
@@ -165,7 +196,7 @@ pub fn draw_tooltip(buf: &mut Buffer, tooltip: &Tooltip, layout: &TooltipLayout,
                 set_cell(buf, x + col, row, ch, border, bg);
             }
         };
-        paint_border_row(buf, y, true, layout.title.as_deref());
+        paint_border_row(buf, y, true, chrome.title.as_deref());
         paint_border_row(buf, y + h - 1, false, None);
     }
 
@@ -225,8 +256,6 @@ mod tests {
         TooltipLayout {
             bounds: QRect::new(x, y, w, h),
             resolved_placement: ResolvedPlacement::Bottom,
-            border: TooltipBorder::default(),
-            title: None,
         }
     }
 
@@ -367,15 +396,20 @@ mod tests {
         Tooltip::new(WidgetId::new("hover"), "hi")
     }
 
-    /// `make_layout` plus the border/title (#541) a test wants — the
-    /// in-crate equivalent of `tooltip.layout(...).with_border(..)
-    /// .with_title(..)`.
-    fn layout_with(w: f32, h: f32, border: TooltipBorder, title: Option<&str>) -> TooltipLayout {
-        let mut layout = make_layout(0.0, 0.0, w, h).with_border(border);
+    /// `make_layout` paired with the [`TooltipChrome`] (#541) a test
+    /// wants — the in-crate equivalent of `tooltip.layout(...)` plus a
+    /// `TooltipChrome::new(..).with_title(..)` sidecar.
+    fn layout_with(
+        w: f32,
+        h: f32,
+        border: TooltipBorder,
+        title: Option<&str>,
+    ) -> (TooltipLayout, TooltipChrome) {
+        let mut chrome = TooltipChrome::new(border);
         if let Some(t) = title {
-            layout = layout.with_title(t);
+            chrome = chrome.with_title(t);
         }
-        layout
+        (make_layout(0.0, 0.0, w, h), chrome)
     }
 
     /// `Sides` must never draw top/bottom rules, even at a height that
@@ -391,8 +425,8 @@ mod tests {
         // "no border here" look identical to a genuinely-suppressed one).
         let mut tt = tooltip_with();
         tt.text = "hi\nhi\nhi\nhi\nhi".into();
-        let layout = layout_with(10.0, 5.0, TooltipBorder::Sides, None);
-        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+        let (layout, chrome) = layout_with(10.0, 5.0, TooltipBorder::Sides, None);
+        draw_tooltip_with_chrome(&mut buf, &tt, &layout, &chrome, &Theme::default());
 
         for row in 0..5u16 {
             assert_eq!(
@@ -425,8 +459,8 @@ mod tests {
     fn none_border_paints_no_chrome() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 8));
         let tt = tooltip_with();
-        let layout = layout_with(10.0, 3.0, TooltipBorder::None, None);
-        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+        let (layout, chrome) = layout_with(10.0, 3.0, TooltipBorder::None, None);
+        draw_tooltip_with_chrome(&mut buf, &tt, &layout, &chrome, &Theme::default());
 
         for row in 0..3u16 {
             for col in 0..10u16 {
@@ -449,8 +483,8 @@ mod tests {
     fn full_border_centers_title_in_top_row() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
         let tt = tooltip_with();
-        let layout = layout_with(12.0, 3.0, TooltipBorder::default(), Some("Hi"));
-        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+        let (layout, chrome) = layout_with(12.0, 3.0, TooltipBorder::default(), Some("Hi"));
+        draw_tooltip_with_chrome(&mut buf, &tt, &layout, &chrome, &Theme::default());
 
         // Interior columns are 1..=10 (corners at 0 and 11); " Hi " (4
         // chars) centred among 10 interior columns starts at col 1 + 3 = 4.
@@ -467,13 +501,13 @@ mod tests {
     fn oversized_title_is_dropped_not_truncated() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
         let tt = tooltip_with();
-        let layout = layout_with(
+        let (layout, chrome) = layout_with(
             12.0,
             3.0,
             TooltipBorder::default(),
             Some("This title is far too long for the box"),
         );
-        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+        draw_tooltip_with_chrome(&mut buf, &tt, &layout, &chrome, &Theme::default());
 
         let top_row: String = (0..12).map(|x| cell_char(&buf, x, 0)).collect();
         assert_eq!(
@@ -489,8 +523,8 @@ mod tests {
         for border in [TooltipBorder::Sides, TooltipBorder::None] {
             let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
             let tt = tooltip_with();
-            let layout = layout_with(12.0, 3.0, border, Some("Hi"));
-            draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+            let (layout, chrome) = layout_with(12.0, 3.0, border, Some("Hi"));
+            draw_tooltip_with_chrome(&mut buf, &tt, &layout, &chrome, &Theme::default());
 
             let screen: String = (0..3)
                 .flat_map(|row| (0..12).map(move |col| (col, row)))
@@ -511,8 +545,8 @@ mod tests {
     fn full_border_drops_title_when_too_short_to_close() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 30, 5));
         let tt = tooltip_with();
-        let layout = layout_with(12.0, 1.0, TooltipBorder::default(), Some("Hi"));
-        draw_tooltip(&mut buf, &tt, &layout, &Theme::default());
+        let (layout, chrome) = layout_with(12.0, 1.0, TooltipBorder::default(), Some("Hi"));
+        draw_tooltip_with_chrome(&mut buf, &tt, &layout, &chrome, &Theme::default());
 
         assert_eq!(cell_char(&buf, 0, 0), '│');
         let row: String = (0..12).map(|x| cell_char(&buf, x, 0)).collect();

--- a/quadraui/tests/conformance/c0.rs
+++ b/quadraui/tests/conformance/c0.rs
@@ -48,7 +48,8 @@ use quadraui::{
     SplitDirection, SplitTree, StageStatus, StatusBar, StatusBarSegment, StyledSpan, StyledText,
     TabBar, TabItem, Terminal, TerminalCell, TextDisplay, TextDisplayLine, TextInput, ToastCorner,
     ToastItem, ToastSeverity, ToastStack, Toolbar, ToolbarButton, ToolbarItemMeasure, Tooltip,
-    TooltipMeasure, TooltipPlacement, TreeRow, TreeStyle, TreeView, UiEvent, WidgetId,
+    TooltipBorder, TooltipMeasure, TooltipPlacement, TreeRow, TreeStyle, TreeView, UiEvent,
+    WidgetId,
 };
 
 use super::runner::{DriverFactory, DynDriver};
@@ -276,6 +277,8 @@ pub const CASES: &[Case] = &[
                 text: "c0tip".to_string(),
                 styled_lines: None,
                 placement: TooltipPlacement::Bottom,
+                border: TooltipBorder::default(),
+                title: None,
                 bg: None,
                 fg: None,
             };

--- a/quadraui/tests/conformance/c0.rs
+++ b/quadraui/tests/conformance/c0.rs
@@ -48,8 +48,8 @@ use quadraui::{
     SplitDirection, SplitTree, StageStatus, StatusBar, StatusBarSegment, StyledSpan, StyledText,
     TabBar, TabItem, Terminal, TerminalCell, TextDisplay, TextDisplayLine, TextInput, ToastCorner,
     ToastItem, ToastSeverity, ToastStack, Toolbar, ToolbarButton, ToolbarItemMeasure, Tooltip,
-    TooltipBorder, TooltipMeasure, TooltipPlacement, TreeRow, TreeStyle, TreeView, UiEvent,
-    WidgetId,
+    TooltipBorder, TooltipChrome, TooltipMeasure, TooltipPlacement, TreeRow, TreeStyle, TreeView,
+    UiEvent, WidgetId,
 };
 
 use super::runner::{DriverFactory, DynDriver};
@@ -278,10 +278,31 @@ pub const CASES: &[Case] = &[
             // measured to exactly `border + text + border` leaves no
             // padding and clips the last glyph.
             let measure = TooltipMeasure::new(cw * 9.0, lh * 3.0);
-            let layout = tooltip
-                .layout(anchor, area, measure, lh)
-                .with_border(TooltipBorder::default());
+            let layout = tooltip.layout(anchor, area, measure, lh);
             b.draw_tooltip(&tooltip, &layout);
+        },
+    },
+    Case {
+        // #541: the chrome-carrying entry point. Same content as
+        // `draw_tooltip` above (which renders `TooltipChrome::default()`),
+        // but asking explicitly for `Sides` chrome so C0 exercises a
+        // non-default request reaching the backend rather than only the
+        // delegating path.
+        method: "draw_tooltip_with_chrome",
+        needle: Some("c0chrome"),
+        paint: |b, area| {
+            let cw = b.char_width();
+            let lh = b.line_height();
+            let anchor = Rect::new(0.0, 0.0, area.width, lh);
+            let tooltip = Tooltip::new(id("tooltip-chrome"), "c0chrome")
+                .with_placement(TooltipPlacement::Bottom);
+            let measure = TooltipMeasure::new(cw * 12.0, lh * 3.0);
+            let layout = tooltip.layout(anchor, area, measure, lh);
+            b.draw_tooltip_with_chrome(
+                &tooltip,
+                &layout,
+                &TooltipChrome::new(TooltipBorder::Sides),
+            );
         },
     },
     Case {

--- a/quadraui/tests/conformance/c0.rs
+++ b/quadraui/tests/conformance/c0.rs
@@ -272,14 +272,15 @@ pub const CASES: &[Case] = &[
             let cw = b.char_width();
             let lh = b.line_height();
             let anchor = Rect::new(0.0, 0.0, area.width, lh);
-            let tooltip = Tooltip::new(id("tooltip"), "c0tip")
-                .with_placement(TooltipPlacement::Bottom)
-                .with_border(TooltipBorder::default());
+            let tooltip =
+                Tooltip::new(id("tooltip"), "c0tip").with_placement(TooltipPlacement::Bottom);
             // Room for a border on all sides plus the whole label — a box
             // measured to exactly `border + text + border` leaves no
             // padding and clips the last glyph.
             let measure = TooltipMeasure::new(cw * 9.0, lh * 3.0);
-            let layout = tooltip.layout(anchor, area, measure, lh);
+            let layout = tooltip
+                .layout(anchor, area, measure, lh)
+                .with_border(TooltipBorder::default());
             b.draw_tooltip(&tooltip, &layout);
         },
     },

--- a/quadraui/tests/conformance/c0.rs
+++ b/quadraui/tests/conformance/c0.rs
@@ -272,16 +272,9 @@ pub const CASES: &[Case] = &[
             let cw = b.char_width();
             let lh = b.line_height();
             let anchor = Rect::new(0.0, 0.0, area.width, lh);
-            let tooltip = Tooltip {
-                id: id("tooltip"),
-                text: "c0tip".to_string(),
-                styled_lines: None,
-                placement: TooltipPlacement::Bottom,
-                border: TooltipBorder::default(),
-                title: None,
-                bg: None,
-                fg: None,
-            };
+            let tooltip = Tooltip::new(id("tooltip"), "c0tip")
+                .with_placement(TooltipPlacement::Bottom)
+                .with_border(TooltipBorder::default());
             // Room for a border on all sides plus the whole label — a box
             // measured to exactly `border + text + border` leaves no
             // padding and clips the last glyph.

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -803,15 +803,17 @@ impl AppLogic for TooltipBorderFixture {
         let viewport = Rect::new(0.0, 0.0, vp.width, vp.height);
         let anchor = Rect::new(0.0, 0.0, vp.width, lh);
 
+        // Built through the `..Default::default()` spread on purpose: this
+        // is the migration shape #541's module doc hands downstream
+        // consumers, so exercising it here from an external crate keeps it
+        // compile-checked rather than merely documented.
         let tooltip = Tooltip {
             id: WidgetId::new(BORDER_TOOLTIP_ID),
             text: BORDER_TOOLTIP_TEXT.to_string(),
-            styled_lines: None,
             placement: TooltipPlacement::Bottom,
             border: self.border,
             title: self.title.clone(),
-            bg: None,
-            fg: None,
+            ..Default::default()
         };
         // Horizontal slack (+4 columns, same margin `structural_parity.rs`
         // uses) so the tier-A control below can't fail for an unrelated

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -760,6 +760,21 @@ fn frame_inventory_relations_agree_tui_and_gtk() {
 // plus an optional title — and this section is its parity coverage: for
 // every setting a consumer can choose, not just the default, TUI and GTK
 // must agree on the resulting chrome shape.
+//
+// Known, documented exception (not covered below): TUI's `Full` falls
+// back to `Sides`-style chrome when the measured box is too short to fit
+// both border rows (`height < 3`, see `tui::tooltip`'s module doc and its
+// `full_border_drops_title_when_too_short_to_close` /
+// `sides_border_never_closes_even_when_height_allows_it` unit tests,
+// which pin that fallback in isolation). GTK and macOS always stroke a
+// full rectangle regardless of height — they have no equivalent
+// short-height degrade. Every `Full` fixture below therefore measures
+// `rows: 3.0` (room enough to close on every backend) specifically so
+// this divergence never fires here; it is TUI's own rendering detail
+// rather than something a consumer selects, and asserting parity at
+// `height < 3` would be asserting two backends *disagree* by design, not
+// a parity bug. Left as a documented exception per the #541 review
+// rather than force-added coverage here.
 
 const BORDER_TOOLTIP_ID: &str = "cbp:541:tooltip";
 const BORDER_TOOLTIP_TEXT: &str = "BorderProbe";

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -19,9 +19,12 @@
 #![cfg(all(feature = "tui", feature = "gtk"))]
 
 use quadraui::gtk::testing::{driver_with_shell as gtk_driver_with_shell, GtkDriver};
-use quadraui::testing::{ConformanceDriver, LogicalViewport};
+use quadraui::testing::{ConformanceDriver, FrameInventory, LogicalViewport};
 use quadraui::tui::testing::{driver_with_shell as tui_driver_with_shell, TuiDriver};
-use quadraui::{AppLogic, DataTableLayout, NamedKey, WidgetId};
+use quadraui::{
+    AppLogic, Backend, DataTableLayout, NamedKey, Reaction, Rect, Tooltip, TooltipBorder,
+    TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
+};
 
 #[path = "../examples/common/pipeline_app.rs"]
 mod pipeline_app;
@@ -745,5 +748,274 @@ fn frame_inventory_relations_agree_tui_and_gtk() {
             "{name}: the sidebar content text must NOT fall inside the \
              main-content zone — the two zones must not overlap"
         );
+    }
+}
+
+// ─── Issue #541: Tooltip border vocabulary agrees across backends ──────────
+//
+// #542 gave the tooltip a *structural-parity* tier (sealed in
+// `tests/acceptance/ms-11/structural_parity.rs`) pinning the *default*
+// border (`TooltipBorder::Full`) so both backends enclose their text on
+// every side. #541 adds the vocabulary itself — `Sides` / `Full` / `None`
+// plus an optional title — and this section is its parity coverage: for
+// every setting a consumer can choose, not just the default, TUI and GTK
+// must agree on the resulting chrome shape.
+
+const BORDER_TOOLTIP_ID: &str = "cbp:541:tooltip";
+const BORDER_TOOLTIP_TEXT: &str = "BorderProbe";
+const BORDER_TOOLTIP_TITLE: &str = "FrameTitle";
+
+/// Draws a single `Tooltip` with the given `border`/`title`. `rows` picks
+/// the measured box height in `line_height` multiples — callers pass
+/// exactly what the variant under test needs to close (1 row for `Sides`/
+/// `None`, which never reserve a border row; 3 for `Full`, matching
+/// `structural_parity.rs`'s fixture) so any gap between the registered
+/// zone and the painted text is attributable to border chrome, not
+/// leftover slack from a box taller than its content.
+struct TooltipBorderFixture {
+    border: TooltipBorder,
+    title: Option<String>,
+    rows: f32,
+}
+
+impl AppLogic for TooltipBorderFixture {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let vp = backend.viewport();
+        let cw = backend.char_width();
+        let lh = backend.line_height();
+        let viewport = Rect::new(0.0, 0.0, vp.width, vp.height);
+        let anchor = Rect::new(0.0, 0.0, vp.width, lh);
+
+        let tooltip = Tooltip {
+            id: WidgetId::new(BORDER_TOOLTIP_ID),
+            text: BORDER_TOOLTIP_TEXT.to_string(),
+            styled_lines: None,
+            placement: TooltipPlacement::Bottom,
+            border: self.border,
+            title: self.title.clone(),
+            bg: None,
+            fg: None,
+        };
+        // Horizontal slack (+4 columns, same margin `structural_parity.rs`
+        // uses) so the tier-A control below can't fail for an unrelated
+        // reason (the last glyph clipped for lack of padding).
+        let measure = TooltipMeasure::new(
+            cw * (BORDER_TOOLTIP_TEXT.chars().count() as f32 + 4.0),
+            lh * self.rows,
+        );
+        let layout = tooltip.layout(anchor, viewport, measure, lh);
+        backend.draw_tooltip(&tooltip, &layout);
+    }
+
+    fn handle(&mut self, _event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
+        Reaction::Continue
+    }
+}
+
+fn border_frame<D, A>(app: A) -> FrameInventory
+where
+    A: AppLogic,
+    D: ConformanceDriver<App = A>,
+{
+    D::new_fixture(app, LogicalViewport::new(60, 12)).inventory()
+}
+
+/// Both backends' inventories for one `(border, title, rows)` combination,
+/// in a fixed order so every assertion below can name them the same way.
+/// `make` is called once per backend so each gets its own `AppLogic`
+/// instance.
+fn border_frames(make: impl Fn() -> TooltipBorderFixture) -> [(&'static str, FrameInventory); 2] {
+    [
+        ("TuiDriver", border_frame::<TuiDriver<_>, _>(make())),
+        ("GtkDriver", border_frame::<GtkDriver<_>, _>(make())),
+    ]
+}
+
+fn border_tooltip_zone(name: &str, inv: &FrameInventory) -> Rect {
+    inv.zones()
+        .iter()
+        .find(|z| z.id.as_str() == BORDER_TOOLTIP_ID)
+        .unwrap_or_else(|| {
+            panic!(
+                "{name}: no {BORDER_TOOLTIP_ID} zone registered — surfaces: {:?}",
+                inv.zones()
+                    .iter()
+                    .map(|z| z.id.as_str())
+                    .collect::<Vec<_>>()
+            )
+        })
+        .bounds
+}
+
+fn border_tooltip_text(name: &str, inv: &FrameInventory) -> Rect {
+    inv.text_runs()
+        .iter()
+        .find(|r| r.text.contains(BORDER_TOOLTIP_TEXT))
+        .unwrap_or_else(|| {
+            panic!(
+                "{name}: no {BORDER_TOOLTIP_TEXT:?} text run painted — \
+             painted runs: {:?}",
+                inv.text_runs()
+                    .iter()
+                    .map(|r| r.text.as_str())
+                    .collect::<Vec<_>>()
+            )
+        })
+        .bounds
+}
+
+/// `(has_top, has_bottom, has_left, has_right)` chrome — purely a
+/// comparison between the registered zone and the painted text's own
+/// bounds, so it's unit-free by construction (each backend's own cells or
+/// pixels) and comparable across backends without a conversion factor,
+/// the same technique
+/// `structural_parity_tooltip_surface_encloses_its_text_on_every_side`
+/// uses for the default (`Full`) setting.
+fn chrome_sides(name: &str, inv: &FrameInventory) -> (bool, bool, bool, bool) {
+    let zone = border_tooltip_zone(name, inv);
+    let text = border_tooltip_text(name, inv);
+    (
+        zone.y < text.y,
+        zone.y + zone.height > text.y + text.height,
+        zone.x < text.x,
+        zone.x + zone.width > text.x + text.width,
+    )
+}
+
+/// Total vertical gap (top + bottom) between the registered zone and the
+/// painted text, as a fraction of the text's own height — unit-free by
+/// construction, like `chrome_sides`, but a ratio rather than a boolean:
+/// GTK reserves a fixed ~2px top pad for content *regardless* of border
+/// (`text_top = by + 2.0` in `gtk::tooltip::draw_tooltip`), so a `Sides`/
+/// `None` tooltip's gap is never *exactly* zero there the way it is on
+/// TUI (whole-cell rows, no sub-cell padding) — an inherent unit
+/// difference, not a chrome difference. Comparing this ratio against the
+/// same backend's `Full` ratio (see the two tests below) routes around
+/// that: what should agree across backends isn't the raw gap, it's
+/// *how much smaller* a borderless variant's gap is than a boxed one's.
+fn vertical_gap_ratio(name: &str, inv: &FrameInventory) -> f32 {
+    let zone = border_tooltip_zone(name, inv);
+    let text = border_tooltip_text(name, inv);
+    let top_gap = (text.y - zone.y).max(0.0);
+    let bottom_gap = ((zone.y + zone.height) - (text.y + text.height)).max(0.0);
+    (top_gap + bottom_gap) / text.height.max(f32::EPSILON)
+}
+
+/// Both backends' `vertical_gap_ratio` for the default (`Full`) setting —
+/// the reference "this is what real border chrome costs" measurement the
+/// borderless-variant tests below compare against.
+fn full_border_vertical_gap_ratios() -> [(&'static str, f32); 2] {
+    let frames = border_frames(|| TooltipBorderFixture {
+        border: TooltipBorder::default(),
+        title: None,
+        rows: 3.0,
+    });
+    [
+        (frames[0].0, vertical_gap_ratio(frames[0].0, &frames[0].1)),
+        (frames[1].0, vertical_gap_ratio(frames[1].0, &frames[1].1)),
+    ]
+}
+
+#[test]
+fn sides_border_has_horizontal_chrome_and_far_less_vertical_gap_than_full_on_both_backends() {
+    let full_ratios = full_border_vertical_gap_ratios();
+    let frames = border_frames(|| TooltipBorderFixture {
+        border: TooltipBorder::Sides,
+        title: None,
+        rows: 1.4,
+    });
+
+    for (i, (name, inv)) in frames.iter().enumerate() {
+        let (_top, _bottom, left, right) = chrome_sides(name, inv);
+        assert!(
+            left && right,
+            "{name}: TooltipBorder::Sides must still enclose its text horizontally — the \
+             side bars are the whole point of this variant (left={left}, right={right})"
+        );
+
+        let sides_ratio = vertical_gap_ratio(name, inv);
+        let full_ratio = full_ratios[i].1;
+        assert!(
+            sides_ratio < full_ratio * 0.5,
+            "{name}: Sides' vertical gap ({sides_ratio}× its text height) should be far \
+             smaller than Full's ({full_ratio}× — real top/bottom border rows) — Sides never \
+             draws a top/bottom rule, regardless of box height"
+        );
+    }
+}
+
+#[test]
+fn none_border_has_far_less_vertical_gap_than_full_on_both_backends() {
+    let full_ratios = full_border_vertical_gap_ratios();
+    let frames = border_frames(|| TooltipBorderFixture {
+        border: TooltipBorder::None,
+        title: None,
+        rows: 1.4,
+    });
+
+    for (i, (name, inv)) in frames.iter().enumerate() {
+        let none_ratio = vertical_gap_ratio(name, inv);
+        let full_ratio = full_ratios[i].1;
+        assert!(
+            none_ratio < full_ratio * 0.5,
+            "{name}: None's vertical gap ({none_ratio}× its text height) should be far \
+             smaller than Full's ({full_ratio}× — real top/bottom border rows) — None draws \
+             no chrome at all"
+        );
+    }
+}
+
+#[test]
+fn full_border_title_reaches_every_backend_and_sits_above_the_content() {
+    let frames = border_frames(|| TooltipBorderFixture {
+        border: TooltipBorder::default(),
+        title: Some(BORDER_TOOLTIP_TITLE.to_string()),
+        rows: 3.0,
+    });
+
+    for (name, inv) in &frames {
+        assert!(
+            inv.screen_has(BORDER_TOOLTIP_TITLE),
+            "{name}: a Full-bordered tooltip's title must reach the screen — \
+             painted runs: {:?}",
+            inv.text_runs()
+                .iter()
+                .map(|r| r.text.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            inv.screen_has(BORDER_TOOLTIP_TEXT),
+            "{name}: the body text must still reach the screen alongside the title"
+        );
+        assert!(
+            inv.above(BORDER_TOOLTIP_TITLE, BORDER_TOOLTIP_TEXT),
+            "{name}: the title (embedded in the top border row) must sit above the body \
+             text (the first content row) — title and content must not collide"
+        );
+    }
+}
+
+#[test]
+fn title_does_not_reach_the_screen_when_border_is_not_full() {
+    for border in [TooltipBorder::Sides, TooltipBorder::None] {
+        let frames = border_frames(|| TooltipBorderFixture {
+            border,
+            title: Some(BORDER_TOOLTIP_TITLE.to_string()),
+            rows: 1.4,
+        });
+
+        for (name, inv) in &frames {
+            assert!(
+                inv.absent(BORDER_TOOLTIP_TITLE),
+                "{name}: {border:?} has no top rule to embed a title in — it must not \
+                 leak into the content area either. painted runs: {:?}",
+                inv.text_runs()
+                    .iter()
+                    .map(|r| r.text.as_str())
+                    .collect::<Vec<_>>()
+            );
+        }
     }
 }

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -23,7 +23,7 @@ use quadraui::testing::{ConformanceDriver, FrameInventory, LogicalViewport};
 use quadraui::tui::testing::{driver_with_shell as tui_driver_with_shell, TuiDriver};
 use quadraui::{
     AppLogic, Backend, DataTableLayout, NamedKey, Reaction, Rect, Tooltip, TooltipBorder,
-    TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
+    TooltipChrome, TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
 };
 
 #[path = "../examples/common/pipeline_app.rs"]
@@ -775,6 +775,18 @@ fn frame_inventory_relations_agree_tui_and_gtk() {
 // `height < 3` would be asserting two backends *disagree* by design, not
 // a parity bug. Left as a documented exception per the #541 review
 // rather than force-added coverage here.
+//
+// Scope note — this file is a *two*-backend harness, not a three-backend
+// one. `ConformanceDriver` has `TuiDriver` and `GtkDriver` implementations
+// only; there is no `MacDriver`, so macOS cannot participate in any test
+// here (pre-existing infra gap, not something #541 introduced or could
+// close). macOS's side of the #541 vocabulary is covered instead by
+// direct pixel-probe unit tests in `src/macos/tooltip.rs`
+// (`sides_border_only_strokes_left_and_right`, `none_border_strokes_nothing`,
+// `full_border_title_punches_a_gap_...`, `title_is_ignored_when_border_is_
+// sides_or_none`), which mirror the GTK rasteriser's assertions one for one.
+// Anyone treating this file as the single source of truth across all three
+// backends should read those too.
 
 const BORDER_TOOLTIP_ID: &str = "cbp:541:tooltip";
 const BORDER_TOOLTIP_TEXT: &str = "BorderProbe";
@@ -803,10 +815,11 @@ impl AppLogic for TooltipBorderFixture {
         let viewport = Rect::new(0.0, 0.0, vp.width, vp.height);
         let anchor = Rect::new(0.0, 0.0, vp.width, lh);
 
-        // `border`/`title` (#541) are set on the *layout*, not the
-        // `Tooltip` itself — see `primitives::tooltip`'s module doc for
-        // why: it keeps every exhaustive `Tooltip { .. }` literal (in-tree
-        // and downstream) compiling untouched by this issue.
+        // `border`/`title` (#541) travel in a `TooltipChrome` sidecar
+        // passed alongside the tooltip and its layout — not as fields on
+        // either. See `primitives::tooltip`'s module doc for why: it keeps
+        // every exhaustive `Tooltip { .. }` *and* `TooltipLayout { .. }`
+        // literal (in-tree and downstream) compiling untouched.
         let tooltip = Tooltip::new(
             WidgetId::new(BORDER_TOOLTIP_ID),
             BORDER_TOOLTIP_TEXT.to_string(),
@@ -819,13 +832,12 @@ impl AppLogic for TooltipBorderFixture {
             cw * (BORDER_TOOLTIP_TEXT.chars().count() as f32 + 4.0),
             lh * self.rows,
         );
-        let mut layout = tooltip
-            .layout(anchor, viewport, measure, lh)
-            .with_border(self.border);
+        let layout = tooltip.layout(anchor, viewport, measure, lh);
+        let mut chrome = TooltipChrome::new(self.border);
         if let Some(title) = self.title.clone() {
-            layout = layout.with_title(title);
+            chrome = chrome.with_title(title);
         }
-        backend.draw_tooltip(&tooltip, &layout);
+        backend.draw_tooltip_with_chrome(&tooltip, &layout, &chrome);
     }
 
     fn handle(&mut self, _event: UiEvent, _backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/tests/cross_backend_parity.rs
+++ b/quadraui/tests/cross_backend_parity.rs
@@ -803,18 +803,15 @@ impl AppLogic for TooltipBorderFixture {
         let viewport = Rect::new(0.0, 0.0, vp.width, vp.height);
         let anchor = Rect::new(0.0, 0.0, vp.width, lh);
 
-        // Built through the `..Default::default()` spread on purpose: this
-        // is the migration shape #541's module doc hands downstream
-        // consumers, so exercising it here from an external crate keeps it
-        // compile-checked rather than merely documented.
-        let tooltip = Tooltip {
-            id: WidgetId::new(BORDER_TOOLTIP_ID),
-            text: BORDER_TOOLTIP_TEXT.to_string(),
-            placement: TooltipPlacement::Bottom,
-            border: self.border,
-            title: self.title.clone(),
-            ..Default::default()
-        };
+        // `border`/`title` (#541) are set on the *layout*, not the
+        // `Tooltip` itself — see `primitives::tooltip`'s module doc for
+        // why: it keeps every exhaustive `Tooltip { .. }` literal (in-tree
+        // and downstream) compiling untouched by this issue.
+        let tooltip = Tooltip::new(
+            WidgetId::new(BORDER_TOOLTIP_ID),
+            BORDER_TOOLTIP_TEXT.to_string(),
+        )
+        .with_placement(TooltipPlacement::Bottom);
         // Horizontal slack (+4 columns, same margin `structural_parity.rs`
         // uses) so the tier-A control below can't fail for an unrelated
         // reason (the last glyph clipped for lack of padding).
@@ -822,7 +819,12 @@ impl AppLogic for TooltipBorderFixture {
             cw * (BORDER_TOOLTIP_TEXT.chars().count() as f32 + 4.0),
             lh * self.rows,
         );
-        let layout = tooltip.layout(anchor, viewport, measure, lh);
+        let mut layout = tooltip
+            .layout(anchor, viewport, measure, lh)
+            .with_border(self.border);
+        if let Some(title) = self.title.clone() {
+            layout = layout.with_title(title);
+        }
         backend.draw_tooltip(&tooltip, &layout);
     }
 

--- a/quadraui/tests/gtk_painted_text_coverage.rs
+++ b/quadraui/tests/gtk_painted_text_coverage.rs
@@ -480,16 +480,9 @@ impl AppLogic for TooltipFixtureApp {
     type AreaId = ();
 
     fn render(&self, backend: &mut dyn Backend, _area: ()) {
-        let tooltip = Tooltip {
-            id: WidgetId::new("tip"),
-            text: "Hover hint".into(),
-            styled_lines: None,
-            placement: TooltipPlacement::Bottom,
-            border: TooltipBorder::default(),
-            title: None,
-            fg: None,
-            bg: None,
-        };
+        let tooltip = Tooltip::new(WidgetId::new("tip"), "Hover hint")
+            .with_placement(TooltipPlacement::Bottom)
+            .with_border(TooltipBorder::default());
         let layout = TooltipLayout {
             bounds: Rect::new(10.0, 10.0, 120.0, 24.0),
             resolved_placement: ResolvedPlacement::Bottom,

--- a/quadraui/tests/gtk_painted_text_coverage.rs
+++ b/quadraui/tests/gtk_painted_text_coverage.rs
@@ -40,7 +40,8 @@ use quadraui::gtk::testing::{driver_with_shell, GtkDriver};
 use quadraui::{
     compute_find_replace_hit_regions, AppLogic, Backend, CommandCenter, CompletionItem,
     CompletionItemMeasure, CompletionKind, Completions, FindReplacePanel, Reaction, Rect,
-    ResolvedPlacement, StyledText, Tooltip, TooltipLayout, TooltipPlacement, UiEvent, WidgetId,
+    ResolvedPlacement, StyledText, Tooltip, TooltipBorder, TooltipLayout, TooltipPlacement,
+    UiEvent, WidgetId,
 };
 
 #[path = "../examples/common/ai_transcript.rs"]
@@ -484,6 +485,8 @@ impl AppLogic for TooltipFixtureApp {
             text: "Hover hint".into(),
             styled_lines: None,
             placement: TooltipPlacement::Bottom,
+            border: TooltipBorder::default(),
+            title: None,
             fg: None,
             bg: None,
         };

--- a/quadraui/tests/gtk_painted_text_coverage.rs
+++ b/quadraui/tests/gtk_painted_text_coverage.rs
@@ -481,11 +481,12 @@ impl AppLogic for TooltipFixtureApp {
 
     fn render(&self, backend: &mut dyn Backend, _area: ()) {
         let tooltip = Tooltip::new(WidgetId::new("tip"), "Hover hint")
-            .with_placement(TooltipPlacement::Bottom)
-            .with_border(TooltipBorder::default());
+            .with_placement(TooltipPlacement::Bottom);
         let layout = TooltipLayout {
             bounds: Rect::new(10.0, 10.0, 120.0, 24.0),
             resolved_placement: ResolvedPlacement::Bottom,
+            border: TooltipBorder::default(),
+            title: None,
         };
         backend.draw_tooltip(&tooltip, &layout);
     }

--- a/quadraui/tests/gtk_painted_text_coverage.rs
+++ b/quadraui/tests/gtk_painted_text_coverage.rs
@@ -40,8 +40,8 @@ use quadraui::gtk::testing::{driver_with_shell, GtkDriver};
 use quadraui::{
     compute_find_replace_hit_regions, AppLogic, Backend, CommandCenter, CompletionItem,
     CompletionItemMeasure, CompletionKind, Completions, FindReplacePanel, Reaction, Rect,
-    ResolvedPlacement, StyledText, Tooltip, TooltipBorder, TooltipLayout, TooltipPlacement,
-    UiEvent, WidgetId,
+    ResolvedPlacement, StyledText, Tooltip, TooltipBorder, TooltipChrome, TooltipLayout,
+    TooltipPlacement, UiEvent, WidgetId,
 };
 
 #[path = "../examples/common/ai_transcript.rs"]
@@ -485,10 +485,12 @@ impl AppLogic for TooltipFixtureApp {
         let layout = TooltipLayout {
             bounds: Rect::new(10.0, 10.0, 120.0, 24.0),
             resolved_placement: ResolvedPlacement::Bottom,
-            border: TooltipBorder::default(),
-            title: None,
         };
-        backend.draw_tooltip(&tooltip, &layout);
+        backend.draw_tooltip_with_chrome(
+            &tooltip,
+            &layout,
+            &TooltipChrome::new(TooltipBorder::default()),
+        );
     }
 
     fn handle(&mut self, _event: UiEvent, _backend: &mut dyn Backend) -> Reaction {

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -96,6 +96,8 @@ mod tab_group_demo;
 mod text_input_demo;
 #[path = "../examples/common/toast_app.rs"]
 mod toast_app;
+#[path = "../examples/common/tooltip_demo.rs"]
+mod tooltip_demo;
 
 use ai_transcript::AiTranscript;
 use appshell_demo::AppShellDemo;
@@ -132,6 +134,7 @@ use split_tree_app::SplitTreeApp;
 use tab_group_demo::TabGroupDemo;
 use text_input_demo::TextInputDemo;
 use toast_app::ToastApp;
+use tooltip_demo::TooltipDemo;
 
 // ─── PipelineApp: mouse + keyboard + reset ──────────────────────────────────
 
@@ -3528,6 +3531,108 @@ fn toast_dismiss_click_removes_it_then_trigger_adds_a_new_one() {
     assert!(
         after_add.contains("Success notification"),
         "pressing '2' should trigger and paint a new Success toast:\n{after_add}"
+    );
+}
+
+// ─── TooltipDemo (#541): border vocabulary + title round-trip ─────────────
+//
+// `TooltipDemo` starts at `TooltipBorder::Full` with a title, so the
+// initial screen should show a closed box (all four corner glyphs) with
+// the title text embedded in the top row. Pressing '1' switches to
+// `Sides`: the corners and top/bottom rule disappear but the left/right
+// `│` bars (and the title, which `Sides` never renders) stay gone.
+// Pressing '3' switches to `None`: no border chrome at all, not even the
+// side bars. Pressing 't' toggles the title independently of the border
+// choice. A regression in `Tooltip::border`/`Tooltip::title` plumbing, or
+// in the TUI rasteriser's per-variant chrome selection, shows up here as
+// the wrong glyphs (or the title) persisting after a mode switch.
+
+#[test]
+fn tooltip_demo_initial_screen_is_a_full_box_with_title() {
+    let driver = TuiDriver::new(TooltipDemo::new(), 60, 12);
+    let screen = driver.screen();
+    assert!(
+        screen.contains("Tooltip content"),
+        "tooltip text should paint:\n{screen}"
+    );
+    assert!(
+        screen.contains('┌')
+            && screen.contains('┐')
+            && screen.contains('└')
+            && screen.contains('┘'),
+        "TooltipDemo starts at TooltipBorder::Full — all four corners should paint:\n{screen}"
+    );
+    assert!(
+        screen.contains("Info"),
+        "TooltipDemo starts with the title shown — it should be embedded in the top border row:\n{screen}"
+    );
+}
+
+#[test]
+fn tooltip_demo_key_1_switches_to_sides_border_and_drops_the_title() {
+    let mut driver = TuiDriver::new(TooltipDemo::new(), 60, 12);
+    driver.type_char('1');
+    let screen = driver.screen();
+    assert!(
+        screen.contains("Tooltip content"),
+        "tooltip text should still paint under Sides:\n{screen}"
+    );
+    assert!(
+        !screen.contains('┌')
+            && !screen.contains('┐')
+            && !screen.contains('└')
+            && !screen.contains('┘'),
+        "Sides never draws top/bottom chrome or corners:\n{screen}"
+    );
+    assert!(
+        screen.contains('│'),
+        "Sides still draws the left/right bars:\n{screen}"
+    );
+    assert!(
+        !screen.contains("Info"),
+        "Sides has no top rule to embed a title in — it must not render:\n{screen}"
+    );
+}
+
+#[test]
+fn tooltip_demo_key_3_switches_to_none_border_dropping_all_chrome() {
+    let mut driver = TuiDriver::new(TooltipDemo::new(), 60, 12);
+    driver.type_char('3');
+    let screen = driver.screen();
+    assert!(
+        screen.contains("Tooltip content"),
+        "tooltip text should still paint under None:\n{screen}"
+    );
+    assert!(
+        !screen.contains('┌') && !screen.contains('│'),
+        "None draws no border chrome at all — not even side bars:\n{screen}"
+    );
+}
+
+#[test]
+fn tooltip_demo_key_t_toggles_the_title_independently_of_the_border() {
+    let mut driver = TuiDriver::new(TooltipDemo::new(), 60, 12);
+    assert!(
+        driver.screen().contains("Info"),
+        "starts with the title shown"
+    );
+
+    driver.type_char('t');
+    let after_off = driver.screen();
+    assert!(
+        !after_off.contains("Info"),
+        "'t' should hide the title:\n{after_off}"
+    );
+    assert!(
+        after_off.contains('┌'),
+        "toggling the title must not affect the border, still Full:\n{after_off}"
+    );
+
+    driver.type_char('t');
+    let after_on = driver.screen();
+    assert!(
+        after_on.contains("Info"),
+        "'t' again should bring the title back:\n{after_on}"
     );
 }
 

--- a/tests/acceptance/ms-11/c0_paint_smoke.rs
+++ b/tests/acceptance/ms-11/c0_paint_smoke.rs
@@ -329,11 +329,6 @@ mod ms11_492_c0_paint_smoke {
                     text: "c0tip".to_string(),
                     styled_lines: None,
                     placement: TooltipPlacement::Bottom,
-                    // #541 added this field after this slice was sealed;
-                    // left at its default (`Full`) — compile-fix, not a
-                    // test-logic change.
-                    border: quadraui::TooltipBorder::default(),
-                    title: None,
                     bg: None,
                     fg: None,
                 };

--- a/tests/acceptance/ms-11/c0_paint_smoke.rs
+++ b/tests/acceptance/ms-11/c0_paint_smoke.rs
@@ -88,8 +88,8 @@ mod ms11_492_c0_paint_smoke {
         DiffMode, DiffPane, DiffView, DropOverlay, ListItem, ListView, MessageList, MessageRow,
         PipelineStage, PipelineView, ProgressBar, Reaction, Rect, ScrollAxis, Scrollbar,
         SelectionMode, Spinner, StageStatus, StatusBar, StatusBarSegment, StyledSpan, StyledText,
-        TabBar, TabItem, TextDisplay, TextDisplayLine, Tooltip, TooltipMeasure, TooltipPlacement,
-        TreeRow, TreeStyle, TreeView, UiEvent, WidgetId,
+        TabBar, TabItem, TextDisplay, TextDisplayLine, Tooltip, TooltipMeasure, TreeRow,
+        TreeStyle, TreeView, UiEvent, WidgetId,
     };
 
     /// Backend-neutral viewport. `LogicalViewport` is the unit-free
@@ -324,14 +324,7 @@ mod ms11_492_c0_paint_smoke {
                 let cw = b.char_width();
                 let lh = b.line_height();
                 let anchor = Rect::new(0.0, 0.0, area.width, lh);
-                let tooltip = Tooltip {
-                    id: id("tooltip"),
-                    text: "c0tip".to_string(),
-                    styled_lines: None,
-                    placement: TooltipPlacement::Bottom,
-                    bg: None,
-                    fg: None,
-                };
+                let tooltip = Tooltip::new(id("tooltip"), "c0tip".to_string());
                 // Room for a border on all four sides plus the whole label
                 // — a box measured to exactly `border + text + border`
                 // leaves a backend no padding and clips the last glyph.

--- a/tests/acceptance/ms-11/c0_paint_smoke.rs
+++ b/tests/acceptance/ms-11/c0_paint_smoke.rs
@@ -329,6 +329,11 @@ mod ms11_492_c0_paint_smoke {
                     text: "c0tip".to_string(),
                     styled_lines: None,
                     placement: TooltipPlacement::Bottom,
+                    // #541 added this field after this slice was sealed;
+                    // left at its default (`Full`) — compile-fix, not a
+                    // test-logic change.
+                    border: quadraui::TooltipBorder::default(),
+                    title: None,
                     bg: None,
                     fg: None,
                 };

--- a/tests/acceptance/ms-11/c0_paint_smoke.rs
+++ b/tests/acceptance/ms-11/c0_paint_smoke.rs
@@ -88,8 +88,8 @@ mod ms11_492_c0_paint_smoke {
         DiffMode, DiffPane, DiffView, DropOverlay, ListItem, ListView, MessageList, MessageRow,
         PipelineStage, PipelineView, ProgressBar, Reaction, Rect, ScrollAxis, Scrollbar,
         SelectionMode, Spinner, StageStatus, StatusBar, StatusBarSegment, StyledSpan, StyledText,
-        TabBar, TabItem, TextDisplay, TextDisplayLine, Tooltip, TooltipMeasure, TreeRow,
-        TreeStyle, TreeView, UiEvent, WidgetId,
+        TabBar, TabItem, TextDisplay, TextDisplayLine, Tooltip, TooltipMeasure, TooltipPlacement,
+        TreeRow, TreeStyle, TreeView, UiEvent, WidgetId,
     };
 
     /// Backend-neutral viewport. `LogicalViewport` is the unit-free
@@ -324,7 +324,14 @@ mod ms11_492_c0_paint_smoke {
                 let cw = b.char_width();
                 let lh = b.line_height();
                 let anchor = Rect::new(0.0, 0.0, area.width, lh);
-                let tooltip = Tooltip::new(id("tooltip"), "c0tip".to_string());
+                let tooltip = Tooltip {
+                    id: id("tooltip"),
+                    text: "c0tip".to_string(),
+                    styled_lines: None,
+                    placement: TooltipPlacement::Bottom,
+                    bg: None,
+                    fg: None,
+                };
                 // Room for a border on all four sides plus the whole label
                 // — a box measured to exactly `border + text + border`
                 // leaves a backend no padding and clips the last glyph.

--- a/tests/acceptance/ms-11/structural_parity.rs
+++ b/tests/acceptance/ms-11/structural_parity.rs
@@ -138,12 +138,6 @@ mod ms11_542_structural_parity {
                 text: TOOLTIP_TEXT.to_string(),
                 styled_lines: None,
                 placement: TooltipPlacement::Bottom,
-                // #541 added this field after this slice was sealed; left at
-                // its default (`Full`) so the enclosure assertions below
-                // keep observing exactly the behaviour they were written
-                // against — this is a compile-fix, not a test-logic change.
-                border: quadraui::TooltipBorder::default(),
-                title: None,
                 bg: None,
                 fg: None,
             };

--- a/tests/acceptance/ms-11/structural_parity.rs
+++ b/tests/acceptance/ms-11/structural_parity.rs
@@ -138,6 +138,12 @@ mod ms11_542_structural_parity {
                 text: TOOLTIP_TEXT.to_string(),
                 styled_lines: None,
                 placement: TooltipPlacement::Bottom,
+                // #541 added this field after this slice was sealed; left at
+                // its default (`Full`) so the enclosure assertions below
+                // keep observing exactly the behaviour they were written
+                // against — this is a compile-fix, not a test-logic change.
+                border: quadraui::TooltipBorder::default(),
+                title: None,
                 bg: None,
                 fg: None,
             };

--- a/tests/acceptance/ms-11/structural_parity.rs
+++ b/tests/acceptance/ms-11/structural_parity.rs
@@ -68,7 +68,7 @@ mod ms11_542_structural_parity {
     use quadraui::tui::testing::TuiDriver;
     use quadraui::{
         AppLogic, AppShell, Backend, Color, PanelDefinition, Reaction, Rect, StatusBar,
-        StatusBarSegment, Tooltip, TooltipMeasure, UiEvent, WidgetId,
+        StatusBarSegment, Tooltip, TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
     };
 
     /// #541's live case, kept verbatim so the clause names the bug it came
@@ -133,7 +133,14 @@ mod ms11_542_structural_parity {
             };
             let _ = backend.draw_status_bar(anchor, &bar, None, None);
 
-            let tooltip = Tooltip::new(WidgetId::new(TOOLTIP_ID), TOOLTIP_TEXT.to_string());
+            let tooltip = Tooltip {
+                id: WidgetId::new(TOOLTIP_ID),
+                text: TOOLTIP_TEXT.to_string(),
+                styled_lines: None,
+                placement: TooltipPlacement::Bottom,
+                bg: None,
+                fg: None,
+            };
             // One text line plus a row of chrome above and below it, and
             // room for chrome either side — i.e. a box big enough for a
             // border on all four sides *and* the whole label. Expressed in

--- a/tests/acceptance/ms-11/structural_parity.rs
+++ b/tests/acceptance/ms-11/structural_parity.rs
@@ -68,7 +68,7 @@ mod ms11_542_structural_parity {
     use quadraui::tui::testing::TuiDriver;
     use quadraui::{
         AppLogic, AppShell, Backend, Color, PanelDefinition, Reaction, Rect, StatusBar,
-        StatusBarSegment, Tooltip, TooltipMeasure, TooltipPlacement, UiEvent, WidgetId,
+        StatusBarSegment, Tooltip, TooltipMeasure, UiEvent, WidgetId,
     };
 
     /// #541's live case, kept verbatim so the clause names the bug it came
@@ -133,14 +133,7 @@ mod ms11_542_structural_parity {
             };
             let _ = backend.draw_status_bar(anchor, &bar, None, None);
 
-            let tooltip = Tooltip {
-                id: WidgetId::new(TOOLTIP_ID),
-                text: TOOLTIP_TEXT.to_string(),
-                styled_lines: None,
-                placement: TooltipPlacement::Bottom,
-                bg: None,
-                fg: None,
-            };
+            let tooltip = Tooltip::new(WidgetId::new(TOOLTIP_ID), TOOLTIP_TEXT.to_string());
             // One text line plus a row of chrome above and below it, and
             // room for chrome either side — i.e. a box big enough for a
             // border on all four sides *and* the whole label. Expressed in


### PR DESCRIPTION
Closes #541

Automated PR opened by coordinator for review of issue #541.