### PR TITLE
#656: GTK runner hard-codes application_id "org.quadraui.app" — no ShellConfig::with_app_id()/with_icon_name(), so every downstream app gets a generic WM icon

### DIFF
--- a/quadraui/src/gtk/run.rs
+++ b/quadraui/src/gtk/run.rs
@@ -219,15 +219,31 @@ pub struct RunConfig {
     /// Window title shown by the window manager (titlebar, taskbar,
     /// Alt-Tab switcher).
     pub title: String,
+    /// Themed icon name (`gtk4::Window::set_icon_name`), e.g.
+    /// `"io.github.jdonaghy.vimcode"`. `None` (the default) leaves GTK's
+    /// own fallback icon in place. Set via [`Self::with_icon_name`] — see
+    /// quadraui#656.
+    pub icon_name: Option<String>,
 }
 
 impl RunConfig {
-    /// Build a config with the given app id and window title.
+    /// Build a config with the given app id and window title. No icon
+    /// override — see [`Self::with_icon_name`].
     pub fn new(app_id: impl Into<String>, title: impl Into<String>) -> Self {
         Self {
             app_id: app_id.into(),
             title: title.into(),
+            icon_name: None,
         }
+    }
+
+    /// Set a themed icon name for the window (quadraui#656). Feeds
+    /// `gtk4::Window::set_icon_name` in [`run_with`] so themed-icon lookup
+    /// works even on window managers that don't resolve `app_id` to an
+    /// installed `.desktop` file.
+    pub fn with_icon_name(mut self, icon_name: impl Into<String>) -> Self {
+        self.icon_name = Some(icon_name.into());
+        self
     }
 }
 
@@ -238,6 +254,7 @@ impl Default for RunConfig {
         Self {
             app_id: "org.quadraui.app".to_string(),
             title: "quadraui app".to_string(),
+            icon_name: None,
         }
     }
 }
@@ -274,6 +291,7 @@ pub fn run_with<A: AppLogic + 'static>(app: A, config: RunConfig) -> std::proces
     let smoke = SmokeConfig::from_env();
     let smoke_failed = Rc::new(Cell::new(false));
     let title = config.title;
+    let icon_name = config.icon_name;
 
     let gapp = Application::builder().application_id(config.app_id).build();
 
@@ -283,6 +301,7 @@ pub fn run_with<A: AppLogic + 'static>(app: A, config: RunConfig) -> std::proces
         let smoke = smoke.clone();
         let smoke_failed = smoke_failed.clone();
         let title = title.clone();
+        let icon_name = icon_name.clone();
         gapp.connect_activate(move |gapp| {
             activate(
                 gapp,
@@ -291,6 +310,7 @@ pub fn run_with<A: AppLogic + 'static>(app: A, config: RunConfig) -> std::proces
                 smoke.clone(),
                 smoke_failed.clone(),
                 title.clone(),
+                icon_name.clone(),
             );
         });
     }
@@ -313,13 +333,19 @@ fn activate<A: AppLogic + 'static>(
     smoke: Option<SmokeConfig>,
     smoke_failed: Rc<Cell<bool>>,
     title: String,
