### PR TITLE
#415: GTK: route clipboard paste + IME/dead-key composition into the focused terminal PTY

### DIFF
--- a/quadraui/examples/common/terminal_app.rs
+++ b/quadraui/examples/common/terminal_app.rs
@@ -19,7 +19,11 @@
 //! - Dragging the scrollbar thumb scrolls the history.
 //! - Window resize triggers a PTY resize.
 //! - Ctrl+Q quits.
-//! - Bracketed paste is forwarded verbatim.
+//! - `ClipboardPaste` is routed through [`TerminalSession::paste`], which
+//!   bracketed-paste-wraps the text when the child has enabled that mode
+//!   and sends it raw otherwise. On GTK this fires for Ctrl-V,
+//!   Ctrl-Shift-V, and middle-click (PRIMARY selection) — all three route
+//!   to the same `ClipboardPaste` event (quadraui#415).
 //! - When the shell exits a status line shows the exit code; Ctrl+Q closes.
 
 use quadraui::terminal_engine::{default_shell, TerminalMouseKind, TerminalSession};
@@ -405,17 +409,15 @@ impl AppLogic for TerminalApp {
                 }
             }
 
-            // ── Bracketed paste ───────────────────────────────────────────────
+            // ── Paste ────────────────────────────────────────────────────────
             UiEvent::ClipboardPaste(text) => {
                 if let Some(ref mut sess) = self.session {
                     if !sess.is_exited() {
-                        // Wrap in bracketed-paste markers so the shell handles it
-                        // correctly (avoids interpreting pasted newlines as commands).
-                        let mut bytes = b"\x1b[200~".to_vec();
-                        bytes.extend_from_slice(text.as_bytes());
-                        bytes.extend_from_slice(b"\x1b[201~");
-                        sess.write_input(&bytes);
-                        sess.scroll_reset();
+                        // `TerminalSession::paste` centralizes the
+                        // bracketed-paste wrap (only applied when the
+                        // child has enabled bracketed-paste mode) so this
+                        // example doesn't hand-roll it — quadraui#415.
+                        sess.paste(&text);
                     }
                 }
                 return Reaction::Redraw;

--- a/quadraui/examples/common/terminal_app.rs
+++ b/quadraui/examples/common/terminal_app.rs
@@ -24,6 +24,14 @@
 //!   and sends it raw otherwise. On GTK this fires for Ctrl-V,
 //!   Ctrl-Shift-V, and middle-click (PRIMARY selection) — all three route
 //!   to the same `ClipboardPaste` event (quadraui#415).
+//! - **IME / dead-key composed input is out of scope here.** quadraui#415
+//!   ("route clipboard paste + IME/dead-key composition into the focused
+//!   terminal PTY") covers only the clipboard-paste half in this example
+//!   and in `gtk::run::dispatch_event`. No backend runs an IME composition
+//!   pipeline yet — see [`quadraui::UiEvent::CharTyped`]'s doc comment and
+//!   epic quadraui#481, which owns wiring a real `GtkIMContext` (commit +
+//!   preedit) end to end. Composed characters (e.g. a dead-key `´` + `e` →
+//!   `é`) are not yet forwarded to the PTY by this example on any backend.
 //! - When the shell exits a status line shows the exit code; Ctrl+Q closes.
 
 use quadraui::terminal_engine::{default_shell, TerminalMouseKind, TerminalSession};

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -1568,6 +1568,20 @@ pub trait Clipboard {
 
     /// Write plain text to the clipboard.
     fn write_text(&self, text: &str);
+
+    /// Read the X11/Wayland **PRIMARY** selection — the platform
+    /// convention behind middle-click paste, distinct from
+    /// [`read_text`](Self::read_text)'s CLIPBOARD selection (populated by
+    /// an explicit copy). Backed by whatever text was last *selected*
+    /// (drag-select, double-click), with no separate copy action needed.
+    ///
+    /// Defaults to `None` — most platforms (Windows, macOS, TUI-over-any-
+    /// terminal) have no PRIMARY-selection concept at all, so this is
+    /// only meaningfully overridden by the GTK backend on Linux/BSD
+    /// (quadraui#415).
+    fn read_primary_selection(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Options for [`PlatformServices::show_file_open_dialog`] and

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -363,6 +363,20 @@ impl GtkBackend {
         self.services.pump_depth()
     }
 
+    /// Seed this backend's clipboard with deterministic in-memory
+    /// contents, so a test can drive the Ctrl-V / Ctrl-Shift-V and
+    /// middle-click paste paths without depending on the host's real
+    /// clipboard state (quadraui#415). Test-only.
+    #[cfg(test)]
+    pub(crate) fn install_test_clipboard(
+        &self,
+        contents: crate::gtk::services::TestClipboardContents,
+    ) {
+        self.services
+            .gtk_clipboard()
+            .install_test_contents(contents);
+    }
+
     /// Stash the raw GDK context of a primary-button press. Called by
     /// `gtk/run.rs`'s `GestureClick::connect_pressed`, before the press is
     /// translated to a portable [`UiEvent`], so

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -1261,16 +1261,18 @@ mod paste_tests {
     //!
     //! `is_paste_keypress` is a pure predicate, tested directly with no
     //! display required. The `GtkDriver`-based tests below exercise the
-    //! actual [`dispatch_event`] wiring end to end; they rely on this
-    //! sandbox having no `DISPLAY` (true in CI's deliberately Xvfb-free
-    //! `gtk` job — see the module doc's "Headless smoke mode" section),
-    //! so `arboard::Clipboard::new()` fails and every clipboard read
-    //! deterministically returns `None` — the "nothing to paste" branch.
-    //! The "there IS something to paste" branch needs a real OS
-    //! clipboard/PRIMARY selection and is only exercised by the
-    //! operator-run Xvfb smoke script (`quadraui/scripts/gtk_smoke.sh`),
-    //! same as the existing Ctrl-V path.
+    //! actual [`dispatch_event`] wiring end to end.
+    //!
+    //! Each of those installs an in-memory clipboard via
+    //! [`GtkBackend::install_test_clipboard`] before dispatching, so both
+    //! the "there IS something to paste" and "there is nothing to paste"
+    //! branches are covered on *any* host. Reading the host's real
+    //! clipboard instead would make these assertions environment-
+    //! dependent — green on a headless box where
+    //! `arboard::Clipboard::new()` fails, red on a developer machine or a
+    //! CI runner with a live display and a non-empty clipboard.
     use super::*;
+    use crate::gtk::services::TestClipboardContents;
     use crate::gtk::testing::GtkDriver;
 
     /// Minimal [`AppLogic`] that records every event `handle` receives,
@@ -1353,22 +1355,106 @@ mod paste_tests {
 
     // ── `dispatch_event` wiring (GtkDriver, no display) ───────────────
 
-    #[test]
-    fn ctrl_shift_v_is_intercepted_not_forwarded_as_raw_v() {
-        let mut driver = GtkDriver::new(RecordingApp::default(), 100, 30);
+    /// Build a driver whose clipboard is an in-memory fake seeded with
+    /// `clipboard` (the CLIPBOARD selection Ctrl-V reads) and `primary`
+    /// (the PRIMARY selection middle-click reads). Nothing here touches
+    /// the host's real clipboard, so every assertion below holds on a
+    /// headless CI runner and on a developer desktop alike.
+    fn driver_with_clipboard(
+        clipboard: Option<&str>,
+        primary: Option<&str>,
+    ) -> GtkDriver<RecordingApp> {
+        let driver = GtkDriver::new(RecordingApp::default(), 100, 30);
+        driver
+            .backend()
+            .install_test_clipboard(TestClipboardContents {
+                clipboard: clipboard.map(str::to_string),
+                primary: primary.map(str::to_string),
+            });
+        driver
+    }
+
+    /// Dispatch `v` with the given modifiers.
+    fn press_v(driver: &mut GtkDriver<RecordingApp>, modifiers: Modifiers) {
         driver.dispatch(UiEvent::KeyPressed {
             key: Key::Char('v'),
-            modifiers: Modifiers {
+            modifiers,
+            repeat: false,
+        });
+    }
+
+    fn middle_click(driver: &mut GtkDriver<RecordingApp>) {
+        driver.dispatch(UiEvent::MouseDown {
+            widget: None,
+            button: MouseButton::Middle,
+            position: Point::new(5.0, 5.0),
+            modifiers: Modifiers::default(),
+        });
+    }
+
+    /// The single event the app received, or a panic naming what it got.
+    fn only_event(driver: &GtkDriver<RecordingApp>) -> &UiEvent {
+        let events = &driver.app().events;
+        assert_eq!(
+            events.len(),
+            1,
+            "expected exactly one event to reach app.handle, got {events:?}"
+        );
+        &events[0]
+    }
+
+    #[test]
+    fn ctrl_v_delivers_the_clipboard_selection_as_a_paste() {
+        let mut driver = driver_with_clipboard(Some("copied text"), None);
+        press_v(
+            &mut driver,
+            Modifiers {
+                ctrl: true,
+                ..Modifiers::default()
+            },
+        );
+        assert!(
+            matches!(only_event(&driver), UiEvent::ClipboardPaste(t) if t == "copied text"),
+            "Ctrl-V should deliver ClipboardPaste with the CLIPBOARD contents, got {:?}",
+            driver.app().events
+        );
+    }
+
+    #[test]
+    fn ctrl_shift_v_delivers_the_clipboard_selection_as_a_paste() {
+        // quadraui#415: Ctrl-Shift-V is the paste shortcut in terminal
+        // emulators that reserve Ctrl-V for a literal control byte.
+        let mut driver = driver_with_clipboard(Some("copied text"), None);
+        press_v(
+            &mut driver,
+            Modifiers {
                 ctrl: true,
                 shift: true,
                 ..Modifiers::default()
             },
-            repeat: false,
-        });
-        // No OS clipboard in this sandbox → nothing to paste, but the
-        // keypress must still be swallowed here rather than falling
-        // through to `app.handle` as a literal 'v' character (which
-        // would be wrong for a focused terminal / text input).
+        );
+        assert!(
+            matches!(only_event(&driver), UiEvent::ClipboardPaste(t) if t == "copied text"),
+            "Ctrl-Shift-V should deliver ClipboardPaste, got {:?}",
+            driver.app().events
+        );
+    }
+
+    #[test]
+    fn ctrl_shift_v_is_intercepted_not_forwarded_as_raw_v() {
+        let mut driver = driver_with_clipboard(None, None);
+        press_v(
+            &mut driver,
+            Modifiers {
+                ctrl: true,
+                shift: true,
+                ..Modifiers::default()
+            },
+        );
+        // Empty clipboard → nothing to paste, but the keypress must
+        // still be swallowed here rather than falling through to
+        // `app.handle` as a literal 'v' character (which would be wrong
+        // for a focused terminal / text input).
         assert!(
             driver.app().events.is_empty(),
             "Ctrl-Shift-V should be intercepted as a paste attempt, not \
@@ -1379,42 +1465,72 @@ mod paste_tests {
 
     #[test]
     fn ctrl_alt_v_falls_through_to_app_unmodified() {
-        let mut driver = GtkDriver::new(RecordingApp::default(), 100, 30);
-        driver.dispatch(UiEvent::KeyPressed {
-            key: Key::Char('v'),
-            modifiers: Modifiers {
+        // Clipboard deliberately non-empty: proves the fall-through is
+        // driven by the modifier combination, not by an empty clipboard.
+        let mut driver = driver_with_clipboard(Some("copied text"), None);
+        press_v(
+            &mut driver,
+            Modifiers {
                 ctrl: true,
                 alt: true,
                 ..Modifiers::default()
             },
-            repeat: false,
-        });
-        assert_eq!(
-            driver.app().events.len(),
-            1,
-            "Ctrl-Alt-V is not a paste trigger and should reach app.handle unmodified"
+        );
+        assert!(
+            matches!(
+                only_event(&driver),
+                UiEvent::KeyPressed {
+                    key: Key::Char('v'),
+                    ..
+                }
+            ),
+            "Ctrl-Alt-V is not a paste trigger and should reach app.handle unmodified, got {:?}",
+            driver.app().events
+        );
+    }
+
+    #[test]
+    fn middle_click_delivers_the_primary_selection_as_a_paste() {
+        let mut driver = driver_with_clipboard(None, Some("selected text"));
+        middle_click(&mut driver);
+        assert!(
+            matches!(only_event(&driver), UiEvent::ClipboardPaste(t) if t == "selected text"),
+            "middle-click should deliver ClipboardPaste with the PRIMARY selection, got {:?}",
+            driver.app().events
+        );
+    }
+
+    #[test]
+    fn middle_click_reads_primary_selection_not_the_clipboard() {
+        // The two selections are distinct on X11/Wayland; middle-click
+        // must never fall back to CLIPBOARD (quadraui#415).
+        let mut driver = driver_with_clipboard(Some("CLIPBOARD"), Some("PRIMARY"));
+        middle_click(&mut driver);
+        assert!(
+            matches!(only_event(&driver), UiEvent::ClipboardPaste(t) if t == "PRIMARY"),
+            "middle-click pasted the wrong selection: {:?}",
+            driver.app().events
         );
     }
 
     #[test]
     fn middle_click_without_primary_selection_falls_through_to_app() {
-        let mut driver = GtkDriver::new(RecordingApp::default(), 100, 30);
-        driver.dispatch(UiEvent::MouseDown {
-            widget: None,
-            button: MouseButton::Middle,
-            position: Point::new(5.0, 5.0),
-            modifiers: Modifiers::default(),
-        });
-        // No OS PRIMARY selection in this sandbox → the intercept must
-        // not swallow the click; it should reach app.handle as an
-        // ordinary MouseDown so apps without terminal focus still see it.
-        assert_eq!(driver.app().events.len(), 1);
-        assert!(matches!(
-            driver.app().events[0],
-            UiEvent::MouseDown {
-                button: MouseButton::Middle,
-                ..
-            }
-        ));
+        // Empty PRIMARY but a non-empty CLIPBOARD: the intercept must
+        // not swallow the click (and must not substitute CLIPBOARD); it
+        // should reach app.handle as an ordinary MouseDown so apps
+        // without terminal focus still see it.
+        let mut driver = driver_with_clipboard(Some("CLIPBOARD"), None);
+        middle_click(&mut driver);
+        assert!(
+            matches!(
+                only_event(&driver),
+                UiEvent::MouseDown {
+                    button: MouseButton::Middle,
+                    ..
+                }
+            ),
+            "middle-click with no PRIMARY selection should fall through, got {:?}",
+            driver.app().events
+        );
     }
 }

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -987,6 +987,19 @@ pub(crate) fn render_frame<A: AppLogic>(
     backend.end_frame();
 }
 
+/// Whether a key press should trigger clipboard paste: plain Ctrl-V or
+/// Ctrl-Shift-V, with Alt/Cmd unheld (quadraui#415). `Shift` is
+/// deliberately not checked — some terminal emulators reserve Ctrl-V
+/// for a literal control byte and use Ctrl-Shift-V as the paste
+/// shortcut instead, and quadraui treats the two identically since a
+/// terminal grid has no "paste without formatting" distinction.
+fn is_paste_keypress(key: &Key, modifiers: &Modifiers) -> bool {
+    matches!(key, Key::Char('v') | Key::Char('V'))
+        && modifiers.ctrl
+        && !modifiers.alt
+        && !modifiers.cmd
+}
+
 /// What the caller should do after [`dispatch_event`] handles one event.
 /// Mirrors [`crate::tui::run::EventOutcome`].
 pub(crate) enum EventOutcome {
@@ -1015,9 +1028,18 @@ pub(crate) enum EventOutcome {
 ///   `UiEvent::Accelerator`.
 /// - Ctrl-C with an active text selection: copy to the clipboard and
 ///   deliver `TextCopied` instead of forwarding the raw key press.
-/// - Ctrl-V: read the system clipboard and deliver `ClipboardPaste`
-///   (GTK has no native paste signal on a bespoke `DrawingArea`, unlike
-///   TUI's crossterm bracketed paste).
+/// - Ctrl-V or Ctrl-Shift-V: read the system clipboard and deliver
+///   `ClipboardPaste` (GTK has no native paste signal on a bespoke
+///   `DrawingArea`, unlike TUI's crossterm bracketed paste). Ctrl-Shift-V
+///   is accepted alongside plain Ctrl-V because several terminal
+///   emulators reserve Ctrl-V for a control byte and use Shift as the
+///   paste-disambiguator (quadraui#415) — quadraui treats them
+///   identically since there's no "paste without formatting" distinction
+///   for a terminal grid.
+/// - Middle-click (`MouseDown` with `MouseButton::Middle`): read the
+///   X11/Wayland PRIMARY selection and deliver `ClipboardPaste` — the
+///   platform convention for "paste what was last selected", distinct
+///   from the CLIPBOARD selection Ctrl-V reads (quadraui#415).
 /// - Ctrl-A: select the entire content of the most-recently focused
 ///   `TextRegion`, if one is registered.
 /// - `MouseDown`: clear the displayed selection highlight (a fresh drag
@@ -1091,27 +1113,39 @@ pub(crate) fn dispatch_event<A: AppLogic>(
         }
     }
 
-    // ── Ctrl-V interception (paste) ───────────────────────────────────
-    if let UiEvent::KeyPressed {
-        key: Key::Char('v') | Key::Char('V'),
-        modifiers:
-            Modifiers {
-                ctrl: true,
-                shift: false,
-                alt: false,
-                cmd: false,
-            },
+    // ── Ctrl-V / Ctrl-Shift-V interception (paste) ────────────────────
+    if let UiEvent::KeyPressed { key, modifiers, .. } = &event {
+        if is_paste_keypress(key, modifiers) {
+            if let Some(text) = backend.services().clipboard().read_text() {
+                return match app.handle(UiEvent::ClipboardPaste(text), backend) {
+                    Reaction::Continue => EventOutcome::Continue,
+                    Reaction::Redraw => EventOutcome::Redraw,
+                    Reaction::Exit => EventOutcome::Exit,
+                };
+            }
+            return EventOutcome::Continue;
+        }
+    }
+
+    // ── Middle-click interception (PRIMARY-selection paste) ───────────
+    //
+    // X11/Wayland convention: middle-click pastes the PRIMARY selection
+    // (whatever text was last selected anywhere), independent of the
+    // CLIPBOARD selection Ctrl-V reads. Falls through to ordinary
+    // `MouseDown` handling (scrollbar drags, text-selection start, …)
+    // when there's no primary selection to paste (quadraui#415).
+    if let UiEvent::MouseDown {
+        button: MouseButton::Middle,
         ..
     } = &event
     {
-        if let Some(text) = backend.services().clipboard().read_text() {
+        if let Some(text) = backend.services().clipboard().read_primary_selection() {
             return match app.handle(UiEvent::ClipboardPaste(text), backend) {
                 Reaction::Continue => EventOutcome::Continue,
                 Reaction::Redraw => EventOutcome::Redraw,
                 Reaction::Exit => EventOutcome::Exit,
             };
         }
-        return EventOutcome::Continue;
     }
 
     // ── Ctrl-A interception (select-all for text regions) ────────────
@@ -1216,6 +1250,171 @@ mod smoke_tests {
         assert!(!smoke_clipboard_round_trip_ok(
             "quadraui smoke",
             Some("something else")
+        ));
+    }
+}
+
+#[cfg(test)]
+mod paste_tests {
+    //! Coverage for quadraui#415 — GTK clipboard-paste and PRIMARY-
+    //! selection routing added to [`dispatch_event`].
+    //!
+    //! `is_paste_keypress` is a pure predicate, tested directly with no
+    //! display required. The `GtkDriver`-based tests below exercise the
+    //! actual [`dispatch_event`] wiring end to end; they rely on this
+    //! sandbox having no `DISPLAY` (true in CI's deliberately Xvfb-free
+    //! `gtk` job — see the module doc's "Headless smoke mode" section),
+    //! so `arboard::Clipboard::new()` fails and every clipboard read
+    //! deterministically returns `None` — the "nothing to paste" branch.
+    //! The "there IS something to paste" branch needs a real OS
+    //! clipboard/PRIMARY selection and is only exercised by the
+    //! operator-run Xvfb smoke script (`quadraui/scripts/gtk_smoke.sh`),
+    //! same as the existing Ctrl-V path.
+    use super::*;
+    use crate::gtk::testing::GtkDriver;
+
+    /// Minimal [`AppLogic`] that records every event `handle` receives,
+    /// so tests can assert on exactly what reached the app — in
+    /// particular, that an intercepted paste trigger does NOT also
+    /// forward the raw key/mouse event underneath it.
+    #[derive(Default)]
+    struct RecordingApp {
+        events: Vec<UiEvent>,
+    }
+
+    impl AppLogic for RecordingApp {
+        type AreaId = ();
+
+        fn render(&self, _backend: &mut dyn Backend, _area: ()) {}
+
+        fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
+            self.events.push(event);
+            Reaction::Continue
+        }
+    }
+
+    // ── `is_paste_keypress` — pure predicate ──────────────────────────
+
+    #[test]
+    fn plain_ctrl_v_is_a_paste_keypress() {
+        let mods = Modifiers {
+            ctrl: true,
+            ..Modifiers::default()
+        };
+        assert!(is_paste_keypress(&Key::Char('v'), &mods));
+        assert!(is_paste_keypress(&Key::Char('V'), &mods));
+    }
+
+    #[test]
+    fn ctrl_shift_v_is_a_paste_keypress() {
+        // quadraui#415: several terminal emulators reserve Ctrl-V for a
+        // control byte and use Ctrl-Shift-V for paste instead.
+        let mods = Modifiers {
+            ctrl: true,
+            shift: true,
+            ..Modifiers::default()
+        };
+        assert!(is_paste_keypress(&Key::Char('v'), &mods));
+    }
+
+    #[test]
+    fn ctrl_alt_v_is_not_a_paste_keypress() {
+        let mods = Modifiers {
+            ctrl: true,
+            alt: true,
+            ..Modifiers::default()
+        };
+        assert!(!is_paste_keypress(&Key::Char('v'), &mods));
+    }
+
+    #[test]
+    fn ctrl_cmd_v_is_not_a_paste_keypress() {
+        let mods = Modifiers {
+            ctrl: true,
+            cmd: true,
+            ..Modifiers::default()
+        };
+        assert!(!is_paste_keypress(&Key::Char('v'), &mods));
+    }
+
+    #[test]
+    fn shift_v_without_ctrl_is_not_a_paste_keypress() {
+        let mods = Modifiers {
+            shift: true,
+            ..Modifiers::default()
+        };
+        assert!(!is_paste_keypress(&Key::Char('v'), &mods));
+    }
+
+    #[test]
+    fn plain_v_is_not_a_paste_keypress() {
+        assert!(!is_paste_keypress(&Key::Char('v'), &Modifiers::default()));
+    }
+
+    // ── `dispatch_event` wiring (GtkDriver, no display) ───────────────
+
+    #[test]
+    fn ctrl_shift_v_is_intercepted_not_forwarded_as_raw_v() {
+        let mut driver = GtkDriver::new(RecordingApp::default(), 100, 30);
+        driver.dispatch(UiEvent::KeyPressed {
+            key: Key::Char('v'),
+            modifiers: Modifiers {
+                ctrl: true,
+                shift: true,
+                ..Modifiers::default()
+            },
+            repeat: false,
+        });
+        // No OS clipboard in this sandbox → nothing to paste, but the
+        // keypress must still be swallowed here rather than falling
+        // through to `app.handle` as a literal 'v' character (which
+        // would be wrong for a focused terminal / text input).
+        assert!(
+            driver.app().events.is_empty(),
+            "Ctrl-Shift-V should be intercepted as a paste attempt, not \
+             forwarded to app.handle as a raw keypress: {:?}",
+            driver.app().events
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_v_falls_through_to_app_unmodified() {
+        let mut driver = GtkDriver::new(RecordingApp::default(), 100, 30);
+        driver.dispatch(UiEvent::KeyPressed {
+            key: Key::Char('v'),
+            modifiers: Modifiers {
+                ctrl: true,
+                alt: true,
+                ..Modifiers::default()
+            },
+            repeat: false,
+        });
+        assert_eq!(
+            driver.app().events.len(),
+            1,
+            "Ctrl-Alt-V is not a paste trigger and should reach app.handle unmodified"
+        );
+    }
+
+    #[test]
+    fn middle_click_without_primary_selection_falls_through_to_app() {
+        let mut driver = GtkDriver::new(RecordingApp::default(), 100, 30);
+        driver.dispatch(UiEvent::MouseDown {
+            widget: None,
+            button: MouseButton::Middle,
+            position: Point::new(5.0, 5.0),
+            modifiers: Modifiers::default(),
+        });
+        // No OS PRIMARY selection in this sandbox → the intercept must
+        // not swallow the click; it should reach app.handle as an
+        // ordinary MouseDown so apps without terminal focus still see it.
+        assert_eq!(driver.app().events.len(), 1);
+        assert!(matches!(
+            driver.app().events[0],
+            UiEvent::MouseDown {
+                button: MouseButton::Middle,
+                ..
+            }
         ));
     }
 }

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -83,6 +83,24 @@
 //! `quadraui/docs/TESTING.md` documents as "live-app headless smoke".
 //! The size/text assertion *logic* is unit-tested below with no display
 //! required.
+//!
+//! ## Clipboard paste vs. IME/dead-key composition (quadraui#415)
+//!
+//! quadraui#415 ("route clipboard paste + IME/dead-key composition into
+//! the focused terminal PTY") is two distinct input paths. Only the
+//! clipboard-paste half — Ctrl-V, Ctrl-Shift-V, and middle-click PRIMARY,
+//! all handled below in [`dispatch_event`] — is implemented by this
+//! module. IME/dead-key composed input (e.g. a dead-key `´` followed by
+//! `e` composing to `é`, or any real IME committing multi-keystroke text)
+//! is **not** wired up: `EventControllerKey` here only ever sees raw,
+//! already-resolved keysyms via `gdk_key_to_uievent`, with no
+//! `gtk4::IMMulticontext` attached to intercept `key-press-event` first
+//! and expose its `commit` / `preedit-changed` signals. That's a
+//! deliberate scope split, not an oversight: no quadraui backend runs an
+//! IME composition pipeline yet (see [`crate::UiEvent::CharTyped`]'s doc
+//! comment), and epic quadraui#481 owns adding one across every backend,
+//! not just GTK's terminal example. `examples/common/terminal_app.rs`'s
+//! module doc carries the consumer-facing version of this note.
 
 use std::cell::{Cell, RefCell};
 use std::env;

--- a/quadraui/src/gtk/services.rs
+++ b/quadraui/src/gtk/services.rs
@@ -252,6 +252,29 @@ impl Clipboard for GtkClipboard {
             let _ = cb.set_text(text);
         }
     }
+
+    /// PRIMARY selection (middle-click paste source) — only meaningful on
+    /// X11/Wayland, where `arboard`'s Linux extension trait exposes it as
+    /// a distinct selection from CLIPBOARD (quadraui#415). Gated to the
+    /// same `cfg` `arboard` itself uses for `GetExtLinux` (see
+    /// `arboard::lib`): on any other target this quietly falls back to
+    /// the trait's default `None`, since Windows/macOS have no PRIMARY
+    /// selection concept and quadraui's `gtk` feature only ships a Linux
+    /// backend in practice.
+    #[cfg(all(
+        unix,
+        not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+    ))]
+    fn read_primary_selection(&self) -> Option<String> {
+        use arboard::{GetExtLinux, LinuxClipboardKind};
+        self.inner
+            .borrow_mut()
+            .as_mut()?
+            .get()
+            .clipboard(LinuxClipboardKind::Primary)
+            .text()
+            .ok()
+    }
 }
 
 #[cfg(test)]

--- a/quadraui/src/gtk/services.rs
+++ b/quadraui/src/gtk/services.rs
@@ -81,6 +81,15 @@ impl GtkPlatformServices {
     pub(crate) fn pump_depth(&self) -> Rc<Cell<u32>> {
         Rc::clone(&self.pumping)
     }
+
+    /// Concrete (non-trait-object) handle on the clipboard, so in-crate
+    /// tests can call [`GtkClipboard::install_test_contents`] — the
+    /// `&dyn Clipboard` returned by [`PlatformServices::clipboard`]
+    /// can't reach an inherent method. Test-only (quadraui#415).
+    #[cfg(test)]
+    pub(crate) fn gtk_clipboard(&self) -> &GtkClipboard {
+        &self.clipboard
+    }
 }
 
 impl Default for GtkPlatformServices {
@@ -228,44 +237,72 @@ impl Drop for PumpGuard<'_> {
     }
 }
 
+/// In-memory stand-in for the two OS selections, installed by
+/// [`GtkClipboard::install_test_contents`] so unit tests can exercise the
+/// clipboard-paste code paths **without** depending on whatever the host
+/// running the tests happens to have on its real clipboard (quadraui#415).
+///
+/// Test-only on purpose: without it, a test asserting "nothing to paste"
+/// passes on a headless box (where `arboard::Clipboard::new()` fails) and
+/// fails on any developer machine or CI runner with a live display and a
+/// non-empty clipboard — a genuinely flaky, environment-dependent
+/// assertion rather than a statement about quadraui's behaviour.
+#[cfg(test)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TestClipboardContents {
+    /// Contents of the CLIPBOARD selection — what Ctrl-V / Ctrl-Shift-V
+    /// reads. `None` models "nothing has been copied".
+    pub clipboard: Option<String>,
+    /// Contents of the PRIMARY selection — what middle-click reads.
+    /// `None` models "nothing is selected anywhere".
+    pub primary: Option<String>,
+}
+
 /// System clipboard via `arboard`. The handle is kept alive for the
 /// process lifetime so Linux clipboard serving threads persist.
 pub struct GtkClipboard {
     inner: RefCell<Option<arboard::Clipboard>>,
+    /// When `Some`, every read/write below is served from this in-memory
+    /// fake instead of the OS, making clipboard-dependent unit tests
+    /// deterministic on any host. Only ever populated by
+    /// [`Self::install_test_contents`]; production builds don't compile
+    /// the field at all.
+    #[cfg(test)]
+    test_contents: RefCell<Option<TestClipboardContents>>,
 }
 
 impl GtkClipboard {
     fn new() -> Self {
         Self {
             inner: RefCell::new(arboard::Clipboard::new().ok()),
-        }
-    }
-}
-
-impl Clipboard for GtkClipboard {
-    fn read_text(&self) -> Option<String> {
-        self.inner.borrow_mut().as_mut()?.get_text().ok()
-    }
-
-    fn write_text(&self, text: &str) {
-        if let Some(cb) = self.inner.borrow_mut().as_mut() {
-            let _ = cb.set_text(text);
+            #[cfg(test)]
+            test_contents: RefCell::new(None),
         }
     }
 
-    /// PRIMARY selection (middle-click paste source) — only meaningful on
-    /// X11/Wayland, where `arboard`'s Linux extension trait exposes it as
-    /// a distinct selection from CLIPBOARD (quadraui#415). Gated to the
-    /// same `cfg` `arboard` itself uses for `GetExtLinux` (see
-    /// `arboard::lib`): on any other target this quietly falls back to
-    /// the trait's default `None`, since Windows/macOS have no PRIMARY
-    /// selection concept and quadraui's `gtk` feature only ships a Linux
-    /// backend in practice.
+    /// Swap this clipboard over to an in-memory fake seeded with
+    /// `contents`. Every subsequent read and write goes to the fake and
+    /// the OS clipboard is left untouched — so a test can assert on the
+    /// "there is something to paste" and "there is nothing to paste"
+    /// branches independently of the host (quadraui#415).
+    #[cfg(test)]
+    pub(crate) fn install_test_contents(&self, contents: TestClipboardContents) {
+        *self.test_contents.borrow_mut() = Some(contents);
+    }
+
+    /// OS-level PRIMARY-selection read, split out from the trait method
+    /// so the trait method itself stays uncfg'd (and therefore honours
+    /// [`Self::install_test_contents`] on every target).
+    ///
+    /// Gated to the same `cfg` `arboard` itself uses for `GetExtLinux`
+    /// (see `arboard::lib`). Windows/macOS have no PRIMARY-selection
+    /// concept, and quadraui's `gtk` feature only ships a Linux backend
+    /// in practice, so there the OS read is simply `None`.
     #[cfg(all(
         unix,
         not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
     ))]
-    fn read_primary_selection(&self) -> Option<String> {
+    fn read_os_primary_selection(&self) -> Option<String> {
         use arboard::{GetExtLinux, LinuxClipboardKind};
         self.inner
             .borrow_mut()
@@ -274,6 +311,56 @@ impl Clipboard for GtkClipboard {
             .clipboard(LinuxClipboardKind::Primary)
             .text()
             .ok()
+    }
+
+    /// Non-Linux counterpart of [`Self::read_os_primary_selection`] —
+    /// there is no PRIMARY selection to read.
+    #[cfg(not(all(
+        unix,
+        not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+    )))]
+    fn read_os_primary_selection(&self) -> Option<String> {
+        None
+    }
+}
+
+impl Clipboard for GtkClipboard {
+    fn read_text(&self) -> Option<String> {
+        #[cfg(test)]
+        {
+            if let Some(fake) = self.test_contents.borrow().as_ref() {
+                return fake.clipboard.clone();
+            }
+        }
+        self.inner.borrow_mut().as_mut()?.get_text().ok()
+    }
+
+    fn write_text(&self, text: &str) {
+        #[cfg(test)]
+        {
+            if let Some(fake) = self.test_contents.borrow_mut().as_mut() {
+                fake.clipboard = Some(text.to_string());
+                return;
+            }
+        }
+        if let Some(cb) = self.inner.borrow_mut().as_mut() {
+            let _ = cb.set_text(text);
+        }
+    }
+
+    /// PRIMARY selection (middle-click paste source) — only meaningful on
+    /// X11/Wayland, where `arboard`'s Linux extension trait exposes it as
+    /// a distinct selection from CLIPBOARD (quadraui#415). See
+    /// [`GtkClipboard::read_os_primary_selection`] for the per-target
+    /// split.
+    fn read_primary_selection(&self) -> Option<String> {
+        #[cfg(test)]
+        {
+            if let Some(fake) = self.test_contents.borrow().as_ref() {
+                return fake.primary.clone();
+            }
+        }
+        self.read_os_primary_selection()
     }
 }
 

