### PR TITLE
#632: Backend seam for layout rounding — consumers hardcode q_rect_to_ratatui's cell snap

### DIFF
--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -665,6 +665,29 @@ pub trait Backend {
         false
     }
 
+    /// Snap a proposed height (in logical units — the same units as
+    /// [`Self::line_height`]) to what this backend will actually paint.
+    ///
+    /// Cell-grid backends (TUI) quantize to whole rows; pixel backends
+    /// paint fractional heights exactly and return the input unchanged.
+    ///
+    /// This is the sanctioned replacement for consumer-side `.round()` on
+    /// a `line_height`-derived extent (quadraui#632). Before this method
+    /// existed, `coord-tui` reimplemented TUI's cell-rounding rule by hand
+    /// in two places — the layout math and the hit-test — that had to be
+    /// kept in sync manually, and drifted by one row twice (#464, #995).
+    /// Call this instead of modelling the rounding yourself:
+    ///
+    /// ```ignore
+    /// let tab_bar_h = backend.snap_height(backend.line_height() * 1.4);
+    /// ```
+    ///
+    /// Default: returns `h` unchanged (correct for every pixel backend).
+    /// Only [`crate::tui::backend::TuiBackend`] overrides it.
+    fn snap_height(&self, h: f32) -> f32 {
+        h
+    }
+
     // ─── Drawing — one method per primitive ────────────────────────────
     //
     // Implementations are thin wrappers around each backend crate's

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -966,6 +966,15 @@ impl Backend for TuiBackend {
         1.0
     }
 
+    fn snap_height(&self, h: f32) -> f32 {
+        // Mirrors the height component of `q_rect_to_ratatui` exactly —
+        // same `.max(0.0).round()` — so a height computed via this method
+        // always matches what a rect with that height paints as. A unit
+        // test below pins the two against each other so they can't drift
+        // (quadraui#632).
+        h.max(0.0).round()
+    }
+
     // ─── Drawing ───────────────────────────────────────────────────────────
     //
     // Implementations call into the public `crate::tui::draw_*` free
@@ -3765,5 +3774,43 @@ mod tests {
             "close-button spans must match between the paint and no-paint \
              paths too"
         );
+    }
+
+    /// `Backend::snap_height` must agree with `q_rect_to_ratatui`'s height
+    /// rounding for every height a rect can carry, since it exists to let
+    /// consumers predict that rounding without reimplementing it
+    /// (quadraui#632). If the two ever drift, a consumer's pre-snapped
+    /// layout height stops matching what the rasteriser actually paints —
+    /// the exact one-row misalignment that bit coord-tui in #464 and #995.
+    #[test]
+    fn snap_height_matches_q_rect_to_ratatui_height_rounding() {
+        let backend = TuiBackend::new();
+        for h in [
+            0.0_f32, 0.2, 0.49, 0.5, 0.51, 1.0, 1.4, 1.6, 2.5, 13.999, -1.0, -0.4,
+        ] {
+            let snapped = backend.snap_height(h);
+            let via_rect = q_rect_to_ratatui(QRect::new(0.0, 0.0, 0.0, h)).height;
+            assert_eq!(
+                snapped as u16, via_rect,
+                "snap_height({h}) = {snapped}, but q_rect_to_ratatui reports \
+                 height {via_rect} for the same input"
+            );
+        }
+    }
+
+    /// A pixel backend must not quantize — `snap_height` returns the input
+    /// unchanged via the trait's default impl. `MockBackend` doesn't
+    /// override `snap_height`, so it stands in for "any backend that only
+    /// paints pixels/DIPs" here (quadraui#632).
+    #[test]
+    fn snap_height_default_impl_is_identity() {
+        let backend = MockBackend::new();
+        for h in [0.0_f32, 0.4, 1.6, 13.999, -1.0] {
+            assert_eq!(
+                Backend::snap_height(&backend, h),
+                h,
+                "default snap_height impl must be identity for pixel backends"
+            );
+        }
     }
 }

--- a/quadraui/tests/conformance/caps.rs
+++ b/quadraui/tests/conformance/caps.rs
@@ -363,6 +363,16 @@ pub const ACCEPTED_DEFAULTS: &[(&str, &str, &str)] = &[
         "the default *is* uniform-monospace division (`EditorLayout::col_at_x`), which is exact \
          for a cell grid — GTK overrides it only because Pango advance widths vary",
     ),
+    // ── GTK, macOS, Win: `snap_height` is deliberately unimplemented on
+    // every pixel backend. The trait's default (identity) *is* the right
+    // answer for them — they paint fractional heights exactly, unlike
+    // TUI's cell grid — so there is nothing to override (quadraui#632).
+    (
+        "gtk",
+        "snap_height",
+        "pixel backend — Cairo paints fractional heights exactly, so the identity default is \
+         correct, not unfinished work (quadraui#632)",
+    ),
     // ── macOS: real backend, genuinely unfinished. `MacDriver`
     // (quadraui#493) gives it a `ConformanceDriver` and a Tier-1
     // (`backends()`) row, but it's deliberately still absent from
@@ -402,6 +412,12 @@ pub const ACCEPTED_DEFAULTS: &[(&str, &str, &str)] = &[
          issue's acceptance bar is TUI + GTK; macOS falls back to the plain `tab_bar_layout` \
          geometry (no bracket reservation) until that lands",
     ),
+    (
+        "macos",
+        "snap_height",
+        "pixel backend — CoreText paints fractional heights exactly, so the identity default is \
+         correct, not unfinished work (quadraui#632)",
+    ),
     // ── Win: every method is a `todo!()` stub (#19). Listed one by one
     // anyway — "the whole backend is a stub" is exactly the kind of
     // blanket excuse that outlives the stub.
@@ -425,6 +441,12 @@ pub const ACCEPTED_DEFAULTS: &[(&str, &str, &str)] = &[
         "win",
         "tab_bar_layout_with_chrome",
         "stub backend — see #19",
+    ),
+    (
+        "win",
+        "snap_height",
+        "pixel backend — DirectWrite paints fractional heights exactly, so the identity default \
+         is correct, not unfinished work (quadraui#632); unrelated to the #19 stub gaps above",
     ),
 ];
 


### PR DESCRIPTION
Closes #632

Automated PR opened by coordinator for review of issue #632.