### PR TITLE
#465: macOS backend: add ShellApp + run_with_shell composition support

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -471,6 +471,11 @@ path = "examples/macos_hscroll.rs"
 required-features = ["macos"]
 
 [[example]]
+name = "macos_appshell_demo"
+path = "examples/macos_appshell_demo.rs"
+required-features = ["macos"]
+
+[[example]]
 name = "tui_bottom_panel"
 path = "examples/tui_bottom_panel.rs"
 required-features = ["tui"]

--- a/quadraui/examples/macos_appshell_demo.rs
+++ b/quadraui/examples/macos_appshell_demo.rs
@@ -1,0 +1,11 @@
+//! macOS runner for AppShell demo — proves `run_with_shell()` pattern
+//! (#465). Same `AppShellDemo` `ShellApp` impl `tui_appshell_demo.rs` /
+//! `gtk_appshell_demo.rs` already share; only the runner call differs.
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    let app = common::appshell_demo::AppShellDemo::new();
+    let config = common::appshell_demo::AppShellDemo::config();
+    quadraui::macos::shell_runner::run_with_shell(app, config)
+}

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -160,13 +160,18 @@ pub mod modal_stack;
 // runners (in `quadraui::tui::run`, `quadraui::gtk::run`) drive against.
 // See `docs/BACKEND_SETUP_AUDIT.md` (#260) for design rationale.
 pub mod runner;
-// `ShellAdapter` is constructed only by the TUI/GTK shell runners
-// (`crate::tui::shell_runner`, `crate::gtk::shell_runner`); under `win` alone
-// (no runner exists yet) nothing builds one, so the whole module — struct,
-// impls, and its private helpers — goes dead-code under `-D warnings` (#540).
-// Gate the module on the features that actually consume it rather than
+// `ShellAdapter` is constructed only by the TUI/GTK/macOS shell runners
+// (`crate::tui::shell_runner`, `crate::gtk::shell_runner`,
+// `crate::macos::shell_runner`, #465); under `win` alone (no runner exists
+// yet) nothing builds one, so the whole module — struct, impls, and its
+// private helpers — goes dead-code under `-D warnings` (#540). Gate the
+// module on the features that actually consume it rather than
 // `#[allow(dead_code)]`-ing the individual items.
-#[cfg(any(feature = "tui", feature = "gtk"))]
+#[cfg(any(
+    feature = "tui",
+    feature = "gtk",
+    all(feature = "macos", target_os = "macos")
+))]
 pub mod shell_adapter;
 
 pub use diff::compute_hunks;

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -169,6 +169,13 @@ pub struct MacBackend {
     /// [`Self::enter_frame_scope`] with `painted_text_recording` on —
     /// see [`Self::set_painted_text_recording`].
     text_runs: Vec<TextRun>,
+    /// `WidgetId` of the [`ActivityBar`] that painted itself with
+    /// `is_keyboard_focused = true` this frame, if any. Set by
+    /// [`Backend::draw_activity_bar`], cleared by [`Backend::begin_frame`]
+    /// (same per-frame lifecycle as `zones`), read by
+    /// [`super::run::dispatch_event`] to redirect the next `KeyPressed`
+    /// into the bar. Mirrors `GtkBackend::focused_activity_bar` (#465).
+    focused_activity_bar: Option<WidgetId>,
 }
 
 /// Position tolerance, in points, for [`MacBackend::fold_double_click`]'s
@@ -245,6 +252,7 @@ impl MacBackend {
             zones: Vec::new(),
             painted_text_recording: false,
             text_runs: Vec::new(),
+            focused_activity_bar: None,
         }
     }
 
@@ -345,6 +353,22 @@ impl MacBackend {
         &self.text_runs
     }
 