--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -274,6 +274,31 @@ pub fn encode_mouse_sgr(
     format!("\x1b[<{cb};{cx};{cy}{}", terminator as char).into_bytes()
 }
 
+/// Encode pasted `text` as PTY input bytes.
+///
+/// When `bracketed` is `true`, wraps `text` in bracketed-paste markers
+/// (`ESC[200~ ... ESC[201~`, DEC private mode 2004) so a program that
+/// understands them (readline-based shells, `vim`, `claude`, ...) can
+/// tell pasted text apart from typed text. When `bracketed` is `false`,
+/// returns `text`'s raw UTF-8 bytes unchanged — wrapping unconditionally
+/// would leak literal escape bytes into programs that never asked for
+/// bracketed paste and don't know to strip them (e.g. `cat`, `less`).
+///
+/// Pulled out as a standalone function (rather than inlined into
+/// [`TerminalSession::paste`]) so the encoding itself is unit-testable
+/// without spawning a PTY — see the `tests` module below.
+fn encode_paste(text: &str, bracketed: bool) -> Vec<u8> {
+    if bracketed {
+        let mut bytes = Vec::with_capacity(text.len() + 12);
+        bytes.extend_from_slice(b"\x1b[200~");
+        bytes.extend_from_slice(text.as_bytes());
+        bytes.extend_from_slice(b"\x1b[201~");
+        bytes
+    } else {
+        text.as_bytes().to_vec()
+    }
+}
+
 // ── TerminalSession ───────────────────────────────────────────────────────────
 
 /// Longest [`TerminalSession::resize`] waits for the child to *begin* its
