### PR TITLE
#600: Backend::draw_board has a no-op default impl, violating rule 7 — macOS silently paints an empty board and the #538 gate cannot see it

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -1197,16 +1197,11 @@ pub trait Backend {
     /// (DataTable pattern: host reads `layout.columns[i].visible_cards`
     /// and adjusts `column.scroll_offset` accordingly).
     ///
-    /// Has a default impl that computes layout without painting anything
-    /// (an empty `BoardLayout` sized to `rect`), so backends that haven't
-    /// implemented a board rasteriser yet (macOS, Windows) still satisfy
-    /// the trait. Override once the backend has a real rasteriser.
-    fn draw_board(&mut self, rect: Rect, _model: &BoardModel) -> BoardLayout {
-        BoardLayout {
-            bounds: rect,
-            columns: vec![],
-        }
-    }
+    /// No default impl — every backend implementer sees this as a compile
+    /// error and fills in a real rasteriser (`PRIMITIVE_RULES.md` rule 7).
+    /// A no-op default here would let a backend silently paint an empty
+    /// board instead of failing to build (quadraui#600, PORT-01).
+    fn draw_board(&mut self, rect: Rect, model: &BoardModel) -> BoardLayout;
 }
 
 // ── Shared layout helpers ───────────────────────────────────────────────

--- a/quadraui/src/primitives/board.rs
+++ b/quadraui/src/primitives/board.rs
@@ -32,11 +32,11 @@
 //!
 //! ## Portability
 //!
-//! Part of the `Backend` trait: `draw_board` has a default (no-op paint)
-//! impl so every backend satisfies the trait, and backends override it
-//! once they have a real rasteriser. Apps write
-//! `backend.draw_board(rect, &model)` once and pick up each backend's
-//! rasteriser as it lands.
+//! Part of the `Backend` trait: `draw_board` is required (no default
+//! impl — quadraui#600), so every backend implementer supplies a real
+//! rasteriser (or an explicit `todo!()` stub, per convention). Apps
+//! write `backend.draw_board(rect, &model)` once and pick up each
+//! backend's rasteriser as it lands.
 
 use crate::event::{Point, Rect};
 use crate::types::{Modifiers, WidgetId};

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -396,6 +396,10 @@ impl Backend for WinBackend {
         todo!("DirectWrite split-tree layout")
     }
 
+    fn draw_board(&mut self, _rect: Rect, _model: &crate::BoardModel) -> crate::BoardLayout {
+        todo!("Direct2D board rasteriser")
+    }
+
     fn draw_panel(&mut self, _rect: Rect, _panel: &Panel) -> PanelLayout {
         todo!("Direct2D panel rasteriser")
     }


### PR DESCRIPTION
Closes #600

Automated PR opened by coordinator for review of issue #600.