+    icon_name: Option<String>,
 ) {
-    let window = ApplicationWindow::builder()
+    let mut window_builder = ApplicationWindow::builder()
         .application(gapp)
         .title(title)
         .default_width(DEFAULT_WINDOW_WIDTH)
-        .default_height(DEFAULT_WINDOW_HEIGHT)
-        .build();
+        .default_height(DEFAULT_WINDOW_HEIGHT);
+    // quadraui#656: themed icon lookup, independent of the app-id ↔
+    // `.desktop` file match — see `RunConfig::icon_name`'s doc comment.
+    if let Some(icon_name) = icon_name {
+        window_builder = window_builder.icon_name(icon_name);
+    }
+    let window = window_builder.build();
 
     // Stash the window handle so `Backend::begin_window_drag` /
     // `Backend::toggle_window_maximize` (#400) have something to drive.
@@ -1294,6 +1320,7 @@ mod run_config_tests {
         let config = RunConfig::default();
         assert_eq!(config.app_id, "org.quadraui.app");
         assert_eq!(config.title, "quadraui app");
+        assert_eq!(config.icon_name, None);
     }
 
     #[test]
@@ -1301,6 +1328,7 @@ mod run_config_tests {
         let config = RunConfig::new("io.github.jdonaghy.kubeui-gtk", "kubeui");
         assert_eq!(config.app_id, "io.github.jdonaghy.kubeui-gtk");
         assert_eq!(config.title, "kubeui");
+        assert_eq!(config.icon_name, None);
     }
 
     #[test]
@@ -1308,6 +1336,17 @@ mod run_config_tests {
         let owned = RunConfig::new(String::from("a.b.c"), String::from("Title"));
         let borrowed = RunConfig::new("a.b.c", "Title");
         assert_eq!(owned, borrowed);
+    }
+
+    /// #656: `with_icon_name` stores the icon name for `activate` to feed
+    /// into `ApplicationWindow::builder().icon_name(..)`.
+    #[test]
+    fn with_icon_name_sets_the_icon() {
+        let config = RunConfig::new("a.b.c", "Title").with_icon_name("io.github.jdonaghy.vimcode");
+        assert_eq!(
+            config.icon_name,
+            Some("io.github.jdonaghy.vimcode".to_string())
+        );
     }
 }
 

--- a/quadraui/src/gtk/shell_runner.rs
+++ b/quadraui/src/gtk/shell_runner.rs
@@ -8,11 +8,31 @@
 //! module re-inlined the same ~45 lines `tui::shell_runner` did). This
 //! module only wires the adapter into the GTK event loop.
 
+use super::run::RunConfig;
 use crate::shell::{ShellApp, ShellConfig};
 use crate::shell_adapter::build_shell_adapter;
 
 /// Run a [`ShellApp`] with AppShell chrome on the GTK backend.
+///
+/// Before quadraui#656, this always ran through [`super::run::run`], which
+/// hardcodes the generic app id (`"org.quadraui.app"`), the generic window
+/// title (`"quadraui app"` — [`ShellConfig::title`] was captured but never
+/// actually reached the GTK window), and no icon. `RunConfig::app_id`
+/// feeds `gtk4::Application::builder().application_id(..)`, which both
+/// live GDK backends derive the toplevel's identity from (Wayland
+/// `xdg_toplevel.set_app_id`; X11 `WM_CLASS`) — the key the window manager
+/// uses to match a live window to an installed `.desktop` file. With the
+/// generic id, every downstream app's taskbar/dock/Alt-Tab entry showed a
+/// generic icon regardless of how correctly it installed its own icon
+/// theme entries. `config.app_id` / `config.icon_name` (set via
+/// [`ShellConfig::with_app_id`] / [`ShellConfig::with_icon_name`]) now
+/// reach the runner via [`RunConfig`], fixing both — and `config.title`
+/// reaching the window is a side effect of the same plumbing.
 pub fn run_with_shell<A: ShellApp + 'static>(app: A, config: ShellConfig) {
+    let mut run_config = RunConfig::new(config.app_id.clone(), config.title.clone());
+    if let Some(icon_name) = config.icon_name.clone() {
+        run_config = run_config.with_icon_name(icon_name);
+    }
     let adapter = build_shell_adapter(app, config);
