### PR TITLE
#617: ShellApp::on_shell_event receives no ShellContext — an app cannot push state back on the frame the shell event fires

### DIFF
--- a/quadraui/examples/common/appshell_demo.rs
+++ b/quadraui/examples/common/appshell_demo.rs
@@ -291,10 +291,10 @@ impl ShellApp for AppShellDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent, ctx: &ShellContext) {
+    fn on_shell_event_ctx(&mut self, event: &AppShellEvent, ctx: &ShellContext) {
         self.last_event = match event {
             AppShellEvent::PanelChanged { panel_id } => {
-                // #617: `on_shell_event` now receives a `ShellContext`, so
+                // #617: `on_shell_event_ctx` receives a `ShellContext`, so
                 // an app can push shell state back on the *same* frame
                 // this notification fires — no intervening `handle`
                 // dispatch required. Reveal the title bar the moment

--- a/quadraui/examples/common/appshell_demo.rs
+++ b/quadraui/examples/common/appshell_demo.rs
@@ -291,9 +291,23 @@ impl ShellApp for AppShellDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent) {
+    fn on_shell_event(&mut self, event: &AppShellEvent, ctx: &ShellContext) {
         self.last_event = match event {
             AppShellEvent::PanelChanged { panel_id } => {
+                // #617: `on_shell_event` now receives a `ShellContext`, so
+                // an app can push shell state back on the *same* frame
+                // this notification fires — no intervening `handle`
+                // dispatch required. Reveal the title bar the moment
+                // Source Control becomes active, the same shape vimcode's
+                // menu-bar-reveal path needed (issue #617's downstream
+                // motivation): before this, `ShellAdapter::handle`
+                // returned immediately after this call, so a
+                // `set_title_bar_visible` here would have been skipped
+                // for the frame and only taken effect once some unrelated
+                // later event happened to reach `handle`.
+                if panel_id.as_str() == "panel:git" {
+                    ctx.shell_mut().set_title_bar_visible(true);
+                }
                 format!("Panel: {}", panel_id.as_str())
             }
             AppShellEvent::SidebarHidden => "Sidebar hidden".into(),

--- a/quadraui/examples/common/bottom_panel_demo.rs
+++ b/quadraui/examples/common/bottom_panel_demo.rs
@@ -202,7 +202,7 @@ impl ShellApp for BottomPanelDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent) {
+    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         self.last_event = match event {
             AppShellEvent::PanelChanged { panel_id } => {
                 format!("Panel: {}", panel_id.as_str())

--- a/quadraui/examples/common/bottom_panel_demo.rs
+++ b/quadraui/examples/common/bottom_panel_demo.rs
@@ -202,7 +202,7 @@ impl ShellApp for BottomPanelDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
+    fn on_shell_event_ctx(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         self.last_event = match event {
             AppShellEvent::PanelChanged { panel_id } => {
                 format!("Panel: {}", panel_id.as_str())

--- a/quadraui/examples/common/full_chrome_demo.rs
+++ b/quadraui/examples/common/full_chrome_demo.rs
@@ -440,7 +440,7 @@ impl ShellAppTrait for FullChromeDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent) {
+    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         self.last_event = match event {
             AppShellEvent::PanelChanged { panel_id } => {
                 format!("Panel: {}", panel_id.as_str())

--- a/quadraui/examples/common/full_chrome_demo.rs
+++ b/quadraui/examples/common/full_chrome_demo.rs
@@ -440,7 +440,7 @@ impl ShellAppTrait for FullChromeDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
+    fn on_shell_event_ctx(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         self.last_event = match event {
             AppShellEvent::PanelChanged { panel_id } => {
                 format!("Panel: {}", panel_id.as_str())

--- a/quadraui/examples/common/help_layer_demo.rs
+++ b/quadraui/examples/common/help_layer_demo.rs
@@ -278,7 +278,7 @@ impl ShellApp for HelpLayerDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
+    fn on_shell_event_ctx(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         if let AppShellEvent::PanelChanged { panel_id } = event {
             self.active_panel = panel_id.clone();
             self.last_message = format!("Panel: {}", panel_id.as_str());

--- a/quadraui/examples/common/help_layer_demo.rs
+++ b/quadraui/examples/common/help_layer_demo.rs
@@ -278,7 +278,7 @@ impl ShellApp for HelpLayerDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent) {
+    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         if let AppShellEvent::PanelChanged { panel_id } = event {
             self.active_panel = panel_id.clone();
             self.last_message = format!("Panel: {}", panel_id.as_str());

--- a/quadraui/examples/common/shell_menu_demo.rs
+++ b/quadraui/examples/common/shell_menu_demo.rs
@@ -159,7 +159,7 @@ impl ShellAppTrait for ShellMenuDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent) {
+    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         match event {
             AppShellEvent::PanelChanged { panel_id } => {
                 self.last_action = format!("Panel: {}", panel_id.as_str());

--- a/quadraui/examples/common/shell_menu_demo.rs
+++ b/quadraui/examples/common/shell_menu_demo.rs
@@ -159,7 +159,7 @@ impl ShellAppTrait for ShellMenuDemo {
         }
     }
 
-    fn on_shell_event(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
+    fn on_shell_event_ctx(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
         match event {
             AppShellEvent::PanelChanged { panel_id } => {
                 self.last_action = format!("Panel: {}", panel_id.as_str());

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -435,22 +435,54 @@ pub trait ShellApp {
     /// Notified when a panel switch occurs (activity bar click or
     /// programmatic). Optional.
     ///
+    /// # Deprecated
+    ///
+    /// Implement [`Self::on_shell_event_ctx`] instead — it receives the
+    /// same notification plus a [`ShellContext`] so an app can push
+    /// shell-state mutations (`set_title_bar_visible`, `set_sidebar_width`,
+    /// `show_panel`, `toggle_sidebar`) back into the shell on the *same
+    /// frame* the event fires (#617). This one-argument hook predates
+    /// that context and is kept, unchanged, purely so pre-#617 overrides
+    /// (e.g. `vimcode`, which path-deps this crate with no version pin —
+    /// see `CLAUDE.md`'s *Downstream consumers* section) keep compiling.
+    /// [`crate::shell_adapter::ShellAdapter`] never calls this method
+    /// directly; [`Self::on_shell_event_ctx`]'s default implementation
+    /// forwards to it, so an override here still fires — just without a
+    /// `ShellContext`.
+    #[deprecated(
+        since = "0.0.1",
+        note = "implement `on_shell_event_ctx` instead — it receives a `&ShellContext` so shell-state pushed back in response to the event lands on the same frame (#617)"
+    )]
+    fn on_shell_event(&mut self, _event: &AppShellEvent) {}
+
+    /// Notified when a panel switch occurs (activity bar click or
+    /// programmatic). Optional.
+    ///
     /// The [`ShellContext`] lends the same scoped `&mut AppShell` borrow
     /// [`Self::handle`] receives (#617) — call `ctx.shell_mut()` mutators
     /// here (e.g. `set_title_bar_visible`, `set_sidebar_width`,
     /// `show_panel`, `toggle_sidebar`) to push state back into the shell
     /// on the *same frame* this event fires.
     ///
-    /// Before this parameter existed, [`crate::shell_adapter::ShellAdapter::handle`]
-    /// returned immediately after calling this hook — it never fell
-    /// through to [`Self::handle`] — so any shell-state mutation an app
-    /// wanted to make in response to a shell event had no way to land
-    /// before the very next `Reaction::Redraw` painted the frame. An app
-    /// that flipped its own view state here (e.g. "show the menu bar")
-    /// and needed the shell to reserve a row for it (`set_title_bar_visible`)
-    /// simply couldn't, and the chrome silently disagreed with the app's
-    /// state until some unrelated later event happened to reach `handle`.
-    fn on_shell_event(&mut self, _event: &AppShellEvent, _ctx: &ShellContext) {}
+    /// Before this method existed, [`crate::shell_adapter::ShellAdapter::handle`]
+    /// returned immediately after calling the (then one-argument)
+    /// `on_shell_event` — it never fell through to [`Self::handle`] — so
+    /// any shell-state mutation an app wanted to make in response to a
+    /// shell event had no way to land before the very next
+    /// `Reaction::Redraw` painted the frame. An app that flipped its own
+    /// view state here (e.g. "show the menu bar") and needed the shell to
+    /// reserve a row for it (`set_title_bar_visible`) simply couldn't, and
+    /// the chrome silently disagreed with the app's state until some
+    /// unrelated later event happened to reach `handle`.
+    ///
+    /// Default implementation forwards to the deprecated
+    /// [`Self::on_shell_event`] (ignoring `ctx`) so implementors of the
+    /// old one-argument hook keep working unchanged. Override this method
+    /// directly — not `on_shell_event` — to use `ctx`.
+    fn on_shell_event_ctx(&mut self, event: &AppShellEvent, _ctx: &ShellContext) {
+        #[allow(deprecated)]
+        self.on_shell_event(event);
+    }
 
     /// Poll for a pending **app-initiated** panel switch — e.g. an action
     /// handler that jumps straight to a different panel (a "launch
@@ -463,9 +495,9 @@ pub trait ShellApp {
     /// (updating the ActivityBar highlight and sidebar panel header, which
     /// are otherwise owned entirely by `AppShell` and invisible to
     /// `ShellApp` implementors) and re-notifies via
-    /// [`Self::on_shell_event`] with [`AppShellEvent::PanelChanged`], the
+    /// [`Self::on_shell_event_ctx`] with [`AppShellEvent::PanelChanged`], the
     /// same notification a mouse click produces — so app code that already
-    /// syncs its own view state from `on_shell_event` doesn't need a
+    /// syncs its own view state from `on_shell_event_ctx` doesn't need a
     /// second code path.
     ///
     /// Before this hook existed, consumers had no way to keep the chrome in

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -434,7 +434,23 @@ pub trait ShellApp {
 
     /// Notified when a panel switch occurs (activity bar click or
     /// programmatic). Optional.
-    fn on_shell_event(&mut self, _event: &AppShellEvent) {}
+    ///
+    /// The [`ShellContext`] lends the same scoped `&mut AppShell` borrow
+    /// [`Self::handle`] receives (#617) — call `ctx.shell_mut()` mutators
+    /// here (e.g. `set_title_bar_visible`, `set_sidebar_width`,
+    /// `show_panel`, `toggle_sidebar`) to push state back into the shell
+    /// on the *same frame* this event fires.
+    ///
+    /// Before this parameter existed, [`crate::shell_adapter::ShellAdapter::handle`]
+    /// returned immediately after calling this hook — it never fell
+    /// through to [`Self::handle`] — so any shell-state mutation an app
+    /// wanted to make in response to a shell event had no way to land
+    /// before the very next `Reaction::Redraw` painted the frame. An app
+    /// that flipped its own view state here (e.g. "show the menu bar")
+    /// and needed the shell to reserve a row for it (`set_title_bar_visible`)
+    /// simply couldn't, and the chrome silently disagreed with the app's
+    /// state until some unrelated later event happened to reach `handle`.
+    fn on_shell_event(&mut self, _event: &AppShellEvent, _ctx: &ShellContext) {}
 
     /// Poll for a pending **app-initiated** panel switch — e.g. an action
     /// handler that jumps straight to a different panel (a "launch

--- a/quadraui/src/shell_adapter.rs
+++ b/quadraui/src/shell_adapter.rs
@@ -75,7 +75,7 @@ impl<A: ShellApp> ShellAdapter<A> {
     /// Apply a pending [`ShellApp::take_requested_panel`] switch, if any.
     /// Updates the underlying `AppShell`'s active panel (ActivityBar
     /// highlight + sidebar header), mirrors it into `active_panel_id`, and
-    /// re-notifies the app via `on_shell_event` — the same notification a
+    /// re-notifies the app via `on_shell_event_ctx` — the same notification a
     /// mouse-driven switch produces. Returns `true` iff a switch was
     /// applied (the caller should redraw).
     fn apply_requested_panel(&mut self, backend: &mut dyn Backend, area: Rect) -> bool {
@@ -89,9 +89,9 @@ impl<A: ShellApp> ShellAdapter<A> {
     }
 
     /// Build a [`ShellContext`] for the current dispatch and notify
-    /// [`ShellApp::on_shell_event`] with it, then return `Reaction::Redraw`
-    /// — the shape every `AppShellEvent` arm in [`Self::handle`] needs
-    /// (#617).
+    /// [`ShellApp::on_shell_event_ctx`] with it, then return
+    /// `Reaction::Redraw` — the shape every `AppShellEvent` arm in
+    /// [`Self::handle`] needs (#617).
     ///
     /// Built fresh per call (rather than once before the caller's match)
     /// so it picks up any state the caller already applied to
@@ -113,7 +113,7 @@ impl<A: ShellApp> ShellAdapter<A> {
             &layout,
             &mut self.shell,
         );
-        self.app.on_shell_event(ev, &ctx);
+        self.app.on_shell_event_ctx(ev, &ctx);
         Reaction::Redraw
     }
 }
@@ -272,7 +272,7 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         // event type — there is nothing for a consumer to opt into or
         // conflict with) and drive `AppShell` directly. Resulting
         // `AppShellEvent`s are reported through the existing
-        // `on_shell_event` notification, exactly like a mouse-driven panel
+        // `on_shell_event_ctx` notification, exactly like a mouse-driven panel
         // switch.
         if let UiEvent::ActivityBar(_, ActivityBarEvent::KeyPressed { ref key, .. }) = event {
             return match key.as_str() {

--- a/quadraui/src/shell_adapter.rs
+++ b/quadraui/src/shell_adapter.rs
@@ -78,15 +78,43 @@ impl<A: ShellApp> ShellAdapter<A> {
     /// re-notifies the app via `on_shell_event` — the same notification a
     /// mouse-driven switch produces. Returns `true` iff a switch was
     /// applied (the caller should redraw).
-    fn apply_requested_panel(&mut self) -> bool {
+    fn apply_requested_panel(&mut self, backend: &mut dyn Backend, area: Rect) -> bool {
         let Some(panel_id) = self.app.take_requested_panel() else {
             return false;
         };
         self.shell.show_panel(&panel_id);
         self.active_panel_id = Some(panel_id.clone());
-        self.app
-            .on_shell_event(&AppShellEvent::PanelChanged { panel_id });
+        self.notify_shell_event(backend, area, &AppShellEvent::PanelChanged { panel_id });
         true
+    }
+
+    /// Build a [`ShellContext`] for the current dispatch and notify
+    /// [`ShellApp::on_shell_event`] with it, then return `Reaction::Redraw`
+    /// — the shape every `AppShellEvent` arm in [`Self::handle`] needs
+    /// (#617).
+    ///
+    /// Built fresh per call (rather than once before the caller's match)
+    /// so it picks up any state the caller already applied to
+    /// `self.active_panel_id` / `self.shell` for this event — the
+    /// `PanelChanged` arm, for instance, sets `active_panel_id` before
+    /// calling this, and the context must reflect that, not the
+    /// pre-update value.
+    fn notify_shell_event(
+        &mut self,
+        backend: &mut dyn Backend,
+        area: Rect,
+        ev: &AppShellEvent,
+    ) -> Reaction {
+        let layout = self.shell.layout(area, backend.line_height());
+        let sidebar_visible = self.shell.sidebar_visible();
+        let ctx = ShellContext::new(
+            self.active_panel_id.as_ref(),
+            sidebar_visible,
+            &layout,
+            &mut self.shell,
+        );
+        self.app.on_shell_event(ev, &ctx);
+        Reaction::Redraw
     }
 }
 
@@ -198,16 +226,13 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         match &shell_ev {
             AppShellEvent::PanelChanged { panel_id } => {
                 self.active_panel_id = Some(panel_id.clone());
-                self.app.on_shell_event(&shell_ev);
-                return Reaction::Redraw;
+                return self.notify_shell_event(backend, area, &shell_ev);
             }
             AppShellEvent::SidebarHidden => {
-                self.app.on_shell_event(&shell_ev);
-                return Reaction::Redraw;
+                return self.notify_shell_event(backend, area, &shell_ev);
             }
             AppShellEvent::SidebarResized { .. } => {
-                self.app.on_shell_event(&shell_ev);
-                return Reaction::Redraw;
+                return self.notify_shell_event(backend, area, &shell_ev);
             }
             AppShellEvent::BottomPanelResized { new_height } => {
                 // Forward as BottomPanelEvent::Resized to app when a controller is present.
@@ -219,16 +244,13 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
                     let ev = BottomPanelEvent::Resized(*new_height);
                     self.app.on_bottom_panel_event(&ev);
                 }
-                self.app.on_shell_event(&shell_ev);
-                return Reaction::Redraw;
+                return self.notify_shell_event(backend, area, &shell_ev);
             }
             AppShellEvent::BottomPanelHidden => {
-                self.app.on_shell_event(&shell_ev);
-                return Reaction::Redraw;
+                return self.notify_shell_event(backend, area, &shell_ev);
             }
             AppShellEvent::BottomItemClicked { .. } => {
-                self.app.on_shell_event(&shell_ev);
-                return Reaction::Redraw;
+                return self.notify_shell_event(backend, area, &shell_ev);
             }
             AppShellEvent::Consumed => return Reaction::Redraw,
             AppShellEvent::Ignored => {}
@@ -268,7 +290,7 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
                         if let AppShellEvent::PanelChanged { ref panel_id } = ev {
                             self.active_panel_id = Some(panel_id.clone());
                         }
-                        self.app.on_shell_event(&ev);
+                        self.notify_shell_event(backend, area, &ev);
                     }
                     Reaction::Redraw
                 }
@@ -323,7 +345,7 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
             }
         }
 
-        if self.apply_requested_panel() {
+        if self.apply_requested_panel(backend, area) {
             reaction = Reaction::Redraw;
         }
 
@@ -336,7 +358,9 @@ impl<A: ShellApp> AppLogic for ShellAdapter<A> {
         // finishing) can also want to land the app on a different panel —
         // poll the same hook `handle()` does so tick-driven switches aren't
         // a second, forgotten code path.
-        if self.apply_requested_panel() && reaction == Reaction::Continue {
+        let viewport = backend.viewport();
+        let area = Rect::new(0.0, 0.0, viewport.width, viewport.height);
+        if self.apply_requested_panel(backend, area) && reaction == Reaction::Continue {
             reaction = Reaction::Redraw;
         }
         reaction

--- a/quadraui/tests/gtk_example_driver.rs
+++ b/quadraui/tests/gtk_example_driver.rs
@@ -213,7 +213,7 @@ fn appshell_demo_tab_focus_then_jj_enter_switches_panel() {
     );
     assert!(
         driver.screen_contains("Panel: panel:git"),
-        "on_shell_event(PanelChanged) must fire for a keyboard-driven switch, \
+        "on_shell_event_ctx(PanelChanged) must fire for a keyboard-driven switch, \
          mirroring the TUI path: {:?}",
         driver.painted_texts()
     );

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -937,6 +937,70 @@ fn appshell_demo_t_toggles_title_bar_and_reflows_sidebar_content_row() {
     );
 }
 
+/// #617 acceptance: `ShellApp::on_shell_event` now receives a
+/// `&ShellContext`, so an app can push state back into the real `AppShell`
+/// on the *same* frame the shell event fires — no intervening
+/// `ShellApp::handle` dispatch required. `AppShellDemo::on_shell_event`
+/// reveals the title bar via `ctx.shell_mut().set_title_bar_visible(true)`
+/// the moment `PanelChanged { panel_id: "panel:git" }` fires (see its
+/// module doc / `on_shell_event` body).
+///
+/// Before #617, `ShellAdapter::handle` returned immediately after calling
+/// `on_shell_event(&shell_ev)` — with no `ShellContext` parameter for the
+/// app to mutate the shell through in the first place — so a title-bar
+/// reveal triggered from inside `on_shell_event` had no way to land before
+/// that `Reaction::Redraw` painted the frame; it would only appear once
+/// some unrelated *later* event happened to reach `handle`. Driving the
+/// programmatic switch (`p`, `take_requested_panel`) with a *single*
+/// `type_char` call and asserting the reserved title-bar row is already
+/// visible in the very next rendered frame proves the fix lands
+/// synchronously within that one dispatch, exactly as
+/// `appshell_demo_t_toggles_title_bar_and_reflows_sidebar_content_row`
+/// proves it for the (already-working) `ctx.shell_mut()` call from inside
+/// `handle` itself.
+#[test]
+fn appshell_demo_on_shell_event_pushes_title_bar_state_same_frame() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, 100, 30);
+
+    // Title bar starts hidden: no `.with_title_bar(..)` in `config()`.
+    let before = driver
+        .find_bounds("(sidebar content")
+        .unwrap_or_else(|| panic!("sidebar content label not painted:\n{}", driver.screen()));
+
+    // A single event dispatch: `p` queues a programmatic switch to
+    // panel:git, which `ShellAdapter::handle` applies (via
+    // `apply_requested_panel` → `notify_shell_event`) *within this same
+    // call* — including the `on_shell_event` notification that reveals
+    // the title bar. No second `type_char`/event is involved.
+    let reaction = driver.type_char('p');
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "queuing + applying the programmatic switch must redraw"
+    );
+
+    let screen = driver.screen();
+    assert!(
+        screen.contains("SOURCE CONTROL"),
+        "the programmatic switch itself must still take effect:\n{screen}"
+    );
+
+    // The title bar row must already be reserved in this very frame —
+    // proven the same way the `t`-key test proves it: the sidebar content
+    // label's row shifted down from its title-bar-hidden position.
+    let after = driver
+        .find_bounds("(sidebar content")
+        .unwrap_or_else(|| panic!("sidebar content label not painted after 'p':\n{screen}"));
+    assert!(
+        after.y > before.y,
+        "on_shell_event's ctx.shell_mut().set_title_bar_visible(true) must reserve the \
+         title bar row on the same frame PanelChanged fires — before y={}, after y={}:\n{screen}",
+        before.y,
+        after.y
+    );
+}
+
 // ─── DialogTableDemo (issue #225): table layout in dialog ───────────────────
 
 /// Initial screen renders dialog title and table headers.

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -682,7 +682,7 @@ fn shell_runner_path_drag_and_ctrl_c_copies_text() {
 /// `Tab` focuses the activity bar, `j` `j` moves the keyboard cursor down
 /// two items (explorer → search → git), and `Enter` activates the
 /// selection — switching to the Source Control panel and notifying
-/// `AppShellDemo::on_shell_event`, which is what paints "Panel: panel:git".
+/// `AppShellDemo::on_shell_event_ctx`, which is what paints "Panel: panel:git".
 #[test]
 fn appshell_demo_tab_focus_then_jj_enter_switches_panel() {
     let config = AppShellDemo::config();
@@ -726,7 +726,7 @@ fn appshell_demo_tab_focus_then_jj_enter_switches_panel() {
     );
     assert!(
         driver.screen_contains("Panel: panel:git"),
-        "activating the cursor item should switch to the git panel and notify on_shell_event:\n{}",
+        "activating the cursor item should switch to the git panel and notify on_shell_event_ctx:\n{}",
         driver.screen()
     );
 }
@@ -773,7 +773,7 @@ fn appshell_demo_escape_cancels_focus_without_switching_panel() {
 /// `ShellApp::take_requested_panel` (coord-tui #1029 bug A): an app can
 /// queue a panel switch from inside its own `handle()` — no ActivityBar
 /// click, no keyboard-cursor mode — and `ShellAdapter` must apply it to the
-/// *real* `AppShell` state (sidebar header) and re-notify `on_shell_event`,
+/// *real* `AppShell` state (sidebar header) and re-notify `on_shell_event_ctx`,
 /// not just let the app's own internal view state drift out of sync with
 /// the chrome. Before this hook, the sidebar header would stay on
 /// "EXPLORER" here even though the app had "moved on" internally — the
@@ -809,7 +809,7 @@ fn appshell_demo_programmatic_panel_switch_updates_chrome() {
     );
     assert!(
         driver.screen_contains("Panel: panel:git"),
-        "on_shell_event(PanelChanged) must fire for a programmatic switch \
+        "on_shell_event_ctx(PanelChanged) must fire for a programmatic switch \
          exactly as it does for a mouse-driven one:\n{}",
         driver.screen()
     );
@@ -937,18 +937,19 @@ fn appshell_demo_t_toggles_title_bar_and_reflows_sidebar_content_row() {
     );
 }
 
-/// #617 acceptance: `ShellApp::on_shell_event` now receives a
+/// #617 acceptance: `ShellApp::on_shell_event_ctx` receives a
 /// `&ShellContext`, so an app can push state back into the real `AppShell`
 /// on the *same* frame the shell event fires — no intervening
-/// `ShellApp::handle` dispatch required. `AppShellDemo::on_shell_event`
+/// `ShellApp::handle` dispatch required. `AppShellDemo::on_shell_event_ctx`
 /// reveals the title bar via `ctx.shell_mut().set_title_bar_visible(true)`
 /// the moment `PanelChanged { panel_id: "panel:git" }` fires (see its
-/// module doc / `on_shell_event` body).
+/// module doc / `on_shell_event_ctx` body).
 ///
 /// Before #617, `ShellAdapter::handle` returned immediately after calling
-/// `on_shell_event(&shell_ev)` — with no `ShellContext` parameter for the
-/// app to mutate the shell through in the first place — so a title-bar
-/// reveal triggered from inside `on_shell_event` had no way to land before
+/// the (now-deprecated) one-argument `on_shell_event(&shell_ev)` — with no
+/// `ShellContext` parameter for the app to mutate the shell through in the
+/// first place — so a title-bar reveal triggered from inside that hook had
+/// no way to land before
 /// that `Reaction::Redraw` painted the frame; it would only appear once
 /// some unrelated *later* event happened to reach `handle`. Driving the
 /// programmatic switch (`p`, `take_requested_panel`) with a *single*
@@ -971,7 +972,7 @@ fn appshell_demo_on_shell_event_pushes_title_bar_state_same_frame() {
     // A single event dispatch: `p` queues a programmatic switch to
     // panel:git, which `ShellAdapter::handle` applies (via
     // `apply_requested_panel` → `notify_shell_event`) *within this same
-    // call* — including the `on_shell_event` notification that reveals
+    // call* — including the `on_shell_event_ctx` notification that reveals
     // the title bar. No second `type_char`/event is involved.
     let reaction = driver.type_char('p');
     assert_eq!(
@@ -994,7 +995,7 @@ fn appshell_demo_on_shell_event_pushes_title_bar_state_same_frame() {
         .unwrap_or_else(|| panic!("sidebar content label not painted after 'p':\n{screen}"));
     assert!(
         after.y > before.y,
-        "on_shell_event's ctx.shell_mut().set_title_bar_visible(true) must reserve the \
+        "on_shell_event_ctx's ctx.shell_mut().set_title_bar_visible(true) must reserve the \
          title bar row on the same frame PanelChanged fires — before y={}, after y={}:\n{screen}",
         before.y,
         after.y


### PR DESCRIPTION
Closes #617

Automated PR opened by coordinator for review of issue #617.