### PR TITLE
#619: Library diagnostics must never reach the host's screen: quadraui eprintln!s smear text across vimcode's live TUI

### DIFF
--- a/quadraui/src/diagnostics.rs
+++ b/quadraui/src/diagnostics.rs
@@ -1,0 +1,190 @@
+//! Library-internal diagnostics sink (#619).
+//!
+//! quadraui must never write to stdout/stderr on its own: a host embedding
+//! one of quadraui's backends (vimcode's TUI, in raw mode on the alternate
+//! screen, is the motivating case) owns the terminal, and a stray
+//! `eprintln!` from library code lands as raw bytes in the host's live
+//! cell grid — bypassing ratatui entirely, so the framework never learns
+//! those cells were overwritten and the text persists until something
+//! forces a full redraw. See #619 for the incident this module exists to
+//! prevent (the #455 unpainted-modal warning smearing over vimcode's
+//! editor on every frame the popup was open).
+//!
+//! Instead, library code that wants to surface a diagnostic calls a
+//! crate-internal `emit` function, which forwards the message to whatever
+//! sink the host installed via [`set_sink`]. With no sink installed — the
+//! default, and the state of every host that never calls `set_sink` —
+//! diagnostics are silently dropped. This holds in debug and release
+//! builds alike; unlike the old call sites, nothing here is gated on
+//! `debug_assertions`.
+//!
+//! Hosts decide what "surfacing" means: a status line, a log file, a
+//! `tracing` event, a debug panel. This module makes no assumption about
+//! any of that — the sink is just `Fn(&str)`.
+//!
+//! # Example
+//!
+//! ```
+//! use std::sync::atomic::{AtomicUsize, Ordering};
+//! use std::sync::Arc;
+//!
+//! let seen = Arc::new(AtomicUsize::new(0));
+//! let seen_in_sink = Arc::clone(&seen);
+//! quadraui::diagnostics::set_sink(move |_msg: &str| {
+//!     seen_in_sink.fetch_add(1, Ordering::SeqCst);
+//! });
+//!
+//! // A host only ever *installs* a sink; `emit` itself is
+//! // crate-internal, called from the small set of library call sites
+//! // listed in #619.
+//!
+//! quadraui::diagnostics::clear_sink();
+//! ```
+
+use std::sync::{OnceLock, RwLock};
+
+/// A host-installed diagnostic sink. See the module doc.
+type Sink = Box<dyn Fn(&str) + Send + Sync + 'static>;
+
+fn sink_slot() -> &'static RwLock<Option<Sink>> {
+    static SLOT: OnceLock<RwLock<Option<Sink>>> = OnceLock::new();
+    SLOT.get_or_init(|| RwLock::new(None))
+}
+
+/// Install the sink that receives every future `emit` call, replacing
+/// any previously installed sink.
+///
+/// The host owns delivery — log to a file, forward to `tracing`, append
+/// to an in-app diagnostics panel, whatever fits. quadraui never touches
+/// stdout/stderr on its own; a host that never calls this gets a
+/// guaranteed-silent library.
+///
+/// # Example
+///
+/// ```
+/// quadraui::diagnostics::set_sink(|msg: &str| {
+///     eprintln!("[quadraui via host sink] {msg}");
+/// });
+/// # quadraui::diagnostics::clear_sink();
+/// ```
+pub fn set_sink<F>(sink: F)
+where
+    F: Fn(&str) + Send + Sync + 'static,
+{
+    let mut slot = sink_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = Some(Box::new(sink));
+}
+
+/// Remove any installed sink, restoring the default silent behaviour.
+/// Mainly useful for tests that install a sink temporarily — the sink is
+/// process-global, so a test that installs one and doesn't clear it can
+/// leak into an unrelated test running later in the same binary.
+pub fn clear_sink() {
+    let mut slot = sink_slot()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = None;
+}
+
+/// Emit a library diagnostic. Never writes anywhere itself — forwards to
+/// the host's sink if one is installed via [`set_sink`], otherwise drops
+/// the message on the floor.
+///
+/// Library-internal call sites only (not `pub`): the small, named set of
+/// places listed in #619 — modal-paint tracking, vt100 panic recovery,
+/// the GTK/macOS siblings of the same modal-paint check. Genuinely
+/// CLI-shaped tools (examples, the GTK headless-smoke harness) print
+/// directly and carry their own justified `#[allow(clippy::print_stderr)]`
+/// instead of going through this sink — they *are* the host, not a
+/// library embedded in one.
+pub(crate) fn emit(message: impl AsRef<str>) {
+    let slot = sink_slot()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(sink) = slot.as_ref() {
+        sink(message.as_ref());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    // These tests share one process-global sink slot, so they can't run
+    // concurrently with each other without stomping on each other's
+    // installed sink. `cargo test` runs `#[test]` fns in this module on
+    // separate threads by default; serialise with a plain mutex rather
+    // than reaching for a test-only dependency.
+    fn guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[test]
+    fn default_sink_is_silent() {
+        let _g = guard();
+        clear_sink();
+        // No sink installed: emit must not panic and must not be
+        // observable — there's nothing to assert *against* here beyond
+        // "this doesn't crash," which is the point.
+        emit("quadraui: nobody is listening");
+    }
+
+    #[test]
+    fn installed_sink_receives_the_message() {
+        let _g = guard();
+        let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let received_in_sink = Arc::clone(&received);
+        set_sink(move |msg: &str| {
+            received_in_sink.lock().unwrap().push(msg.to_string());
+        });
+
+        emit("quadraui: hello");
+
+        assert_eq!(received.lock().unwrap().as_slice(), ["quadraui: hello"]);
+        clear_sink();
+    }
+
+    #[test]
+    fn clear_sink_restores_silence() {
+        let _g = guard();
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_in_sink = Arc::clone(&count);
+        set_sink(move |_msg: &str| {
+            count_in_sink.fetch_add(1, Ordering::SeqCst);
+        });
+        emit("quadraui: one");
+        clear_sink();
+        emit("quadraui: two — should not be counted");
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn set_sink_replaces_previous_sink() {
+        let _g = guard();
+        let first_calls = Arc::new(AtomicUsize::new(0));
+        let first_calls_in_sink = Arc::clone(&first_calls);
+        set_sink(move |_msg: &str| {
+            first_calls_in_sink.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let second_calls = Arc::new(AtomicUsize::new(0));
+        let second_calls_in_sink = Arc::clone(&second_calls);
+        set_sink(move |_msg: &str| {
+            second_calls_in_sink.fetch_add(1, Ordering::SeqCst);
+        });
+
+        emit("quadraui: routed to whichever sink is current");
+
+        assert_eq!(first_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(second_calls.load(Ordering::SeqCst), 1);
+        clear_sink();
+    }
+}

--- a/quadraui/src/diagnostics.rs
+++ b/quadraui/src/diagnostics.rs
@@ -99,6 +99,27 @@ pub fn clear_sink() {
 /// directly and carry their own justified `#[allow(clippy::print_stderr)]`
 /// instead of going through this sink — they *are* the host, not a
 /// library embedded in one.
+///
+/// Every one of those call sites lives in a feature-gated module —
+/// `tui/backend.rs`, `gtk/backend.rs`, `macos/backend.rs` (itself
+/// additionally `target_os = "macos"`-gated in `lib.rs`, so on Linux the
+/// `macos` feature compiles none of it) and `terminal_engine.rs`. This
+/// module is not gated, so a configuration that enables none of them —
+/// CI's `cargo check -p quadraui --features win` gate is exactly that
+/// one — compiles `emit` with zero callers and trips `dead_code` under
+/// the workflow's `-D warnings`. The allow is scoped by `cfg_attr` to
+/// precisely that case rather than applied unconditionally, so
+/// dead-code detection stays live in every configuration where a call
+/// site actually compiles.
+#[cfg_attr(
+    not(any(
+        feature = "tui",
+        feature = "gtk",
+        feature = "terminal",
+        all(feature = "macos", target_os = "macos")
+    )),
+    allow(dead_code)
+)]
 pub(crate) fn emit(message: impl AsRef<str>) {
     let slot = sink_slot()
         .read()

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1202,11 +1202,7 @@ impl Backend for GtkBackend {
         // of silently shipping.
         #[cfg(debug_assertions)]
         for id in self.modal_stack.borrow().unpainted_ids() {
-            eprintln!(
-                "quadraui: modal {id:?} is registered in ModalStack (and therefore \
-                 hit-testable) but was not painted this frame — see quadraui#455 \
-                 (\"ModalStack drives hit-testing but not paint\")"
-            );
+            crate::diagnostics::emit(crate::modal_stack::ModalStack::unpainted_modal_message(&id));
         }
     }
 

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -818,6 +818,14 @@ fn activate<A: AppLogic + 'static>(
 /// and replays it as a synthetic Ctrl-V through [`dispatch_event`], then
 /// always closes the window so an unattended `xvfb-run` invocation exits
 /// deterministically instead of hanging.
+///
+/// #619: exempt from the crate-wide `print_stderr` deny. This is the
+/// headless smoke harness itself — opt-in via `QUADRAUI_GTK_SMOKE_MS`,
+/// invoked directly by `xvfb-run`/CI, never by a host embedding a live
+/// quadraui backend — so its failure output *is* the tool's normal
+/// output, the same way a CLI's own diagnostics aren't routed through
+/// `diagnostics::emit`.
+#[allow(clippy::print_stderr)]
 fn schedule_smoke_check<A: AppLogic + 'static>(
     cfg: SmokeConfig,
     da: DrawingArea,

--- a/quadraui/src/gtk/services.rs
+++ b/quadraui/src/gtk/services.rs
@@ -306,6 +306,12 @@ mod tests {
     /// Rust test harness run them on different OS threads, which
     /// deterministically panics every thread except whichever one wins
     /// the `require_gtk()` / `gtk4::init()` race.
+    // #619: exempt from the crate-wide `print_stderr` deny. `cargo test`
+    // output, not code that runs inside a host's live UI session — this
+    // line only ever executes on a headless dev box with no display,
+    // where it's the reason the test reports "ok" without covering
+    // anything.
+    #[allow(clippy::print_stderr)]
     #[test]
     fn build_file_dialog_behaviors() {
         if !require_gtk() {

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -83,6 +83,25 @@
 //!
 //! Verify all six when adding a new primitive or extending an existing one.
 
+// #619: library code must never write to stdout/stderr — a host embedding
+// a quadraui backend (vimcode's TUI, in raw mode on the alternate screen)
+// owns the terminal, and a stray `eprintln!`/`println!` lands as raw bytes
+// in its live cell grid, bypassing ratatui entirely. Denied here, not just
+// asked for at review, so the next print macro added anywhere under `src/`
+// fails the build instead of reaching a user's screen. Diagnostics route
+// through `diagnostics::emit` instead (see that module).
+//
+// The handful of genuinely CLI-shaped call sites this deny would otherwise
+// break (the GTK headless-smoke harness in `gtk/run.rs`, the macOS
+// visual-confirmation dev tool in `macos/headless.rs`, a test-skip notice
+// in `gtk/services.rs`) carry their own justified
+// `#[allow(clippy::print_stderr)]` — they print to a human running a tool
+// directly, not into a host's live UI. `examples/*` and any `bin/` are
+// compiled as separate crates and are unaffected by this inner attribute;
+// they're expected to print freely.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
+pub mod diagnostics;
 pub mod diff;
 pub mod frame;
 pub mod primitives;

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -437,11 +437,7 @@ impl Backend for MacBackend {
         // of silently shipping.
         #[cfg(debug_assertions)]
         for id in self.modal_stack.unpainted_ids() {
-            eprintln!(
-                "quadraui: modal {id:?} is registered in ModalStack (and therefore \
-                 hit-testable) but was not painted this frame — see quadraui#455 \
-                 (\"ModalStack drives hit-testing but not paint\")"
-            );
+            crate::diagnostics::emit(crate::modal_stack::ModalStack::unpainted_modal_message(&id));
         }
     }
 

--- a/quadraui/src/macos/headless.rs
+++ b/quadraui/src/macos/headless.rs
@@ -181,6 +181,13 @@ impl BitmapSurface {
     /// across the chrome rasterisers — the shared visual-confirmation
     /// path. Failures from `open` (no Preview, sandboxed env) are
     /// non-fatal; the PPM file is still on disk.
+    ///
+    /// #619: exempt from the crate-wide `print_stderr` deny. This is a
+    /// manual, `#[ignore]`d-test-only visual-confirmation tool run
+    /// directly by a developer at a terminal, not code a host embeds
+    /// into a live UI session — the printed path *is* the output the
+    /// human runs this for.
+    #[allow(clippy::print_stderr)]
     pub fn write_ppm_and_open(&self, path: &str) {
         use std::fs::File;
         use std::io::Write;

--- a/quadraui/src/modal_stack.rs
+++ b/quadraui/src/modal_stack.rs
@@ -212,6 +212,23 @@ impl ModalStack {
     /// (#619) instead of three near-identical `eprintln!` bodies. Callers
     /// route this through [`crate::diagnostics::emit`] rather than
     /// printing it directly — see that module for why.
+    ///
+    /// All three callers are feature-gated backends while this module is
+    /// not, so a build that enables no backend (CI's `cargo check -p
+    /// quadraui --features win` gate — `WinBackend::end_frame` is still a
+    /// `todo!()` stub with no modal-paint check to make) compiles this
+    /// with zero callers and trips `dead_code` under `-D warnings`. Scoped
+    /// by `cfg_attr` to exactly that configuration so the lint keeps
+    /// working wherever a caller is actually compiled. Same reasoning, and
+    /// the same shape, as `diagnostics::emit`.
+    #[cfg_attr(
+        not(any(
+            feature = "tui",
+            feature = "gtk",
+            all(feature = "macos", target_os = "macos")
+        )),
+        allow(dead_code)
+    )]
     pub(crate) fn unpainted_modal_message(id: &WidgetId) -> String {
         format!(
             "quadraui: modal {id:?} is registered in ModalStack (and therefore \

--- a/quadraui/src/modal_stack.rs
+++ b/quadraui/src/modal_stack.rs
@@ -206,6 +206,19 @@ impl ModalStack {
             .map(|e| e.id.clone())
             .collect()
     }
+
+    /// The #455 unpainted-modal diagnostic text for `id`, shared by every
+    /// backend's `end_frame` so the message exists in exactly one place
+    /// (#619) instead of three near-identical `eprintln!` bodies. Callers
+    /// route this through [`crate::diagnostics::emit`] rather than
+    /// printing it directly — see that module for why.
+    pub(crate) fn unpainted_modal_message(id: &WidgetId) -> String {
+        format!(
+            "quadraui: modal {id:?} is registered in ModalStack (and therefore \
+             hit-testable) but was not painted this frame — see quadraui#455 \
+             (\"ModalStack drives hit-testing but not paint\")"
+        )
+    }
 }
 
 fn rect_contains(rect: &Rect, point: Point) -> bool {

--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -1131,9 +1131,9 @@ impl TerminalSession {
                     }))
                     .is_err()
                     {
-                        eprintln!(
+                        crate::diagnostics::emit(
                             "quadraui: vt100 parser panic in process_with_capture; \
-                             dropping chunk, session kept alive"
+                             dropping chunk, session kept alive",
                         );
                     }
                     self.capture_scrolled_rows(nl_count);
@@ -1150,9 +1150,9 @@ impl TerminalSession {
             }))
             .is_err()
             {
-                eprintln!(
+                crate::diagnostics::emit(
                     "quadraui: vt100 parser panic in process_with_capture; \
-                     dropping chunk, session kept alive"
+                     dropping chunk, session kept alive",
                 );
             }
             if remaining_nl > 0 {

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -835,11 +835,7 @@ impl Backend for TuiBackend {
         // of silently shipping.
         #[cfg(debug_assertions)]
         for id in self.modal_stack.unpainted_ids() {
-            eprintln!(
-                "quadraui: modal {id:?} is registered in ModalStack (and therefore \
-                 hit-testable) but was not painted this frame — see quadraui#455 \
-                 (\"ModalStack drives hit-testing but not paint\")"
-            );
+            crate::diagnostics::emit(crate::modal_stack::ModalStack::unpainted_modal_message(&id));
         }
     }
 

--- a/quadraui/tests/diagnostics_sink.rs
+++ b/quadraui/tests/diagnostics_sink.rs
@@ -1,0 +1,103 @@
+//! Regression coverage for #619: library diagnostics must never reach the
+//! host's screen.
+//!
+//! `UnpaintedModalApp` deliberately reproduces the #455 defect class this
+//! bug report is about — it registers a modal in the [`quadraui::Backend`]'s
+//! `ModalStack` (making it hit-testable) but never paints it, which is
+//! exactly the shape of vimcode's `editor_hover` popup: pushed onto the
+//! stack, painted through a path (`draw_rich_text_popup` there) that
+//! doesn't call `mark_painted`. That drives `TuiBackend::end_frame`'s #455
+//! detector every frame — before #619 that meant an `eprintln!` landing
+//! directly on the host's screen, on every single frame the modal stayed
+//! open.
+#![cfg(feature = "tui")]
+
+use quadraui::tui::testing::TuiDriver;
+use quadraui::{AppLogic, Backend, Reaction, Rect, UiEvent, WidgetId};
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// [`quadraui::diagnostics`]'s sink is process-global, and `cargo test`
+/// runs the `#[test]` fns below on separate threads by default. Without
+/// serialising, one test's `set_sink` can race another's `clear_sink` /
+/// assertion window. Both tests in this file acquire this before touching
+/// the sink.
+fn sink_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[derive(Default)]
+struct UnpaintedModalApp;
+
+impl AppLogic for UnpaintedModalApp {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        // Register a modal so it's hit-testable — but never call any
+        // `draw_*` for it, so `ModalStack::mark_painted` is never reached.
+        // This is the exact "registered but invisible" shape #455 detects.
+        backend.modal_stack_mut().push(
+            WidgetId::new("unpainted_modal"),
+            Rect {
+                x: 2.0,
+                y: 2.0,
+                width: 10.0,
+                height: 3.0,
+            },
+        );
+    }
+
+    fn handle(&mut self, _event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
+        Reaction::Continue
+    }
+}
+
+/// The headline regression: with no sink installed (the default — and the
+/// state of every host that never opts in), the #455 diagnostic must never
+/// reach the rendered screen, in debug builds (where the detector is
+/// compiled in) same as release.
+#[test]
+fn unpainted_modal_diagnostic_never_reaches_the_screen() {
+    let _guard = sink_test_guard();
+    quadraui::diagnostics::clear_sink();
+
+    let driver = TuiDriver::new(UnpaintedModalApp, 40, 10);
+
+    let screen = driver.screen();
+    assert!(
+        !driver.screen_contains("quadraui:"),
+        "a library diagnostic must never be painted onto the host's screen \
+         (quadraui#619):\n{screen}"
+    );
+}
+
+/// The detector must still be doing its job — #619 is "route it to a
+/// sink," not "delete it." A host that opts in by installing a sink must
+/// still see the #455 warning; the fix only changes *where* it goes, not
+/// *whether* it exists.
+#[test]
+fn unpainted_modal_diagnostic_still_reaches_an_installed_sink() {
+    let _guard = sink_test_guard();
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let received_in_sink = Arc::clone(&received);
+    quadraui::diagnostics::set_sink(move |msg: &str| {
+        received_in_sink.lock().unwrap().push(msg.to_string());
+    });
+
+    let driver = TuiDriver::new(UnpaintedModalApp, 40, 10);
+
+    let messages = received.lock().unwrap();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("unpainted_modal") && m.contains("quadraui#455")),
+        "the #455 diagnostic should still be generated and delivered to an \
+         installed sink, just never printed directly: {messages:?}\nscreen:\n{}",
+        driver.screen()
+    );
+    drop(messages);
+
+    quadraui::diagnostics::clear_sink();
+}


### PR DESCRIPTION
Closes #619

Automated PR opened by coordinator for review of issue #619.