### PR TITLE
#418: GTK: verify/fix per-surface scroll-wheel direction (events.rs dy negation) + natural-scroll option

### DIFF
--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -1080,6 +1080,61 @@ mod tests {
         assert_eq!(tc.scroll_offset(), 0);
     }
 
+    // ── GTK wheel-direction round-trip (quadraui#418) ────────────────
+    //
+    // Regression guard tying the real GDK → UiEvent translator to a
+    // compose controller's scroll behavior, not just the internal
+    // ScrollDelta convention (`UiEvent::Scroll` built by hand). Confirms
+    // the GTK backend's traditional (non-natural) wheel-down actually
+    // moves the tree toward later rows, and that flipping
+    // `natural_scroll` flips the observed direction too.
+
+    #[cfg(feature = "gtk")]
+    #[test]
+    fn gtk_wheel_down_scrolls_tree_toward_later_rows_traditional() {
+        use crate::gtk::events::gdk_scroll_to_uievent_with_direction;
+
+        let mut tc = TreeController::new("t");
+        tc.set_rows(fake_rows("row", 20));
+        let rect = Rect::new(0.0, 0.0, 40.0, 3.0); // 3 visible rows
+
+        // Raw GDK dy > 0 == wheel rotated down / two-finger-down on a
+        // non-natural-scroll touchpad. `natural_scroll = false` is the
+        // GTK runner's default (quadraui::AppLogic::natural_scroll).
+        let ev = gdk_scroll_to_uievent_with_direction(0.0, 1.0, 5.0, 5.0, false);
+        let outcome = tc.handle(&ev, &mut MockBackend, rect);
+
+        assert_eq!(outcome, TreeControllerEvent::Consumed);
+        assert!(
+            tc.scroll_offset() > 0,
+            "wheel-down should move the view toward later rows, got offset={}",
+            tc.scroll_offset()
+        );
+    }
+
+    #[cfg(feature = "gtk")]
+    #[test]
+    fn gtk_wheel_down_scrolls_tree_toward_earlier_rows_when_natural() {
+        use crate::gtk::events::gdk_scroll_to_uievent_with_direction;
+
+        let mut tc = TreeController::new("t");
+        tc.set_rows(fake_rows("row", 20));
+        tc.set_scroll_offset(5);
+        let rect = Rect::new(0.0, 0.0, 40.0, 3.0);
+
+        // Same raw wheel-down gesture, but with the natural-scroll
+        // override on: direction flips relative to the traditional case.
+        let ev = gdk_scroll_to_uievent_with_direction(0.0, 1.0, 5.0, 5.0, true);
+        let outcome = tc.handle(&ev, &mut MockBackend, rect);
+
+        assert_eq!(outcome, TreeControllerEvent::Consumed);
+        assert!(
+            tc.scroll_offset() < 5,
+            "natural_scroll should flip wheel-down toward earlier rows, got offset={}",
+            tc.scroll_offset()
+        );
+    }
+
     // ── Page scroll ─────────────────────────────────────────────────
 
     #[test]

--- a/quadraui/src/gtk/events.rs
+++ b/quadraui/src/gtk/events.rs
@@ -93,14 +93,52 @@ pub fn gdk_motion_to_uievent(x: f64, y: f64, buttons: crate::ButtonMask) -> UiEv
 }
 
 /// Translate a GDK scroll event into [`UiEvent::Scroll`]. `dx`/`dy`