-    super::run::run(adapter);
+    super::run::run_with(adapter, run_config);
 }

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -51,6 +51,26 @@ pub struct ShellConfig {
     /// the app's own `setup()` runs, so painted glyphs and click-column
     /// math derive from the same font from the very first frame (#422).
     pub editor_font: Option<(String, f32)>,
+    /// GTK application id, e.g. `"io.github.jdonaghy.VimCode"`. Feeds
+    /// `gtk4::Application::builder().application_id(..)` in the GTK shell
+    /// runner (`quadraui::gtk::run_with_shell`), which is what a live GDK
+    /// backend derives the toplevel's identity from: Wayland
+    /// `xdg_toplevel.set_app_id`, X11 `WM_CLASS`. The window manager uses
+    /// that id to match a live window to an installed `.desktop` file —
+    /// with the default generic id, every downstream app's taskbar/dock/
+    /// alt-tab entry shows a generic icon instead of the app's own (#656).
+    /// Defaults to `"org.quadraui.app"` so existing callers are
+    /// unaffected. Set via [`Self::with_app_id`]. Backends with no
+    /// window-manager concept (TUI) ignore this field.
+    pub app_id: String,
+    /// Themed icon name, e.g. `"io.github.jdonaghy.vimcode"`, matching an
+    /// icon installed under an XDG icon theme directory. Feeds
+    /// `gtk4::Window::set_icon_name` in the GTK shell runner so themed-icon
+    /// lookup works even on window managers that don't resolve the app id
+    /// to a `.desktop` file (#656). `None` (the default) leaves GTK's own
+    /// fallback icon in place. Set via [`Self::with_icon_name`]. Backends
+    /// with no icon-theme concept (TUI) ignore this field.
+    pub icon_name: Option<String>,
 }
 
 impl ShellConfig {
@@ -73,6 +93,8 @@ impl ShellConfig {
             has_status_bar: false,
             bottom_panel: None,
             editor_font: None,
+            app_id: "org.quadraui.app".to_string(),
+            icon_name: None,
         }
     }
 
@@ -140,6 +162,25 @@ impl ShellConfig {
     /// zoom-in/out keybinding.
     pub fn with_editor_font(mut self, family: impl Into<String>, size_pt: f32) -> Self {
         self.editor_font = Some((family.into(), size_pt));
+        self
+    }
+
+    /// Override the GTK application id (`"org.quadraui.app"` by default).
+    ///
+    /// Should be a reverse-DNS id — see the
+    /// [GNOME application ID guidelines](https://developer.gnome.org/documentation/tutorials/application-id.html).
+    /// GTK warns and ignores a malformed id rather than rejecting it
+    /// outright, so this method does not validate the string itself.
+    /// See [`Self::app_id`] for why this matters (#656).
+    pub fn with_app_id(mut self, app_id: impl Into<String>) -> Self {
+        self.app_id = app_id.into();
+        self
+    }
+
+    /// Set a themed icon name for the window (unset — GTK's own fallback —
+    /// by default). See [`Self::icon_name`] for why this matters (#656).
+    pub fn with_icon_name(mut self, icon_name: impl Into<String>) -> Self {
+        self.icon_name = Some(icon_name.into());
         self
     }
 }
@@ -572,6 +613,36 @@ mod tests {
     fn shell_config_with_editor_font_sets_family_and_size() {
         let config = ShellConfig::new("test", Vec::new()).with_editor_font("Fira Code", 14.0);
         assert_eq!(config.editor_font, Some(("Fira Code".to_string(), 14.0)));
+    }
+
+    /// #656: a fresh `ShellConfig` keeps the generic app id and no icon
+    /// override, so nothing that predates this field changes behavior.
+    #[test]
+    fn shell_config_app_id_defaults_to_generic() {
+        let config = ShellConfig::new("test", Vec::new());
+        assert_eq!(config.app_id, "org.quadraui.app");
+        assert_eq!(config.icon_name, None);
+    }
+
+    /// #656: `with_app_id` stores the caller's id verbatim, replacing the
+    /// generic default the GTK shell runner would otherwise announce to
+    /// the window manager (Wayland `app_id` / X11 `WM_CLASS`).
+    #[test]
+    fn shell_config_with_app_id_overrides_the_default() {
+        let config = ShellConfig::new("test", Vec::new()).with_app_id("io.github.jdonaghy.VimCode");
+        assert_eq!(config.app_id, "io.github.jdonaghy.VimCode");
+    }
+
+    /// #656: `with_icon_name` stores the themed icon name for the GTK
+    /// shell runner to apply via `gtk4::Window::set_icon_name`.
+    #[test]
+    fn shell_config_with_icon_name_sets_the_icon() {
+        let config =
+            ShellConfig::new("test", Vec::new()).with_icon_name("io.github.jdonaghy.vimcode");
+        assert_eq!(
+            config.icon_name,
+            Some("io.github.jdonaghy.vimcode".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #656

Automated PR opened by coordinator for review of issue #656.