+    /// `WidgetId` of the [`ActivityBar`] that declared
+    /// `is_keyboard_focused = true` during the most recent render pass,
+    /// or `None` if no bar is focused.
+    ///
+    /// Read by [`super::run::dispatch_event`] to decide whether a
+    /// `KeyPressed` should be redirected into
+    /// `UiEvent::ActivityBar(id, ActivityBarEvent::KeyPressed { … })`
+    /// instead of reaching `AppLogic::handle` as a raw key. The macOS twin
+    /// of `GtkBackend::focused_activity_bar_id` / `TuiBackend`'s
+    /// `apply_dispatch` translation (#465) — without it, `ShellAdapter`'s
+    /// built-in activity-bar keyboard navigation (#409) is unreachable on
+    /// this backend.
+    pub(crate) fn focused_activity_bar_id(&self) -> Option<&WidgetId> {
+        self.focused_activity_bar.as_ref()
+    }
+
     /// Zones registered during the last frame via
     /// [`Backend::register_zone`].
     pub(crate) fn zones(&self) -> &[ZoneRec] {
@@ -420,6 +444,10 @@ impl Backend for MacBackend {
         // `enter_frame_scope`) until whatever reads them after the frame
         // (e.g. `MacDriver::inventory`).
         self.zones.clear();
+        // Clear the focused activity bar — re-set by `draw_activity_bar`
+        // during this render pass if a bar is still keyboard-focused. Same
+        // per-frame lifecycle as `zones`, matching `GtkBackend::begin_frame`.
+        self.focused_activity_bar = None;
         // #455: clear last frame's modal paint marks so this frame has
         // to earn them again (via draw_dialog/draw_palette/draw_context_menu).
         self.modal_stack.reset_frame_paint();
@@ -892,6 +920,12 @@ impl Backend for MacBackend {
         bar: &ActivityBar,
         hovered_idx: Option<usize>,
     ) -> Vec<ActivityBarRowHit> {
+        // Track keyboard focus so `run::dispatch_event` can redirect the
+        // next `KeyPressed` into this bar (#465) — same contract
+        // `GtkBackend::draw_activity_bar` implements.
+        if bar.is_keyboard_focused {
+            self.focused_activity_bar = Some(bar.id.clone());
+        }
         let ctx = self.current_cg();
         debug_assert!(
             !ctx.is_null(),

--- a/quadraui/src/macos/mod.rs
+++ b/quadraui/src/macos/mod.rs
@@ -51,6 +51,7 @@ pub mod rich_text_popup;
 mod run;
 pub mod scrollbar;
 pub mod services;
+pub mod shell_runner;
 pub mod sidebar_panel;
 pub mod spinner;
 pub mod split;

--- a/quadraui/src/macos/run.rs
+++ b/quadraui/src/macos/run.rs
@@ -147,6 +147,14 @@ impl From<Reaction> for EventOutcome {
 ///   detector's time/position window. Runs on the *dispatched* events,
 ///   after modal arbitration — same relative order as
 ///   `TuiBackend::translate_events`.
+/// - ActivityBar keyboard-focus redirect (#465): while the last painted
+///   frame contained an `ActivityBar` with `is_keyboard_focused = true`,
+///   every `KeyPressed` becomes
+///   `UiEvent::ActivityBar(bar_id, ActivityBarEvent::KeyPressed { … })`
+///   instead of reaching the app as a raw key. This must win over
+///   accelerator dispatch below (same ordering `gtk::run::dispatch_event`
+///   uses), otherwise a bound accelerator would steal a navigation key
+///   out from under the focused bar.
 /// - Global accelerator dispatch (#486): a `KeyPressed` matching a
 ///   registered `Global`-scope accelerator becomes `UiEvent::Accelerator`.
 /// - Cmd-V paste interception (#486): AppKit has no native paste signal
@@ -210,7 +218,37 @@ pub(crate) fn dispatch_event<A: AppLogic>(
 
     // `MouseDown` is the only variant `fold_double_click` acts on, and
     // every `MouseDown` returned above — so the remaining pipeline
-    // (accelerators, Cmd-V paste, plain forward) skips the fold.
+    // (activity-bar redirect, accelerators, Cmd-V paste, plain forward)
+    // skips the fold.
+
+    // ── ActivityBar keyboard focus intercept (#465) ──────────────────
+    //
+    // `AppShell`/`ShellAdapter`'s built-in activity-bar keyboard cursor
+    // (#409) is driven by `UiEvent::ActivityBar(id, KeyPressed { … })`,
+    // which is *synthesized by the backend* — `TuiBackend::apply_dispatch`
+    // and `gtk::run::dispatch_event` both do it. Without this arm the
+    // macOS backend delivered the raw `KeyPressed` instead, so `j`/`k`/
+    // `Enter` fell through to `ShellApp::handle` and the shell's cursor
+    // never moved: every `ShellApp` on macOS (#465's `run_with_shell`)
+    // silently lost keyboard navigation the other two backends have.
+    //
+    // Ordered before accelerator matching, matching `gtk::run`.
+    if let UiEvent::KeyPressed {
+        ref key, modifiers, ..
+    } = event
+    {
+        if let Some(bar_id) = backend.focused_activity_bar_id().cloned() {
+            let key_str = crate::primitives::activity_bar::key_to_activity_bar_string(key);
+            let bar_ev = UiEvent::ActivityBar(
+                bar_id,
+                crate::ActivityBarEvent::KeyPressed {
+                    key: key_str,
+                    modifiers,
+                },
+            );
+            return app.handle(bar_ev, backend).into();
+        }
+    }
 
     let event = if let UiEvent::KeyPressed { key, modifiers, .. } = &event {
         match backend.match_keypress(key, *modifiers) {

--- a/quadraui/src/macos/shell_runner.rs
+++ b/quadraui/src/macos/shell_runner.rs
@@ -1,0 +1,30 @@
+//! macOS shell runner: `run_with_shell()` wraps a [`ShellApp`] in an
+//! AppShell and drives it through the standard macOS (AppKit) event loop.
+//!
+//! The shared [`crate::shell_adapter::ShellAdapter`] owns all runtime logic
+//! (bottom-panel init, panel routing, resize recalc, click dispatch), and
+//! [`crate::shell_adapter::build_shell_adapter`] owns assembling one from a
+//! [`ShellConfig`] — shared across every backend since #497. This module
+//! only wires the adapter into the macOS event loop, mirroring
+//! `tui::shell_runner` / `gtk::shell_runner` (#465).
+//!
+//! `MacBackend` already implements every `Backend` trait method `AppShell`
+//! renders through (`draw_activity_bar`, `draw_sidebar_panel`,
+//! `draw_tab_bar`, `draw_panel`, `draw_status_bar`, …), so no new rasteriser
+//! work is needed here — this is pure composition, same as the TUI/GTK
+//! runners.
+
+use crate::shell::{ShellApp, ShellConfig};
+use crate::shell_adapter::build_shell_adapter;
+
+/// Run a [`ShellApp`] with AppShell chrome on the macOS backend.
+///
+/// **Must be called from the main thread** — enforced transitively by
+/// [`super::run::run`].
+pub fn run_with_shell<A: ShellApp + 'static>(
+    app: A,
+    config: ShellConfig,
+) -> std::process::ExitCode {
+    let adapter = build_shell_adapter(app, config);
+    super::run::run(adapter)
+}

--- a/quadraui/src/macos/testing.rs
+++ b/quadraui/src/macos/testing.rs
@@ -48,6 +48,7 @@
 
 use crate::backend::Backend;
 use crate::runner::{AppLogic, Reaction};
+use crate::shell::{ShellApp, ShellConfig};
 use crate::testing::{Anchor, ConformanceDriver, FrameInventory, LogicalViewport};
 use crate::{ButtonMask, Key, Modifiers, MouseButton, NamedKey, Point, ScrollDelta, UiEvent};
 
@@ -55,6 +56,48 @@ use super::backend::MacBackend;
 use super::headless::BitmapSurface;
 use super::run::{dispatch_event, render_frame, EventOutcome};
 use super::text::make_font;
+
+/// Build a [`MacDriver`] that wraps `app` in the full
+/// [`crate::shell_adapter::ShellAdapter`] stack, mirroring exactly what
+/// [`crate::macos::shell_runner::run_with_shell`] does at runtime — but
+/// returning a testable driver instead of entering the live `NSApplication`
+/// run loop. The macOS twin of [`crate::tui::testing::driver_with_shell`] /
+/// [`crate::gtk::testing::driver_with_shell`]; all three share the same
+/// [`ShellApp`] + [`ShellConfig`] input, differing only in the native units
+/// their respective drivers take (TUI cells vs GTK/macOS points/pixels).
+///
+/// Use this constructor in tests that need to verify the full
+/// `ShellApp → ShellAdapter → dispatch_event` integration path on the macOS
+/// backend — e.g. confirming that shell chrome (activity bar, sidebar
+/// panel) renders and that panel switches reach the real [`AppShell`]
+/// instance [`crate::shell_adapter::ShellAdapter`] paints, not a shadow
+/// copy.
+///
+/// [`AppShell`]: crate::compose::app_shell::AppShell
+///
+/// # Example
+///
+/// ```no_run
+/// # use quadraui::macos::testing::driver_with_shell;
+/// # use quadraui::{ShellApp, ShellConfig, Backend, ShellContext, Reaction, UiEvent};
+/// # struct MyApp;
+/// # impl ShellApp for MyApp {
+/// #     fn render_content(&self, _: &mut dyn Backend, _: &quadraui::compose::app_shell::AppShellLayout) {}
+/// #     fn handle(&mut self, _: UiEvent, _: &mut dyn Backend, _: &ShellContext) -> Reaction { Reaction::Continue }
+/// # }
+/// let config = ShellConfig::new("Demo", vec![]);
+/// let mut driver = driver_with_shell(MyApp, config, 800, 480);
+/// let _ = driver.pixel(0, 0);
+/// ```
+pub fn driver_with_shell<A: ShellApp + 'static>(
+    app: A,
+    config: ShellConfig,
+    width: u32,
+    height: u32,
+) -> MacDriver<impl AppLogic> {
+    let adapter = crate::shell_adapter::build_shell_adapter(app, config);
+    MacDriver::new(adapter, width, height)
+}
 
 /// Drives an [`AppLogic`] impl headlessly against the macOS backend for
 /// tests. Construct with [`Self::new`] (runs `setup` + paints the first

--- a/quadraui/src/macos/testing.rs
+++ b/quadraui/src/macos/testing.rs
@@ -645,4 +645,123 @@ mod tests {
         assert!(driver.app().quit, "app.handle should have run");
         assert!(driver.exited(), "'q' should make the app exit");
     }
+
+    // ── ActivityBar keyboard-focus redirect (#465) ────────────────────
+
+    /// App that paints one [`crate::primitives::activity_bar::ActivityBar`]
+    /// whose `is_keyboard_focused` flag is fixed at construction, and
+    /// records every event `dispatch_event` hands it.
+    struct ActivityBarApp {
+        focused: bool,
+        seen: Vec<UiEvent>,
+    }
+
+    impl AppLogic for ActivityBarApp {
+        type AreaId = ();
+
+        fn render(&self, backend: &mut dyn Backend, _area: ()) {
+            use crate::primitives::activity_bar::{ActivityBar, ActivityItem};
+            backend.draw_activity_bar(
+                Rect::new(0.0, 0.0, W as f32, H as f32),
+                &ActivityBar {
+                    id: WidgetId::new("bar"),
+                    top_items: vec![ActivityItem {
+                        id: WidgetId::new("panel:explorer"),
+                        icon: "E".into(),
+                        tooltip: "Explorer".into(),
+                        is_active: true,
+                        is_keyboard_selected: self.focused,
+                    }],
+                    bottom_items: Vec::new(),
+                    active_accent: None,
+                    selection_bg: None,
+                    is_keyboard_focused: self.focused,
+                },
+                None,
+            );
+        }
+
+        fn handle(&mut self, event: UiEvent, _backend: &mut dyn Backend) -> Reaction {
+            self.seen.push(event);
+            Reaction::Continue
+        }
+    }
+
+    /// Regression for #465: while a painted `ActivityBar` declares
+    /// `is_keyboard_focused`, `dispatch_event` must hand the app
+    /// `UiEvent::ActivityBar(bar_id, ActivityBarEvent::KeyPressed { … })`
+    /// — the synthesized form `ShellAdapter`'s built-in activity-bar
+    /// navigation (#409) matches on — rather than the raw `KeyPressed`.
+    /// TUI (`TuiBackend::apply_dispatch`) and GTK (`gtk::run::dispatch_event`)
+    /// already did this; macOS did not, so every `ShellApp` driven through
+    /// `macos::shell_runner::run_with_shell` silently lost `j`/`k`/`Enter`
+    /// panel navigation.
+    #[test]
+    fn keypress_redirects_to_focused_activity_bar() {
+        let mut driver = MacDriver::new(
+            ActivityBarApp {
+                focused: true,
+                seen: Vec::new(),
+            },
+            W,
+            H,
+        );
+
+        driver.type_char('j');
+        driver.press_named(crate::NamedKey::Enter);
+
+        let keys: Vec<String> = driver
+            .app()
+            .seen
+            .iter()
+            .filter_map(|ev| match ev {
+                UiEvent::ActivityBar(id, crate::ActivityBarEvent::KeyPressed { key, .. }) => {
+                    Some(format!("{}:{key}", id.as_str()))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["bar:j".to_string(), "bar:Enter".to_string()],
+            "focused bar must receive normalised ActivityBar key events, got {:?}",
+            driver.app().seen
+        );
+        assert!(
+            !driver
+                .app()
+                .seen
+                .iter()
+                .any(|ev| matches!(ev, UiEvent::KeyPressed { .. })),
+            "no raw KeyPressed should leak through while the bar is focused"
+        );
+    }
+
+    /// The complement: with no keyboard-focused bar painted, keys reach the
+    /// app unchanged — the redirect must not swallow ordinary typing.
+    #[test]
+    fn keypress_untouched_when_no_activity_bar_is_focused() {
+        let mut driver = MacDriver::new(
+            ActivityBarApp {
+                focused: false,
+                seen: Vec::new(),
+            },
+            W,
+            H,
+        );
+
+        driver.type_char('j');
+
+        assert!(
+            driver.app().seen.iter().any(|ev| matches!(
+                ev,
+                UiEvent::KeyPressed {
+                    key: Key::Char('j'),
+                    ..
+                }
+            )),
+            "unfocused bar must not intercept: {:?}",
+            driver.app().seen
+        );
+    }
 }

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -50,8 +50,8 @@ pub struct ActivityBar {
     /// `None` = backends fall back to their own default.
     #[serde(default)]
     pub selection_bg: Option<Color>,
-    /// When `true` the bar is accepting keyboard input. Both TUI and GTK
-    /// backends intercept key events and emit
+    /// When `true` the bar is accepting keyboard input. The TUI, GTK and
+    /// macOS backends intercept key events and emit
     /// [`ActivityBarEvent::KeyPressed`] (wrapped in
     /// [`crate::UiEvent::ActivityBar`]) rather than forwarding them as raw
     /// [`crate::UiEvent::KeyPressed`] events.
@@ -328,17 +328,21 @@ pub enum ActivityBarEvent {
 /// - Printable characters map to their single-character string (`"j"`, `"k"`, …).
 /// - Named keys use TitleCase names (`"Escape"`, `"Enter"`, `"Up"`, …).
 ///
-/// Both the TUI and GTK backends use this helper so the emitted key strings
-/// are identical regardless of which backend is active.
+/// The TUI, GTK and macOS backends all use this helper so the emitted key
+/// strings are identical regardless of which backend is active.
 ///
 /// This is `pub(crate)` because external consumers receive the already-normalised
 /// string from [`ActivityBarEvent::KeyPressed::key`] — they have no reason to call
 /// the conversion helper directly.
 ///
-/// `cfg`-gated: only `crate::tui::backend` and `crate::gtk::run` call this
-/// today. Under `win` alone (no consumer yet) it goes dead-code under
-/// `-D warnings` (#540).
-#[cfg(any(feature = "tui", feature = "gtk"))]
+/// `cfg`-gated: only `crate::tui::backend`, `crate::gtk::run` and
+/// `crate::macos::run` (#465) call this today. Under `win` alone (no
+/// consumer yet) it goes dead-code under `-D warnings` (#540).
+#[cfg(any(
+    feature = "tui",
+    feature = "gtk",
+    all(feature = "macos", target_os = "macos")
+))]
 pub(crate) fn key_to_activity_bar_string(key: &crate::event::Key) -> String {
     use crate::event::{Key, NamedKey};
     match key {

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -187,7 +187,8 @@ impl<'a> ShellContext<'a> {
     ///
     /// `cfg`-gated with `ShellAdapter` itself (#540): under `win` alone
     /// there is no caller, so this and `take_activity_focus_requested`
-    /// below go dead-code under `-D warnings`.
+    /// below go dead-code under `-D warnings`. `macos` joined the gate in
+    /// #465 alongside `crate::macos::shell_runner`.
     ///
     /// `test` is in the gate too (#484): this module's own tests build a
     /// `ShellContext` through it, and without `test` here
@@ -195,7 +196,12 @@ impl<'a> ShellContext<'a> {
     /// first feature set to exercise that combination. In a non-test
     /// build the gate is unchanged, so the dead-code guard #540 added
     /// still holds.
-    #[cfg(any(feature = "tui", feature = "gtk", test))]
+    #[cfg(any(
+        feature = "tui",
+        feature = "gtk",
+        all(feature = "macos", target_os = "macos"),
+        test
+    ))]
     pub(crate) fn new(
         active_panel_id: Option<&'a WidgetId>,
         sidebar_visible: bool,
@@ -268,7 +274,11 @@ impl<'a> ShellContext<'a> {
     /// `ShellApp::handle` returns.
     ///
     /// `cfg`-gated with `ShellAdapter` itself (#540); see [`Self::new`].
-    #[cfg(any(feature = "tui", feature = "gtk"))]
+    #[cfg(any(
+        feature = "tui",
+        feature = "gtk",
+        all(feature = "macos", target_os = "macos")
+    ))]
     pub(crate) fn take_activity_focus_requested(&self) -> bool {
         self.activity_focus_requested.replace(false)
     }

--- a/quadraui/tests/macos_example_driver.rs
+++ b/quadraui/tests/macos_example_driver.rs
@@ -14,12 +14,16 @@
 //! `pipeline_parity_macos_agrees_with_tui_and_gtk_on_logical_state`.
 #![cfg(all(feature = "macos", target_os = "macos"))]
 
-use quadraui::macos::testing::MacDriver;
-use quadraui::Reaction;
+use quadraui::macos::testing::{driver_with_shell, MacDriver};
+use quadraui::{NamedKey, Reaction};
 
 #[path = "../examples/common/pipeline_app.rs"]
 mod pipeline_app;
 use pipeline_app::PipelineApp;
+
+#[path = "../examples/common/appshell_demo.rs"]
+mod appshell_demo;
+use appshell_demo::AppShellDemo;
 
 #[path = "../examples/common/data_table_app.rs"]
 mod data_table_app;
@@ -98,6 +102,159 @@ fn pipeline_clicking_a_stage_action_routes_the_click() {
         driver.screen_contains("stage 3"),
         "clicking the Deploy action should update the status to mention stage 3: {:?}",
         driver.painted_texts()
+    );
+}
+
+// ─── AppShellDemo: `driver_with_shell` (ShellApp) coverage (#465) ──────────
+//
+// `AppShellDemo` implements `ShellApp` (not `AppLogic` directly) and is
+// driven by `macos::shell_runner::run_with_shell` in production.
+// `driver_with_shell` builds the identical `ShellAdapter` stack — through
+// the same `build_shell_adapter` factory `run_with_shell` calls — then
+// scripts events through it headlessly, with no `NSApplication` / window.
+// These are the macOS twins of `tests/tui_example_driver.rs` /
+// `tests/gtk_example_driver.rs`'s `appshell_demo_*` tests, proving #465's
+// `macos::shell_runner` reaches the same `ShellAdapter` composition the
+// other two backends already do.
+
+// Point canvas sized for the shell chrome (activity bar + sidebar + main
+// content), distinct from the pipeline canvas above.
+const SHELL_W: u32 = 800;
+const SHELL_H: u32 = 480;
+
+/// The initial frame paints real shell chrome — the sidebar header for the
+/// default-active panel and the app's own content — asserted via
+/// `find_bounds`/`painted_texts` (real painted geometry), not just "it did
+/// not panic".
+#[test]
+fn appshell_demo_renders_shell_chrome_via_driver_with_shell() {
+    let config = AppShellDemo::config();
+    let driver = driver_with_shell(AppShellDemo::new(), config, SHELL_W, SHELL_H);
+
+    let bounds = driver
+        .find_bounds("EXPLORER")
+        .expect("sidebar header for the default-active panel should be painted");
+    assert!(
+        bounds.width > 0.0 && bounds.height > 0.0,
+        "sidebar header bounds should be non-empty: {bounds:?}"
+    );
+    assert!(
+        driver
+            .painted_texts()
+            .iter()
+            .any(|t| t.contains("Tab=focus bar")),
+        "main content hint should be painted: {:?}",
+        driver.painted_texts()
+    );
+}
+
+/// `Tab` focuses the activity bar, `j` `j` moves the keyboard cursor down
+/// two items (explorer → search → git), and `Enter` activates the
+/// selection — switching the *real* `AppShell` panel, visible as the
+/// sidebar header flipping from "EXPLORER" to "SOURCE CONTROL".
+///
+/// This is the acceptance criterion that the macOS test path and the live
+/// `macos::run` path build the adapter through the same function: the
+/// ActivityBar keyboard-focus intercept lives in `macos::run::dispatch_event`
+/// (shared by `MacDriver::dispatch`) and reads `ShellAdapter` state built by
+/// `build_shell_adapter` — if `driver_with_shell` constructed that adapter
+/// differently than `run_with_shell` does, this round trip would desync
+/// exactly the way vimcode's Ctrl+B bug (#454) did for the sidebar toggle.
+#[test]
+fn appshell_demo_tab_focus_then_jj_enter_switches_panel() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, SHELL_W, SHELL_H);
+
+    assert!(
+        driver.find_bounds("EXPLORER").is_some(),
+        "starts on the default (index 0) Explorer panel"
+    );
+
+    let reaction = driver.press_named(NamedKey::Tab);
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Tab should request activity-bar keyboard focus and redraw"
+    );
+    assert!(
+        driver.screen_contains("Activity bar focused"),
+        "focusing the bar should update the status hint: {:?}",
+        driver.painted_texts()
+    );
+
+    // Cursor starts at index 0 (explorer). Two `j` presses move it to
+    // index 2 (git) — 3 top panels, cursor saturates instead of wrapping.
+    for _ in 0..2 {
+        let reaction = driver.type_char('j');
+        assert_eq!(
+            reaction,
+            Reaction::Redraw,
+            "'j' while focused must be intercepted as ActivityBar nav, not fall through"
+        );
+    }
+
+    let reaction = driver.press_named(NamedKey::Enter);
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Enter should activate the selected item and redraw"
+    );
+
+    let bounds = driver
+        .find_bounds("SOURCE CONTROL")
+        .expect("sidebar header must switch to the git panel's real title");
+    assert!(bounds.width > 0.0 && bounds.height > 0.0);
+    assert!(
+        driver.find_bounds("EXPLORER").is_none(),
+        "the stale Explorer header must not still be painted"
+    );
+    assert!(
+        driver.screen_contains("Panel: panel:git"),
+        "on_shell_event_ctx(PanelChanged) must fire for a keyboard-driven switch, \
+         mirroring the TUI/GTK paths: {:?}",
+        driver.painted_texts()
+    );
+}
+
+/// #454's fix, proven on macOS: `ctx.shell_mut()` reaches the real `AppShell`
+/// instance `ShellAdapter` renders, so `Ctrl+B` hides/shows the sidebar
+/// `driver_with_shell` actually painted — not a shadow copy. Mirrors
+/// `tests/tui_example_driver.rs` / `tests/gtk_example_driver.rs`'s
+/// `appshell_demo_ctrl_b_toggles_the_real_rendered_sidebar`.
+#[test]
+fn appshell_demo_ctrl_b_toggles_the_real_rendered_sidebar() {
+    let config = AppShellDemo::config();
+    let mut driver = driver_with_shell(AppShellDemo::new(), config, SHELL_W, SHELL_H);
+
+    assert!(
+        driver.find_bounds("(sidebar content here)").is_some(),
+        "sidebar should be visible on the initial screen"
+    );
+
+    let reaction = driver.ctrl_char('b');
+    assert_eq!(
+        reaction,
+        Reaction::Redraw,
+        "Ctrl+B toggling the real AppShell must redraw"
+    );
+    assert!(
+        driver.find_bounds("(sidebar content here)").is_none(),
+        "Ctrl+B must hide the sidebar that ShellAdapter actually renders, not a shadow copy"
+    );
+    assert!(
+        driver.screen_contains("Sidebar hidden (Ctrl+B via ctx.shell_mut())"),
+        "status line should confirm the toggle went through ctx.shell_mut()"
+    );
+
+    let reaction = driver.ctrl_char('b');
+    assert_eq!(reaction, Reaction::Redraw);
+    assert!(
+        driver.find_bounds("(sidebar content here)").is_some(),
+        "a second Ctrl+B should show the sidebar again"
+    );
+    assert!(
+        driver.screen_contains("Sidebar shown (Ctrl+B via ctx.shell_mut())"),
+        "status line should confirm the second toggle"
     );
 }
 


### PR DESCRIPTION
Closes #465

Automated merge from the coordinator for assignment 7f8e06935448 on issue #465.

Worker branch: `issue-465-macos-backend-add-shellapp-run-with-shel` → `develop`.