### PR TITLE
#595: SidebarSystem: reveal(section, path) — a programmatic selection never scrolls into view

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -646,3 +646,18 @@ required-features = ["gtk"]
 name = "tui_wide_tab_bar_demo"
 path = "examples/tui_wide_tab_bar_demo.rs"
 required-features = ["tui"]
+
+# #595 — `SidebarSystem::reveal`. Both entries are mandatory, not
+# cosmetic: without an explicit `[[example]]`, cargo's autodiscovery
+# picks the file up with NO `required-features`, so
+# `gtk_sidebar_reveal.rs` gets compiled by `cargo test --features tui`
+# and fails on `quadraui::gtk` being configured out.
+[[example]]
+name = "tui_sidebar_reveal"
+path = "examples/tui_sidebar_reveal.rs"
+required-features = ["tui"]
+
+[[example]]
+name = "gtk_sidebar_reveal"
+path = "examples/gtk_sidebar_reveal.rs"
+required-features = ["gtk"]

--- a/quadraui/examples/common/folder_picker_app.rs
+++ b/quadraui/examples/common/folder_picker_app.rs
@@ -32,6 +32,10 @@ pub struct FolderPickerApp {
     picker: Option<FolderPickerController>,
     confirmed_path: Option<PathBuf>,
     status: String,
+    /// Directory the picker is (re)opened at — captured once so `o`
+    /// reopens where the app started rather than re-reading the
+    /// process's working directory.
+    root: PathBuf,
 }
 
 impl FolderPickerApp {
@@ -41,11 +45,24 @@ impl FolderPickerApp {
         // platform-neutral. The picker will still walk something sensible
         // from the process's working directory.
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let picker = FolderPickerController::new(cwd, vec![], false);
+        Self::with_root(cwd)
+    }
+
+    /// Open the picker at an explicit `root` instead of the process's
+    /// working directory.
+    ///
+    /// The runnable examples use [`Self::new`]; this exists so tests can
+    /// drive the demo against a directory they control (path length,
+    /// entry names) rather than inheriting whatever the checkout
+    /// happens to sit under.
+    pub fn with_root(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        let picker = FolderPickerController::new(root.clone(), vec![], false);
         Self {
             picker: Some(picker),
             confirmed_path: None,
             status: "Open Folder picker — navigate and press Enter to confirm".into(),
+            root,
         }
     }
 
@@ -75,8 +92,21 @@ impl FolderPickerApp {
                 action_id: None,
             }],
             right_segments: if let Some(ref p) = self.confirmed_path {
+                // Only the final component — the full path is already in
+                // the left segment. A right segment wider than the bar is
+                // laid out at column 0 (see `StatusBar::layout`: the
+                // highest-priority right segment is kept even when it
+                // alone overflows) and painted *after* the left segments,
+                // so an absolute path longer than the terminal is wide
+                // would blank the "Confirmed: …" message entirely — which
+                // is exactly what happens when the checkout lives under a
+                // long directory.
+                let leaf = p
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| p.display().to_string());
                 vec![StatusBarSegment {
-                    text: format!(" ✓ {} ", p.display()),
+                    text: format!(" ✓ {leaf} "),
                     fg: Color::rgb(150, 240, 150),
                     bg: Color::rgb(30, 80, 30),
                     bold: false,
@@ -153,12 +183,13 @@ impl AppLogic for FolderPickerApp {
                         return Reaction::Exit;
                     }
                     Key::Char('o') => {
-                        // Fallback to "." (current dir relative) if `current_dir()` fails.
-                        // `PathBuf::from("/")` would be invalid on Windows, so we keep this
-                        // platform-neutral. The picker will still walk something sensible
-                        // from the process's working directory.
-                        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-                        self.picker = Some(FolderPickerController::new(cwd, vec![], false));
+                        // Reopen at the root this app was constructed with
+                        // (the process's working directory for `new()`).
+                        self.picker = Some(FolderPickerController::new(
+                            self.root.clone(),
+                            vec![],
+                            false,
+                        ));
                         self.status =
                             "Open Folder picker — navigate and press Enter to confirm".into();
                         return Reaction::Redraw;

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -23,6 +23,9 @@
 //! - [`ChatDemo`] (in [`chat_demo`]) — `ChatController` overlay with
 //!   scrollable transcript, multi-line input, history, and spinner,
 //!   used by `tui_chat` / `gtk_chat`.
+//! - [`SidebarRevealDemo`] (in [`sidebar_reveal_demo`]) — single Tree
+//!   section exercising `SidebarSystem::reveal` (#595), used by
+//!   `tui_sidebar_reveal` / `gtk_sidebar_reveal`.
 
 // Each example uses a subset of the shared items, so dead-code +
 // unused-import warnings are expected and not actionable here.
@@ -72,6 +75,7 @@ pub mod selection_app;
 pub mod shell_app;
 pub mod shell_menu_demo;
 pub mod sidebar_panel_app;
+pub mod sidebar_reveal_demo;
 pub mod sidebar_search;
 pub mod split_app;
 pub mod split_tree_app;
@@ -119,6 +123,7 @@ pub use selection_app::SelectionDemo;
 pub use shell_app::ShellApp;
 pub use shell_menu_demo::ShellMenuDemo;
 pub use sidebar_panel_app::SidebarPanelApp;
+pub use sidebar_reveal_demo::SidebarRevealDemo;
 pub use sidebar_search::SidebarSearchApp;
 pub use split_app::SplitApp;
 pub use split_tree_app::SplitTreeApp;

--- a/quadraui/examples/common/sidebar_reveal_demo.rs
+++ b/quadraui/examples/common/sidebar_reveal_demo.rs
@@ -1,0 +1,193 @@
+//! Minimal `SidebarSystem` demo for `SidebarSystem::reveal` (#595) — a
+//! *programmatic* selection (no click, no arrow key) that must select
+//! the target row, expand its section if collapsed, and scroll it into
+//! view.
+//!
+//! One Tree section with more rows than fit on screen at once, so `g`
+//! (reveal the section's last row) has to actually move the viewport to
+//! prove anything happened. This demo relies on `PerSection` scroll mode
+//! — `SidebarSystem`'s default. `ScrollMode::WholePanel` (see
+//! `multi_tree.rs`'s `DebugSidebar`) drives the viewport from a single
+//! panel-level scroll offset instead of each section's own
+//! `TreeController::scroll_offset`, so `reveal`'s
+//! `TreeController::scroll_to_visible` call — correct as it is — has no
+//! visible effect under that mode. This demo intentionally stays in the
+//! default mode so `reveal` actually moves the screen.
+//!
+//! Controls:
+//! - `↑` / `↓`     move selection (interactive nav — already scrolls)
+//! - `z`           toggle collapse of the section
+//! - `g`           reveal (#595): select + expand + scroll the
+//!                 section's last row into view, without going through
+//!                 interactive nav — simulates a caller restoring a
+//!                 saved selection or jumping to a search hit
+//! - `q` / `Esc`   quit
+
+use quadraui::{
+    AppLogic, Backend, Color, Decoration, Key, NamedKey, NavigationMode, Reaction, Rect,
+    SidebarEvent, SidebarSectionDef, SidebarSystem, StatusBar, StatusBarSegment, StyledText,
+    TreeRow, UiEvent, WidgetId,
+};
+
+const STATUS_BAR_LINES: f32 = 1.0;
+/// Row count for the single "ITEMS" section — kept alongside the
+/// `fake_rows` call in [`SidebarRevealDemo::new`] so the `g` handler
+/// knows the last row's path without needing a public "row count"
+/// getter on `SidebarSystem`.
+const ROW_COUNT: usize = 30;
+
+pub struct SidebarRevealDemo {
+    sidebar: SidebarSystem,
+    last_action: String,
+}
+
+impl SidebarRevealDemo {
+    pub fn new() -> Self {
+        let mut sidebar = SidebarSystem::new(vec![SidebarSectionDef::new("items", "ITEMS")]);
+        sidebar.set_rows(0, fake_rows(ROW_COUNT));
+        sidebar.set_navigation_mode(NavigationMode::Selection);
+        sidebar.set_active_section(Some(0));
+        Self {
+            sidebar,
+            last_action: "—".into(),
+        }
+    }
+
+    fn sidebar_rect(backend: &dyn Backend) -> Rect {
+        let viewport = backend.viewport();
+        let status_h = backend.line_height() * STATUS_BAR_LINES;
+        Rect::new(
+            0.0,
+            0.0,
+            viewport.width,
+            (viewport.height - status_h).max(0.0),
+        )
+    }
+
+    fn status_rect(backend: &dyn Backend) -> Rect {
+        let viewport = backend.viewport();
+        let status_h = backend.line_height() * STATUS_BAR_LINES;
+        Rect::new(
+            0.0,
+            (viewport.height - status_h).max(0.0),
+            viewport.width,
+            status_h,
+        )
+    }
+
+    fn build_status_bar(&self) -> StatusBar {
+        let fg = Color::rgb(220, 220, 220);
+        let bg = Color::rgb(40, 40, 60);
+        StatusBar {
+            id: WidgetId::new("reveal-status"),
+            left_segments: vec![StatusBarSegment {
+                text: format!(" last: {} ", self.last_action),
+                fg,
+                bg,
+                bold: false,
+                action_id: None,
+            }],
+            right_segments: vec![StatusBarSegment {
+                text: " ↑↓ / z=collapse / g=reveal / q ".into(),
+                fg,
+                bg,
+                bold: false,
+                action_id: None,
+            }],
+        }
+    }
+}
+
+impl Default for SidebarRevealDemo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppLogic for SidebarRevealDemo {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let sidebar = Self::sidebar_rect(backend);
+        let status = Self::status_rect(backend);
+        self.sidebar.render(backend, sidebar);
+        let _ = backend.draw_status_bar(status, &self.build_status_bar(), None, None);
+    }
+
+    fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+        // `reveal` is backend-free and needs this cached first — see
+        // `SidebarSystem::set_backend_info`.
+        self.sidebar
+            .set_backend_info(backend.line_height(), backend.msv_metrics());
+
+        let rect = Self::sidebar_rect(backend);
+        match self.sidebar.handle(&event, backend, rect) {
+            SidebarEvent::RowSelected { section, path } => {
+                self.last_action = format!("sel→{section} {path:?}");
+                Reaction::Redraw
+            }
+            SidebarEvent::HeaderActivated { section } => {
+                self.last_action = format!("header→{section}");
+                Reaction::Redraw
+            }
+            SidebarEvent::StateChanged
+            | SidebarEvent::Consumed
+            | SidebarEvent::ScrollChanged { .. } => Reaction::Redraw,
+            SidebarEvent::Ignored => match event {
+                // #595: toggle collapse of the section — lets `g` (below)
+                // exercise "reveal on a collapsed section expands it
+                // first, then scrolls".
+                UiEvent::KeyPressed {
+                    key: Key::Char('z'),
+                    ..
+                } => {
+                    let collapsed = !self.sidebar.is_collapsed(0);
+                    self.sidebar.set_collapsed(0, collapsed);
+                    self.last_action =
+                        format!("{}→0", if collapsed { "collapsed" } else { "expanded" });
+                    Reaction::Redraw
+                }
+                // #595: `reveal` — a *programmatic* selection (no click,
+                // no arrow key) of the section's last row. Proves
+                // `reveal` selects the row, expands the section if it
+                // was collapsed via `z`, and scrolls it into view.
+                UiEvent::KeyPressed {
+                    key: Key::Char('g'),
+                    ..
+                } => {
+                    let target = vec![(ROW_COUNT - 1) as u16];
+                    let rect = Self::sidebar_rect(backend);
+                    self.sidebar.reveal(0, &target, rect);
+                    self.last_action = format!("reveal→0 {target:?}");
+                    Reaction::Redraw
+                }
+                UiEvent::KeyPressed {
+                    key: Key::Char('q'),
+                    ..
+                }
+                | UiEvent::KeyPressed {
+                    key: Key::Named(NamedKey::Escape),
+                    ..
+                } => Reaction::Exit,
+                UiEvent::WindowResized { .. } => Reaction::Redraw,
+                _ => Reaction::Continue,
+            },
+            _ => Reaction::Redraw,
+        }
+    }
+}
+
+fn fake_rows(n: usize) -> Vec<TreeRow> {
+    (0..n)
+        .map(|i| TreeRow {
+            path: vec![i as u16],
+            indent: 0,
+            icon: None,
+            text: StyledText::plain(format!("item{i}")),
+            badge: None,
+            is_expanded: None,
+            decoration: Decoration::Normal,
+            edit: None,
+        })
+        .collect()
+}

--- a/quadraui/examples/gtk_sidebar_reveal.rs
+++ b/quadraui/examples/gtk_sidebar_reveal.rs
@@ -1,0 +1,14 @@
+//! `SidebarSystem::reveal` (#595) `AppLogic` + `quadraui::gtk::run`
+//! example. Same logic as `tui_sidebar_reveal`, paired by shape — see
+//! `examples/common/sidebar_reveal_demo.rs`.
+//!
+//! ```sh
+//! cargo run --example gtk_sidebar_reveal --features gtk
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::gtk::run(common::SidebarRevealDemo::new())
+}

