### PR TITLE
#455: ModalStack drives hit-testing but not paint — 'registered but invisible' is undetectable

### DIFF
--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1173,6 +1173,9 @@ impl Backend for GtkBackend {
         // `zones` — a bar that stops painting must stop resolving
         // `tab_center`/`tab_close_center` too.
         self.tab_bar_layouts.clear();
+        // #455: clear last frame's modal paint marks so this frame has
+        // to earn them again (via draw_dialog/draw_palette/draw_context_menu).
+        self.modal_stack.borrow_mut().reset_frame_paint();
     }
 
     fn register_text_region(&mut self, region: TextRegion) {
@@ -1188,9 +1191,23 @@ impl Backend for GtkBackend {
     }
 
     fn end_frame(&mut self) {
-        // No-op. GTK's `set_draw_func` closure flushes when it returns;
-        // this method exists for parity with backends that need an
-        // explicit flush.
+        // No-op flush-wise. GTK's `set_draw_func` closure flushes when it
+        // returns; this method exists for parity with backends that need
+        // an explicit flush.
+        //
+        // #455: in debug builds, warn about any modal that's registered
+        // in the ModalStack (and therefore hit-testable) but that this
+        // frame's `AppLogic::render` never painted — the "registered but
+        // invisible" defect class (vimcode#587) made detectable instead
+        // of silently shipping.
+        #[cfg(debug_assertions)]
+        for id in self.modal_stack.borrow().unpainted_ids() {
+            eprintln!(
+                "quadraui: modal {id:?} is registered in ModalStack (and therefore \
+                 hit-testable) but was not painted this frame — see quadraui#455 \
+                 (\"ModalStack drives hit-testing but not paint\")"
+            );
+        }
     }
 
     fn set_theme(&mut self, theme: crate::Theme) {
@@ -1655,6 +1672,9 @@ impl Backend for GtkBackend {
     }
 
     fn draw_palette(&mut self, rect: QRect, palette: &Palette) {
+        // #455: see `modal_stack.rs`'s "Paint-consistency detection" docs —
+        // records that this palette's surface was actually painted this frame.
+        self.modal_stack.borrow_mut().mark_painted(&palette.id);
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_palette called outside enter_frame_scope");
@@ -2169,6 +2189,8 @@ impl Backend for GtkBackend {
         menu: &crate::ContextMenu,
         layout_arg: &crate::ContextMenuLayout,
     ) -> Vec<(QRect, crate::WidgetId)> {
+        // #455: see draw_palette for why this happens before the frame borrow.
+        self.modal_stack.borrow_mut().mark_painted(&menu.id);
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_context_menu called outside enter_frame_scope");
@@ -2192,6 +2214,8 @@ impl Backend for GtkBackend {
         dialog: &crate::Dialog,
         dialog_layout: &crate::DialogLayout,
     ) -> Vec<QRect> {
+        // #455: see draw_palette for why this happens before the frame borrow.
+        self.modal_stack.borrow_mut().mark_painted(&dialog.id);
         let line_height = self.current_line_height;
         let theme = self.current_theme;
         let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -420,12 +420,29 @@ impl Backend for MacBackend {
         // `enter_frame_scope`) until whatever reads them after the frame
         // (e.g. `MacDriver::inventory`).
         self.zones.clear();
+        // #455: clear last frame's modal paint marks so this frame has
+        // to earn them again (via draw_dialog/draw_palette/draw_context_menu).
+        self.modal_stack.reset_frame_paint();
     }
 
     fn end_frame(&mut self) {
-        // No-op. AppKit's `drawRect:` flushes when it returns; this
-        // method exists for parity with backends that need an explicit
-        // flush.
+        // No-op flush-wise. AppKit's `drawRect:` flushes when it returns;
+        // this method exists for parity with backends that need an
+        // explicit flush.
+        //
+        // #455: in debug builds, warn about any modal that's registered
+        // in the ModalStack (and therefore hit-testable) but that this
+        // frame's `AppLogic::render` never painted — the "registered but
+        // invisible" defect class (vimcode#587) made detectable instead
+        // of silently shipping.
+        #[cfg(debug_assertions)]
+        for id in self.modal_stack.unpainted_ids() {
+            eprintln!(
+                "quadraui: modal {id:?} is registered in ModalStack (and therefore \
+                 hit-testable) but was not painted this frame — see quadraui#455 \
+                 (\"ModalStack drives hit-testing but not paint\")"
+            );
+        }
     }
 
     fn set_theme(&mut self, theme: Theme) {
@@ -718,6 +735,9 @@ impl Backend for MacBackend {
         }
     }
     fn draw_palette(&mut self, rect: Rect, palette: &Palette) {
+        // #455: see `modal_stack.rs`'s "Paint-consistency detection" docs —
+        // records that this palette's surface was actually painted this frame.
+        self.modal_stack.mark_painted(&palette.id);
         let ctx = self.current_cg();
         debug_assert!(
             !ctx.is_null(),
@@ -1127,6 +1147,8 @@ impl Backend for MacBackend {
         menu: &ContextMenu,
         layout: &ContextMenuLayout,
     ) -> Vec<(Rect, WidgetId)> {
+        // #455: see draw_palette for why this happens before the CG borrow.
+        self.modal_stack.mark_painted(&menu.id);
         let ctx = self.current_cg();
         debug_assert!(
             !ctx.is_null(),
@@ -1141,6 +1163,8 @@ impl Backend for MacBackend {
         unsafe { super::context_menu::draw_context_menu(ctx, font, menu, layout, &theme) }
     }
     fn draw_dialog(&mut self, dialog: &Dialog, layout: &DialogLayout) -> Vec<Rect> {
+        // #455: see draw_palette for why this happens before the CG borrow.
+        self.modal_stack.mark_painted(&dialog.id);
         let ctx = self.current_cg();
         debug_assert!(
             !ctx.is_null(),

--- a/quadraui/src/modal_stack.rs
+++ b/quadraui/src/modal_stack.rs
@@ -33,6 +33,31 @@
 //!   arbitration only. Once a hit lands inside a modal, the app still
 //!   asks the primitive itself (e.g. [`crate::PaletteLayout::hit_test`])
 //!   for the semantic hit inside it.
+//!
+//! # Paint-consistency detection (#455)
+//!
+//! Registering a modal in this stack makes it hit-testable, but nothing
+//! *forces* a backend to also paint it — those are two independent code
+//! paths (`modal_stack_mut().push(...)` vs. `backend.draw_dialog(...)`),
+//! and a backend that pushes without ever painting (or paints without
+//! ever pushing) produces a defect that reads correctly at every other
+//! layer: input is healthy, state is right, hit-testing works — the
+//! feature is simply invisible (vimcode#587: a command palette
+//! captured clicks and had 78 items for weeks before anyone noticed it
+//! never painted).
+//!
+//! This module can't force a paint (that's the "full paint-ownership"
+//! redesign #455 sketches as future work), but it *can* make the drift
+//! detectable for free: [`Self::mark_painted`] records that a modal's
+//! surface was actually drawn during the current frame, backends call
+//! [`Self::reset_frame_paint`] from `Backend::begin_frame` and
+//! [`Self::unpainted_ids`] from `Backend::end_frame` to warn (in debug
+//! builds) about any entry that's registered but was never marked
+//! painted that frame. See `TuiBackend::draw_dialog` /
+//! `GtkBackend::draw_dialog` / `MacBackend::draw_dialog` (and the
+//! `draw_palette` / `draw_context_menu` siblings) for where the mark
+//! happens, and the same backends' `begin_frame` / `end_frame` for
+//! where the reset/check happens.
 
 use crate::event::{Point, Rect};
 use crate::types::WidgetId;
@@ -49,6 +74,13 @@ use crate::types::WidgetId;
 pub struct ModalEntry {
     pub id: WidgetId,
     pub bounds: Rect,
+    /// #455: set by [`ModalStack::mark_painted`] when a backend's
+    /// `draw_*` call for this modal actually runs during the current
+    /// frame. Reset to `false` by [`ModalStack::reset_frame_paint`] at
+    /// the start of every frame. Not `pub` — entries are only ever
+    /// constructed by [`ModalStack::push`], which always starts this
+    /// `false` for a freshly (re-)opened modal.
+    painted_this_frame: bool,
 }
 
 /// Top-of-stack-is-topmost ordered list of open modal overlays.
@@ -78,7 +110,11 @@ impl ModalStack {
     /// the stack never contains duplicates.
     pub fn push(&mut self, id: WidgetId, bounds: Rect) {
         self.entries.retain(|e| e.id != id);
-        self.entries.push(ModalEntry { id, bounds });
+        self.entries.push(ModalEntry {
+            id,
+            bounds,
+            painted_this_frame: false,
+        });
     }
 
     /// Remove the modal with this id, if present. Returns true on
@@ -126,6 +162,49 @@ impl ModalStack {
             }
         }
         None
+    }
+
+    // ─── Paint-consistency detection (#455) ─────────────────────────
+
+    /// Record that `id`'s surface was actually drawn this frame. A no-op
+    /// if `id` isn't currently registered — some backends draw preview
+    /// or ghost content by id outside the modal stack, and that isn't
+    /// the "registered but invisible" defect this exists to catch.
+    ///
+    /// Call from a backend's `draw_dialog` / `draw_palette` /
+    /// `draw_context_menu` (and any future modal-capable rasteriser)
+    /// with the primitive's own `id` field, right where it already
+    /// paints — see `TuiBackend::draw_dialog` for the pattern.
+    pub fn mark_painted(&mut self, id: &WidgetId) {
+        if let Some(entry) = self.entries.iter_mut().find(|e| &e.id == id) {
+            entry.painted_this_frame = true;
+        }
+    }
+
+    /// Clear every entry's per-frame painted flag. Call once per frame,
+    /// before painting starts — backends do this from `Backend::begin_frame`,
+    /// alongside their other "per-frame cache" resets (text regions,
+    /// zones, tab-bar layouts, …).
+    pub fn reset_frame_paint(&mut self) {
+        for entry in &mut self.entries {
+            entry.painted_this_frame = false;
+        }
+    }
+
+    /// Ids of modals that are registered (and therefore hit-testable)
+    /// but were not [`Self::mark_painted`] this frame — the #455
+    /// "registered but invisible" defect made detectable. Call from
+    /// `Backend::end_frame`, after `AppLogic::render` has had its
+    /// chance to paint every open modal.
+    ///
+    /// Empty whenever every open modal was painted (the healthy case)
+    /// or no modals are open at all.
+    pub fn unpainted_ids(&self) -> Vec<WidgetId> {
+        self.entries
+            .iter()
+            .filter(|e| !e.painted_this_frame)
+            .map(|e| e.id.clone())
+            .collect()
     }
 }
 
@@ -241,5 +320,69 @@ mod tests {
         assert_eq!(s.hit_test(pt(0.0, 0.0)), Some(&id("m"))); // inclusive
         assert!(s.hit_test(pt(10.0, 5.0)).is_none()); // exclusive right edge
         assert!(s.hit_test(pt(5.0, 10.0)).is_none()); // exclusive bottom edge
+    }
+
+    // ─── Paint-consistency detection (#455) ─────────────────────────
+
+    #[test]
+    fn freshly_pushed_modal_is_unpainted_until_marked() {
+        // The exact vimcode#587 shape: registered (hit-testable) but no
+        // corresponding draw call happened yet.
+        let mut s = ModalStack::new();
+        s.push(id("palette"), rect(0.0, 0.0, 10.0, 10.0));
+        assert_eq!(s.unpainted_ids(), vec![id("palette")]);
+
+        s.mark_painted(&id("palette"));
+        assert!(s.unpainted_ids().is_empty());
+    }
+
+    #[test]
+    fn reset_frame_paint_clears_marks_for_the_next_frame() {
+        // A modal painted last frame must be painted *again* this frame
+        // to count — otherwise a backend that paints once and then stops
+        // (e.g. a redraw path that silently drops the modal) would never
+        // be flagged.
+        let mut s = ModalStack::new();
+        s.push(id("dialog"), rect(0.0, 0.0, 10.0, 10.0));
+        s.mark_painted(&id("dialog"));
+        assert!(s.unpainted_ids().is_empty());
+
+        s.reset_frame_paint();
+        assert_eq!(s.unpainted_ids(), vec![id("dialog")]);
+    }
+
+    #[test]
+    fn mark_painted_on_unregistered_id_is_a_no_op() {
+        // Backends may draw preview/ghost content by id outside the
+        // modal stack; marking an id that was never pushed must not
+        // panic or fabricate an entry.
+        let mut s = ModalStack::new();
+        s.mark_painted(&id("nothing-registered"));
+        assert!(s.is_empty());
+        assert!(s.unpainted_ids().is_empty());
+    }
+
+    #[test]
+    fn only_the_unpainted_entry_is_reported_among_several() {
+        let mut s = ModalStack::new();
+        s.push(id("palette"), rect(0.0, 0.0, 10.0, 10.0));
+        s.push(id("dialog"), rect(0.0, 0.0, 10.0, 10.0));
+        s.mark_painted(&id("palette"));
+        // "dialog" is registered (topmost, wins hit-testing) but never
+        // painted — exactly the bug this exists to surface.
+        assert_eq!(s.unpainted_ids(), vec![id("dialog")]);
+        assert_eq!(s.hit_test(pt(5.0, 5.0)), Some(&id("dialog")));
+    }
+
+    #[test]
+    fn re_pushing_an_existing_id_clears_its_painted_mark() {
+        // Re-push (bump-to-top) is treated as a fresh open — an entry
+        // that was painted before the bump shouldn't be considered
+        // painted this frame just because its old self was.
+        let mut s = ModalStack::new();
+        s.push(id("a"), rect(0.0, 0.0, 10.0, 10.0));
+        s.mark_painted(&id("a"));
+        s.push(id("a"), rect(1.0, 1.0, 5.0, 5.0));
+        assert_eq!(s.unpainted_ids(), vec![id("a")]);
     }
 }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -806,6 +806,9 @@ impl Backend for TuiBackend {
         // `zones` — a bar that stops painting must stop resolving
         // `tab_center`/`tab_close_center` too.
         self.tab_bar_layouts.clear();
+        // #455: clear last frame's modal paint marks so this frame has
+        // to earn them again (via draw_dialog/draw_palette/draw_context_menu).
+        self.modal_stack.reset_frame_paint();
     }
 
     fn register_text_region(&mut self, region: TextRegion) {
@@ -824,6 +827,20 @@ impl Backend for TuiBackend {
         // No-op. The frame's actual flush happens when ratatui's
         // `terminal.draw(|frame| …)` closure returns; this method
         // exists for parity with backends that need explicit flush.
+        //
+        // #455: in debug builds, warn about any modal that's registered
+        // in the ModalStack (and therefore hit-testable) but that this
+        // frame's `AppLogic::render` never painted — the "registered but
+        // invisible" defect class (vimcode#587) made detectable instead
+        // of silently shipping.
+        #[cfg(debug_assertions)]
+        for id in self.modal_stack.unpainted_ids() {
+            eprintln!(
+                "quadraui: modal {id:?} is registered in ModalStack (and therefore \
+                 hit-testable) but was not painted this frame — see quadraui#455 \
+                 (\"ModalStack drives hit-testing but not paint\")"
+            );
+        }
     }
 
     fn set_theme(&mut self, theme: crate::Theme) {
@@ -1046,6 +1063,9 @@ impl Backend for TuiBackend {
     }
 
     fn draw_palette(&mut self, rect: QRect, palette: &Palette) {
+        // #455: mark before borrowing the frame — a modal-stack entry
+        // whose id matches this palette is now known-painted this frame.
+        self.modal_stack.mark_painted(&palette.id);
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
         let nerd_fonts = self.nerd_fonts_enabled;
@@ -1382,6 +1402,8 @@ impl Backend for TuiBackend {
         menu: &crate::ContextMenu,
         layout: &crate::ContextMenuLayout,
     ) -> Vec<(QRect, crate::WidgetId)> {
+        // #455: see draw_palette for why this happens before the frame borrow.
+        self.modal_stack.mark_painted(&menu.id);
         let theme = self.current_theme;
         let frame = self
             .current_frame_mut()
@@ -1408,6 +1430,8 @@ impl Backend for TuiBackend {
         dialog: &crate::primitives::dialog::Dialog,
         layout: &crate::primitives::dialog::DialogLayout,
     ) -> Vec<QRect> {
+        // #455: see draw_palette for why this happens before the frame borrow.
+        self.modal_stack.mark_painted(&dialog.id);
         let theme = self.current_theme;
         let frame = self
             .current_frame_mut()
@@ -2703,6 +2727,84 @@ mod tests {
         mock.modal_stack_mut()
             .push(WidgetId::new("test:popup"), QRect::new(0.0, 0.0, 10.0, 5.0));
         assert_eq!(mock.modal_stack_mut().len(), 1);
+    }
+
+    /// #455 regression: `TuiBackend::draw_dialog` must mark the modal
+    /// stack entry it paints, so `ModalStack::unpainted_ids` can catch a
+    /// backend that registers a modal for hit-testing but never actually
+    /// paints it — vimcode#587's exact failure shape ("registered but
+    /// invisible"), reproduced here at the backend-wiring level rather
+    /// than `ModalStack` in isolation (already covered in
+    /// `crate::modal_stack::tests`).
+    #[test]
+    fn draw_dialog_marks_its_modal_stack_entry_painted() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let dialog_id = WidgetId::new("confirm");
+        let dialog = crate::Dialog {
+            id: dialog_id.clone(),
+            title: crate::StyledText::plain("Confirm"),
+            body: vec![crate::StyledText::plain("Really?")],
+            table: None,
+            buttons: vec![crate::DialogButton {
+                id: WidgetId::new("ok"),
+                label: "OK".into(),
+                is_default: true,
+                is_cancel: false,
+                tint: None,
+            }],
+            severity: None,
+            vertical_buttons: false,
+            input: None,
+        };
+        let measure = crate::DialogMeasure {
+            width: 40.0,
+            title_height: 1.0,
+            body_height: 1.0,
+            table_height: 0.0,
+            input_height: 0.0,
+            button_row_height: 1.0,
+            button_width: 10.0,
+            button_gap: 2.0,
+            padding: 1.0,
+        };
+        let viewport_rect = QRect::new(0.0, 0.0, 80.0, 24.0);
+        let layout = dialog.layout(viewport_rect, measure, |_| {
+            crate::ToolbarItemMeasure::new(0.0)
+        });
+
+        let mut backend = TuiBackend::new();
+        backend.begin_frame(Viewport::new(80.0, 24.0, 1.0));
+        backend
+            .modal_stack_mut()
+            .push(dialog_id.clone(), layout.bounds);
+
+        // Registered but not yet drawn this frame — exactly the drift
+        // #455 wants surfaced.
+        assert_eq!(
+            backend.modal_stack_mut().unpainted_ids(),
+            vec![dialog_id.clone()]
+        );
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                backend.enter_frame_scope(frame, |b| {
+                    b.draw_dialog(&dialog, &layout);
+                });
+            })
+            .expect("draw");
+
+        // draw_dialog ran through the real trait method and marked its
+        // own id painted — the drift is gone for this frame.
+        assert!(backend.modal_stack_mut().unpainted_ids().is_empty());
+
+        // The next frame must reset the mark: a backend that stops
+        // calling draw_dialog (even though the modal stays registered)
+        // has to be caught again, not remembered as painted forever.
+        backend.begin_frame(Viewport::new(80.0, 24.0, 1.0));
+        assert_eq!(backend.modal_stack_mut().unpainted_ids(), vec![dialog_id]);
     }
 
     // ─── Stage 6: accelerator matching ──────────────────────────────────────


### PR DESCRIPTION
Closes #455

Automated PR opened by coordinator for review of issue #455.