-/// are GTK's `EventControllerScroll` deltas (positive `dy` = down).
-/// We negate `dy` for `UiEvent::Scroll`'s convention (positive y =
-/// up toward the top of content) — same as the TUI translator does
-/// for crossterm scroll events.
+/// are GTK's `EventControllerScroll` deltas (positive `dy` = down —
+/// this is the sign GTK4 apps consume directly when driving a
+/// `GtkAdjustment`, e.g. `value += dy`; wheel-down / two-finger-down
+/// on a non-natural-scroll touchpad reports positive `dy`). We negate
+/// `dy` for `UiEvent::Scroll`'s convention (positive y = up toward
+/// the top of content) — same as the TUI translator does for
+/// crossterm scroll events, and the same negation `macos::events::ns_scroll`
+/// applies to `NSEvent` deltas. Win32 is the one native backend that
+/// *doesn't* negate — see `win::events::win_wheel_to_uievent`'s doc
+/// for why.
+///
+/// This is the `natural_scroll = false` case of
+/// [`gdk_scroll_to_uievent_with_direction`]; kept as its own function
+/// so existing callers (and the GTK runner's default wiring) don't
+/// need to thread an extra argument through for the common case.
 pub fn gdk_scroll_to_uievent(dx: f64, dy: f64, x: f64, y: f64) -> UiEvent {
+    gdk_scroll_to_uievent_with_direction(dx, dy, x, y, false)
+}
+
+/// Translate a GDK scroll event into [`UiEvent::Scroll`], with an
+/// explicit natural-scroll override (quadraui#418).
+///
+/// `natural_scroll = false` reproduces [`gdk_scroll_to_uievent`]'s
+/// traditional-direction behavior exactly: wheel-down (positive raw
+/// `dy`) becomes negative `delta.y`, i.e. "not up", so compose
+/// controllers (`TreeController`, `SidebarSystem`, `ChatController`,
+/// `FormController`) scroll the view toward later content.
+///
+/// `natural_scroll = true` flips the sign again — content follows the
+/// gesture, matching touchscreen/trackpad "natural scrolling"
+/// semantics — for apps that want an in-app toggle independent of (or
+/// layered on top of) the OS-level libinput natural-scroll setting.
+/// [`crate::AppLogic::natural_scroll`] is the trait hook the GTK
+/// runner reads to pick the flag; `wire_da_events_with_scroll_direction`
+/// is the equivalent for consumers wiring their own `DrawingArea`.
+pub fn gdk_scroll_to_uievent_with_direction(
+    dx: f64,
+    dy: f64,
+    x: f64,
+    y: f64,
+    natural_scroll: bool,
+) -> UiEvent {
+    let sign: f32 = if natural_scroll { 1.0 } else { -1.0 };
     UiEvent::Scroll {
         widget: None,
-        delta: crate::ScrollDelta::new(dx as f32, -dy as f32),
+        delta: crate::ScrollDelta::new(dx as f32, sign * dy as f32),
         position: Point::new(x as f32, y as f32),
     }
 }
