### PR TITLE
#416: GTK: glyph-capable font fallback for UI-chrome icons (list/toolbar/activity-bar/status glyphs)

### DIFF
--- a/quadraui/docs/LESSONS.md
+++ b/quadraui/docs/LESSONS.md
@@ -210,6 +210,48 @@ sufficient — the consumer's own root `Cargo.toml` must add a matching
 location. Document that companion requirement explicitly wherever the
 quadraui-side patch is added; don't assume it propagates.
 
+## GTK chrome glyphs need an explicit Nerd-Font fallback family, not implicit fontconfig fallback
+
+`GtkBackend::draw_tree`/`draw_status_bar`/`draw_tab_bar`/etc. paint
+`Icon::glyph` and consumer-composed status-bar text through a shared
+`pango::Layout` whose font description came straight from `ui_font`
+(e.g. `"Sans 11"`, `#624`). Nerd-Font icon glyphs live in Private-Use-Area
+codepoints that "Sans" (or any ordinary system UI font) has zero
+coverage for — Pango's automatic per-character fallback then has to
+guess at *some* installed font that claims coverage of that codepoint
+range, and PUA ranges are exactly where unrelated fonts (icon fonts for
+other toolkits, private vendor glyphs) squat on the same numbers. The
+result is nondeterministic: works on one machine's font set, renders
+tofu/blank or the wrong glyph on another's, with no error anywhere.
+
+Two more rasterisers had a *worse* version of the same gap: `draw_list`
+and `draw_palette` never swapped the shared layout onto `ui_font` at
+all (`draw_tree`/`draw_status_bar`/`draw_tab_bar` did, per #624) — their
+icon glyphs painted in whatever font the frame's *editor* content
+happened to leave behind, which is a doubly-wrong font for both the row
+label and the icon.
+
+Fix (#416): a shared `gtk::chrome_font_description(ui_font)` /
+`gtk::with_nerd_font_fallback(base)` pair *appends*
+`Symbols Nerd Font` to the family list instead of relying on implicit
+fallback — Pango only consults the appended family for characters the
+primary one can't cover, so ordinary text is unaffected. `draw_tab_bar`
+icons and `ActivityBar` icons (#620) already used this append/replace
+pattern in isolation; #416 generalized it into one named constant
+(`gtk::NERD_FONT_FALLBACK_FAMILY`) so every chrome glyph path resolves
+against the same font, instead of five call sites each hand-rolling
+(or omitting) their own version of the same fix.
+
+Rule: any GTK rasteriser that paints a glyph outside the BMP-common
+range — an icon, a status/badge symbol, anything sourced from an
+`Icon`/similar glyph+fallback pair — must build its `FontDescription`
+through `chrome_font_description`/`with_nerd_font_fallback`, not a bare
+`pango::FontDescription::from_string`. And when adding a new
+icon-bearing chrome rasteriser: check whether it also needs the
+`ui_font`-not-editor-font swap `draw_tree` established in #624 — don't
+assume a new `draw_*` inherits the right font just because it shares
+the frame's `pango::Layout` with rasterisers that got it right.
+
 ## What NOT to do
 
 - **Don't re-derive layouts with different inputs in click vs paint.**

--- a/quadraui/docs/LESSONS.md
+++ b/quadraui/docs/LESSONS.md
@@ -229,7 +229,25 @@ and `draw_palette` never swapped the shared layout onto `ui_font` at
 all (`draw_tree`/`draw_status_bar`/`draw_tab_bar` did, per #624) — their
 icon glyphs painted in whatever font the frame's *editor* content
 happened to leave behind, which is a doubly-wrong font for both the row
-label and the icon.
+label and the icon. The two didn't get identical treatment, though:
+`draw_list` (and `draw_multi_section_view`) got the full `draw_tree`-style
+save/swap/restore, so its row label *and* icon both paint in
+`chrome_font_description(ui_font)`. `draw_palette` only got a narrow
+per-glyph `with_nerd_font_fallback` swap scoped to `item.icon`'s glyph —
+its title/query/row-label/detail text still paints in whatever font was
+live going in, because `draw_palette` also paints an optional preview
+pane through the same layout, and that pane's content (a file/diff
+preview) must keep the caller's own font rather than being forced onto
+chrome's `ui_font`. Widening `draw_palette`'s swap to match `draw_list`
+would fix the row-label gap but incorrectly drag the preview pane onto
+`ui_font` too — left as a follow-up, not folded into #416.
+
+`draw_toolbar` and `draw_sidebar_panel` (which composes a `Toolbar`
+header internally) got the same gap too, and #416 gave both the full
+`draw_list`-style save/swap/restore around the whole paint call —
+unlike `draw_palette`, a toolbar has no "preview pane" content sharing
+the layout, so there's no reason to scope the swap narrower than the
+whole button strip.
 
 Fix (#416): a shared `gtk::chrome_font_description(ui_font)` /
 `gtk::with_nerd_font_fallback(base)` pair *appends*

--- a/quadraui/docs/LESSONS.md
+++ b/quadraui/docs/LESSONS.md
@@ -249,6 +249,26 @@ unlike `draw_palette`, a toolbar has no "preview pane" content sharing
 the layout, so there's no reason to scope the swap narrower than the
 whole button strip.
 
+**Moving a rasteriser's paint font moves its hit regions too.** The
+first cut of that toolbar change swapped only `GtkBackend::draw_toolbar`
+and broke every toolbar *click*: `AppLogic::handle` hit-tests by calling
+`Backend::toolbar_layout` between frames, and that method still measured
+with whatever font was live, so the button the user visibly clicked was
+no longer the one the hit test reported. Any `draw_*` font swap must be
+mirrored into its `*_layout` twin — the same contract #624 wrote into
+`status_bar_layout` ("measure with `ui_font`, matching the paint font").
+Two related traps sit behind it: those `*_layout` calls run *outside*
+`enter_frame_scope`, so they fall back to the persistent `pango_ctx`,
+and if there is no `pango_ctx` either they fall back again to
+`chars().count() * char_width` — an estimate that is only right for a
+monospace font and silently drifts under a proportional `ui_font`. That
+second fallback is what hid the bug from `GtkDriver`-based tests until
+the driver started seeding `pango_ctx` the way `gtk::run::activate`
+does. Prefer production parity in the harness over a "close enough"
+measurement fallback; a fallback that is accurate only for the font you
+happened to be using is a test that stops testing the moment the font
+changes.
+
 Fix (#416): a shared `gtk::chrome_font_description(ui_font)` /
 `gtk::with_nerd_font_fallback(base)` pair *appends*
 `Symbols Nerd Font` to the family list instead of relying on implicit

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -314,9 +314,27 @@ pub trait Backend {
     /// `draw_multi_section_view`, etc.) render `Icon::glyph` when `true`
     /// and `Icon::fallback` when `false`.
     ///
-    /// Call at the start of `render_content()` (or once from `setup()` if
-    /// the setting is static) so that the runner-owned backend picks up the
-    /// app's preference before any draw calls are made.
+    /// Call at the start of `render_content()` if the setting can change
+    /// at runtime (a settings toggle, a config file reload), or once from
+    /// `setup()` only if it is truly static for the process lifetime.
+    /// This mirrors `set_theme`'s contract above, and for the same
+    /// reason: the backend does not re-derive this flag on its own each
+    /// frame the way it re-derives `line_height`/`char_width` from the
+    /// editor font — whatever was last set stays set until the host sets
+    /// it again.
+    ///
+    /// **Don't call this only from `setup()` and assume it stays synced.**
+    /// vimcode#547 was exactly this bug: nerd-fonts detection used to be
+    /// re-applied on a periodic "refresh" message, which stopped firing
+    /// after the `ShellApp` cutover — nothing re-called `set_nerd_fonts`
+    /// after the first frame, so the flag silently stuck at whatever
+    /// `setup()` had seen (often `false`, if the capability probe hadn't
+    /// resolved yet at startup), and every icon fell back to ASCII from
+    /// then on with no visible error. If the setting can ever change
+    /// after `setup()` runs — including "probe finishes after the first
+    /// frame" — call this from `render_content()` every frame instead;
+    /// it's cheap, and correctness doesn't depend on remembering to
+    /// re-fire a refresh path elsewhere.
     ///
     /// Default: no-op. Backends that always use one icon form (e.g. a
     /// headless test backend) can accept this default.

--- a/quadraui/src/gtk/activity_bar.rs
+++ b/quadraui/src/gtk/activity_bar.rs
@@ -25,6 +25,13 @@ pub const ACTIVITY_ROW_PX: f64 = 48.0;
 /// ≈ 24px at the standard 96 dpi (`18 * 96 / 72 = 24`), matching VS
 /// Code's 24px codicons — the pre-#620 "… 20" size rendered ≈ 26.7px,
 /// visibly oversized against the unchanged 48px row (`ACTIVITY_ROW_PX`).
+///
+/// The family (`"Symbols Nerd Font"`) is the same one
+/// [`super::NERD_FONT_FALLBACK_FAMILY`] names for every other GTK
+/// chrome glyph path (#416) — kept as a literal here rather than built
+/// from the constant because `pub const` string concatenation isn't
+/// expressible on stable Rust; if the fallback family ever changes,
+/// update both.
 pub const ICON_FONT_DESC: &str = "Symbols Nerd Font, monospace 18";
 
 /// Draw an [`ActivityBar`] into `(0, 0, width, height)` on `cr`.

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -3336,10 +3336,21 @@ impl Backend for GtkBackend {
         pressed_id: Option<&crate::types::WidgetId>,
     ) -> crate::primitives::toolbar::ToolbarLayout {
         let theme = self.current_theme;
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_toolbar called outside enter_frame_scope");
-        crate::gtk::draw_toolbar(
+        // #416: action labels and `Toolbar::Action` icon glyphs are chrome,
+        // not editor content — mirrors `Self::draw_list`/`Self::draw_tree`'s
+        // save/swap/restore. Before this, `draw_toolbar` painted with
+        // whatever font the shared layout happened to carry into the frame
+        // (typically the editor font, set once at frame start in
+        // `gtk/run.rs`), which has no Nerd-Font fallback family, so an
+        // icon glyph in `ToolbarButton::Action.icon` could render as
+        // tofu/blank depending on what else is installed.
+        let saved_font = pango_layout.font_description();
+        pango_layout.set_font_description(Some(&ui_font_desc));
+        let layout = crate::gtk::draw_toolbar(
             cr,
             pango_layout,
             rect.x as f64,
@@ -3350,7 +3361,9 @@ impl Backend for GtkBackend {
             &theme,
             hovered_id,
             pressed_id,
-        )
+        );
+        pango_layout.set_font_description(saved_font.as_ref());
+        layout
     }
 
     fn toolbar_layout(
@@ -3382,10 +3395,19 @@ impl Backend for GtkBackend {
         let theme = self.current_theme;
         let line_height = self.current_line_height;
         let char_width = self.current_char_width;
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_sidebar_panel called outside enter_frame_scope");
-        crate::gtk::draw_sidebar_panel(
+        // #416: `SidebarPanel` composes a `Toolbar` header internally
+        // (`gtk::sidebar_panel::draw_sidebar_panel` calls
+        // `gtk::toolbar::draw_toolbar` directly, not through
+        // `Self::draw_toolbar`), so the same save/swap/restore has to
+        // happen here too or its icon glyphs inherit the same gap
+        // `Self::draw_toolbar` had.
+        let saved_font = pango_layout.font_description();
+        pango_layout.set_font_description(Some(&ui_font_desc));
+        let layout = crate::gtk::draw_sidebar_panel(
             cr,
             pango_layout,
             line_height,
@@ -3398,7 +3420,9 @@ impl Backend for GtkBackend {
             &theme,
             hovered_toolbar_id,
             pressed_toolbar_id,
-        )
+        );
+        pango_layout.set_font_description(saved_font.as_ref());
+        layout
     }
 
     fn sidebar_panel_layout(
@@ -4693,6 +4717,121 @@ mod tests {
             ui_font_extent > small_editor_extent + 20,
             "changing ui_font alone must visibly widen the painted row label: \
              default_ui_font={small_editor_extent}, ui_font_Sans_40={ui_font_extent}"
+        );
+    }
+
+    fn ui_font_test_toolbar() -> crate::primitives::toolbar::Toolbar {
+        crate::primitives::toolbar::Toolbar {
+            id: WidgetId::new("test:toolbar"),
+            buttons: vec![crate::primitives::toolbar::ToolbarButton::Action {
+                id: WidgetId::new("test:toolbar:action"),
+                label: "Refine".to_string(),
+                icon: None,
+                key_hint: None,
+                enabled: true,
+                is_active: false,
+                tooltip: String::new(),
+            }],
+            bg: None,
+            focused_index: None,
+        }
+    }
+
+    /// #416 review follow-up: `draw_toolbar` painted `ToolbarButton::Action`
+    /// text with whatever font the shared layout happened to carry into the
+    /// frame (typically the editor font) — the one rasteriser this review
+    /// found the original #416 fix skipped. Same shape as
+    /// `gtk_backend_draw_list_uses_ui_font_not_editor_font` above: painted
+    /// width must be editor-font-size independent, then move when `ui_font`
+    /// itself changes.
+    #[test]
+    fn gtk_backend_draw_toolbar_uses_ui_font_not_editor_font() {
+        let (surface, small_editor_font, large_editor_font) = ui_font_test_surface_and_contexts();
+        let cr = pangocairo::cairo::Context::new(&surface).expect("Context::new");
+        let bar = ui_font_test_toolbar();
+        let rect = QRect::new(0.0, 0.0, 400.0, 24.0);
+
+        let width_at = |editor_font: &pango::FontDescription, ui_font: Option<&str>| {
+            let pango_ctx = pangocairo::functions::create_context(&cr);
+            pango_ctx.set_font_description(Some(editor_font));
+            let layout = pango::Layout::new(&pango_ctx);
+            let mut backend = GtkBackend::new();
+            if let Some(f) = ui_font {
+                Backend::set_ui_font(&mut backend, f);
+            }
+            backend.enter_frame_scope(&cr, &layout, |b| {
+                b.draw_toolbar(rect, &bar, None, None).visible_items[0]
+                    .bounds
+                    .width
+            })
+        };
+
+        let small_editor_width = width_at(&small_editor_font, None);
+        let large_editor_width = width_at(&large_editor_font, None);
+        assert!(
+            (small_editor_width - large_editor_width).abs() <= 1.0,
+            "toolbar action width must be editor-font-size independent: \
+             small_editor={small_editor_width}, large_editor={large_editor_width}"
+        );
+
+        let ui_font_width = width_at(&small_editor_font, Some("Sans 40"));
+        assert!(
+            ui_font_width > small_editor_width + 20.0,
+            "changing ui_font alone must visibly widen the painted toolbar action: \
+             default_ui_font={small_editor_width}, ui_font_Sans_40={ui_font_width}"
+        );
+    }
+
+    /// #416 review follow-up: `SidebarPanel` composes a `Toolbar` header
+    /// internally (`gtk::sidebar_panel::draw_sidebar_panel` calls
+    /// `gtk::toolbar::draw_toolbar` directly, bypassing
+    /// `GtkBackend::draw_toolbar`), so the same editor-font leak the
+    /// previous test guards against propagates here too unless
+    /// `GtkBackend::draw_sidebar_panel` does its own save/swap/restore.
+    #[test]
+    fn gtk_backend_draw_sidebar_panel_toolbar_uses_ui_font_not_editor_font() {
+        let (surface, small_editor_font, large_editor_font) = ui_font_test_surface_and_contexts();
+        let cr = pangocairo::cairo::Context::new(&surface).expect("Context::new");
+        let panel = crate::primitives::sidebar_panel::SidebarPanel {
+            id: WidgetId::new("test:sidebar-panel"),
+            toolbar: Some(ui_font_test_toolbar()),
+            toolbar_height: None,
+        };
+        let rect = QRect::new(0.0, 0.0, 400.0, 200.0);
+
+        let width_at = |editor_font: &pango::FontDescription, ui_font: Option<&str>| {
+            let pango_ctx = pangocairo::functions::create_context(&cr);
+            pango_ctx.set_font_description(Some(editor_font));
+            let layout = pango::Layout::new(&pango_ctx);
+            let mut backend = GtkBackend::new();
+            if let Some(f) = ui_font {
+                Backend::set_ui_font(&mut backend, f);
+            }
+            backend.enter_frame_scope(&cr, &layout, |b| {
+                b.draw_sidebar_panel(rect, &panel, None, None)
+                    .toolbar_layout
+                    .expect("panel has a toolbar")
+                    .visible_items[0]
+                    .bounds
+                    .width
+            })
+        };
+
+        let small_editor_width = width_at(&small_editor_font, None);
+        let large_editor_width = width_at(&large_editor_font, None);
+        assert!(
+            (small_editor_width - large_editor_width).abs() <= 1.0,
+            "sidebar-panel toolbar action width must be editor-font-size \
+             independent: small_editor={small_editor_width}, \
+             large_editor={large_editor_width}"
+        );
+
+        let ui_font_width = width_at(&small_editor_font, Some("Sans 40"));
+        assert!(
+            ui_font_width > small_editor_width + 20.0,
+            "changing ui_font alone must visibly widen the painted \
+             sidebar-panel toolbar action: default_ui_font={small_editor_width}, \
+             ui_font_Sans_40={ui_font_width}"
         );
     }
 

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -3374,7 +3374,19 @@ impl Backend for GtkBackend {
         let char_w = self.current_char_width;
         let frame_layout = self.current_frame_refs().map(|(_, l)| l.clone());
         let pango_layout = frame_layout.or_else(|| self.pango_ctx.as_ref().map(pango::Layout::new));
-        crate::gtk::gtk_toolbar_layout(
+        // #416: measure with `ui_font`, matching `Self::draw_toolbar`'s
+        // paint font — same #624 contract `status_bar_layout` documents.
+        // A no-paint caller (hit-testing without repainting, which is
+        // exactly what `AppLogic::handle` does on every mouse event) must
+        // resolve the same button widths the paint path produced, or the
+        // button the user visibly clicked is not the one the hit test
+        // reports.
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
+        let saved_font = pango_layout.as_ref().and_then(|pl| pl.font_description());
+        if let Some(pl) = &pango_layout {
+            pl.set_font_description(Some(&ui_font_desc));
+        }
+        let result = crate::gtk::gtk_toolbar_layout(
             bar,
             pango_layout.as_ref(),
             char_w,
@@ -3382,7 +3394,11 @@ impl Backend for GtkBackend {
             rect.y as f64,
             rect.width as f64,
             rect.height as f64,
-        )
+        );
+        if let Some(pl) = &pango_layout {
+            pl.set_font_description(saved_font.as_ref());
+        }
+        result
     }
 
     fn draw_sidebar_panel(
@@ -3434,7 +3450,16 @@ impl Backend for GtkBackend {
         let line_h = self.current_line_height;
         let frame_layout = self.current_frame_refs().map(|(_, l)| l.clone());
         let pango_layout = frame_layout.or_else(|| self.pango_ctx.as_ref().map(pango::Layout::new));
-        crate::gtk::gtk_sidebar_panel_layout(
+        // #416: the panel's header is a `Toolbar`, so its measured button
+        // widths must come from the same `ui_font`
+        // `Self::draw_sidebar_panel` now paints with — see
+        // `Self::toolbar_layout` above.
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
+        let saved_font = pango_layout.as_ref().and_then(|pl| pl.font_description());
+        if let Some(pl) = &pango_layout {
+            pl.set_font_description(Some(&ui_font_desc));
+        }
+        let result = crate::gtk::gtk_sidebar_panel_layout(
             panel,
             pango_layout.as_ref(),
             char_w,
@@ -3443,7 +3468,11 @@ impl Backend for GtkBackend {
             rect.y as f64,
             rect.width as f64,
             rect.height as f64,
-        )
+        );
+        if let Some(pl) = &pango_layout {
+            pl.set_font_description(saved_font.as_ref());
+        }
+        result
     }
 
     fn draw_diff_view(
@@ -4779,6 +4808,51 @@ mod tests {
             ui_font_width > small_editor_width + 20.0,
             "changing ui_font alone must visibly widen the painted toolbar action: \
              default_ui_font={small_editor_width}, ui_font_Sans_40={ui_font_width}"
+        );
+    }
+
+    /// #416 regression guard: moving `draw_toolbar`'s paint onto
+    /// `ui_font` without moving `toolbar_layout`'s *measurement* with it
+    /// splits paint from hit-test. `AppLogic::handle` hit-tests by
+    /// calling `Backend::toolbar_layout` between frames — outside any
+    /// `enter_frame_scope` — so the two must resolve identical button
+    /// bounds or the button the user visibly clicked is not the one the
+    /// hit test reports (which is exactly how
+    /// `gtk_example_driver::toolbar_clicking_filter_toggles_it_without_keyboard_focus`
+    /// failed). Deliberately measured with the *editor* font live on
+    /// both the frame layout and the stable `pango_ctx`, so a regression
+    /// that drops either swap shows up as a width mismatch here.
+    #[test]
+    fn gtk_backend_toolbar_layout_matches_draw_toolbar_bounds_outside_frame() {
+        let (surface, editor_font, _) = ui_font_test_surface_and_contexts();
+        let cr = pangocairo::cairo::Context::new(&surface).expect("Context::new");
+        let bar = ui_font_test_toolbar();
+        let rect = QRect::new(0.0, 0.0, 400.0, 24.0);
+
+        let pango_ctx = pangocairo::functions::create_context(&cr);
+        pango_ctx.set_font_description(Some(&editor_font));
+        let layout = pango::Layout::new(&pango_ctx);
+        let mut backend = GtkBackend::new();
+        // Stable click-time context, as `gtk::run::activate` seeds it on
+        // `DrawingArea` realize — also carrying the editor font, so the
+        // hit-test path can only agree with paint by swapping onto
+        // `ui_font` itself.
+        let stable_ctx = pangocairo::functions::create_context(&cr);
+        stable_ctx.set_font_description(Some(&editor_font));
+        backend.set_pango_context(stable_ctx);
+        Backend::set_ui_font(&mut backend, "Sans 40");
+
+        let painted = backend.enter_frame_scope(&cr, &layout, |b| {
+            b.draw_toolbar(rect, &bar, None, None).visible_items[0].bounds
+        });
+        // Outside the frame scope — the click-time path.
+        let hit_tested = Backend::toolbar_layout(&backend, rect, &bar).visible_items[0].bounds;
+
+        assert!(
+            (painted.width - hit_tested.width).abs() <= 1.0
+                && (painted.x - hit_tested.x).abs() <= 1.0,
+            "click-time toolbar_layout must resolve the same button bounds \
+             draw_toolbar painted: painted={painted:?}, hit_tested={hit_tested:?}"
         );
     }
 

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1488,7 +1488,7 @@ impl Backend for GtkBackend {
     }
 
     fn draw_tree(&mut self, rect: QRect, tree: &TreeView) {
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_tree called outside enter_frame_scope");
@@ -1516,9 +1516,19 @@ impl Backend for GtkBackend {
     }
 
     fn draw_list(&mut self, rect: QRect, list: &ListView) {
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_list called outside enter_frame_scope");
+        // #416: row labels and icon glyphs (`Icon::glyph`) are chrome, not
+        // editor content — mirrors `Self::draw_tree`'s save/swap/restore
+        // above. Before this, `draw_list` painted with whatever font the
+        // shared layout happened to carry into the frame (typically the
+        // editor font), which has no Nerd-Font fallback family, so an
+        // icon glyph could render as tofu/blank depending on what else is
+        // installed.
+        let saved_font = layout.font_description();
+        layout.set_font_description(Some(&ui_font_desc));
         crate::gtk::draw_list(
             cr,
             layout,
@@ -1531,6 +1541,7 @@ impl Backend for GtkBackend {
             self.current_line_height,
             self.nerd_fonts_enabled,
         );
+        layout.set_font_description(saved_font.as_ref());
     }
 
     fn draw_data_table(
@@ -1793,7 +1804,7 @@ impl Backend for GtkBackend {
         hovered_id: Option<&crate::types::WidgetId>,
         pressed_id: Option<&crate::types::WidgetId>,
     ) -> crate::StatusBarLayout {
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_status_bar called outside enter_frame_scope");
@@ -1880,7 +1891,7 @@ impl Backend for GtkBackend {
         icons: &[Option<crate::TabIcon>],
         hovered_close_tab: Option<usize>,
     ) -> crate::TabBarHits {
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_tab_bar called outside enter_frame_scope");
@@ -1923,7 +1934,7 @@ impl Backend for GtkBackend {
         hovered_close_tab: Option<usize>,
         chrome: &TabChrome,
     ) -> crate::TabBarHits {
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_tab_bar_with_chrome called outside enter_frame_scope");
@@ -1986,7 +1997,7 @@ impl Backend for GtkBackend {
         // #624: measure with `ui_font`, matching `draw_status_bar`'s paint
         // font — a no-paint caller (hit-testing without repainting) must
         // resolve the same segment widths the paint path produced.
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let saved_font = pango_layout.as_ref().and_then(|pl| pl.font_description());
         if let Some(pl) = &pango_layout {
             pl.set_font_description(Some(&ui_font_desc));
@@ -2039,7 +2050,7 @@ impl Backend for GtkBackend {
         // path uses, or its reported widths (and the icon-font it derives
         // from `base` below) drift from what's actually on screen —
         // restored to whatever was set before returning.
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let saved_font = pango_layout.as_ref().and_then(|pl| pl.font_description());
         if let Some(pl) = &pango_layout {
             pl.set_font_description(Some(&ui_font_desc));
@@ -2190,7 +2201,7 @@ impl Backend for GtkBackend {
             }
         }
 
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let saved_font = pango_layout.as_ref().and_then(|pl| pl.font_description());
         if let Some(pl) = &pango_layout {
             pl.set_font_description(Some(&ui_font_desc));
@@ -2527,7 +2538,7 @@ impl Backend for GtkBackend {
         self.modal_stack.borrow_mut().mark_painted(&dialog.id);
         let line_height = self.current_line_height;
         let theme = self.current_theme;
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_dialog called outside enter_frame_scope");
@@ -2556,9 +2567,18 @@ impl Backend for GtkBackend {
         let line_height = self.current_line_height;
         let theme = self.current_theme;
         let nerd_fonts = self.nerd_fonts_enabled;
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_multi_section_view called outside enter_frame_scope");
+        // #416: section headers and `Tree`/`List` body rows (icon glyphs
+        // included) are sidebar chrome, not editor content — same
+        // save/swap/restore `Self::draw_tree`/`Self::draw_list` use.
+        // `SectionBody::Terminal`/`Custom` are host-painted no-ops here
+        // (see `gtk::draw_multi_section_view`'s own body dispatch), so
+        // they're unaffected by the swap.
+        let saved_font = layout.font_description();
+        layout.set_font_description(Some(&ui_font_desc));
         crate::gtk::draw_multi_section_view(
             cr,
             layout,
@@ -2571,6 +2591,7 @@ impl Backend for GtkBackend {
             line_height,
             nerd_fonts,
         );
+        layout.set_font_description(saved_font.as_ref());
     }
 
     fn msv_layout(
@@ -2780,7 +2801,7 @@ impl Backend for GtkBackend {
         layout_arg: &crate::primitives::rich_text_popup::RichTextPopupLayout,
     ) {
         let theme = self.current_theme;
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, pango_layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_rich_text_popup called outside enter_frame_scope");
@@ -2865,7 +2886,7 @@ impl Backend for GtkBackend {
         rect: QRect,
         bar: &MenuBar,
     ) -> crate::primitives::menu_bar::MenuBarLayout {
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let (cr, layout) = self
             .current_frame_refs()
             .expect("GtkBackend::draw_menu_bar called outside enter_frame_scope");
@@ -2922,7 +2943,7 @@ impl Backend for GtkBackend {
         // click-time-only) its *current* font state, not a snapshot from
         // when it was cached, is whatever the most recent draw call left
         // it as.
-        let ui_font_desc = pango::FontDescription::from_string(&self.ui_font);
+        let ui_font_desc = crate::gtk::chrome_font_description(&self.ui_font);
         let saved_font = pango_layout.as_ref().and_then(|pl| pl.font_description());
         if let Some(pl) = &pango_layout {
             pl.set_font_description(Some(&ui_font_desc));
@@ -4571,6 +4592,99 @@ mod tests {
         assert!(
             small_editor_extent.abs_diff(large_editor_extent) <= 1,
             "tree row glyph extent must be editor-font-size independent: \
+             small_editor={small_editor_extent}, large_editor={large_editor_extent}"
+        );
+
+        let ui_font_extent = row_text_extent(&small_editor_font, Some("Sans 40"));
+        assert!(
+            ui_font_extent > small_editor_extent + 20,
+            "changing ui_font alone must visibly widen the painted row label: \
+             default_ui_font={small_editor_extent}, ui_font_Sans_40={ui_font_extent}"
+        );
+    }
+
+    /// #416: `draw_list` previously painted item labels and icon glyphs
+    /// with whatever font the frame's editor-content layout happened to
+    /// carry — unlike `draw_tree`/`draw_status_bar`/`draw_tab_bar`
+    /// (#624), it never swapped the shared layout onto `ui_font` at all.
+    /// Same shape as `gtk_backend_draw_tree_uses_ui_font_not_editor_font`
+    /// above: paint the same single-item list under two wildly different
+    /// "editor" font sizes with `ui_font` left at its default — the
+    /// painted extent must be identical — then change `ui_font` alone as
+    /// a positive control and see the extent move.
+    #[test]
+    fn gtk_backend_draw_list_uses_ui_font_not_editor_font() {
+        let small_editor_font = pango::FontDescription::from_string("Sans 8");
+        let large_editor_font = pango::FontDescription::from_string("Sans 40");
+        const W: i32 = 1600;
+        const H: i32 = 60;
+
+        let row_text_extent = |editor_font: &pango::FontDescription, ui_font: Option<&str>| {
+            let mut surface =
+                pangocairo::cairo::ImageSurface::create(pangocairo::cairo::Format::ARgb32, W, H)
+                    .expect("create ImageSurface");
+            let list = ListView {
+                id: WidgetId::new("test:list"),
+                title: None,
+                items: vec![crate::primitives::list::ListItem {
+                    text: crate::types::StyledText::plain("m".to_string()),
+                    icon: None,
+                    detail: None,
+                    decoration: crate::types::Decoration::Normal,
+                }],
+                selected_idx: 0,
+                scroll_offset: 0,
+                has_focus: false,
+                bordered: false,
+                h_scroll: 0,
+                max_content_width: None,
+                show_v_scrollbar: false,
+            };
+            let rect = QRect::new(0.0, 0.0, W as f32, H as f32);
+            {
+                let cr = pangocairo::cairo::Context::new(&surface).expect("Context::new");
+                cr.set_source_rgb(1.0, 1.0, 1.0);
+                cr.paint().ok();
+                let pango_ctx = pangocairo::functions::create_context(&cr);
+                pango_ctx.set_font_description(Some(editor_font));
+                let layout = pango::Layout::new(&pango_ctx);
+                let mut backend = GtkBackend::new();
+                // White `background` so the row's own fill doesn't itself
+                // read as "non-white" and saturate the scan below.
+                backend.set_current_theme(crate::Theme {
+                    background: crate::types::Color::rgb(255, 255, 255),
+                    foreground: crate::types::Color::rgb(0, 0, 0),
+                    ..crate::Theme::default()
+                });
+                if let Some(f) = ui_font {
+                    Backend::set_ui_font(&mut backend, f);
+                }
+                backend.enter_frame_scope(&cr, &layout, |b| {
+                    b.draw_list(rect, &list);
+                });
+            }
+            surface.flush();
+            let stride = surface.stride() as usize;
+            let data = surface.data().expect("surface data");
+            // Rightmost non-white pixel within the first (only) row's
+            // vertical span — proxy for the painted label's glyph extent.
+            // `current_line_height` defaults to 16px, so y=10 sits inside
+            // row 0 regardless of which font is under test.
+            let y = 10usize;
+            (0..W as usize)
+                .rev()
+                .find(|&x| {
+                    let off = y * stride + x * 4;
+                    !(data[off] == 255 && data[off + 1] == 255 && data[off + 2] == 255)
+                })
+                .unwrap_or(0)
+        };
+
+        let small_editor_extent = row_text_extent(&small_editor_font, None);
+        let large_editor_extent = row_text_extent(&large_editor_font, None);
+        assert!(
+            small_editor_extent.abs_diff(large_editor_extent) <= 1,
+            "list row glyph extent must be editor-font-size independent: \
              small_editor={small_editor_extent}, large_editor={large_editor_extent}"
         );
 

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -148,3 +148,108 @@ pub(crate) fn rounded_rect_path(cr: &Context, x: f64, y: f64, w: f64, h: f64, r:
 /// Re-export so apps can name the Pango layout type without depending
 /// on `gtk4::pango` directly.
 pub use pango::Layout as PangoLayout;
+
+/// Font family GTK chrome text falls back to for Nerd-Font glyphs.
+///
+/// Matches the family [`activity_bar::ICON_FONT_DESC`] and
+/// [`tab_bar::tab_icon_font`] already pin for the activity bar and tab
+/// icons (#620) — kept as one named constant so retargeting to a
+/// differently-named Nerd Font patch (or a consumer's fontconfig alias)
+/// is a one-line change instead of hunting every rasteriser that
+/// references the literal.
+pub const NERD_FONT_FALLBACK_FAMILY: &str = "Symbols Nerd Font";
+
+/// Build a Pango font description for GTK chrome text (list/tree/
+/// palette rows, status bar segments, menu items, dialogs, ...) from a
+/// `ui_font`-style description string (e.g. `"Sans 11"`), appending
+/// [`NERD_FONT_FALLBACK_FAMILY`] to the family list.
+///
+/// Chrome primitives paint icon glyphs (`Icon::glyph`) and — on the
+/// status bar — consumer-composed segment text that can itself embed a
+/// raw Nerd-Font codepoint, inline with ordinary label text, all using
+/// the *same* Pango layout and font. Most system UI fonts ("Sans",
+/// "Cantarell", ...) have no coverage for the Private-Use-Area
+/// codepoints Nerd Font glyphs live in, so without an explicit fallback
+/// family in the description Pango's per-character font substitution is
+/// left to guess at a system font that happens to cover that codepoint
+/// range — unreliable, and prone to picking an unrelated font that
+/// defines *something* there, rather than the intended glyph. Naming
+/// the fallback family explicitly, in family-list order right after the
+/// caller's own family, makes glyph resolution deterministic instead of
+/// dependent on what else is installed (quadraui#416).
+///
+/// Harmless when no glyph is being painted: Pango only consults a later
+/// family in the list for characters the earlier one doesn't cover, so
+/// plain text keeps rendering in the caller's own `ui_font` family.
+pub(crate) fn chrome_font_description(ui_font: &str) -> pango::FontDescription {
+    with_nerd_font_fallback(&pango::FontDescription::from_string(ui_font))
+}
+
+/// Clone `base` with [`NERD_FONT_FALLBACK_FAMILY`] appended to its family
+/// list. Used where a rasteriser can't build a fresh description from a
+/// `ui_font` string (the caller only hands it an already-live
+/// [`pango::FontDescription`] to paint one glyph with, e.g. an icon
+/// inside an otherwise editor-font-painted row) — see
+/// [`chrome_font_description`] for the string-based sibling and the full
+/// rationale.
+pub(crate) fn with_nerd_font_fallback(base: &pango::FontDescription) -> pango::FontDescription {
+    let mut desc = base.clone();
+    let family = desc.family().map(|f| f.to_string()).unwrap_or_default();
+    let with_fallback = if family.is_empty() {
+        NERD_FONT_FALLBACK_FAMILY.to_string()
+    } else {
+        format!("{family},{NERD_FONT_FALLBACK_FAMILY}")
+    };
+    desc.set_family(&with_fallback);
+    desc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The family list must lead with the caller's own `ui_font` family
+    /// (so ordinary chrome text keeps rendering in the configured font)
+    /// and include [`NERD_FONT_FALLBACK_FAMILY`] afterward (so a glyph
+    /// the primary family can't cover — e.g. a Nerd-Font icon — still
+    /// resolves instead of rendering tofu/blank).
+    #[test]
+    fn chrome_font_description_appends_nerd_font_fallback() {
+        let desc = chrome_font_description("Sans 11");
+        let family = desc.family().expect("family set").to_string();
+        assert_eq!(family, "Sans,Symbols Nerd Font");
+    }
+
+    /// The point size from the input description string must survive —
+    /// only the family list is touched.
+    #[test]
+    fn chrome_font_description_preserves_size() {
+        let plain = pango::FontDescription::from_string("Sans 11");
+        let desc = chrome_font_description("Sans 11");
+        assert_eq!(desc.size(), plain.size());
+    }
+
+    /// A caller-supplied multi-family list (a consumer's own fallback
+    /// chain) is preserved verbatim, with the Nerd Font family appended
+    /// rather than replacing it.
+    #[test]
+    fn chrome_font_description_appends_after_existing_family_list() {
+        let desc = chrome_font_description("Cantarell,DejaVu Sans 12");
+        let family = desc.family().expect("family set").to_string();
+        assert_eq!(family, "Cantarell,DejaVu Sans,Symbols Nerd Font");
+    }
+
+    /// [`with_nerd_font_fallback`] mirrors [`chrome_font_description`]
+    /// for callers that only have a live `FontDescription` to hand (e.g.
+    /// `gtk::palette::draw_palette`'s icon-glyph swap, which must not
+    /// disturb the row's base font for the label text painted around
+    /// it) — same family-list-append behaviour, size preserved.
+    #[test]
+    fn with_nerd_font_fallback_appends_to_an_existing_description() {
+        let base = pango::FontDescription::from_string("Monospace 13");
+        let desc = with_nerd_font_fallback(&base);
+        let family = desc.family().expect("family set").to_string();
+        assert_eq!(family, "Monospace,Symbols Nerd Font");
+        assert_eq!(desc.size(), base.size());
+    }
+}

--- a/quadraui/src/gtk/palette.rs
+++ b/quadraui/src/gtk/palette.rs
@@ -275,10 +275,23 @@ pub fn draw_palette(
             };
             layout.set_attributes(None);
             cr.set_source_rgb(fg.0, fg.1, fg.2);
+            // #416: swap in a Nerd-Font-fallback variant of whatever base
+            // font the row is painting with (the caller's `ui_font`, or —
+            // for a palette with no explicit override — whatever font was
+            // live before `draw_palette` was called) just for the glyph,
+            // then restore immediately so the label/detail text painted
+            // around it is unaffected. Without the swap, `icon.glyph`'s
+            // Private-Use-Area codepoint depends on Pango finding some
+            // installed font that covers it — unreliable, and prone to a
+            // blank/tofu glyph.
+            let base_font = layout.font_description().unwrap_or_default();
+            let icon_font = super::with_nerd_font_fallback(&base_font);
+            layout.set_font_description(Some(&icon_font));
             layout.set_text(glyph);
             let (iw, ih) = layout.pixel_size();
             cr.move_to(cursor, row_y + (row_h - ih as f64) / 2.0);
             super::painted_text::show_layout(cr, layout);
+            layout.set_font_description(Some(&base_font));
             cursor += iw as f64 + 6.0;
         }
 

--- a/quadraui/src/gtk/tab_bar.rs
+++ b/quadraui/src/gtk/tab_bar.rs
@@ -41,6 +41,14 @@ const TAB_ACTIVE_BORDER_TOP_PX: f64 = 1.0;
 ///
 /// Shared by [`draw_tab_bar_icons`] and `GtkBackend::tab_bar_layout_icons`
 /// so the no-paint measurement can't drift from the painted glyph.
+///
+/// Unlike [`super::with_nerd_font_fallback`] (#416, used by
+/// list/tree/palette icon glyphs), this *replaces* the family entirely
+/// rather than appending — tab icons are always painted as a Nerd-Font
+/// glyph with no ASCII-fallback text form (`TabIcon` carries just one
+/// `glyph` field, unlike `Icon`'s `glyph`/`fallback` pair), so there's
+/// no caller-family text to preserve. The family name itself
+/// (`"Symbols Nerd Font"`) still matches [`super::NERD_FONT_FALLBACK_FAMILY`].
 pub(crate) fn tab_icon_font(base: &pango::FontDescription) -> pango::FontDescription {
     let mut f = base.clone();
     f.set_family("Symbols Nerd Font, monospace");

--- a/quadraui/src/gtk/tab_bar.rs
+++ b/quadraui/src/gtk/tab_bar.rs
@@ -47,11 +47,14 @@ const TAB_ACTIVE_BORDER_TOP_PX: f64 = 1.0;
 /// rather than appending — tab icons are always painted as a Nerd-Font
 /// glyph with no ASCII-fallback text form (`TabIcon` carries just one
 /// `glyph` field, unlike `Icon`'s `glyph`/`fallback` pair), so there's
-/// no caller-family text to preserve. The family name itself
-/// (`"Symbols Nerd Font"`) still matches [`super::NERD_FONT_FALLBACK_FAMILY`].
+/// no caller-family text to preserve. Built from
+/// [`super::NERD_FONT_FALLBACK_FAMILY`] (unlike
+/// [`super::activity_bar::ICON_FONT_DESC`], which hand-rolls the same
+/// family name because it's a `pub const` and consts can't be
+/// concatenated on stable) so the two can't drift apart.
 pub(crate) fn tab_icon_font(base: &pango::FontDescription) -> pango::FontDescription {
     let mut f = base.clone();
-    f.set_family("Symbols Nerd Font, monospace");
+    f.set_family(&format!("{}, monospace", super::NERD_FONT_FALLBACK_FAMILY));
     f
 }
 

--- a/quadraui/src/gtk/testing.rs
+++ b/quadraui/src/gtk/testing.rs
@@ -127,6 +127,26 @@ impl<A: AppLogic> GtkDriver<A> {
         // hand-roll a `record_painted_text` call (quadraui#489). Off in
         // production runners — a live app never reads the map.
         backend.set_painted_text_recording(true);
+        // Seed the backend's persistent Pango context, exactly as
+        // `gtk::run::activate` does from the realized `DrawingArea`
+        // (same `"Sans 11"` UI font it sets there). Without this, every
+        // `*_layout()` method called *outside* a frame scope — which is
+        // where all click hit-testing happens, since `AppLogic::handle`
+        // runs between frames — had no Pango layout at all and silently
+        // fell back to `chars().count() * char_width`. That estimate is
+        // only accurate for a monospace font, so the driver's hit
+        // regions drifted off the painted labels for any chrome painted
+        // in the proportional `ui_font` (quadraui#416), while the same
+        // click landed correctly in a real window. Seeding it here makes
+        // the harness measure clicks the way production does.
+        {
+            let cr = Context::new(&surface).expect("Context::new on headless ImageSurface");
+            let pctx = pangocairo::functions::create_context(&cr);
+            pctx.set_font_description(Some(&pangocairo::pango::FontDescription::from_string(
+                "Sans 11",
+            )));
+            backend.set_pango_context(pctx);
+        }
         // Seed the viewport from the driver's surface size BEFORE setup,
         // exactly as the live `gtk::run::activate` does (quadraui#437):
         // without this, `app.setup()` would read `GtkBackend::new()`'s


### PR DESCRIPTION
Closes #416

Automated PR opened by coordinator for review of issue #416.