@@ -693,6 +718,31 @@ impl TerminalSession {
     /// dropped. Backed by vt100's tracking of the DEC private mode `2004`.
     pub fn bracketed_paste_enabled(&self) -> bool {
         self.parser.screen().bracketed_paste()
+    }
+
+    /// Send pasted text to the shell — the single paste entry point every
+    /// paste source (GTK Ctrl-V/Ctrl-Shift-V, GTK middle-click PRIMARY
+    /// selection, TUI crossterm bracketed paste, a supervising process)
+    /// should call instead of hand-rolling the bracketed-paste wrap
+    /// (quadraui#415).
+    ///
+    /// Wraps `text` in bracketed-paste markers (`ESC[200~ ... ESC[201~`)
+    /// when the child has enabled bracketed-paste mode
+    /// ([`bracketed_paste_enabled`](Self::bracketed_paste_enabled)), so
+    /// programs that understand it (readline-based shells, `vim`, `claude`,
+    /// ...) can tell pasted text apart from typed text — most importantly,
+    /// so pasted newlines don't get interpreted as "run this line" one at a
+    /// time. Sends `text` raw when the child hasn't enabled that mode,
+    /// since wrapping unconditionally would leak literal escape bytes into
+    /// programs that don't strip them (e.g. `cat`, `less`).
+    ///
+    /// Also resets the scroll offset to the live view — like ordinary
+    /// keystroke input — so a paste is always visible immediately even if
+    /// the user had scrolled into history first.
+    pub fn paste(&mut self, text: &str) {
+        self.scroll_reset();
+        let bytes = encode_paste(text, self.bracketed_paste_enabled());
+        self.write_input(&bytes);
     }
 
     /// Returns `true` when the child has enabled application-cursor-keys mode
@@ -2299,6 +2349,37 @@ mod tests {
         sess.send_str("exit\n");
     }
 
+    /// `TerminalSession::paste` resets the scroll offset back to the live
+    /// view — mirroring ordinary keystroke input — so a paste is always
+    /// visible immediately even if the user had scrolled into history.
+    /// (Real-PTY test since `scroll_reset`/`cursor_visible` are session
+    /// state, not the pure `encode_paste` byte-encoding covered above.)
+    #[test]
+    #[cfg(unix)]
+    fn paste_resets_scroll_to_live_view() {
+        let cwd = std::env::temp_dir();
+        let mut sess = TerminalSession::spawn(80, 24, "/bin/sh", &cwd, 1000).expect("spawn failed");
+
+        for _ in 0..30 {
+            sess.send_str("echo line\n");
+        }
+        let _ = poll_until(&mut sess, 5000, |s| s.history_len() > 0);
+
+        sess.scroll_up(5);
+        assert!(
+            !sess.cursor_visible(),
+            "precondition: scrolled into history should hide the cursor"
+        );
+
+        sess.paste("hello");
+        assert!(
+            sess.cursor_visible(),
+            "paste should reset scroll back to the live view"
+        );
+
+        sess.send_str("exit\n");
+    }
+
     /// `bracketed_paste_enabled()` reflects the child's DEC private mode
     /// 2004 (`ESC[?2004h` / `ESC[?2004l`) — the input-readiness signal a
     /// programmatic driver waits on before injecting input (quadraui #343).
@@ -2550,6 +2631,54 @@ mod tests {
             Modifiers::default(),
         );
         assert_eq!(bytes, b"\x1b[<1;5;3m");
+    }
+
+    // ── Paste → PTY encoding (quadraui#415) ──────────────────────────────────
+
+    /// Bracketed-paste mode on: `text` gets wrapped in `ESC[200~` /
+    /// `ESC[201~` markers so the child can tell pasted text apart from
+    /// typed text.
+    #[test]
+    fn encode_paste_wraps_when_bracketed() {
+        let bytes = encode_paste("hello", true);
+        assert_eq!(bytes, b"\x1b[200~hello\x1b[201~");
+    }
+
+    /// Bracketed-paste mode off: `text` is sent completely raw — no
+    /// markers. Wrapping unconditionally would leak literal escape bytes
+    /// into programs that never asked for bracketed paste.
+    #[test]
+    fn encode_paste_is_raw_when_not_bracketed() {
+        let bytes = encode_paste("hello", false);
+        assert_eq!(bytes, b"hello");
+    }
+
+    /// Multi-line paste (the case bracketed paste exists to protect —
+    /// without it, a shell would try to run each line as it arrives)
+    /// wraps the whole blob once, not per line.
+    #[test]
+    fn encode_paste_wraps_multiline_text_once() {
+        let bytes = encode_paste("echo one\necho two\n", true);
+        assert_eq!(bytes, b"\x1b[200~echo one\necho two\n\x1b[201~");
+    }
+
+    /// Non-ASCII UTF-8 text round-trips through the wrap byte-for-byte.
+    #[test]
+    fn encode_paste_preserves_utf8() {
+        let bytes = encode_paste("日本語 🎉", true);
+        let mut expected = b"\x1b[200~".to_vec();
+        expected.extend_from_slice("日本語 🎉".as_bytes());
+        expected.extend_from_slice(b"\x1b[201~");
+        assert_eq!(bytes, expected);
+    }
+
+    /// Empty paste still gets wrapped (a paste of "nothing" is still a
+    /// paste event as far as the child's bracketed-paste state machine is
+    /// concerned) — no special-casing to drop the markers.
+    #[test]
+    fn encode_paste_wraps_empty_text() {
+        let bytes = encode_paste("", true);
+        assert_eq!(bytes, b"\x1b[200~\x1b[201~");
     }
 
     // ── Mouse → PTY encoding (require a real PTY) ────────────────────────────

--- a/quadraui/src/terminal_engine.rs
+++ b/quadraui/src/terminal_engine.rs
@@ -722,9 +722,10 @@ impl TerminalSession {
 
     /// Send pasted text to the shell — the single paste entry point every
     /// paste source (GTK Ctrl-V/Ctrl-Shift-V, GTK middle-click PRIMARY
-    /// selection, TUI crossterm bracketed paste, a supervising process)
-    /// should call instead of hand-rolling the bracketed-paste wrap
-    /// (quadraui#415).
+    /// selection, TUI crossterm bracketed paste) should call instead of
+    /// hand-rolling the bracketed-paste wrap (quadraui#415). Also the
+    /// natural entry point for a future supervising process that wants to
+    /// inject text programmatically, though nothing wires that up today.
     ///
     /// Wraps `text` in bracketed-paste markers (`ESC[200~ ... ESC[201~`)
     /// when the child has enabled bracketed-paste mode


### PR DESCRIPTION
Closes #415

Automated PR opened by coordinator for review of issue #415.