### PR TITLE
#657: AppShell activity bar is 3.0 line-heights (~60px) wide vs VS Code's 48px, and ShellConfig can't override it

### DIFF
--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -87,6 +87,14 @@ pub struct AppShell {
     max_sidebar_width: f32,
     /// Activity bar width in line_height multiples.
     activity_bar_width: f32,
+    /// Fixed-pixel activity bar width override, set via
+    /// [`Self::with_activity_bar_width_px`]. When `Some`, this wins over
+    /// `activity_bar_width` and is used verbatim regardless of
+    /// `line_height` — VS Code's activity bar is a fixed 48px (matching
+    /// `ACTIVITY_ROW_PX`) independent of editor font size, and font-scaled
+    /// chrome is the wrong unit for a bar whose contents are fixed-size
+    /// icons (#657).
+    activity_bar_width_px: Option<f32>,
     position: ShellPosition,
     drag_offset: Option<f32>,
     hovered_activity_idx: Option<usize>,
@@ -136,6 +144,7 @@ impl AppShell {
             min_sidebar_width: 8.0,
             max_sidebar_width: 800.0,
             activity_bar_width: 3.0,
+            activity_bar_width_px: None,
             position: ShellPosition::Left,
             drag_offset: None,
             hovered_activity_idx: None,
@@ -173,6 +182,23 @@ impl AppShell {
 
     pub fn with_activity_bar_width(mut self, width: f32) -> Self {
         self.activity_bar_width = width;
+        self
+    }
+
+    /// Pin the activity bar to a fixed pixel width, overriding the
+    /// line-height-derived width from [`Self::with_activity_bar_width`].
+    ///
+    /// The row height GTK/macOS paint each activity item at
+    /// (`ACTIVITY_ROW_PX = 48.0`) is already a fixed pixel constant, not a
+    /// `line_height` multiple — so a `with_activity_bar_width(2.4)`-style
+    /// call only produces a square 48×48 bar at whatever `line_height`
+    /// happens to make `2.4 * lh == 48.0`. Passing `48.0` here keeps the
+    /// bar square regardless of the app's editor font size (#657).
+    ///
+    /// `None` (the default) leaves the existing `line_height`-derived
+    /// width in place — this call is additive, not a replacement.
+    pub fn with_activity_bar_width_px(mut self, width_px: f32) -> Self {
+        self.activity_bar_width_px = Some(width_px);
         self
     }
 
@@ -857,7 +883,9 @@ impl AppShell {
 
         // ── Horizontal carve: activity bar + sidebar + divider + main ──
 
-        let ab_w = (self.activity_bar_width * lh).round();
+        let ab_w = self
+            .activity_bar_width_px
+            .unwrap_or_else(|| (self.activity_bar_width * lh).round());
         let divider_w = (lh * 0.25).max(1.0).round().min(4.0);
 
         if !self.sidebar_visible || self.panels.is_empty() {
@@ -1125,6 +1153,47 @@ mod tests {
         let content = l.sidebar_content_bounds.unwrap();
         assert_eq!(content.y, header.y + header.height);
         assert_eq!(content.width, header.width);
+    }
+
+    // ── Activity bar width (#657) ───────────────────────────────────
+
+    /// The default activity bar width (3.0 line-heights) tracks
+    /// `line_height`, same as every other chrome dimension.
+    #[test]
+    fn activity_bar_width_tracks_line_height_by_default() {
+        let s = shell();
+        assert_eq!(s.layout(area(), 20.0).activity_bar_bounds.width, 60.0);
+        assert_eq!(s.layout(area(), 10.0).activity_bar_bounds.width, 30.0);
+    }
+
+    /// `with_activity_bar_width` overrides the line-height multiple itself
+    /// — e.g. 2.4 lh lands on 48px at lh=20, matching VS Code's 48px bar.
+    #[test]
+    fn with_activity_bar_width_overrides_the_multiple() {
+        let s = shell().with_activity_bar_width(2.4);
+        assert_eq!(s.layout(area(), 20.0).activity_bar_bounds.width, 48.0);
+    }
+
+    /// `with_activity_bar_width_px` pins the bar to an exact pixel width
+    /// that does not move when `line_height` changes — the fix for a bar
+    /// that's only square by coincidence of the app's editor font size.
+    #[test]
+    fn with_activity_bar_width_px_is_independent_of_line_height() {
+        let s = shell().with_activity_bar_width_px(48.0);
+        assert_eq!(s.layout(area(), 20.0).activity_bar_bounds.width, 48.0);
+        assert_eq!(s.layout(area(), 10.0).activity_bar_bounds.width, 48.0);
+        assert_eq!(s.layout(area(), 37.5).activity_bar_bounds.width, 48.0);
+    }
+
+    /// A fixed-px override wins over a line-height multiple set via
+    /// `with_activity_bar_width` on the same shell, not the other way
+    /// around.
+    #[test]
+    fn with_activity_bar_width_px_wins_over_line_height_multiple() {
+        let s = shell()
+            .with_activity_bar_width(3.0)
+            .with_activity_bar_width_px(48.0);
+        assert_eq!(s.layout(area(), 20.0).activity_bar_bounds.width, 48.0);
     }
 
     // ── Layout — sidebar hidden ─────────────────────────────────────

--- a/quadraui/src/shell.rs
+++ b/quadraui/src/shell.rs
@@ -24,6 +24,19 @@ pub struct ShellConfig {
     pub default_sidebar_width: f32,
     pub min_sidebar_width: f32,
     pub max_sidebar_width: f32,
+    /// Activity bar width in line-height multiples (`3.0` by default,
+    /// matching [`AppShell`]'s own default) — same unit as
+    /// `default_sidebar_width`. Set via [`Self::with_activity_bar_width`].
+    /// See [`Self::activity_bar_width_px`] for a fixed-pixel alternative
+    /// that doesn't move with the app's editor font (#657).
+    pub activity_bar_width: f32,
+    /// Fixed-pixel activity bar width override. `None` (the default)
+    /// leaves `activity_bar_width` (a line-height multiple) in charge.
+    /// Set via [`Self::with_activity_bar_width_px`] to pin the bar to an
+    /// exact width — e.g. `48.0` to match VS Code's activity bar and the
+    /// `ACTIVITY_ROW_PX` row height GTK/macOS already paint each item at
+    /// — regardless of `line_height` (#657).
+    pub activity_bar_width_px: Option<f32>,
     pub position: ShellPosition,
     pub has_title_bar: bool,
     pub title_bar_height_lh: f32,
@@ -82,6 +95,8 @@ impl ShellConfig {
             default_sidebar_width: 20.0,
             min_sidebar_width: 8.0,
             max_sidebar_width: 50.0,
+            activity_bar_width: 3.0,
+            activity_bar_width_px: None,
             position: ShellPosition::Left,
             has_title_bar: false,
             title_bar_height_lh: 1.5,
@@ -105,6 +120,24 @@ impl ShellConfig {
 
     pub fn with_position(mut self, position: ShellPosition) -> Self {
         self.position = position;
+        self
+    }
+
+    /// Override the activity bar width in line-height multiples (`3.0` by
+    /// default). Same unit as `default_sidebar_width`. See
+    /// [`Self::with_activity_bar_width_px`] for a fixed-pixel alternative
+    /// (#657).
+    pub fn with_activity_bar_width(mut self, width_lh: f32) -> Self {
+        self.activity_bar_width = width_lh;
+        self
+    }
+
+    /// Pin the activity bar to a fixed pixel width, overriding
+    /// `activity_bar_width`. Independent of `line_height` — e.g. `48.0`
+    /// keeps the bar square against `ACTIVITY_ROW_PX` regardless of the
+    /// app's editor font size (#657).
+    pub fn with_activity_bar_width_px(mut self, width_px: f32) -> Self {
+        self.activity_bar_width_px = Some(width_px);
         self
     }
 
@@ -643,6 +676,33 @@ mod tests {
             config.icon_name,
             Some("io.github.jdonaghy.vimcode".to_string())
         );
+    }
+
+    /// #657: a fresh `ShellConfig` keeps `AppShell`'s own default (3.0
+    /// line-heights) and no fixed-pixel override, so nothing that predates
+    /// this field changes behavior.
+    #[test]
+    fn shell_config_activity_bar_width_defaults_match_app_shell() {
+        let config = ShellConfig::new("test", Vec::new());
+        assert_eq!(config.activity_bar_width, 3.0);
+        assert_eq!(config.activity_bar_width_px, None);
+    }
+
+    /// #657: `with_activity_bar_width` stores the line-height multiple
+    /// verbatim for `build_shell_adapter` to pass through to `AppShell`.
+    #[test]
+    fn shell_config_with_activity_bar_width_overrides_the_multiple() {
+        let config = ShellConfig::new("test", Vec::new()).with_activity_bar_width(2.4);
+        assert_eq!(config.activity_bar_width, 2.4);
+    }
+
+    /// #657: `with_activity_bar_width_px` stores a fixed-pixel override,
+    /// letting a consumer pin the bar to VS Code's 48px regardless of the
+    /// app's editor font / line height.
+    #[test]
+    fn shell_config_with_activity_bar_width_px_sets_the_override() {
+        let config = ShellConfig::new("test", Vec::new()).with_activity_bar_width_px(48.0);
+        assert_eq!(config.activity_bar_width_px, Some(48.0));
     }
 
     #[test]

--- a/quadraui/src/shell_adapter.rs
+++ b/quadraui/src/shell_adapter.rs
@@ -140,7 +140,14 @@ pub(crate) fn build_shell_adapter<A: ShellApp + 'static>(
         .with_bottom_items(config.bottom_items)
         .with_min_width(config.min_sidebar_width)
         .with_max_width(config.max_sidebar_width)
+        .with_activity_bar_width(config.activity_bar_width)
         .with_position(config.position);
+
+    // Fixed-pixel override wins over the line-height multiple set just
+    // above — see `AppShell::with_activity_bar_width_px` (#657).
+    if let Some(width_px) = config.activity_bar_width_px {
+        shell = shell.with_activity_bar_width_px(width_px);
+    }
 
     // Configure the height unconditionally and let `has_title_bar` control
     // only initial visibility. Gating the whole call on `has_title_bar`


### PR DESCRIPTION
Closes #657

Automated PR opened by coordinator for review of issue #657.