--- a/quadraui/examples/tui_sidebar_reveal.rs
+++ b/quadraui/examples/tui_sidebar_reveal.rs
@@ -1,0 +1,20 @@
+//! `SidebarSystem::reveal` (#595) `AppLogic` + `quadraui::tui::run`
+//! example. See `examples/common/sidebar_reveal_demo.rs` for the
+//! consumer pattern.
+//!
+//! - `↑` / `↓`     move selection (interactive nav)
+//! - `z`           toggle collapse of the section
+//! - `g`           reveal: select + expand + scroll the last row into
+//!                 view, without interactive nav
+//! - `q` / `Esc`   quit
+//!
+//! ```sh
+//! cargo run --example tui_sidebar_reveal --features tui
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::io::Result<()> {
+    quadraui::tui::run(common::SidebarRevealDemo::new())
+}

--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -316,6 +316,38 @@ impl SidebarSystem {
         }
     }
 
+    /// Scroll `section`'s viewport so `path` is visible, without touching
+    /// the current selection.
+    ///
+    /// Interactive navigation (arrow keys, click) already keeps the
+    /// selected row on-screen — [`Self::move_selection_by`] and friends
+    /// call [`TreeController::scroll_to_visible`] after moving the
+    /// selection. A *programmatic* selection made via [`Self::set_selected_path`]
+    /// (e.g. restoring a saved path, jumping to a search hit) bypasses
+    /// that path and can leave the row scrolled off-screen. Call `reveal`
+    /// after such a change to bring it into view using the exact same
+    /// scroll-to-follow math as interactive nav.
+    ///
+    /// No-op if `section` is out of range, hosts a Form (not a Tree),
+    /// `path` isn't among the section's current rows, or
+    /// [`Self::set_backend_info`] hasn't been called yet (the viewport's
+    /// row capacity is unknown without it).
+    pub fn reveal(&mut self, section: usize, path: &TreePath, rect: Rect) {
+        let Some(ref info) = self.backend_info else {
+            return;
+        };
+        let lh = info.line_height;
+        let metrics = info.metrics;
+        let viewport_rows = self.section_viewport_rows(section, rect, lh, &metrics);
+        let Some(SectionController::Tree(tc)) = self.sections.get_mut(section) else {
+            return;
+        };
+        let Some(row) = tc.rows().iter().position(|r| &r.path == path) else {
+            return;
+        };
+        tc.scroll_to_visible(row, viewport_rows);
+    }
+
     pub fn set_collapsed(&mut self, section: usize, collapsed: bool) {
         if section < self.collapsed.len() {
             self.collapsed[section] = collapsed;
@@ -3249,6 +3281,96 @@ mod tests {
         ss.set_selected_path(0, Some(vec![2])); // leaf
         let ev = ss.toggle_expand_selected();
         assert_eq!(ev, SidebarEvent::Ignored);
+    }
+
+    // ── Programmatic reveal (#reveal) ────────────────────────────────
+
+    /// `reveal` scrolls a section so a programmatically-selected row (one
+    /// set via `set_selected_path` without going through interactive
+    /// nav) ends up inside the visible window.
+    #[test]
+    fn reveal_scrolls_row_into_visible_window() {
+        let mut ss = SidebarSystem::new(sample_defs());
+        ss.set_rows(0, fake_rows("v", 50));
+        let lh = 1.0_f32;
+        let metrics = LayoutMetrics::default();
+        ss.set_backend_info(lh, metrics);
+        let rect = Rect::new(0.0, 0.0, 20.0, 40.0);
+
+        // A caller sets the selection directly (e.g. restoring saved
+        // state) — no click, no arrow key, so nothing has scrolled yet.
+        ss.set_selected_path(0, Some(vec![40]));
+        assert_eq!(ss.scroll_offset(0), 0);
+
+        ss.reveal(0, &vec![40], rect);
+
+        let viewport_rows = ss.section_viewport_rows(0, rect, lh, &metrics);
+        let offset = ss.scroll_offset(0);
+        assert!(
+            offset <= 40 && 40 < offset + viewport_rows,
+            "row 40 not within visible window: offset={offset} viewport_rows={viewport_rows}"
+        );
+    }
+
+    /// `reveal` must reuse `TreeController::scroll_to_visible` — the same
+    /// scroll-to-follow math that interactive arrow-key navigation uses —
+    /// rather than re-deriving it. Drive selection down to row 40 via the
+    /// interactive path to capture the "correct" resulting offset, then
+    /// reset the scroll and confirm `reveal` lands on the identical value.
+    #[test]
+    fn reveal_matches_interactive_scroll_to_follow() {
+        let mut ss = SidebarSystem::new(sample_defs());
+        ss.set_rows(0, fake_rows("v", 50));
+        ss.set_active_section(Some(0));
+        let lh = 1.0_f32;
+        let metrics = LayoutMetrics::default();
+        ss.set_backend_info(lh, metrics);
+        let rect = Rect::new(0.0, 0.0, 20.0, 40.0);
+
+        // First move (no prior selection) lands on row 0; 40 further
+        // moves advance to row 40.
+        for _ in 0..41 {
+            ss.move_selection(1, rect, lh, &metrics);
+        }
+        assert_eq!(ss.selected_path(0), Some(&vec![40]));
+        let expected_offset = ss.scroll_offset(0);
+        assert!(
+            expected_offset > 0,
+            "row 40 should have scrolled the viewport during interactive nav"
+        );
+
+        // Simulate an off-screen programmatic selection by resetting the
+        // scroll offset while leaving the selected path untouched.
+        if let SectionController::Tree(tc) = &mut ss.sections[0] {
+            tc.set_scroll_offset(0);
+        }
+        assert_eq!(ss.scroll_offset(0), 0);
+
+        ss.reveal(0, &vec![40], rect);
+
+        assert_eq!(
+            ss.scroll_offset(0),
+            expected_offset,
+            "reveal should reuse the same scroll-to-follow math as interactive nav"
+        );
+    }
+
+    /// `reveal` is a safe no-op when `set_backend_info` was never called
+    /// (viewport size unknown) or `path` doesn't match any current row.
+    #[test]
+    fn reveal_is_noop_without_backend_info_or_unknown_path() {
+        let mut ss = SidebarSystem::new(sample_defs());
+        ss.set_rows(0, fake_rows("v", 50));
+        ss.set_selected_path(0, Some(vec![40]));
+        let rect = Rect::new(0.0, 0.0, 20.0, 40.0);
+
+        // No `set_backend_info` call yet.
+        ss.reveal(0, &vec![40], rect);
+        assert_eq!(ss.scroll_offset(0), 0);
+
+        ss.set_backend_info(1.0, LayoutMetrics::default());
+        ss.reveal(0, &vec![999], rect); // path not present among rows
+        assert_eq!(ss.scroll_offset(0), 0);
     }
 
     #[cfg(feature = "gtk")]

--- a/quadraui/src/compose/sidebar_system.rs
+++ b/quadraui/src/compose/sidebar_system.rs
@@ -316,32 +316,52 @@ impl SidebarSystem {
         }
     }
 
-    /// Scroll `section`'s viewport so `path` is visible, without touching
-    /// the current selection.
+    /// Select `path` within `section`, expand the section if it's
+    /// currently collapsed, and scroll its viewport so `path` ends up
+    /// visible.
     ///
     /// Interactive navigation (arrow keys, click) already keeps the
     /// selected row on-screen — [`Self::move_selection_by`] and friends
     /// call [`TreeController::scroll_to_visible`] after moving the
-    /// selection. A *programmatic* selection made via [`Self::set_selected_path`]
-    /// (e.g. restoring a saved path, jumping to a search hit) bypasses
-    /// that path and can leave the row scrolled off-screen. Call `reveal`
-    /// after such a change to bring it into view using the exact same
-    /// scroll-to-follow math as interactive nav.
+    /// selection. A *programmatic* selection (e.g. restoring a saved
+    /// path, jumping to a search hit) bypasses that path: nothing
+    /// selects the row, un-collapses its section, or scrolls it into
+    /// view on its own. `reveal` does all three in one call, reusing
+    /// [`TreeController::scroll_to_visible`] — the exact same
+    /// scroll-to-follow math interactive nav uses — rather than
+    /// re-deriving it.
     ///
     /// No-op if `section` is out of range, hosts a Form (not a Tree),
     /// `path` isn't among the section's current rows, or
     /// [`Self::set_backend_info`] hasn't been called yet (the viewport's
-    /// row capacity is unknown without it).
+    /// row capacity is unknown without it). A collapsed section is
+    /// expanded *before* the viewport is measured, so the row-capacity
+    /// computation reflects the now-visible body rather than the
+    /// collapsed (zero-height) one.
     pub fn reveal(&mut self, section: usize, path: &TreePath, rect: Rect) {
-        let Some(ref info) = self.backend_info else {
+        let Some(info) = self.backend_info.as_ref() else {
             return;
         };
         let lh = info.line_height;
         let metrics = info.metrics;
+
+        let Some(SectionController::Tree(tc)) = self.sections.get(section) else {
+            return;
+        };
+        if !tc.rows().iter().any(|r| &r.path == path) {
+            return;
+        }
+
+        if let Some(collapsed) = self.collapsed.get_mut(section) {
+            *collapsed = false;
+        }
+
         let viewport_rows = self.section_viewport_rows(section, rect, lh, &metrics);
+
         let Some(SectionController::Tree(tc)) = self.sections.get_mut(section) else {
             return;
         };
+        tc.set_selected_path(Some(path.clone()));
         let Some(row) = tc.rows().iter().position(|r| &r.path == path) else {
             return;
         };
@@ -3284,32 +3304,63 @@ mod tests {
     }
 
     // ── Programmatic reveal (#reveal) ────────────────────────────────
+    //
+    // The "row actually ends up on screen" claim is proven end-to-end by
+    // the `TuiDriver` tests in `tests/tui_example_driver.rs`
+    // (`sidebar_reveal_*`), which render the real `SidebarRevealDemo`
+    // example (`examples/common/sidebar_reveal_demo.rs`) and read row
+    // text back off the rendered grid — not by inspecting
+    // `scroll_offset`. (`DebugSidebar`/`multi_tree.rs` can't host that
+    // proof: it uses `ScrollMode::WholePanel`, which ignores each
+    // section's own `TreeController::scroll_offset` entirely, so even
+    // interactive arrow-key nav never moves its screen.) The unit tests
+    // below cover the state transitions `reveal` is responsible for
+    // (selection, un-collapse, no-op guards) and the one
+    // internal-consistency check that isn't observable from rendered
+    // text: that `reveal` reuses `TreeController::scroll_to_visible`
+    // rather than re-deriving its own scroll math.
 
-    /// `reveal` scrolls a section so a programmatically-selected row (one
-    /// set via `set_selected_path` without going through interactive
-    /// nav) ends up inside the visible window.
+    /// `reveal` selects `path` in the target section — the bug #595 was
+    /// filed against was that the old scroll-only version left selection
+    /// untouched, so every caller had to remember to also call
+    /// `set_selected_path` themselves.
     #[test]
-    fn reveal_scrolls_row_into_visible_window() {
+    fn reveal_selects_the_target_row() {
         let mut ss = SidebarSystem::new(sample_defs());
         ss.set_rows(0, fake_rows("v", 50));
-        let lh = 1.0_f32;
-        let metrics = LayoutMetrics::default();
-        ss.set_backend_info(lh, metrics);
+        ss.set_backend_info(1.0, LayoutMetrics::default());
         let rect = Rect::new(0.0, 0.0, 20.0, 40.0);
 
-        // A caller sets the selection directly (e.g. restoring saved
-        // state) — no click, no arrow key, so nothing has scrolled yet.
-        ss.set_selected_path(0, Some(vec![40]));
-        assert_eq!(ss.scroll_offset(0), 0);
+        assert_eq!(ss.selected_path(0), None);
+        ss.reveal(0, &vec![40], rect);
+        assert_eq!(
+            ss.selected_path(0),
+            Some(&vec![40]),
+            "reveal must select the row, not just scroll to it"
+        );
+    }
+
+    /// `reveal` expands a collapsed section before scrolling — the old
+    /// version left `self.collapsed[section]` untouched, and since a
+    /// collapsed section's body has zero rows, `scroll_to_visible` was
+    /// guaranteed to no-op (acceptance criterion 3: "reveal on a
+    /// collapsed section expands it first, then scrolls").
+    #[test]
+    fn reveal_expands_a_collapsed_section() {
+        let mut ss = SidebarSystem::new(sample_defs());
+        ss.set_rows(0, fake_rows("v", 50));
+        ss.set_backend_info(1.0, LayoutMetrics::default());
+        ss.set_collapsed(0, true);
+        assert!(ss.is_collapsed(0));
+        let rect = Rect::new(0.0, 0.0, 20.0, 40.0);
 
         ss.reveal(0, &vec![40], rect);
 
-        let viewport_rows = ss.section_viewport_rows(0, rect, lh, &metrics);
-        let offset = ss.scroll_offset(0);
         assert!(
-            offset <= 40 && 40 < offset + viewport_rows,
-            "row 40 not within visible window: offset={offset} viewport_rows={viewport_rows}"
+            !ss.is_collapsed(0),
+            "reveal must expand a collapsed section before scrolling"
         );
+        assert_eq!(ss.selected_path(0), Some(&vec![40]));
     }
 
     /// `reveal` must reuse `TreeController::scroll_to_visible` — the same
@@ -3317,8 +3368,10 @@ mod tests {
     /// rather than re-deriving it. Drive selection down to row 40 via the
     /// interactive path to capture the "correct" resulting offset, then
     /// reset the scroll and confirm `reveal` lands on the identical value.
+    /// (This checks the *implementation* shares one code path, not the
+    /// user-visible "is it on screen" claim — see the module note above.)
     #[test]
-    fn reveal_matches_interactive_scroll_to_follow() {
+    fn reveal_reuses_interactive_scroll_to_follow_math() {
         let mut ss = SidebarSystem::new(sample_defs());
         ss.set_rows(0, fake_rows("v", 50));
         ss.set_active_section(Some(0));
@@ -3356,21 +3409,30 @@ mod tests {
     }
 
     /// `reveal` is a safe no-op when `set_backend_info` was never called
-    /// (viewport size unknown) or `path` doesn't match any current row.
+    /// (viewport size unknown) or `path` doesn't match any current row —
+    /// selection must stay exactly as it was before the call.
     #[test]
     fn reveal_is_noop_without_backend_info_or_unknown_path() {
         let mut ss = SidebarSystem::new(sample_defs());
         ss.set_rows(0, fake_rows("v", 50));
-        ss.set_selected_path(0, Some(vec![40]));
+        ss.set_selected_path(0, Some(vec![3]));
         let rect = Rect::new(0.0, 0.0, 20.0, 40.0);
 
         // No `set_backend_info` call yet.
         ss.reveal(0, &vec![40], rect);
-        assert_eq!(ss.scroll_offset(0), 0);
+        assert_eq!(
+            ss.selected_path(0),
+            Some(&vec![3]),
+            "reveal without backend info must not change selection"
+        );
 
         ss.set_backend_info(1.0, LayoutMetrics::default());
         ss.reveal(0, &vec![999], rect); // path not present among rows
-        assert_eq!(ss.scroll_offset(0), 0);
+        assert_eq!(
+            ss.selected_path(0),
+            Some(&vec![3]),
+            "reveal for an unknown path must not change selection"
+        );
     }
 
     #[cfg(feature = "gtk")]

--- a/quadraui/tests/example_manifest.rs
+++ b/quadraui/tests/example_manifest.rs
@@ -1,0 +1,276 @@
+//! Manifest hygiene for `quadraui/examples/` — every example file must have
+//! an explicit `[[example]]` entry in `quadraui/Cargo.toml` whose
+//! `required-features` names the backend it actually calls into (#595).
+//!
+//! Why this is a *test* and not a review checklist: cargo's example
+//! autodiscovery is silently permissive. Drop `examples/gtk_foo.rs` into the
+//! tree with no `[[example]]` stanza and cargo happily picks it up — with
+//! **no** `required-features` — so `cargo test --features tui` tries to
+//! compile a file whose body is `quadraui::gtk::run(..)` and dies on
+//! `could not find gtk in quadraui`. Nothing about the example itself is
+//! wrong; the manifest is. That is precisely how #595's first CI run went
+//! red on the `tui (build, test, clippy)` job.
+//!
+//! Two properties make that failure mode expensive enough to gate:
+//!
+//! - **`cargo build` does not catch it.** Examples aren't built by a plain
+//!   `cargo build`, only by `cargo test` / `cargo build --examples`, so the
+//!   build step goes green and the break surfaces one step later.
+//! - **It is invisible locally to whoever added the pair.** A worker who
+//!   runs `cargo test --features gtk` (or runs the demo, per CLAUDE.md's
+//!   "demos are mandatory") sees nothing — the mismatch only bites the
+//!   *other* backend's job.
+//!
+//! This test reads the real manifest and the real directory listing, so it
+//! fails at the moment the pair is added, in whichever feature set the
+//! worker happened to run.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The `quadraui` crate root — where `Cargo.toml` and `examples/` live.
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// One `[[example]]` stanza, reduced to the fields this test cares about.
+#[derive(Debug, Default)]
+struct ExampleEntry {
+    name: String,
+    path: String,
+    required_features: Vec<String>,
+}
+
+/// Minimal, deliberately dumb TOML slice: collect every `[[example]]` table
+/// and its `name` / `path` / `required-features` keys.
+///
+/// A full TOML parser isn't a dependency of this crate and isn't worth
+/// adding for three flat string keys. The manifest's example stanzas are
+/// uniform single-line `key = value` pairs, and the assertions below fail
+/// loudly (missing entry / empty features) rather than silently passing if
+/// this parser ever fails to understand a stanza.
+fn parse_example_entries(manifest: &str) -> Vec<ExampleEntry> {
+    let mut entries = Vec::new();
+    let mut current: Option<ExampleEntry> = None;
+
+    for raw in manifest.lines() {
+        let line = raw.trim();
+        if line.starts_with('[') {
+            // Any new table header closes the stanza we were filling.
+            if let Some(entry) = current.take() {
+                entries.push(entry);
+            }
+            if line == "[[example]]" {
+                current = Some(ExampleEntry::default());
+            }
+            continue;
+        }
+        let Some(entry) = current.as_mut() else {
+            continue;
+        };
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        match key {
+            "name" => entry.name = unquote(value),
+            "path" => entry.path = unquote(value),
+            "required-features" => {
+                entry.required_features = value
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(unquote)
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+    if let Some(entry) = current.take() {
+        entries.push(entry);
+    }
+    entries
+}
+
+fn unquote(value: &str) -> String {
+    value.trim().trim_matches('"').to_string()
+}
+
+/// Every `examples/*.rs`, relative to the crate root, as it would be spelled
+/// in a `path = ...` key. `examples/common/` is a module directory shared by
+/// the runners, not an example target, so it's excluded by only listing
+/// files at the top level.
+fn example_files(root: &Path) -> Vec<String> {
+    let dir = root.join("examples");
+    let mut files: Vec<String> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()))
+        .map(|e| e.expect("readable dir entry"))
+        .filter(|e| e.file_type().expect("entry file type").is_file())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with(".rs"))
+        .map(|n| format!("examples/{n}"))
+        .collect();
+    files.sort();
+    files
+}
+
+/// Backend feature a file name commits the example to, by prefix.
+/// `msv_*` (multi-section view) examples are TUI runners.
+fn required_backend_for(file: &str) -> Option<&'static str> {
+    let name = file.strip_prefix("examples/").unwrap_or(file);
+    if name.starts_with("gtk_") {
+        Some("gtk")
+    } else if name.starts_with("macos_") {
+        Some("macos")
+    } else if name.starts_with("tui_") || name.starts_with("msv_") {
+        Some("tui")
+    } else {
+        None
+    }
+}
+
+fn entries_by_path() -> BTreeMap<String, ExampleEntry> {
+    let manifest = fs::read_to_string(crate_root().join("Cargo.toml")).expect("read Cargo.toml");
+    let entries = parse_example_entries(&manifest);
+    assert!(
+        !entries.is_empty(),
+        "parsed zero [[example]] stanzas out of quadraui/Cargo.toml — the \
+         parser in this test has drifted from the manifest format, so every \
+         other assertion here would pass vacuously"
+    );
+    let mut by_path = BTreeMap::new();
+    for entry in entries {
+        if let Some(prev) = by_path.insert(entry.path.clone(), entry) {
+            panic!(
+                "duplicate [[example]] stanzas for path {:?} (name {:?})",
+                prev.path, prev.name
+            );
+        }
+    }
+    by_path
+}
+
+/// The regression #595 hit: a new `examples/*.rs` with no `[[example]]`
+/// stanza is autodiscovered with no `required-features` and compiled under
+/// every feature set.
+#[test]
+fn every_example_file_has_a_manifest_entry() {
+    let by_path = entries_by_path();
+    let missing: Vec<String> = example_files(&crate_root())
+        .into_iter()
+        .filter(|f| !by_path.contains_key(f))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "these example files have no [[example]] entry in quadraui/Cargo.toml: \
+         {missing:?}\n\nWithout one, cargo autodiscovers them with NO \
+         required-features, so e.g. a gtk_* example is compiled by \
+         `cargo test --features tui` and fails on `quadraui::gtk` being \
+         configured out. Add:\n\n\
+         [[example]]\nname = \"<file stem>\"\npath = \"examples/<file>.rs\"\n\
+         required-features = [\"<backend>\"]"
+    );
+}
+
+/// Every stanza must actually gate on its backend — an entry that exists but
+/// declares no `required-features` (or the wrong one) fails identically to
+/// having no entry at all.
+#[test]
+fn every_example_entry_requires_its_backend_feature() {
+    let by_path = entries_by_path();
+    let mut problems = Vec::new();
+
+    for file in example_files(&crate_root()) {
+        let Some(entry) = by_path.get(&file) else {
+            continue; // reported by every_example_file_has_a_manifest_entry
+        };
+        assert_eq!(
+            entry.name,
+            file.trim_start_matches("examples/").trim_end_matches(".rs"),
+            "[[example]] name must match its file stem for {file}"
+        );
+        match required_backend_for(&file) {
+            Some(feature) if !entry.required_features.iter().any(|f| f == feature) => problems
+                .push(format!(
+                    "{file}: required-features = {:?} does not include {feature:?}",
+                    entry.required_features
+                )),
+            None if entry.required_features.is_empty() => {
+                problems.push(format!("{file}: no required-features declared"));
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "example manifest entries are missing their backend feature gate:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// Anti-vacuity + parser sanity: the stanza shape this test relies on is the
+/// one the manifest actually uses, and a missing/ungated stanza is really
+/// detected rather than skipped.
+#[test]
+fn parser_detects_missing_and_ungated_entries() {
+    let manifest = r#"
+[package]
+name = "demo"
+
+[[example]]
+name = "tui_ok"
+path = "examples/tui_ok.rs"
+required-features = ["tui"]
+
+[[example]]
+name = "gtk_ungated"
+path = "examples/gtk_ungated.rs"
+
+[[example]]
+name = "tui_terminal"
+path = "examples/tui_terminal.rs"
+required-features = ["tui", "terminal"]
+
+[dev-dependencies]
+serde_json = "1.0"
+"#;
+    let entries = parse_example_entries(manifest);
+    assert_eq!(entries.len(), 3, "parsed: {entries:?}");
+
+    assert_eq!(entries[0].name, "tui_ok");
+    assert_eq!(entries[0].path, "examples/tui_ok.rs");
+    assert_eq!(entries[0].required_features, vec!["tui".to_string()]);
+
+    // The exact shape #595 shipped: a stanza with no feature gate at all.
+    assert!(entries[1].required_features.is_empty());
+    assert!(!entries[1]
+        .required_features
+        .iter()
+        .any(|f| f == required_backend_for("examples/gtk_ungated.rs").unwrap()));
+
+    // Multi-feature lists parse as lists, not as one blob.
+    assert_eq!(
+        entries[2].required_features,
+        vec!["tui".to_string(), "terminal".to_string()]
+    );
+
+    // A trailing `[dev-dependencies]` table must not leak keys into the last
+    // stanza.
+    assert_eq!(entries[2].path, "examples/tui_terminal.rs");
+
+    assert_eq!(
+        required_backend_for("examples/msv_sc_panel.rs"),
+        Some("tui")
+    );
+    assert_eq!(
+        required_backend_for("examples/macos_demo.rs"),
+        Some("macos")
+    );
+    assert_eq!(required_backend_for("examples/whatever.rs"), None);
+}

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -86,6 +86,8 @@ mod selection_app;
 mod shell_menu_demo;
 #[path = "../examples/common/sidebar_panel_app.rs"]
 mod sidebar_panel_app;
+#[path = "../examples/common/sidebar_reveal_demo.rs"]
+mod sidebar_reveal_demo;
 #[path = "../examples/common/split_app.rs"]
 mod split_app;
 #[path = "../examples/common/split_tree_app.rs"]
@@ -131,6 +133,7 @@ use search_panel::SearchPanelApp;
 use selection_app::SelectionDemo;
 use shell_menu_demo::ShellMenuDemo;
 use sidebar_panel_app::SidebarPanelApp;
+use sidebar_reveal_demo::SidebarRevealDemo;
 use split_app::SplitApp;
 use split_tree_app::SplitTreeApp;
 use tab_group_demo::TabGroupDemo;
@@ -3839,6 +3842,110 @@ fn multi_tree_tab_then_down_selects_a_row_in_the_newly_active_section() {
         screen.contains("sel→1 [0]"),
         "Down after Tab should select WATCH's own first row (w0), not \
          VARIABLES' — proving focus followed the newly active section:\n{screen}"
+    );
+}
+
+// ─── SidebarRevealDemo: SidebarSystem::reveal (#595) ───────────────────────
+//
+// `DebugSidebar` above uses `ScrollMode::WholePanel`, where the rendered
+// viewport is driven by a single panel-level scroll offset, not each
+// section's own `TreeController::scroll_offset` — under that mode, even
+// *interactive* arrow-key nav never moves the screen, so it can't prove
+// anything about `reveal`. `SidebarRevealDemo` (`examples/common/
+// sidebar_reveal_demo.rs`) stays on `SidebarSystem`'s default
+// `PerSection` scroll mode instead, so `reveal`'s call to
+// `TreeController::scroll_to_visible` has a real, on-screen effect these
+// tests can read back off the rendered grid — not by inspecting
+// `scroll_offset` (see the `compose::sidebar_system::tests` module note
+// by the same name for the unit-level state-transition coverage).
+
+/// `reveal` scrolls a programmatically-selected, currently off-screen row
+/// into view. The demo's 30-row ITEMS section only shows ~8 rows at a
+/// time, so `item29` (the section's last row) starts off-screen; `g`
+/// reveals it with no click and no arrow key.
+#[test]
+fn sidebar_reveal_scrolls_offscreen_row_into_view() {
+    let mut driver = TuiDriver::new(SidebarRevealDemo::new(), 60, 10);
+    let before = driver.screen();
+    assert!(
+        !before.contains("item29"),
+        "item29 should start off-screen (only ~8 of 30 rows fit):\n{before}"
+    );
+
+    driver.type_char('g'); // reveal(0, [29], ...) — programmatic, not interactive nav
+
+    let after = driver.screen();
+    assert!(
+        after.contains("item29"),
+        "reveal should scroll item29 into view:\n{after}"
+    );
+    assert!(
+        after.contains("reveal→0 [29]"),
+        "status bar should confirm reveal ran:\n{after}"
+    );
+}
+
+/// `reveal` selects the target row, not just scrolls to it (the bug
+/// #595 was filed against: a scroll-only `reveal` left every caller
+/// needing a separate `set_selected_path` call with no guarantee both
+/// were made together). Proven behaviorally: `TreeController::
+/// move_selection_by` treats "no selection yet" specially — pressing Up
+/// with nothing selected jumps to the *last* row (item29), not up by
+/// one. So if `reveal` had only scrolled and left selection untouched,
+/// Up afterward would land back on item29. It instead lands on item28,
+/// which is only possible if `reveal` already selected item29.
+#[test]
+fn sidebar_reveal_selects_the_row_so_interactive_nav_continues_from_it() {
+    let mut driver = TuiDriver::new(SidebarRevealDemo::new(), 60, 10);
+    driver.type_char('g'); // reveal(0, [29], ...)
+    assert!(
+        driver.screen_contains("reveal→0 [29]"),
+        "reveal should have run:\n{}",
+        driver.screen()
+    );
+
+    driver.press_named(NamedKey::Up);
+
+    let screen = driver.screen();
+    assert!(
+        screen.contains("sel→0 [28]"),
+        "Up after reveal should move selection down from item29 to item28 — \
+         landing on item29 again would mean reveal never selected it:\n{screen}"
+    );
+}
+
+/// `reveal` on a collapsed section expands it first, then scrolls
+/// (acceptance criterion 3, #595) — a collapsed section's body renders
+/// zero rows, so a version that scrolled without expanding would be a
+/// silent no-op here. `z` collapses the section (the header stays, but
+/// every row disappears), `g` then reveals item29, which must first
+/// show the section's body again.
+#[test]
+fn sidebar_reveal_expands_a_collapsed_section_then_scrolls() {
+    let mut driver = TuiDriver::new(SidebarRevealDemo::new(), 60, 10);
+    assert!(
+        driver.screen_contains("item0"),
+        "item0 should be visible before collapsing:\n{}",
+        driver.screen()
+    );
+
+    driver.type_char('z'); // collapse the ITEMS section
+    let collapsed = driver.screen();
+    assert!(
+        collapsed.contains("ITEMS"),
+        "the section header should remain after collapsing:\n{collapsed}"
+    );
+    assert!(
+        !collapsed.contains("item0"),
+        "collapsing must hide the section's rows:\n{collapsed}"
+    );
+
+    driver.type_char('g'); // reveal(0, [29], ...) on the collapsed section
+
+    let after = driver.screen();
+    assert!(
+        after.contains("item29"),
+        "reveal must expand the collapsed section before scrolling item29 into view:\n{after}"
     );
 }
 

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -3778,6 +3778,55 @@ fn folder_picker_navigating_into_a_subdirectory_updates_visible_path() {
     );
 }
 
+/// folder_picker: the confirmed-path status must survive a root whose
+/// absolute path is longer than the terminal is wide.
+///
+/// `StatusBar::layout` keeps the highest-priority right segment even when
+/// it alone overflows the bar (it lands at column 0), and right segments
+/// paint *after* left ones — so a right segment carrying the full
+/// confirmed path used to blank the whole "Confirmed: …" message once the
+/// checkout lived under a long enough directory. That is not hypothetical:
+/// `folder_picker_navigating_into_a_subdirectory_updates_visible_path`
+/// above passes or fails purely on how deep the checkout sits, because it
+/// picks up `env::current_dir()`. This test pins the behaviour to a root
+/// it controls instead of the checkout's, so the regression can't hide
+/// again on a short path.
+#[test]
+fn folder_picker_confirmed_status_survives_a_path_longer_than_the_screen() {
+    // 140-char directory name ⇒ an absolute path comfortably wider than
+    // the 100-column screen below, whatever tempdir's base is.
+    let long_name = "q".repeat(140);
+    let tmp = tempfile::Builder::new()
+        .prefix(&long_name)
+        .tempdir()
+        .expect("create temp dir");
+    std::fs::create_dir(tmp.path().join("childdir")).expect("create child dir");
+    assert!(
+        tmp.path().join("childdir").display().to_string().len() > 100,
+        "the temp root must be wider than the screen for this test to mean anything"
+    );
+
+    let mut driver = TuiDriver::new(FolderPickerApp::with_root(tmp.path()), 100, 30);
+    driver.press_named(NamedKey::Down); // off ".." onto "."
+    driver.press_named(NamedKey::Down); // onto "childdir"
+    driver.press_named(NamedKey::Enter); // confirm it
+
+    let after = driver.screen();
+    assert!(
+        after.contains("Confirmed:"),
+        "the confirmed-path message must stay visible even when the path \
+         is longer than the bar is wide:\n{after}"
+    );
+    assert!(
+        after.contains("✓ childdir"),
+        "the right segment should show the confirmed directory's leaf name:\n{after}"
+    );
+    assert!(
+        !after.contains("Open Folder picker"),
+        "the picker should be dismissed after confirming:\n{after}"
+    );
+}
+
 /// search_panel (issue #306): typing into the (mock) search input updates
 /// `SearchPanelApp::query` and the status bar echoes it as "Searching:
 /// <query>" — the module doc comment calls this a "mock" that "cycles


### PR DESCRIPTION
Closes #595

Automated PR opened by coordinator for review of issue #595.