### PR TITLE
#649: TUI draw_command_center returns a hit-testable layout for a paint it skipped — invisible-but-clickable by construction

### DIFF
--- a/quadraui/src/primitives/command_center.rs
+++ b/quadraui/src/primitives/command_center.rs
@@ -53,6 +53,23 @@ pub struct CommandCenterLayout {
 }
 
 impl CommandCenterLayout {
+    /// A layout for an area the rasteriser did not (or could not) paint
+    /// into: no hit regions at all, so [`Self::hit_test`] returns
+    /// [`CommandCenterHit::Outside`] for every point. Use this instead of
+    /// [`CommandCenter::layout`]'s geometric result whenever the paint
+    /// loop skips the widget entirely — a `width == 0` / `height == 0`
+    /// area, for instance — so the returned layout never describes cells
+    /// that were never actually drawn (quadraui#649).
+    pub fn empty(bounds: Rect) -> Self {
+        CommandCenterLayout {
+            bounds,
+            back_bounds: None,
+            forward_bounds: None,
+            search_bounds: None,
+            hit_regions: Vec::new(),
+        }
+    }
+
     pub fn hit_test(&self, x: f32, y: f32) -> CommandCenterHit {
         for (rect, hit) in &self.hit_regions {
             if x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height {

--- a/quadraui/src/primitives/toolbar.rs
+++ b/quadraui/src/primitives/toolbar.rs
@@ -181,6 +181,20 @@ pub struct ToolbarLayout {
 }
 
 impl ToolbarLayout {
+    /// A layout for an area the rasteriser did not (or could not) paint
+    /// into: no visible items at all, so [`Self::hit_test`] returns
+    /// [`ToolbarHit::Empty`] for every point. Use this instead of
+    /// [`Toolbar::layout`]'s geometric result whenever the paint loop
+    /// skips the widget entirely — a `width == 0` / `height == 0` area,
+    /// for instance — so the returned layout never describes cells that
+    /// were never actually drawn (quadraui#649).
+    pub fn empty(bar_bounds: Rect) -> Self {
+        ToolbarLayout {
+            bar_bounds,
+            visible_items: Vec::new(),
+        }
+    }
+
     /// Test which clickable action (if any) contains point `(x, y)`.
     /// Returns [`ToolbarHit::Empty`] when no clickable region matches —
     /// disabled actions, separators, labels, and the gap between buttons

--- a/quadraui/src/tui/command_center.rs
+++ b/quadraui/src/tui/command_center.rs
@@ -6,7 +6,9 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 
 use super::{ratatui_color, set_cell};
-use crate::primitives::command_center::{CommandCenter, CommandCenterLayout, CommandCenterMeasure};
+use crate::primitives::command_center::{
+    CommandCenter, CommandCenterHit, CommandCenterLayout, CommandCenterMeasure,
+};
 use crate::theme::Theme;
 
 const TUI_ARROW_WIDTH: f32 = 2.0;
@@ -43,11 +45,45 @@ pub fn draw_command_center(
     cc: &CommandCenter,
     theme: &Theme,
 ) -> CommandCenterLayout {
-    let layout = tui_command_center_layout(cc, area);
-
     if area.width == 0 || area.height == 0 {
-        return layout;
+        return CommandCenterLayout::empty(crate::event::Rect::new(
+            area.x as f32,
+            area.y as f32,
+            area.width as f32,
+            area.height as f32,
+        ));
     }
+
+    let mut layout = tui_command_center_layout(cc, area);
+
+    // The paint loop below only draws an element that fits entirely
+    // within `area`; drop bounds/hit-regions for anything that would
+    // spill past the edge so the returned layout never describes cells
+    // it didn't actually paint (quadraui#649). At `area` widths used in
+    // practice this never trips — it only matters when the command
+    // center is squeezed narrower than its own content.
+    let area_right = area.x as f32 + area.width as f32;
+    let fits = |r: crate::event::Rect| r.x >= area.x as f32 && r.x + r.width <= area_right;
+
+    let back_fits = layout.back_bounds.is_some_and(fits);
+    let forward_fits = layout.forward_bounds.is_some_and(fits);
+    let search_fits = layout.search_bounds.is_some_and(fits);
+
+    if !back_fits {
+        layout.back_bounds = None;
+    }
+    if !forward_fits {
+        layout.forward_bounds = None;
+    }
+    if !search_fits {
+        layout.search_bounds = None;
+    }
+    layout.hit_regions.retain(|(_, hit)| match hit {
+        CommandCenterHit::Back => back_fits,
+        CommandCenterHit::Forward => forward_fits,
+        CommandCenterHit::SearchBox => search_fits,
+        CommandCenterHit::Bar | CommandCenterHit::Outside => true,
+    });
 
     let bg = ratatui_color(theme.tab_bar_bg);
     let enabled_fg = ratatui_color(theme.tab_inactive_fg);
@@ -105,7 +141,6 @@ pub fn draw_command_center(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::primitives::command_center::CommandCenterHit;
     use crate::types::WidgetId;
 
     fn cell_char(buf: &Buffer, x: u16, y: u16) -> char {
@@ -211,7 +246,71 @@ mod tests {
         let buf_area = Rect::new(0, 0, 10, 1);
         let mut buf = Buffer::empty(buf_area);
         let cc = mk_cc("X");
-        let _layout = draw_command_center(&mut buf, Rect::new(0, 0, 0, 0), &cc, &Theme::default());
+        let layout = draw_command_center(&mut buf, Rect::new(0, 0, 0, 0), &cc, &Theme::default());
         assert_eq!(cell_char(&buf, 0, 0), ' ');
+        assert!(layout.back_bounds.is_none());
+        assert!(layout.forward_bounds.is_none());
+        assert!(layout.search_bounds.is_none());
+        assert_eq!(layout.hit_test(0.0, 0.0), CommandCenterHit::Outside);
+    }
+
+    /// Issue #649: a `width == 0` area used to still get a fully
+    /// populated layout back from `tui_command_center_layout` — nothing
+    /// painted, but every hit region present, so a host caching that
+    /// layout would treat empty cells as clickable.
+    #[test]
+    fn zero_width_area_is_hit_testably_empty() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+        let cc = mk_cc("X");
+        let layout = draw_command_center(&mut buf, Rect::new(0, 0, 0, 1), &cc, &Theme::default());
+
+        assert!(layout.back_bounds.is_none());
+        assert!(layout.forward_bounds.is_none());
+        assert!(layout.search_bounds.is_none());
+        for x in 0..10 {
+            assert_eq!(
+                layout.hit_test(x as f32 + 0.5, 0.5),
+                CommandCenterHit::Outside
+            );
+        }
+    }
+
+    /// Same as `zero_width_area_is_hit_testably_empty` but for
+    /// `height == 0` — the other half of the degenerate-area guard.
+    #[test]
+    fn zero_height_area_is_hit_testably_empty() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+        let cc = mk_cc("X");
+        let layout = draw_command_center(&mut buf, Rect::new(0, 0, 10, 0), &cc, &Theme::default());
+
+        assert!(layout.back_bounds.is_none());
+        assert!(layout.forward_bounds.is_none());
+        assert!(layout.search_bounds.is_none());
+        assert_eq!(layout.hit_test(0.0, 0.0), CommandCenterHit::Outside);
+    }
+
+    /// Issue #649: when the command center is squeezed narrower than its
+    /// own content, the search box doesn't fit inside `area` — the paint
+    /// loop must skip it (not spill past the edge into a wider host
+    /// buffer), and the returned layout must not report `search_bounds`
+    /// or hit-test it, matching what was actually painted.
+    #[test]
+    fn clipped_search_box_does_not_report_search_bounds() {
+        // content_width for "Search" is 16 cells (2 arrows * 2 + gap 1 +
+        // gap 1 + search box 10); an 8-wide area can fit the arrows but
+        // not the search box.
+        let area = Rect::new(0, 0, 8, 1);
+        let mut buf = Buffer::empty(area);
+        let cc = mk_cc("Search");
+        let layout = draw_command_center(&mut buf, area, &cc, &Theme::default());
+
+        assert!(
+            layout.search_bounds.is_none(),
+            "search box doesn't fit in an 8-wide area; its bounds must not be reported"
+        );
+        // Paint and layout must agree: nothing was drawn at the search
+        // box's would-be position (column 6), so it stays background.
+        assert_eq!(cell_char(&buf, 6, 0), ' ');
+        assert_eq!(layout.hit_test(6.5, 0.5), CommandCenterHit::Bar);
     }
 }

--- a/quadraui/src/tui/toolbar.rs
+++ b/quadraui/src/tui/toolbar.rs
@@ -91,11 +91,22 @@ pub fn draw_toolbar(
     hovered_id: Option<&WidgetId>,
     pressed_id: Option<&WidgetId>,
 ) -> ToolbarLayout {
-    let layout = tui_toolbar_layout(bar, area);
-
     if area.width == 0 || area.height == 0 {
-        return layout;
+        // `tui_toolbar_layout` forces `bar_height` to `area.height.max(1)`
+        // (so single-row callers don't have to special-case it), which
+        // means a `height == 0` area would otherwise still get back a
+        // fully populated, clickable layout for a row that was never
+        // painted — the same footgun as quadraui#649's command-center
+        // bug. Return an empty layout instead of computing one.
+        return ToolbarLayout::empty(crate::event::Rect::new(
+            area.x as f32,
+            area.y as f32,
+            area.width as f32,
+            area.height as f32,
+        ));
     }
+
+    let layout = tui_toolbar_layout(bar, area);
 
     let bar_bg = qc(bar.bg.unwrap_or(theme.header_bg));
     let fg = qc(theme.foreground);
@@ -386,8 +397,36 @@ mod tests {
             bg: None,
             focused_index: None,
         };
-        let _ = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
+        let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
         assert_eq!(cell_char(&buf, 0, 0), ' ');
+        assert!(layout.visible_items.is_empty());
+        assert_eq!(layout.hit_test(0.0, 0.0), ToolbarHit::Empty);
+    }
+
+    /// Issue #649 (same shape as the `CommandCenter` bug it names):
+    /// `tui_toolbar_layout` forces `bar_height` to `area.height.max(1)`,
+    /// so a `height == 0` area used to still come back with real,
+    /// clickable `visible_items` — a row that was never painted, but
+    /// whose action buttons hit-tested as if it had been. A host that
+    /// hides a toolbar by zeroing its height (rather than not calling
+    /// `draw_toolbar` at all) would inherit an invisible-but-clickable
+    /// button.
+    #[test]
+    fn zero_height_area_has_no_hit_testable_buttons() {
+        let buf_area = Rect::new(0, 0, 10, 1);
+        let mut buf = Buffer::empty(buf_area);
+        let area = Rect::new(0, 0, 10, 0);
+        let bar = Toolbar {
+            id: WidgetId::new("tb"),
+            buttons: vec![mk_action("a", "X", true)],
+            bg: None,
+            focused_index: None,
+        };
+        let layout = draw_toolbar(&mut buf, area, &bar, &Theme::default(), None, None);
+        assert!(layout.visible_items.is_empty());
+        // Pre-fix, the forced `bar_height.max(1)` row band at y == 0
+        // would hit-test the button here even though nothing painted.
+        assert_eq!(layout.hit_test(1.0, 0.0), ToolbarHit::Empty);
     }
 
     // ── Gap 1: multi-row rasteriser ─────────────────────────────────────


### PR DESCRIPTION
Closes #649

## Problem

`draw_command_center` returned a **fully populated `CommandCenterLayout` for a paint it never performed**:

```rust
// quadraui/src/tui/command_center.rs (before)
let layout = tui_command_center_layout(cc, area);
if area.width == 0 || area.height == 0 {
    return layout;          // nothing painted, but the caller gets hit regions
}
```

Hosts cache that return value and hit-test against it (vimcode `tui_main/shell_app.rs:1390` →
`tui_main/mouse.rs:1990`), so a zero-width/zero-height area yields a widget that is **invisible and
fully clickable** — the user clicks empty cells and a picker opens. Surfaced by vimcode#712.

The same divergence existed for elements the paint loop *skips because they don't fit*: a command
center squeezed narrower than its own content still reported `search_bounds` for a search box that
was never drawn.

The invariant this PR restores: **the layout a rasteriser returns describes cells it actually
painted.** A host cannot then get it wrong by omission — which is the failure mode behind the whole
paint↔hit-test divergence class (quadraui#494, vimcode#693, vimcode#695).

## Change

- **`CommandCenterLayout::empty(bounds)`** and **`ToolbarLayout::empty(bar_bounds)`** — new
  constructors that produce "nothing painted, nothing clickable": no hit regions / no visible items,
  so `hit_test` returns `Outside` / `Empty` at every point.
- `draw_command_center` returns `CommandCenterLayout::empty(area)` on the degenerate
  (`width == 0 || height == 0`) path, **and** drops `back_bounds` / `forward_bounds` /
  `search_bounds` (plus their `hit_regions` entries) for any element that would spill past
  `area`'s right edge — exactly the elements the paint loop skips.
- `draw_toolbar` returns `ToolbarLayout::empty(area)` on its degenerate path (see audit below).

## Sibling-rasteriser audit

The issue asked for an explicit write-up of the audit across the five sibling TUI rasterisers, so
here it is in full — including the ones that were already fine.

| Rasteriser | Degenerate-area branch | Verdict |
|---|---|---|
| `tui/menu_bar.rs:37` | `bar.layout(bounds, \|_\| MenuBarItemMeasure::new(0.0))` — builds the layout from an **all-zero-width measurer** against a zero-sized `bounds` | **Already safe.** Every item rect is zero-width/zero-height, so point-in-rect hit-testing never matches. A different shape from the `::empty()` convention this PR establishes, and a more fragile one (it stops being safe if `hit_test` ever changes to `<=`, or if a future measurer on this path stops being all-zero) — flagged for a follow-up `MenuBarLayout::empty()`, deliberately **not** changed here to keep this PR to one behavioural change. |
| `tui/tab_bar.rs:135` | `return TabBarHits::default()` | **Already correct** — genuinely empty. |
| `tui/activity_bar.rs:23` | `return Vec::new()` | **Already correct** — no rows, nothing to hit. |
| `tui/status_bar.rs:51` | returns a literal `StatusBarLayout` with `bar_width: 0.0`, `bar_height: 0.0`, empty `visible_segments`, empty `hit_regions` | **Already correct.** |
| `tui/toolbar.rs:91` | `let layout = tui_toolbar_layout(bar, area); if area.width == 0 \|\| area.height == 0 { return layout; }` | **Same bug as `command_center` — fixed in this PR.** Worse than the command-center case in one respect: `tui_toolbar_layout` forces `bar_height` to `area.height.max(1)` so single-row callers don't have to special-case it, which means a `height == 0` area produced *real, clickable* `visible_items` for a row that was never painted. Now returns `ToolbarLayout::empty(area)`. |

Net: **one sibling shared the bug (`toolbar.rs`, fixed here), three are already correct, one
(`menu_bar.rs`) is correct-by-accident and worth a consistency follow-up.**

The GTK/macOS rasterisers were out of scope per the issue unless the audit found the identical early
return there; it did not, so they are untouched.

## Downstream impact

Two new `pub` items are added — `CommandCenterLayout::empty` and `ToolbarLayout::empty` — both
**purely additive constructors**. No field, variant, or signature moves; no existing item is
renamed, removed, or has its type changed. Nothing to migrate, and no CLAUDE.md rule-3 deprecation
shim is needed.

The behavioural change is strictly **narrowing**: hit regions that used to be reported for cells
that were never painted stop being reported. Nothing that was previously `None`/absent becomes
present.

Blast-radius grep (CLAUDE.md rule 1):

```
$ grep -rn 'CommandCenterLayout\|command_center_layout\|ToolbarLayout\|toolbar_layout' \
      ~/src/vimcode/src ~/src/coord-tui/src

~/src/vimcode/src/core/engine/mod.rs:2930:    pub debug_toolbar_layout: RefCell<Option<quadraui::ToolbarLayout>>,
~/src/vimcode/src/core/engine/mod.rs:3037:    pub command_center_layout: RefCell<Option<quadraui::CommandCenterLayout>>,
~/src/vimcode/src/core/engine/mod.rs:3795:            debug_toolbar_layout: RefCell::new(None),
~/src/vimcode/src/core/engine/mod.rs:3836:            command_center_layout: RefCell::new(None),
~/src/vimcode/src/core/engine/source_control.rs:1201:  layout.as_ref()?.toolbar_layout.as_ref()?.hit_test(x, y)
~/src/vimcode/src/core/engine/dap_ops.rs:1508:        let layout = self.debug_toolbar_layout.borrow();
~/src/vimcode/src/render.rs:2697:    engine.debug_toolbar_layout.replace(Some(layout));
~/src/vimcode/src/render.rs:14655,14674,14904,14937:  quadraui::tui::tui_toolbar_layout(&bar, area)
~/src/vimcode/src/tui_main/render_impl.rs:451,454:  engine.command_center_layout.replace(...)
~/src/vimcode/src/tui_main/shell_app.rs:939,1390,1393
~/src/vimcode/src/tui_main/mouse.rs:1990:            .command_center_layout
~/src/vimcode/src/gtk/mod.rs:3257,4188,9379,9396,9398,9635
~/src/vimcode/src/gtk/testing.rs:3011,3089,3249,3310,3388,3401,3407,3418,3450
~/src/coord-tui/src/app/events.rs:5530,5685,5697,5707:  backend.toolbar_layout(bar_rect, &action_toolbar)
~/src/coord-tui/src/app/tests.rs:18120,18123:            backend.toolbar_layout(Rect::new(...), &bar)
```

- **vimcode** — every hit *consumes* a cached layout (stores it, then hit-tests it). These are the
  call sites that want this fix: they are precisely the "cache the returned layout, hit-test it
  later" pattern the bug exploits. No signature they touch changes. vimcode's own remaining half of
  vimcode#712 (it clears `command_center_layout` only on the `menu_bar_visible == false` branch) is
  explicitly **out of scope** here.
- **coord-tui** — its four hits are all `Backend::toolbar_layout(rect, bar)`, a *layout-only* trait
  method that delegates to `tui_toolbar_layout` and is **not touched by this PR**; `draw_toolbar`
  (the changed function) has no coord-tui call sites. coord-tui is unaffected either way.
- Both consumers build fine against this change; coord-tui is additionally insulated by its git-rev
  pin.

## Tests

New in-crate `#[cfg(test)]` coverage in `quadraui/src/tui/command_center.rs` and
`quadraui/src/tui/toolbar.rs`, one per acceptance criterion:

- `zero_width_area_is_hit_testably_empty` — `width == 0`: no bounds reported, `hit_test` returns
  `Outside` at every column, and no cells painted.
- `zero_height_area_is_hit_testably_empty` — same for `height == 0`.
- `clipped_search_box_does_not_report_search_bounds` — an 8-wide area fits the arrows but not the
  10-wide search box; asserts `search_bounds.is_none()`, that the search box's would-be column is
  still background, and that hit-testing there yields `Bar` rather than `SearchBox`.
- `draw_toolbar`: `zero_size_area_is_noop` (extended to assert `visible_items.is_empty()` and
  `hit_test == ToolbarHit::Empty`) and a new `zero_height_area_has_no_hit_testable_buttons` covering
  the `bar_height = area.height.max(1)` case specifically.
- The existing paint↔click round-trip tests for both primitives still pass at a zero **and** a
  non-zero `area` origin (the quadraui#494 convention) — the non-degenerate path is unchanged.

## Acceptance criteria

- [x] `draw_command_center` into a `width == 0` area returns a layout whose `hit_test` yields
      `Outside` at every point, and paints no cells
- [x] same for `height == 0`
- [x] the non-degenerate path is unchanged — existing paint↔click round-trip tests still pass at
      both a zero and a non-zero `area` origin
- [x] a clipped search box does not report `search_bounds`
- [x] the sibling-rasteriser audit is written up in the PR description (above)