@@ -224,8 +262,29 @@ pub fn gdk_button_to_quadraui(button: u32) -> MouseButton {
 ///
 /// This eliminates ~40 lines of per-DrawingArea signal wiring that
 /// every GTK consumer otherwise needs to write manually.
+///
+/// Scroll direction always follows [`gdk_scroll_to_uievent`]'s
+/// traditional (`natural_scroll = false`) convention. Use
+/// [`wire_da_events_with_scroll_direction`] to make it configurable
+/// (quadraui#418).
 pub fn wire_da_events<F>(da: &gtk4::DrawingArea, on_event: F)
 where
+    F: Fn(UiEvent) + Clone + 'static,
+{
+    wire_da_events_with_scroll_direction(da, on_event, false);
+}
+
+/// Same as [`wire_da_events`], with an explicit natural-scroll flag
+/// (quadraui#418) passed straight through to
+/// [`gdk_scroll_to_uievent_with_direction`]. Consumers building their
+/// own `DrawingArea` outside [`crate::gtk::run`] (which reads
+/// [`crate::AppLogic::natural_scroll`] instead) use this to honour
+/// the same preference.
+pub fn wire_da_events_with_scroll_direction<F>(
+    da: &gtk4::DrawingArea,
+    on_event: F,
+    natural_scroll: bool,
+) where
     F: Fn(UiEvent) + Clone + 'static,
 {
     use gtk4::{
@@ -284,7 +343,13 @@ where
         let on_event = on_event.clone();
         scroll.connect_scroll(move |_ctrl, dx, dy| {
             let (x, y) = cursor_pos.get();
-            on_event(gdk_scroll_to_uievent(dx, dy, x, y));
+            on_event(gdk_scroll_to_uievent_with_direction(
+                dx,
+                dy,
+                x,
+                y,
+                natural_scroll,
+            ));
             glib::Propagation::Stop
         });
     }
@@ -404,6 +469,30 @@ mod tests {
                 assert_eq!(position.x, 10.0);
                 assert_eq!(position.y, 20.0);
             }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn scroll_with_direction_false_matches_default_translator() {
+        let a = gdk_scroll_to_uievent(0.0, 1.0, 10.0, 20.0);
+        let b = gdk_scroll_to_uievent_with_direction(0.0, 1.0, 10.0, 20.0, false);
+        match (a, b) {
+            (UiEvent::Scroll { delta: da, .. }, UiEvent::Scroll { delta: db, .. }) => {
+                assert_eq!(da, db);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn scroll_with_direction_true_flips_sign() {
+        // Same raw wheel-down gesture (dy = 1.0), but with the
+        // natural-scroll override on: the sign flips relative to
+        // `gdk_scroll_to_uievent`'s traditional -1.0.
+        let ev = gdk_scroll_to_uievent_with_direction(0.0, 1.0, 10.0, 20.0, true);
+        match ev {
+            UiEvent::Scroll { delta, .. } => assert_eq!(delta.y, 1.0),
             _ => panic!(),
         }
     }

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -83,7 +83,7 @@ pub use dialog::draw_dialog;
 pub use diff_view::draw_diff_view;
 pub use drop_overlay::draw_drop_overlay;
 pub use editor::{draw_editor, editor_col_at_x};
-pub use events::wire_da_events;
+pub use events::{wire_da_events, wire_da_events_with_scroll_direction};
 pub use find_replace::draw_find_replace;
 pub use form::{draw_form, draw_settings_chrome};
 pub use list::draw_list;

--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -119,7 +119,7 @@ use pangocairo::functions as pcfn;
 use super::backend::GtkBackend;
 use super::events::{
     gdk_button_to_quadraui, gdk_key_to_uievent, gdk_modifiers_to_quadraui, gdk_resize_to_uievent,
-    gdk_scroll_to_uievent,
+    gdk_scroll_to_uievent_with_direction,
 };
 use crate::backend::Backend;
 use crate::dispatch::{dispatch_click, dispatch_mouse_drag, dispatch_mouse_up};
@@ -653,7 +653,8 @@ fn activate<A: AppLogic + 'static>(
                 return glib::Propagation::Proceed;
             }
             let (x, y) = cursor_pos.get();
-            let ev = gdk_scroll_to_uievent(dx, dy, x, y);
+            let natural_scroll = app.borrow().natural_scroll();
+            let ev = gdk_scroll_to_uievent_with_direction(dx, dy, x, y, natural_scroll);
             let outcome = {
                 let mut backend_mut = backend.borrow_mut();
                 let mut app_mut = app.borrow_mut();

--- a/quadraui/src/runner.rs
+++ b/quadraui/src/runner.rs
@@ -105,4 +105,30 @@ pub trait AppLogic {
     fn tick(&mut self, _backend: &mut dyn Backend) -> Reaction {
         Reaction::Continue
     }
+
+    /// Whether wheel/trackpad scroll events should use "natural scroll"
+    /// direction (content follows the gesture, like a touchscreen) instead
+    /// of the traditional wheel convention (wheel-down reveals content
+    /// further down the document, i.e. `UiEvent::Scroll`'s `delta.y`
+    /// becomes negative on wheel-down).
+    ///
+    /// Defaults to `false` (traditional direction), so apps that don't
+    /// override this method keep quadraui's existing behavior unchanged.
+    ///
+    /// Only [`crate::gtk::run`] consults this today (quadraui#418) — TUI
+    /// and Win32 wheel events already arrive in a single fixed direction
+    /// with no natural-scroll concept, and macOS's translator
+    /// (`crate::macos::events::ns_scroll`) doesn't yet expose the option.
+    /// Consumers wiring their own `DrawingArea` outside `crate::gtk::run`
+    /// use `crate::gtk::events::wire_da_events_with_scroll_direction`
+    /// directly instead of this trait hook. On Linux, libinput already applies
+    /// the OS-level natural-scroll preference
+    /// (`org.gnome.desktop.peripherals.touchpad natural-scroll`) before
+    /// GTK ever sees the event, so most apps should leave this `false`
+    /// and let the OS handle it — override it only if the app wants an
+    /// in-app preference independent of (or layered on top of) the OS
+    /// setting.
+    fn natural_scroll(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
Closes #418

Automated merge from the coordinator for assignment 92a8c3273574 on issue #418.

Worker branch: `issue-418-gtk-verify-fix-per-surface-scroll-wheel` → `develop`.