### PR TITLE
#658: ActivityBar active item: only a 2px left-edge accent line — add active_bg so consumers can match VS Code's background-fill indicator

### DIFF
--- a/quadraui/Cargo.toml
+++ b/quadraui/Cargo.toml
@@ -656,6 +656,16 @@ path = "examples/gtk_activity_nav.rs"
 required-features = ["gtk"]
 
 [[example]]
+name = "tui_activity_style"
+path = "examples/tui_activity_style.rs"
+required-features = ["tui"]
+
+[[example]]
+name = "gtk_activity_style"
+path = "examples/gtk_activity_style.rs"
+required-features = ["gtk"]
+
+[[example]]
 name = "tui_dialog_table"
 path = "examples/tui_dialog_table.rs"
 required-features = ["tui"]

--- a/quadraui/examples/common/activity_nav.rs
+++ b/quadraui/examples/common/activity_nav.rs
@@ -111,7 +111,10 @@ impl ActivityNavApp {
             id: WidgetId::new("demo:activity-bar"),
             top_items: items,
             bottom_items: vec![],
+            // JetBrains-style accent line. See issue #658 for the
+            // VS-Code-style alternative (`active_bg` row fill).
             active_accent: Some(Color::rgb(100, 150, 255)),
+            active_bg: None,
             selection_bg: Some(Color::rgb(70, 70, 100)),
             is_keyboard_focused: self.bar_focused,
         }

--- a/quadraui/examples/common/activity_nav.rs
+++ b/quadraui/examples/common/activity_nav.rs
@@ -111,10 +111,11 @@ impl ActivityNavApp {
             id: WidgetId::new("demo:activity-bar"),
             top_items: items,
             bottom_items: vec![],
-            // JetBrains-style accent line. See issue #658 for the
-            // VS-Code-style alternative (`active_bg` row fill).
+            // JetBrains-style accent line. See `tui_activity_style` /
+            // `gtk_activity_style` (issue #658) for the VS-Code-style
+            // alternative (an `ActivityBarStyle::active_bg` row fill,
+            // passed to `Backend::draw_activity_bar_with_style`).
             active_accent: Some(Color::rgb(100, 150, 255)),
-            active_bg: None,
             selection_bg: Some(Color::rgb(70, 70, 100)),
             is_keyboard_focused: self.bar_focused,
         }

--- a/quadraui/examples/common/activity_style_demo.rs
+++ b/quadraui/examples/common/activity_style_demo.rs
@@ -1,0 +1,162 @@
+//! Minimal `AppLogic` painting an `ActivityBar` whose active item shows a
+//! VS-Code-style row fill via [`ActivityBarStyle::active_bg`] (quadraui#658)
+//! instead of the left-edge accent line `ActivityNavApp` (`tui_activity_nav`
+//! / `gtk_activity_nav`) demonstrates.
+//!
+//! The point of the demo is the **sidecar**: the fill is requested through
+//! [`Backend::draw_activity_bar_with_style`] — never a field on
+//! [`ActivityBar`] itself, which is exactly the break #658 exists to avoid
+//! (see [`quadraui::ActivityBarStyle`]'s doc for the full reasoning).
+//! `active_accent` stays `None` throughout, so there is **zero**
+//! accent-line rendering; the row fill is the only active-item indicator.
+//!
+//! Click an icon (or press **1**/**2**/**3**) to activate it, **q** to quit.
+
+use quadraui::{
+    ActivityBar, ActivityBarStyle, ActivityItem, AppLogic, Backend, Color, Key, Reaction, Rect,
+    StatusBar, StatusBarSegment, UiEvent, WidgetId,
+};
+
+/// Item labels, index-stable across activation (only `is_active` moves).
+pub const LABELS: [&str; 3] = ["Explorer", "Search", "Source Control"];
+const ICONS: [&str; 3] = ["E", "S", "G"];
+
+fn item_id(i: usize) -> WidgetId {
+    WidgetId::new(format!("activity-style-demo:{i}"))
+}
+
+pub struct ActivityStyleDemo {
+    active: usize,
+    last_action: String,
+}
+
+impl ActivityStyleDemo {
+    pub fn new() -> Self {
+        Self {
+            active: 0,
+            last_action: "ready".to_string(),
+        }
+    }
+
+    /// `active_accent: None` — zero accent-line pixels. The row fill in
+    /// [`Self::style`] is the only active-item indicator (#658).
+    fn bar(&self) -> ActivityBar {
+        let items = ICONS
+            .iter()
+            .enumerate()
+            .map(|(i, icon)| ActivityItem {
+                id: item_id(i),
+                icon: (*icon).to_string(),
+                tooltip: LABELS[i].to_string(),
+                is_active: i == self.active,
+                is_keyboard_selected: false,
+            })
+            .collect();
+        ActivityBar {
+            id: WidgetId::new("activity-style-demo:bar"),
+            top_items: items,
+            bottom_items: vec![],
+            active_accent: None,
+            selection_bg: None,
+            is_keyboard_focused: false,
+        }
+    }
+
+    /// VS-Code-style soft chip fill — the whole point of the demo.
+    fn style(&self) -> ActivityBarStyle {
+        ActivityBarStyle::new().with_active_bg(Color::rgb(49, 50, 51))
+    }
+
+    fn bar_rect(&self, backend: &dyn Backend) -> Rect {
+        let vp = backend.viewport();
+        let lh = backend.line_height();
+        Rect::new(0.0, 0.0, lh * 3.0, vp.height - lh)
+    }
+
+    fn hint_bar(&self) -> StatusBar {
+        StatusBar {
+            id: WidgetId::new("activity-style-demo:hint"),
+            left_segments: vec![StatusBarSegment {
+                text: format!(" {} ", self.last_action),
+                fg: Color::rgb(255, 255, 255),
+                bg: Color::rgb(40, 80, 120),
+                bold: true,
+                action_id: None,
+            }],
+            right_segments: vec![StatusBarSegment {
+                text: " 1/2/3 = activate · q = quit ".to_string(),
+                fg: Color::rgb(220, 220, 220),
+                bg: Color::rgb(40, 80, 120),
+                bold: false,
+                action_id: None,
+            }],
+        }
+    }
+
+    fn activate(&mut self, idx: usize) {
+        self.active = idx;
+        self.last_action = format!("activated {}", LABELS[idx]);
+    }
+}
+
+impl Default for ActivityStyleDemo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppLogic for ActivityStyleDemo {
+    type AreaId = ();
+
+    fn render(&self, backend: &mut dyn Backend, _area: ()) {
+        let vp = backend.viewport();
+        let lh = backend.line_height();
+        let bar_rect = self.bar_rect(backend);
+        let _ = backend.draw_activity_bar_with_style(bar_rect, &self.bar(), None, &self.style());
+        let _ = backend.draw_status_bar(
+            Rect::new(0.0, vp.height - lh, vp.width, lh),
+            &self.hint_bar(),
+            None,
+            None,
+        );
+    }
+
+    fn handle(&mut self, event: UiEvent, backend: &mut dyn Backend) -> Reaction {
+        match event {
+            UiEvent::KeyPressed {
+                key: Key::Char('q'),
+                ..
+            } => Reaction::Exit,
+            UiEvent::KeyPressed {
+                key: Key::Char(c @ '1'..='3'),
+                ..
+            } => {
+                self.activate((c as usize) - ('1' as usize));
+                Reaction::Redraw
+            }
+            UiEvent::MouseDown { position, .. } => {
+                let bar_rect = self.bar_rect(backend);
+                if position.x < bar_rect.x
+                    || position.x >= bar_rect.x + bar_rect.width
+                    || position.y < bar_rect.y
+                    || position.y >= bar_rect.y + bar_rect.height
+                {
+                    return Reaction::Continue;
+                }
+                let hits = backend.activity_bar_layout(bar_rect, &self.bar());
+                let rel_y = position.y - bar_rect.y;
+                for hit in &hits {
+                    if (rel_y as f64) >= hit.y_start && (rel_y as f64) < hit.y_end {
+                        if let Some(idx) = (0..LABELS.len()).find(|&i| hit.id == item_id(i)) {
+                            self.activate(idx);
+                            return Reaction::Redraw;
+                        }
+                    }
+                }
+                Reaction::Continue
+            }
+            UiEvent::WindowResized { .. } => Reaction::Redraw,
+            _ => Reaction::Continue,
+        }
+    }
+}

--- a/quadraui/examples/common/mod.rs
+++ b/quadraui/examples/common/mod.rs
@@ -37,6 +37,7 @@ pub mod terminal_app;
 pub use terminal_app::TerminalApp;
 
 pub mod activity_nav;
+pub mod activity_style_demo;
 pub mod ai_transcript;
 pub mod appshell_demo;
 pub mod board_app;
@@ -91,6 +92,7 @@ pub mod tooltip_demo;
 pub mod wide_tab_bar_demo;
 
 pub use activity_nav::ActivityNavApp;
+pub use activity_style_demo::ActivityStyleDemo;
 pub use ai_transcript::AiTranscript;
 pub use board_app::BoardApp;
 pub use chart_app::ChartApp;

--- a/quadraui/examples/gtk_activity_style.rs
+++ b/quadraui/examples/gtk_activity_style.rs
@@ -1,0 +1,17 @@
+//! `ActivityStyleDemo` `AppLogic` + `quadraui::gtk::run` example.
+//!
+//! GTK twin of `tui_activity_style` — the same `AppLogic`, so the
+//! VS-Code-style row fill (quadraui#658) is exercised through the
+//! Pango/Cairo rasteriser instead of the cell grid. Click an icon (or
+//! press `1`/`2`/`3`) to activate it, `q` quits.
+//!
+//! ```sh
+//! cargo run --example gtk_activity_style --features gtk
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::process::ExitCode {
+    quadraui::gtk::run(common::ActivityStyleDemo::new())
+}

--- a/quadraui/examples/tui_activity_style.rs
+++ b/quadraui/examples/tui_activity_style.rs
@@ -1,0 +1,19 @@
+//! `ActivityStyleDemo` `AppLogic` + `quadraui::tui::run` example.
+//!
+//! VS-Code-style activity-bar row fill (quadraui#658):
+//! `Backend::draw_activity_bar_with_style` paints the active item's row in
+//! `ActivityBarStyle::active_bg` instead of the left-edge accent line
+//! `tui_activity_nav` demonstrates — `active_accent` stays `None`, so
+//! there is zero accent-line rendering. Click an icon (or press
+//! `1`/`2`/`3`) to activate it, `q` quits.
+//!
+//! ```sh
+//! cargo run --example tui_activity_style --features tui
+//! ```
+
+#[path = "common/mod.rs"]
+mod common;
+
+fn main() -> std::io::Result<()> {
+    quadraui::tui::run(common::ActivityStyleDemo::new())
+}

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use crate::dispatch::DragState;
 use crate::event::{Rect, UiEvent, Viewport};
 use crate::modal_stack::ModalStack;
-use crate::primitives::activity_bar::ActivityBarRowHit;
+use crate::primitives::activity_bar::{ActivityBarRowHit, ActivityBarStyle};
 use crate::primitives::board::{BoardLayout, BoardModel};
 use crate::primitives::chart::{Chart, ChartLayout};
 use crate::primitives::command_center::{CommandCenter, CommandCenterLayout};
@@ -901,6 +901,36 @@ pub trait Backend {
         bar: &ActivityBar,
         hovered_idx: Option<usize>,
     ) -> Vec<ActivityBarRowHit>;
+
+    /// Draw an activity bar with an explicit [`ActivityBarStyle`] request
+    /// (#658) — currently just the active item's row-fill colour, VS Code
+    /// style (no line, a soft chip on the row itself).
+    ///
+    /// Added rather than folded into [`Self::draw_activity_bar`]'s
+    /// signature, and given a default body, so that #658 breaks no existing
+    /// `Backend` implementor and no existing call site — mirrors
+    /// [`crate::TooltipChrome`] / [`Self::draw_tooltip_with_chrome`] (#541)
+    /// and [`TabChrome`] / [`Self::draw_tab_bar_with_chrome`] (#631), which
+    /// solve the identical "additive field would break exhaustive
+    /// downstream literals" problem for `Tooltip` and `TabBar`. See
+    /// [`ActivityBarStyle`]'s doc for the full reasoning.
+    ///
+    /// The default body **ignores `style`** and delegates to
+    /// [`Self::draw_activity_bar`] — the correct fallback for a backend
+    /// with no fill vocabulary of its own. The TUI, GTK, and macOS
+    /// backends override it and honour `style.active_bg` in full; Win
+    /// takes the default for now (#19 — every `draw_*` method there is a
+    /// stub).
+    fn draw_activity_bar_with_style(
+        &mut self,
+        rect: Rect,
+        bar: &ActivityBar,
+        hovered_idx: Option<usize>,
+        style: &ActivityBarStyle,
+    ) -> Vec<ActivityBarRowHit> {
+        let _ = style;
+        self.draw_activity_bar(rect, bar, hovered_idx)
+    }
 
     /// Compute the status bar layout without painting. Same measurement
     /// logic as `draw_status_bar` — call after `ScreenLayout::draw()` to

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -584,13 +584,16 @@ impl AppShell {
             top_items,
             bottom_items,
             // #658: `AppShell` has no `Theme` in scope here to source a
-            // colour from (that wiring is #381's job), so both active-item
-            // indicators are left unset rather than hardcoded. As of #658
-            // neither rasteriser falls back to a theme default anymore, so
-            // this means the built-in shell chrome paints no active-item
-            // indicator until #381 lands.
+            // colour from (that wiring is #381's job), so the accent line
+            // is left unset rather than hardcoded. As of #658 the
+            // rasterisers no longer fall back to a theme default, so this
+            // means the built-in shell chrome paints no active-item
+            // indicator until #381 lands. (The VS-Code-style row fill is a
+            // separate `ActivityBarStyle` sidecar passed to
+            // `Backend::draw_activity_bar_with_style`, not a field here —
+            // `AppShell` still calls the plain `draw_activity_bar`, which
+            // never paints a fill.)
             active_accent: None,
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: focused,
         }

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -583,7 +583,14 @@ impl AppShell {
             id: WidgetId::new("app-shell:activity-bar"),
             top_items,
             bottom_items,
+            // #658: `AppShell` has no `Theme` in scope here to source a
+            // colour from (that wiring is #381's job), so both active-item
+            // indicators are left unset rather than hardcoded. As of #658
+            // neither rasteriser falls back to a theme default anymore, so
+            // this means the built-in shell chrome paints no active-item
+            // indicator until #381 lands.
             active_accent: None,
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: focused,
         }

--- a/quadraui/src/gtk/activity_bar.rs
+++ b/quadraui/src/gtk/activity_bar.rs
@@ -45,8 +45,13 @@ pub const ICON_FONT_DESC: &str = "Symbols Nerd Font, monospace 18";
 ///
 /// - **Background:** filled with `theme.tab_bar_bg`.
 /// - **Right-edge separator:** 1 px column in `theme.separator`.
-/// - **Active row:** 2 px left-edge accent bar in
-///   `theme.accent_fg` (or `bar.active_accent` if the bar overrides).
+/// - **Active row:** two independent, opt-in indicators (#658), each
+///   `None` (no rendering) unless the bar sets it:
+///   - `bar.active_bg` fills the whole row (VS Code style).
+///   - `bar.active_accent` paints a 2 px left-edge line (JetBrains style).
+///
+///   Set either, both, or neither — there is no theme fallback for
+///   either knob.
 /// - **Hovered row:** subtle background tint
 ///   (`theme.tab_bar_bg.lighten(0.10)`).
 /// - **Icon glyph:** centred in each row using [`ICON_FONT_DESC`]
@@ -89,16 +94,14 @@ pub fn draw_activity_bar(
     pango_layout.set_font_description(Some(&icon_font));
     pango_layout.set_attributes(None);
 
+    // #658: no theme fallback for either knob — `None` genuinely means
+    // "don't paint this". `Some` colours pass straight through.
     let accent_col = bar
         .active_accent
-        .map(|c| (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0))
-        .unwrap_or_else(|| {
-            (
-                theme.accent_fg.r as f64 / 255.0,
-                theme.accent_fg.g as f64 / 255.0,
-                theme.accent_fg.b as f64 / 255.0,
-            )
-        });
+        .map(|c| (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0));
+    let active_bg_col = bar
+        .active_bg
+        .map(|c| (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0));
     let inactive_fg = (
         theme.inactive_fg.r as f64 / 255.0,
         theme.inactive_fg.g as f64 / 255.0,
@@ -131,6 +134,18 @@ pub fn draw_activity_bar(
 
         let is_hovered = hovered_idx == Some(flat_idx);
 
+        // Active-row fill (VS Code style). Lowest-priority layer — painted
+        // first so hover/keyboard-selection tints below still take visual
+        // precedence over it when they also apply to this row. `None`
+        // (the default) paints nothing here (#658).
+        if item.is_active {
+            if let Some((r, g, b)) = active_bg_col {
+                cr.set_source_rgb(r, g, b);
+                cr.rectangle(0.0, y, width, row_h);
+                cr.fill().ok();
+            }
+        }
+
         // Hover tint (lower priority: painted first so selection can win).
         if is_hovered {
             cr.set_source_rgb(hover_bg.0, hover_bg.1, hover_bg.2);
@@ -156,9 +171,11 @@ pub fn draw_activity_bar(
         }
 
         if item.is_active {
-            cr.set_source_rgb(accent_col.0, accent_col.1, accent_col.2);
-            cr.rectangle(0.0, y, 2.0, row_h);
-            cr.fill().ok();
+            if let Some((r, g, b)) = accent_col {
+                cr.set_source_rgb(r, g, b);
+                cr.rectangle(0.0, y, 2.0, row_h);
+                cr.fill().ok();
+            }
         }
 
         pango_layout.set_text(&item.icon);
@@ -237,5 +254,140 @@ mod tests {
             "new icon glyph width ({new_w}) should not exceed the pre-#620 20pt \
              width ({old_w})"
         );
+    }
+
+    // ── #658: active_bg / active_accent independence ────────────────────
+
+    use crate::primitives::activity_bar::ActivityItem;
+    use crate::types::{Color, WidgetId};
+
+    const ROW_W: i32 = 48;
+
+    /// Read an RGB triple from an ARgb32 surface at pixel (x, y).
+    ///
+    /// Cairo's `ARgb32` stores each pixel as four bytes in native
+    /// (little-endian) byte order: [B, G, R, A].
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    fn one_item_bar(active_accent: Option<Color>, active_bg: Option<Color>) -> ActivityBar {
+        ActivityBar {
+            id: WidgetId::new("bar"),
+            top_items: vec![ActivityItem {
+                id: WidgetId::new("activity:explorer"),
+                icon: "E".into(),
+                tooltip: String::new(),
+                is_active: true,
+                is_keyboard_selected: false,
+            }],
+            bottom_items: vec![],
+            active_accent,
+            active_bg,
+            selection_bg: None,
+            is_keyboard_focused: false,
+        }
+    }
+
+    fn paint_one_row(bar: &ActivityBar) -> ImageSurface {
+        let surface = ImageSurface::create(Format::ARgb32, ROW_W, ACTIVITY_ROW_PX as i32)
+            .expect("create ImageSurface");
+        {
+            let cr = Context::new(&surface).expect("Context::new");
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            draw_activity_bar(
+                &cr,
+                &pango_layout,
+                ROW_W as f64,
+                ACTIVITY_ROW_PX,
+                bar,
+                &Theme::default(),
+                None,
+            );
+        }
+        surface.flush();
+        surface
+    }
+
+    /// #658 acceptance: `active_bg: Some(..)` + `active_accent: None` paints
+    /// a filled active row with **zero** accent-line pixels — the legacy
+    /// 2px left-edge column (x ∈ [0, 2)) must show the fill colour, not a
+    /// leftover accent tint (the pre-#658 rasteriser fell back to
+    /// `theme.accent_fg` there regardless of `active_accent`).
+    #[test]
+    fn active_bg_fills_row_with_zero_accent_pixels_when_accent_is_none() {
+        let active_bg = Color::rgb(49, 50, 51);
+        let bar = one_item_bar(None, Some(active_bg));
+        let mut surface = paint_one_row(&bar);
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        let mid_y = (ACTIVITY_ROW_PX as i32) / 2;
+        for x in 0..2 {
+            let px = pixel(&data, stride, x, mid_y);
+            assert_eq!(
+                px,
+                (active_bg.r, active_bg.g, active_bg.b),
+                "x={x} is inside the legacy accent column; with active_accent \
+                 None it must show the active_bg fill, not any accent tint \
+                 (zero accent-line pixels)"
+            );
+        }
+        // Deep in the row, away from the glyph, should also be filled.
+        let px = pixel(&data, stride, ROW_W - 4, mid_y);
+        assert_eq!(px, (active_bg.r, active_bg.g, active_bg.b));
+    }
+
+    /// The flip side: `active_accent: Some(..)` with no `active_bg` still
+    /// paints the traditional 2px line, and nothing past it.
+    #[test]
+    fn active_accent_paints_two_px_line_when_set() {
+        let accent = Color::rgb(80, 140, 255);
+        let bar = one_item_bar(Some(accent), None);
+        let mut surface = paint_one_row(&bar);
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        let mid_y = (ACTIVITY_ROW_PX as i32) / 2;
+        assert_eq!(
+            pixel(&data, stride, 0, mid_y),
+            (accent.r, accent.g, accent.b)
+        );
+        assert_eq!(
+            pixel(&data, stride, 1, mid_y),
+            (accent.r, accent.g, accent.b)
+        );
+
+        let theme = Theme::default();
+        let bg_px = pixel(&data, stride, 2, 2);
+        assert_eq!(
+            bg_px,
+            (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+            "x=2 is past the 2px accent strip and should be tab_bar_bg"
+        );
+    }
+
+    /// Neither knob set: the active row paints exactly like an inactive
+    /// row — no fill, no line. This is "today's behaviour" the doc on
+    /// both fields promises stays the default.
+    #[test]
+    fn neither_knob_set_paints_plain_row() {
+        let bar = one_item_bar(None, None);
+        let mut surface = paint_one_row(&bar);
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+        let theme = Theme::default();
+
+        let mid_y = (ACTIVITY_ROW_PX as i32) / 2;
+        for x in [0, 1, ROW_W - 4] {
+            let px = pixel(&data, stride, x, mid_y);
+            assert_eq!(
+                px,
+                (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
+                "x={x} should be plain tab_bar_bg when neither active_bg nor \
+                 active_accent is set"
+            );
+        }
     }
 }

--- a/quadraui/src/gtk/activity_bar.rs
+++ b/quadraui/src/gtk/activity_bar.rs
@@ -14,7 +14,9 @@ use gtk4::cairo::Context;
 use gtk4::pango;
 use gtk4::pango::FontDescription;
 
-use crate::primitives::activity_bar::{ActivityBar, ActivityBarRowHit, ActivitySide};
+use crate::primitives::activity_bar::{
+    ActivityBar, ActivityBarRowHit, ActivityBarStyle, ActivitySide,
+};
 use crate::theme::Theme;
 
 /// Fixed height (in pixels) of a single activity bar row — matches the
@@ -41,13 +43,42 @@ pub const ICON_FONT_DESC: &str = "Symbols Nerd Font, monospace 18";
 /// `visible_items`. Returns per-row hit regions for click + tooltip
 /// dispatch.
 ///
+/// Equivalent to [`draw_activity_bar_with_style`] with
+/// `ActivityBarStyle::default()`, i.e. no active-row fill — see that
+/// function for the full visual contract and #658's reasoning for why the
+/// fill lives in a separate style value rather than a field here.
+pub fn draw_activity_bar(
+    cr: &Context,
+    pango_layout: &pango::Layout,
+    width: f64,
+    height: f64,
+    bar: &ActivityBar,
+    theme: &Theme,
+    hovered_idx: Option<usize>,
+) -> Vec<ActivityBarRowHit> {
+    draw_activity_bar_with_style(
+        cr,
+        pango_layout,
+        width,
+        height,
+        bar,
+        &ActivityBarStyle::default(),
+        theme,
+        hovered_idx,
+    )
+}
+
+/// [`draw_activity_bar`] with an explicit [`ActivityBarStyle`] request
+/// (#658). `ActivityBarStyle::default()` reproduces [`draw_activity_bar`]
+/// pixel for pixel.
+///
 /// # Visual contract
 ///
 /// - **Background:** filled with `theme.tab_bar_bg`.
 /// - **Right-edge separator:** 1 px column in `theme.separator`.
 /// - **Active row:** two independent, opt-in indicators (#658), each
-///   `None` (no rendering) unless the bar sets it:
-///   - `bar.active_bg` fills the whole row (VS Code style).
+///   producing zero pixels unless requested:
+///   - `style.active_bg` fills the whole row (VS Code style).
 ///   - `bar.active_accent` paints a 2 px left-edge line (JetBrains style).
 ///
 ///   Set either, both, or neither — there is no theme fallback for
@@ -60,12 +91,14 @@ pub const ICON_FONT_DESC: &str = "Symbols Nerd Font, monospace 18";
 ///   `theme.foreground` for active/hovered rows, `theme.inactive_fg`
 ///   otherwise. `ACTIVITY_ROW_PX` (the 48px row) is unrelated and
 ///   unchanged — only the glyph shrank.
-pub fn draw_activity_bar(
+#[allow(clippy::too_many_arguments)]
+pub fn draw_activity_bar_with_style(
     cr: &Context,
     pango_layout: &pango::Layout,
     width: f64,
     height: f64,
     bar: &ActivityBar,
+    style: &ActivityBarStyle,
     theme: &Theme,
     hovered_idx: Option<usize>,
 ) -> Vec<ActivityBarRowHit> {
@@ -99,7 +132,7 @@ pub fn draw_activity_bar(
     let accent_col = bar
         .active_accent
         .map(|c| (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0));
-    let active_bg_col = bar
+    let active_bg_col = style
         .active_bg
         .map(|c| (c.r as f64 / 255.0, c.g as f64 / 255.0, c.b as f64 / 255.0));
     let inactive_fg = (
@@ -272,7 +305,7 @@ mod tests {
         (data[off + 2], data[off + 1], data[off])
     }
 
-    fn one_item_bar(active_accent: Option<Color>, active_bg: Option<Color>) -> ActivityBar {
+    fn one_item_bar(active_accent: Option<Color>) -> ActivityBar {
         ActivityBar {
             id: WidgetId::new("bar"),
             top_items: vec![ActivityItem {
@@ -284,24 +317,24 @@ mod tests {
             }],
             bottom_items: vec![],
             active_accent,
-            active_bg,
             selection_bg: None,
             is_keyboard_focused: false,
         }
     }
 
-    fn paint_one_row(bar: &ActivityBar) -> ImageSurface {
+    fn paint_one_row(bar: &ActivityBar, style: &ActivityBarStyle) -> ImageSurface {
         let surface = ImageSurface::create(Format::ARgb32, ROW_W, ACTIVITY_ROW_PX as i32)
             .expect("create ImageSurface");
         {
             let cr = Context::new(&surface).expect("Context::new");
             let pango_layout = pangocairo::functions::create_layout(&cr);
-            draw_activity_bar(
+            draw_activity_bar_with_style(
                 &cr,
                 &pango_layout,
                 ROW_W as f64,
                 ACTIVITY_ROW_PX,
                 bar,
+                style,
                 &Theme::default(),
                 None,
             );
@@ -310,16 +343,17 @@ mod tests {
         surface
     }
 
-    /// #658 acceptance: `active_bg: Some(..)` + `active_accent: None` paints
-    /// a filled active row with **zero** accent-line pixels — the legacy
-    /// 2px left-edge column (x ∈ [0, 2)) must show the fill colour, not a
-    /// leftover accent tint (the pre-#658 rasteriser fell back to
+    /// #658 acceptance: `style.active_bg: Some(..)` + `active_accent: None`
+    /// paints a filled active row with **zero** accent-line pixels — the
+    /// legacy 2px left-edge column (x ∈ [0, 2)) must show the fill colour,
+    /// not a leftover accent tint (the pre-#658 rasteriser fell back to
     /// `theme.accent_fg` there regardless of `active_accent`).
     #[test]
     fn active_bg_fills_row_with_zero_accent_pixels_when_accent_is_none() {
         let active_bg = Color::rgb(49, 50, 51);
-        let bar = one_item_bar(None, Some(active_bg));
-        let mut surface = paint_one_row(&bar);
+        let bar = one_item_bar(None);
+        let style = ActivityBarStyle::new().with_active_bg(active_bg);
+        let mut surface = paint_one_row(&bar, &style);
         let stride = surface.stride() as usize;
         let data = surface.data().expect("surface data");
 
@@ -344,8 +378,8 @@ mod tests {
     #[test]
     fn active_accent_paints_two_px_line_when_set() {
         let accent = Color::rgb(80, 140, 255);
-        let bar = one_item_bar(Some(accent), None);
-        let mut surface = paint_one_row(&bar);
+        let bar = one_item_bar(Some(accent));
+        let mut surface = paint_one_row(&bar, &ActivityBarStyle::default());
         let stride = surface.stride() as usize;
         let data = surface.data().expect("surface data");
 
@@ -373,8 +407,8 @@ mod tests {
     /// both fields promises stays the default.
     #[test]
     fn neither_knob_set_paints_plain_row() {
-        let bar = one_item_bar(None, None);
-        let mut surface = paint_one_row(&bar);
+        let bar = one_item_bar(None);
+        let mut surface = paint_one_row(&bar, &ActivityBarStyle::default());
         let stride = surface.stride() as usize;
         let data = surface.data().expect("surface data");
         let theme = Theme::default();

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -2062,6 +2062,37 @@ impl Backend for GtkBackend {
         hits
     }
 
+    fn draw_activity_bar_with_style(
+        &mut self,
+        rect: QRect,
+        bar: &ActivityBar,
+        hovered_idx: Option<usize>,
+        style: &crate::ActivityBarStyle,
+    ) -> Vec<crate::ActivityBarRowHit> {
+        // Track keyboard focus so the GTK runner's key handler can
+        // redirect KeyPressed events to this bar.
+        if bar.is_keyboard_focused {
+            self.focused_activity_bar = Some(bar.id.clone());
+        }
+        let (cr, layout) = self
+            .current_frame_refs()
+            .expect("GtkBackend::draw_activity_bar_with_style called outside enter_frame_scope");
+        cr.save().ok();
+        cr.translate(rect.x as f64, rect.y as f64);
+        let hits = crate::gtk::draw_activity_bar_with_style(
+            cr,
+            layout,
+            rect.width as f64,
+            rect.height as f64,
+            bar,
+            style,
+            &self.current_theme,
+            hovered_idx,
+        );
+        cr.restore().ok();
+        hits
+    }
+
     fn status_bar_layout(&self, rect: QRect, bar: &StatusBar) -> crate::StatusBarLayout {
         let char_w = self.current_char_width as f32;
         let lh = self.current_line_height as f32;

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -72,7 +72,7 @@ mod tooltip;
 mod tree;
 
 pub use crate::primitives::tab_bar::TabBarHits;
-pub use activity_bar::{draw_activity_bar, ACTIVITY_ROW_PX};
+pub use activity_bar::{draw_activity_bar, draw_activity_bar_with_style, ACTIVITY_ROW_PX};
 pub use backend::GtkBackend;
 pub use board::{draw_board, gtk_board_layout};
 pub use chart::{draw_chart, gtk_chart_layout};

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -1115,12 +1115,30 @@ mod tests {
                 is_keyboard_selected: false,
             }],
             active_accent: Some(Color::rgb(120, 180, 255)),
+            active_bg: Some(Color::rgb(49, 50, 51)),
             selection_bg: Some(Color::rgb(80, 80, 80)),
             is_keyboard_focused: false,
         };
         let json = serde_json::to_string(&bar).unwrap();
         let back: ActivityBar = serde_json::from_str(&json).unwrap();
         assert_eq!(bar, back);
+    }
+
+    /// #658: `active_bg` is new — a payload serialized before it existed
+    /// (no `active_bg` key at all) must still deserialize, defaulting the
+    /// field to `None`.
+    #[test]
+    fn activity_bar_active_bg_defaults_to_none_for_pre_658_payloads() {
+        let old_json = r#"{
+            "id": "main-activity-bar",
+            "top_items": [],
+            "bottom_items": [],
+            "active_accent": null,
+            "selection_bg": null,
+            "is_keyboard_focused": false
+        }"#;
+        let bar: ActivityBar = serde_json::from_str(old_json).unwrap();
+        assert_eq!(bar.active_bg, None);
     }
 
     #[test]
@@ -3453,6 +3471,7 @@ mod tests {
             top_items: vec![],
             bottom_items: vec![],
             active_accent: None,
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3471,6 +3490,7 @@ mod tests {
             ],
             bottom_items: vec![],
             active_accent: None,
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3492,6 +3512,7 @@ mod tests {
             top_items: vec![make_activity_item("activity:explorer", 'E')],
             bottom_items: vec![make_activity_item("activity:settings", 'G')],
             active_accent: None,
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3534,6 +3555,7 @@ mod tests {
                 .map(|i| make_activity_item(&format!("bot:{i}"), 'B'))
                 .collect(),
             active_accent: None,
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3565,6 +3587,7 @@ mod tests {
                 .collect(),
             bottom_items: vec![make_activity_item("activity:settings", 'G')],
             active_accent: None,
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -177,7 +177,7 @@ pub mod shell_adapter;
 pub use diff::compute_hunks;
 pub use primitives::activity_bar::{
     ActivityBar, ActivityBarEvent, ActivityBarHit, ActivityBarLayout, ActivityBarRowHit,
-    ActivityItem, ActivitySide, VisibleActivityItem,
+    ActivityBarStyle, ActivityItem, ActivitySide, VisibleActivityItem,
 };
 pub use primitives::board::{
     board_layout, BadgeStatus, BoardAction, BoardCard, BoardColumn, BoardHit, BoardLayout,
@@ -1115,7 +1115,6 @@ mod tests {
                 is_keyboard_selected: false,
             }],
             active_accent: Some(Color::rgb(120, 180, 255)),
-            active_bg: Some(Color::rgb(49, 50, 51)),
             selection_bg: Some(Color::rgb(80, 80, 80)),
             is_keyboard_focused: false,
         };
@@ -1124,21 +1123,23 @@ mod tests {
         assert_eq!(bar, back);
     }
 
-    /// #658: `active_bg` is new — a payload serialized before it existed
-    /// (no `active_bg` key at all) must still deserialize, defaulting the
-    /// field to `None`.
+    /// #658: `ActivityBarStyle` round-trips, and a payload with no
+    /// `active_bg` key at all (as if serialized before the type existed)
+    /// still deserializes, defaulting the field to `None`. It's a sidecar
+    /// rather than a field on `ActivityBar` itself specifically so that no
+    /// existing `ActivityBar { .. }` literal — in-tree or downstream — ever
+    /// needs to change; see `ActivityBarStyle`'s doc for the full reasoning.
     #[test]
-    fn activity_bar_active_bg_defaults_to_none_for_pre_658_payloads() {
-        let old_json = r#"{
-            "id": "main-activity-bar",
-            "top_items": [],
-            "bottom_items": [],
-            "active_accent": null,
-            "selection_bg": null,
-            "is_keyboard_focused": false
-        }"#;
-        let bar: ActivityBar = serde_json::from_str(old_json).unwrap();
-        assert_eq!(bar.active_bg, None);
+    fn activity_bar_style_roundtrip_and_defaults_to_none_for_pre_658_payloads() {
+        let style = ActivityBarStyle::new().with_active_bg(Color::rgb(49, 50, 51));
+        let json = serde_json::to_string(&style).unwrap();
+        let back: ActivityBarStyle = serde_json::from_str(&json).unwrap();
+        assert_eq!(style, back);
+
+        let old_json = "{}";
+        let defaulted: ActivityBarStyle = serde_json::from_str(old_json).unwrap();
+        assert_eq!(defaulted, ActivityBarStyle::default());
+        assert_eq!(defaulted.active_bg, None);
     }
 
     #[test]
@@ -3471,7 +3472,6 @@ mod tests {
             top_items: vec![],
             bottom_items: vec![],
             active_accent: None,
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3490,7 +3490,6 @@ mod tests {
             ],
             bottom_items: vec![],
             active_accent: None,
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3512,7 +3511,6 @@ mod tests {
             top_items: vec![make_activity_item("activity:explorer", 'E')],
             bottom_items: vec![make_activity_item("activity:settings", 'G')],
             active_accent: None,
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3555,7 +3553,6 @@ mod tests {
                 .map(|i| make_activity_item(&format!("bot:{i}"), 'B'))
                 .collect(),
             active_accent: None,
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };
@@ -3587,7 +3584,6 @@ mod tests {
                 .collect(),
             bottom_items: vec![make_activity_item("activity:settings", 'G')],
             active_accent: None,
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         };

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -33,7 +33,9 @@ use core_graphics::sys::CGContextRef;
 use core_text::font::CTFont;
 
 use super::text::{draw_text, measure_text};
-use crate::primitives::activity_bar::{ActivityBar, ActivityBarRowHit, ActivityItem};
+use crate::primitives::activity_bar::{
+    ActivityBar, ActivityBarRowHit, ActivityBarStyle, ActivityItem,
+};
 use crate::theme::Theme;
 use crate::types::Color;
 
@@ -94,6 +96,11 @@ pub fn mac_activity_bar_layout(
 
 /// Paint `bar` into `(0, 0, width, height)` on `ctx`.
 ///
+/// Equivalent to [`draw_activity_bar_with_style`] with
+/// `ActivityBarStyle::default()`, i.e. no active-row fill — see that
+/// function for the full behaviour and #658's reasoning for why the fill
+/// lives in a separate style value rather than a field on [`ActivityBar`].
+///
 /// # Safety
 ///
 /// `ctx` must be a valid `CGContextRef` borrowed for the duration of
@@ -104,6 +111,37 @@ pub unsafe fn draw_activity_bar(
     width: f64,
     height: f64,
     bar: &ActivityBar,
+    theme: &Theme,
+    hovered_idx: Option<usize>,
+) -> Vec<ActivityBarRowHit> {
+    draw_activity_bar_with_style(
+        ctx,
+        font,
+        width,
+        height,
+        bar,
+        &ActivityBarStyle::default(),
+        theme,
+        hovered_idx,
+    )
+}
+
+/// [`draw_activity_bar`] with an explicit [`ActivityBarStyle`] request
+/// (#658). `ActivityBarStyle::default()` reproduces [`draw_activity_bar`]
+/// pixel for pixel.
+///
+/// # Safety
+///
+/// `ctx` must be a valid `CGContextRef` borrowed for the duration of
+/// the call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn draw_activity_bar_with_style(
+    ctx: CGContextRef,
+    font: &CTFont,
+    width: f64,
+    height: f64,
+    bar: &ActivityBar,
+    style: &ActivityBarStyle,
     theme: &Theme,
     hovered_idx: Option<usize>,
 ) -> Vec<ActivityBarRowHit> {
@@ -131,7 +169,7 @@ pub unsafe fn draw_activity_bar(
         // it when it also applies to this row. `None` (the default) paints
         // nothing here (#658).
         if item.is_active {
-            if let Some(bgc) = bar.active_bg {
+            if let Some(bgc) = style.active_bg {
                 fill_rect(ctx, 0.0, y, width, ACTIVITY_ROW_PX, bgc);
             }
         }
@@ -252,7 +290,6 @@ mod tests {
                 is_keyboard_selected: false,
             }],
             active_accent: Some(Color::rgb(80, 140, 255)),
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         }
@@ -271,6 +308,31 @@ mod tests {
         let regions = std::cell::RefCell::new(Vec::new());
         backend.enter_frame_scope(surface.context_ptr(), |b| {
             let r = b.draw_activity_bar(QRect::new(0.0, 0.0, W as f32, H as f32), bar, hovered);
+            *regions.borrow_mut() = r;
+        });
+        backend.end_frame();
+        (surface, regions.into_inner())
+    }
+
+    fn paint_via_backend_with_style(
+        bar: &ActivityBar,
+        style: &crate::ActivityBarStyle,
+        hovered: Option<usize>,
+    ) -> (BitmapSurface, Vec<ActivityBarRowHit>) {
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+
+        let mut backend = MacBackend::new();
+        backend.set_current_font(font());
+        backend.begin_frame(Viewport::new(W as f32, H as f32, 1.0));
+        let regions = std::cell::RefCell::new(Vec::new());
+        backend.enter_frame_scope(surface.context_ptr(), |b| {
+            let r = b.draw_activity_bar_with_style(
+                QRect::new(0.0, 0.0, W as f32, H as f32),
+                bar,
+                hovered,
+                style,
+            );
             *regions.borrow_mut() = r;
         });
         backend.end_frame();
@@ -316,6 +378,33 @@ mod tests {
             (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b),
             "x=2 should be tab_bar_bg, not accent",
         );
+    }
+
+    /// #658 acceptance: `style.active_bg: Some(..)` + `active_accent: None`
+    /// paints a filled active row with **zero** accent-line pixels — the
+    /// legacy 2-pt left-edge strip (x ∈ [0, 2)) must show the fill colour,
+    /// not any accent tint. macOS parity with the GTK/TUI acceptance tests.
+    #[test]
+    fn active_bg_fills_row_with_zero_accent_pixels_when_accent_is_none() {
+        let mut bar = sample_bar();
+        bar.active_accent = None;
+        let fill = Color::rgb(49, 50, 51);
+        let style = crate::ActivityBarStyle::new().with_active_bg(fill);
+        let (surface, _) = paint_via_backend_with_style(&bar, &style, None);
+
+        let probe_y = (ACTIVITY_ROW_PX as u32) / 2;
+        for x in [0, 1] {
+            let (r, g, b, _) = surface.pixel(x, probe_y);
+            assert_eq!(
+                (r, g, b),
+                (fill.r, fill.g, fill.b),
+                "x={x} is inside the legacy accent strip; with active_accent \
+                 None it must show the active_bg fill, not any accent tint"
+            );
+        }
+        // Deep in the row, away from the glyph, should also be filled.
+        let (r, g, b, _) = surface.pixel(W - 6, probe_y);
+        assert_eq!((r, g, b), (fill.r, fill.g, fill.b));
     }
 
     #[test]

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -114,7 +114,9 @@ pub unsafe fn draw_activity_bar(
     // Right-edge separator (1 point).
     fill_rect(ctx, width - 1.0, 0.0, 1.0, height, theme.separator);
 
-    let accent_col = bar.active_accent.unwrap_or(theme.accent_fg);
+    // #658: no theme fallback for either knob — `None` genuinely means
+    // "don't paint this" for both the accent line and the row fill.
+    let accent_col = bar.active_accent;
     let inactive_fg = theme.inactive_fg;
     let active_fg = theme.foreground;
     let hover_bg = theme.tab_bar_bg.lighten(0.10);
@@ -124,11 +126,24 @@ pub unsafe fn draw_activity_bar(
     let draw_row = |y: f64, item: &ActivityItem, row_idx: usize, regions: &mut Vec<_>| {
         let is_hovered = hovered_idx == Some(row_idx);
 
+        // Active-row fill (VS Code style). Lowest-priority layer — painted
+        // first so the hover tint below still takes visual precedence over
+        // it when it also applies to this row. `None` (the default) paints
+        // nothing here (#658).
+        if item.is_active {
+            if let Some(bgc) = bar.active_bg {
+                fill_rect(ctx, 0.0, y, width, ACTIVITY_ROW_PX, bgc);
+            }
+        }
         if is_hovered {
             fill_rect(ctx, 0.0, y, width, ACTIVITY_ROW_PX, hover_bg);
         }
+        // Left-edge accent line — only when the bar opts in via
+        // `active_accent`. `None` paints zero accent-line pixels (#658).
         if item.is_active {
-            fill_rect(ctx, 0.0, y, 2.0, ACTIVITY_ROW_PX, accent_col);
+            if let Some(ac) = accent_col {
+                fill_rect(ctx, 0.0, y, 2.0, ACTIVITY_ROW_PX, ac);
+            }
         }
 
         let (iw, ih) = measure_text(font, &item.icon);
@@ -237,6 +252,7 @@ mod tests {
                 is_keyboard_selected: false,
             }],
             active_accent: Some(Color::rgb(80, 140, 255)),
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         }

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -950,6 +950,42 @@ impl Backend for MacBackend {
         }
     }
 
+    fn draw_activity_bar_with_style(
+        &mut self,
+        rect: Rect,
+        bar: &ActivityBar,
+        hovered_idx: Option<usize>,
+        style: &crate::ActivityBarStyle,
+    ) -> Vec<ActivityBarRowHit> {
+        // Track keyboard focus — same contract as `draw_activity_bar` above.
+        if bar.is_keyboard_focused {
+            self.focused_activity_bar = Some(bar.id.clone());
+        }
+        let ctx = self.current_cg();
+        debug_assert!(
+            !ctx.is_null(),
+            "MacBackend::draw_activity_bar_with_style called outside enter_frame_scope",
+        );
+        let font = self
+            .current_font
+            .as_ref()
+            .expect("MacBackend::draw_activity_bar_with_style requires set_current_font");
+        let theme = self.current_theme;
+        // SAFETY: ctx non-null inside frame scope.
+        unsafe {
+            super::activity_bar::draw_activity_bar_with_style(
+                ctx,
+                font,
+                rect.width as f64,
+                rect.height as f64,
+                bar,
+                style,
+                &theme,
+                hovered_idx,
+            )
+        }
+    }
+
     fn status_bar_layout(&self, rect: Rect, bar: &StatusBar) -> StatusBarLayout {
         // No-paint twin of `draw_status_bar`: same `mac_status_bar_layout`
         // call, so hit regions match the painted frame exactly. Hit

--- a/quadraui/src/macos/mod.rs
+++ b/quadraui/src/macos/mod.rs
@@ -67,7 +67,7 @@ pub mod toolbar;
 pub mod tooltip;
 pub mod tree;
 
-pub use activity_bar::{draw_activity_bar, mac_activity_bar_layout};
+pub use activity_bar::{draw_activity_bar, draw_activity_bar_with_style, mac_activity_bar_layout};
 pub use backend::MacBackend;
 pub use board::{draw_board, mac_board_layout};
 pub use chart::{draw_chart, mac_chart_layout};

--- a/quadraui/src/macos/testing.rs
+++ b/quadraui/src/macos/testing.rs
@@ -674,6 +674,7 @@ mod tests {
                     }],
                     bottom_items: Vec::new(),
                     active_accent: None,
+                    active_bg: None,
                     selection_bg: None,
                     is_keyboard_focused: self.focused,
                 },

--- a/quadraui/src/macos/testing.rs
+++ b/quadraui/src/macos/testing.rs
@@ -674,7 +674,6 @@ mod tests {
                     }],
                     bottom_items: Vec::new(),
                     active_accent: None,
-                    active_bg: None,
                     selection_bg: None,
                     is_keyboard_focused: self.focused,
                 },

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -49,16 +49,10 @@ pub struct ActivityBar {
     /// rasterisers silently fell back to `theme.accent_fg`, which
     /// contradicted this doc; see
     /// `active_bg_fills_row_with_zero_accent_pixels_when_accent_is_none`
-    /// in `crate::gtk::activity_bar::tests`).
+    /// in `crate::gtk::activity_bar::tests`). See [`ActivityBarStyle`] for
+    /// the independent VS-Code-style row-fill knob.
     #[serde(default)]
     pub active_accent: Option<Color>,
-    /// Background fill colour for the active item's row (VS Code style —
-    /// no line, a soft chip on the row itself). `None` = no fill, today's
-    /// behaviour. Independent of `active_accent`: set `active_bg` alone
-    /// for a VS-Code-style fill, `active_accent` alone for a
-    /// JetBrains-style line, both, or neither. (#658)
-    #[serde(default)]
-    pub active_bg: Option<Color>,
     /// Background colour for keyboard-selected items (arrow-nav highlight).
     /// `None` = backends fall back to their own default.
     #[serde(default)]
@@ -105,6 +99,67 @@ pub struct ActivityItem {
     /// `ActivityBar::is_keyboard_focused` is `true`.
     #[serde(default)]
     pub is_keyboard_selected: bool,
+}
+
+/// Per-frame style overrides for
+/// [`crate::Backend::draw_activity_bar_with_style`] (#658) — currently just
+/// the active-item row-fill colour, VS Code style (no line, a soft chip on
+/// the row itself).
+///
+/// This is a **sidecar** passed alongside an [`ActivityBar`] rather than a
+/// field on it. `ActivityBar` is a plain, non-`#[non_exhaustive]`,
+/// all-`pub`-field struct constructed via *exhaustive* literals both
+/// in-tree and downstream (`vimcode`'s `src/render.rs`), so adding a
+/// required field to it is an `error[E0063]: missing fields` break for
+/// every one of those call sites the instant it lands — Rust offers no
+/// shim that keeps an exhaustive literal compiling across an added field
+/// (`Default` + `..Default::default()` only helps literals that already
+/// spread, and `#[non_exhaustive]` retrofitted onto `ActivityBar` now would
+/// swap that break for `E0639: cannot construct non-exhaustive struct
+/// outside its crate` — strictly worse, since it would break *every*
+/// existing exhaustive `ActivityBar { .. }` literal, not just ones missing
+/// the new field). Threading the row-fill colour through this separate
+/// value sidesteps the break entirely — mirrors [`crate::TooltipChrome`]
+/// (#541) and [`crate::TabChrome`] (#631), which solve the identical
+/// problem for `Tooltip` and `TabBar`. See those types' module docs for the
+/// full reasoning.
+///
+/// [`crate::Backend::draw_activity_bar`] keeps its exact signature and
+/// behaviour (delegates to the new method with
+/// `ActivityBarStyle::default()`, i.e. no fill), so existing `Backend`
+/// implementors and callers are untouched.
+///
+/// `#[non_exhaustive]`: brand new this PR, so marking it costs no consumer
+/// anything today (nobody has an exhaustive literal of it yet), and it
+/// means a future style knob (e.g. a corner radius for the fill) is
+/// additive rather than the very breaking change this type exists to
+/// avoid. Construct with [`ActivityBarStyle::new`] /
+/// [`ActivityBarStyle::default`] and the `with_*` builders; the field
+/// stays `pub` for reading.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ActivityBarStyle {
+    /// Background fill colour for the active item's row. `None` (the
+    /// default) = no fill, i.e. today's behaviour. Independent of
+    /// [`ActivityBar::active_accent`]: set this alone for a VS-Code-style
+    /// fill, `active_accent` alone for a JetBrains-style line, both, or
+    /// neither.
+    #[serde(default)]
+    pub active_bg: Option<Color>,
+}
+
+impl ActivityBarStyle {
+    /// Style with no overrides — identical to [`Self::default`], provided
+    /// for symmetry with [`crate::TooltipChrome::new`] / [`crate::TabChrome::new`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the active-item row-fill colour.
+    pub fn with_active_bg(mut self, color: Color) -> Self {
+        self.active_bg = Some(color);
+        self
+    }
 }
 
 // ── D6 Layout API ───────────────────────────────────────────────────────────

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -43,9 +43,22 @@ pub struct ActivityBar {
     #[serde(default)]
     pub bottom_items: Vec<ActivityItem>,
     /// Colour of the left-edge accent bar on active items.
-    /// `None` = no accent rendering.
+    /// `None` = no accent rendering. Every rasteriser honours this
+    /// literally as of #658 — there is no theme fallback, so `None`
+    /// genuinely paints zero accent pixels (previously the GTK/TUI/macOS
+    /// rasterisers silently fell back to `theme.accent_fg`, which
+    /// contradicted this doc; see
+    /// `active_bg_fills_row_with_zero_accent_pixels_when_accent_is_none`
+    /// in `crate::gtk::activity_bar::tests`).
     #[serde(default)]
     pub active_accent: Option<Color>,
+    /// Background fill colour for the active item's row (VS Code style —
+    /// no line, a soft chip on the row itself). `None` = no fill, today's
+    /// behaviour. Independent of `active_accent`: set `active_bg` alone
+    /// for a VS-Code-style fill, `active_accent` alone for a
+    /// JetBrains-style line, both, or neither. (#658)
+    #[serde(default)]
+    pub active_bg: Option<Color>,
     /// Background colour for keyboard-selected items (arrow-nav highlight).
     /// `None` = backends fall back to their own default.
     #[serde(default)]

--- a/quadraui/src/tui/activity_bar.rs
+++ b/quadraui/src/tui/activity_bar.rs
@@ -10,13 +10,40 @@ use ratatui::layout::Rect;
 use ratatui::style::Modifier;
 
 use super::{qc, set_cell, set_cell_wide};
-use crate::primitives::activity_bar::{ActivityBar, ActivityBarRowHit, ActivitySide};
+use crate::primitives::activity_bar::{
+    ActivityBar, ActivityBarRowHit, ActivityBarStyle, ActivitySide,
+};
 use crate::theme::Theme;
 
+/// Equivalent to [`draw_activity_bar_with_style`] with
+/// `ActivityBarStyle::default()`, i.e. no active-row fill — see that
+/// function for the full behaviour and #658's reasoning for why the fill
+/// lives in a separate style value rather than a field on [`ActivityBar`].
 pub fn draw_activity_bar(
     buf: &mut Buffer,
     area: Rect,
     bar: &ActivityBar,
+    theme: &Theme,
+    hovered_idx: Option<usize>,
+) -> Vec<ActivityBarRowHit> {
+    draw_activity_bar_with_style(
+        buf,
+        area,
+        bar,
+        &ActivityBarStyle::default(),
+        theme,
+        hovered_idx,
+    )
+}
+
+/// [`draw_activity_bar`] with an explicit [`ActivityBarStyle`] request
+/// (#658). `ActivityBarStyle::default()` reproduces [`draw_activity_bar`]
+/// cell for cell.
+pub fn draw_activity_bar_with_style(
+    buf: &mut Buffer,
+    area: Rect,
+    bar: &ActivityBar,
+    style: &ActivityBarStyle,
     theme: &Theme,
     hovered_idx: Option<usize>,
 ) -> Vec<ActivityBarRowHit> {
@@ -29,7 +56,7 @@ pub fn draw_activity_bar(
     // #658: no theme fallback for either knob — `None` genuinely means
     // "don't paint this" for both the accent line and the row fill.
     let accent: Option<ratatui::style::Color> = bar.active_accent.map(qc);
-    let active_bg: Option<ratatui::style::Color> = bar.active_bg.map(qc);
+    let active_bg: Option<ratatui::style::Color> = style.active_bg.map(qc);
     let active_fg = qc(theme.foreground);
     let inactive_fg = qc(theme.inactive_fg);
     let hover_bg = qc(theme.tab_bar_bg.lighten(0.10));
@@ -160,7 +187,7 @@ pub fn draw_activity_bar(
 mod tests {
     use super::*;
     use crate::primitives::activity_bar::ActivityItem;
-    use crate::types::WidgetId;
+    use crate::types::{Color, WidgetId};
 
     fn item(id: &str, icon: &str) -> ActivityItem {
         ActivityItem {
@@ -178,7 +205,6 @@ mod tests {
             top_items: vec![item("explorer", "E"), item("search", "S"), item("git", "G")],
             bottom_items: vec![item("settings", "*")],
             active_accent: None,
-            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         }
@@ -285,6 +311,79 @@ mod tests {
             row_text(4).contains('S'),
             "second icon on screen row 4, got {:?}",
             row_text(4)
+        );
+    }
+
+    // ── #658: active_bg / active_accent independence (TUI parity with the
+    //    GTK acceptance test in `crate::gtk::activity_bar::tests`) ────────
+
+    /// `style.active_bg: Some(..)` with `active_accent: None` fills the
+    /// active row's cells with the requested colour and paints **zero**
+    /// accent-line pixels — the accent column (`area.x`) must not carry
+    /// the `'▎'` glyph, only the plain fill background.
+    #[test]
+    fn active_bg_fills_row_cells_with_zero_accent_glyph_when_accent_is_none() {
+        let mut b = bar();
+        b.top_items[0].is_active = true; // "explorer"
+        let theme = Theme::default();
+        let fill_color = Color::rgb(49, 50, 51);
+        let style = ActivityBarStyle::new().with_active_bg(fill_color);
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
+        let area = Rect::new(0, 0, 3, 10);
+        draw_activity_bar_with_style(&mut buf, area, &b, &style, &theme, None);
+
+        let fill = qc(fill_color);
+        assert_ne!(
+            buf[(area.x, area.y)].symbol(),
+            "▎",
+            "active_accent is None: the accent column must not carry the \
+             accent glyph (zero accent-line pixels)"
+        );
+        assert_eq!(
+            buf[(area.x, area.y)].bg,
+            fill,
+            "accent column should carry the active_bg fill, not the plain bar bg"
+        );
+        let icon_col = area.x + 1;
+        assert_eq!(
+            buf[(icon_col, area.y)].bg,
+            fill,
+            "icon column should also carry the active_bg fill"
+        );
+    }
+
+    /// The flip side: `active_accent: Some(..)` with no `style.active_bg`
+    /// still paints the traditional accent glyph, and the row keeps the
+    /// plain bar background elsewhere.
+    #[test]
+    fn active_accent_paints_glyph_when_set_with_no_active_bg() {
+        let mut b = bar();
+        b.top_items[0].is_active = true; // "explorer"
+        b.active_accent = Some(Color::rgb(80, 140, 255));
+        let theme = Theme::default();
+
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
+        let area = Rect::new(0, 0, 3, 10);
+        draw_activity_bar_with_style(
+            &mut buf,
+            area,
+            &b,
+            &ActivityBarStyle::default(),
+            &theme,
+            None,
+        );
+
+        assert_eq!(
+            buf[(area.x, area.y)].symbol(),
+            "▎",
+            "active_accent is set: the accent column should carry the accent glyph"
+        );
+        let icon_col = area.x + 1;
+        assert_eq!(
+            buf[(icon_col, area.y)].bg,
+            qc(theme.tab_bar_bg),
+            "with no active_bg, the icon column keeps the plain bar background"
         );
     }
 }

--- a/quadraui/src/tui/activity_bar.rs
+++ b/quadraui/src/tui/activity_bar.rs
@@ -26,10 +26,10 @@ pub fn draw_activity_bar(
 
     let bg = qc(theme.tab_bar_bg);
     let sep = qc(theme.separator);
-    let accent = bar
-        .active_accent
-        .map(qc)
-        .unwrap_or_else(|| qc(theme.accent_fg));
+    // #658: no theme fallback for either knob — `None` genuinely means
+    // "don't paint this" for both the accent line and the row fill.
+    let accent: Option<ratatui::style::Color> = bar.active_accent.map(qc);
+    let active_bg: Option<ratatui::style::Color> = bar.active_bg.map(qc);
     let active_fg = qc(theme.foreground);
     let inactive_fg = qc(theme.inactive_fg);
     let hover_bg = qc(theme.tab_bar_bg.lighten(0.10));
@@ -77,6 +77,8 @@ pub fn draw_activity_bar(
             sel_explicit_bg.unwrap_or(if is_hovered { hover_bg } else { bg })
         } else if is_hovered {
             hover_bg
+        } else if item.is_active {
+            active_bg.unwrap_or(bg)
         } else {
             bg
         };
@@ -86,18 +88,24 @@ pub fn draw_activity_bar(
             inactive_fg
         };
 
-        // Row background fill (hover tint or explicit keyboard-selection bg).
-        // Both use the same `row_bg` computed above, but we only fill when
-        // there is actually a tint to apply.
-        if is_hovered || (item.is_keyboard_selected && sel_explicit_bg.is_some()) {
+        // Row background fill (hover tint, explicit keyboard-selection bg,
+        // or the active-row fill). All three use the same `row_bg` computed
+        // above, but we only fill when there is actually a tint to apply.
+        if is_hovered
+            || (item.is_keyboard_selected && sel_explicit_bg.is_some())
+            || (item.is_active && active_bg.is_some())
+        {
             for col in area.x..sep_col {
                 set_cell(buf, col, y, ' ', fg, row_bg);
             }
         }
 
-        // Left-edge accent bar for active items.
+        // Left-edge accent bar for active items — only when the bar opts in
+        // via `active_accent`. `None` paints zero accent-line pixels (#658).
         if item.is_active {
-            set_cell(buf, area.x, y, '▎', accent, row_bg);
+            if let Some(ac) = accent {
+                set_cell(buf, area.x, y, '▎', ac, row_bg);
+            }
         }
 
         // Icon glyph — centered in the available width (excluding accent
@@ -170,6 +178,7 @@ mod tests {
             top_items: vec![item("explorer", "E"), item("search", "S"), item("git", "G")],
             bottom_items: vec![item("settings", "*")],
             active_accent: None,
+            active_bg: None,
             selection_bg: None,
             is_keyboard_focused: false,
         }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1304,6 +1304,34 @@ impl Backend for TuiBackend {
         crate::tui::draw_activity_bar(frame.buffer_mut(), area, bar, &theme, hovered_idx)
     }
 
+    fn draw_activity_bar_with_style(
+        &mut self,
+        rect: QRect,
+        bar: &ActivityBar,
+        hovered_idx: Option<usize>,
+        style: &crate::ActivityBarStyle,
+    ) -> Vec<crate::ActivityBarRowHit> {
+        // Track keyboard focus: if this bar declares `is_keyboard_focused`,
+        // record its id so `apply_dispatch` can convert incoming `KeyPressed`
+        // events to `UiEvent::ActivityBar(id, KeyPressed { … })`.
+        if bar.is_keyboard_focused {
+            self.focused_activity_bar = Some(bar.id.clone());
+        }
+        let area = q_rect_to_ratatui(rect);
+        let theme = self.current_theme;
+        let frame = self
+            .current_frame_mut()
+            .expect("TuiBackend::draw_activity_bar_with_style called outside enter_frame_scope");
+        crate::tui::draw_activity_bar_with_style(
+            frame.buffer_mut(),
+            area,
+            bar,
+            style,
+            &theme,
+            hovered_idx,
+        )
+    }
+
     fn status_bar_layout(&self, rect: QRect, bar: &StatusBar) -> crate::StatusBarLayout {
         bar.layout(rect.width, 1.0, MIN_GAP_CELLS, |seg| {
             crate::StatusSegmentMeasure::new(seg.text.chars().count() as f32)

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -73,7 +73,7 @@ mod tree;
 #[cfg(feature = "terminal")]
 pub mod vt_testing;
 
-pub use activity_bar::draw_activity_bar;
+pub use activity_bar::{draw_activity_bar, draw_activity_bar_with_style};
 pub use backend::TuiBackend;
 pub use board::{draw_board, tui_board_layout};
 pub use chart::{draw_chart, tui_chart_layout};

--- a/quadraui/tests/conformance/c0.rs
+++ b/quadraui/tests/conformance/c0.rs
@@ -34,11 +34,11 @@
 //! entry here, or a stale entry naming a method that no longer exists.
 
 use quadraui::{
-    compute_hunks, ActivityBar, ActivityItem, AppLogic, Backend, BadgeStatus, BoardCard,
-    BoardColumn, BoardModel, CardBadge, Chart, ChartKind, Color, Column, ColumnAlign, ColumnWidth,
-    CommandCenter, CommandLine, CompletionItem, CompletionItemMeasure, Completions, ContextMenu,
-    ContextMenuItem, ContextMenuItemMeasure, ContextMenuPlacement, DataRow, DataTable, Decoration,
-    Dialog, DialogButton, DialogMeasure, DiffEditability, DiffMode, DiffPane, DiffView,
+    compute_hunks, ActivityBar, ActivityBarStyle, ActivityItem, AppLogic, Backend, BadgeStatus,
+    BoardCard, BoardColumn, BoardModel, CardBadge, Chart, ChartKind, Color, Column, ColumnAlign,
+    ColumnWidth, CommandCenter, CommandLine, CompletionItem, CompletionItemMeasure, Completions,
+    ContextMenu, ContextMenuItem, ContextMenuItemMeasure, ContextMenuPlacement, DataRow, DataTable,
+    Decoration, Dialog, DialogButton, DialogMeasure, DiffEditability, DiffMode, DiffPane, DiffView,
     DropOverlay, Editor, EditorCursor, EditorCursorPos, EditorCursorShape, EditorLine, EditorStyle,
     EditorStyledSpan, FieldKind, FindReplacePanel, Form, FormField, ListItem, ListView, MenuBar,
     MenuBarItem, MessageList, MessageRow, Minimap, MinimapLine, MsvAxis, MultiSectionView, Palette,
@@ -562,11 +562,43 @@ pub const CASES: &[Case] = &[
                 }],
                 bottom_items: vec![],
                 active_accent: None,
-                active_bg: None,
                 selection_bg: None,
                 is_keyboard_focused: false,
             };
             let _ = b.draw_activity_bar(Rect::new(0.0, 0.0, lh * 3.0, area.height), &bar, None);
+        },
+    },
+    Case {
+        // #658: the style-carrying entry point. Same content as
+        // `draw_activity_bar` above, but asking explicitly for an
+        // `ActivityBarStyle` row fill so C0 exercises a non-default
+        // request reaching the backend rather than only the delegating
+        // path (mirrors `draw_tab_bar_with_chrome` above).
+        method: "draw_activity_bar_with_style",
+        needle: None,
+        paint: |b, area| {
+            let lh = b.line_height();
+            let bar = ActivityBar {
+                id: id("activity-bar-style"),
+                top_items: vec![ActivityItem {
+                    id: id("activity-item-style"),
+                    icon: "c0actystyle".to_string(),
+                    tooltip: String::new(),
+                    is_active: true,
+                    is_keyboard_selected: false,
+                }],
+                bottom_items: vec![],
+                active_accent: None,
+                selection_bg: None,
+                is_keyboard_focused: false,
+            };
+            let style = ActivityBarStyle::new().with_active_bg(Color::rgb(49, 50, 51));
+            let _ = b.draw_activity_bar_with_style(
+                Rect::new(0.0, 0.0, lh * 3.0, area.height),
+                &bar,
+                None,
+                &style,
+            );
         },
     },
     Case {

--- a/quadraui/tests/conformance/c0.rs
+++ b/quadraui/tests/conformance/c0.rs
@@ -562,6 +562,7 @@ pub const CASES: &[Case] = &[
                 }],
                 bottom_items: vec![],
                 active_accent: None,
+                active_bg: None,
                 selection_bg: None,
                 is_keyboard_focused: false,
             };

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -20,6 +20,8 @@ use shell_app_ex::ShellApp as ShellAppEx;
 mod toolbar_app;
 use toolbar_app::ToolbarApp;
 
+#[path = "../examples/common/activity_style_demo.rs"]
+mod activity_style_demo;
 #[path = "../examples/common/ai_transcript.rs"]
 mod ai_transcript;
 #[path = "../examples/common/appshell_demo.rs"]
@@ -110,6 +112,7 @@ mod tooltip_demo;
 #[path = "../examples/common/wide_tab_bar_demo.rs"]
 mod wide_tab_bar_demo;
 
+use activity_style_demo::ActivityStyleDemo;
 use ai_transcript::AiTranscript;
 use appshell_demo::AppShellDemo;
 use bottom_panel_demo::BottomPanelDemo;
@@ -4726,6 +4729,61 @@ fn tab_chrome_demo_q_exits() {
     let mut driver = TuiDriver::new(TabChromeDemo::new(), 100, 10);
     driver.type_char('q');
     assert!(driver.exited(), "'q' should exit the tab chrome demo");
+}
+
+// ─── ActivityStyleDemo: VS-Code-style row fill through
+//     Backend::draw_activity_bar_with_style (#658) ────────────────────────
+//
+// #658 adds `ActivityBarStyle::active_bg` as a sidecar rather than a field
+// on `ActivityBar` — see that type's doc for why a new field there would
+// have broken every existing exhaustive `ActivityBar { .. }` literal. These
+// drive the shipping `tui_activity_style` example through the new
+// `Backend::draw_activity_bar_with_style` entry point end to end. The TUI
+// rasteriser's actual fill *colour* is a cell-background assertion, already
+// covered at the primitive level by
+// `tui::activity_bar::tests::active_bg_fills_row_cells_with_zero_accent_glyph_when_accent_is_none`
+// — this driver test instead proves the example's own behaviour: no
+// left-edge accent glyph on screen, and a click on an icon activates it.
+
+#[test]
+fn activity_style_demo_paints_no_accent_glyph() {
+    // `active_accent` is `None` throughout this demo — the row fill is the
+    // only active-item indicator. `'▎'` is the glyph
+    // `tui::activity_bar::draw_activity_bar_with_style` paints for a
+    // *set* `active_accent`, so its total absence here is the observable
+    // proxy for "zero accent-line pixels" that a text-only driver can
+    // assert (the actual fill colour is a cell-background test, covered
+    // at the primitive level).
+    let driver = TuiDriver::new(ActivityStyleDemo::new(), 100, 10);
+    assert!(
+        !driver.screen_contains("▎"),
+        "active_accent is None throughout this demo: zero accent-line \
+         pixels expected:\n{}",
+        driver.screen()
+    );
+    assert!(driver.screen_contains(" ready "));
+}
+
+#[test]
+fn activity_style_demo_click_on_icon_activates_it() {
+    let mut driver = TuiDriver::new(ActivityStyleDemo::new(), 100, 10);
+    let (x, y) = driver
+        .find("S")
+        .unwrap_or_else(|| panic!("Search icon 'S' should be painted:\n{}", driver.screen()));
+    driver.click(x, y);
+
+    assert!(
+        driver.screen_contains(" activated Search "),
+        "clicking the Search icon should activate it:\n{}",
+        driver.screen()
+    );
+}
+
+#[test]
+fn activity_style_demo_q_exits() {
+    let mut driver = TuiDriver::new(ActivityStyleDemo::new(), 100, 10);
+    driver.type_char('q');
+    assert!(driver.exited(), "'q' should exit the activity style demo");
 }
 
 // ─── MinimapApp (issue #382): braille density view + click-to-seek ────────

--- a/quadraui/tests/tui_example_driver.rs
+++ b/quadraui/tests/tui_example_driver.rs
@@ -2156,21 +2156,23 @@ fn shell_menu_dropdown_item_over_activity_bar_activates() {
 /// cursor.
 ///
 /// Locates the click target instead of guessing a row: `ShellMenuDemo`'s
-/// first panel (Explorer) is active by default, and
-/// `tui::activity_bar::draw_activity_bar` paints its left-edge accent glyph
-/// (`'▎'`) at exactly the row `AppShell`'s cached hit-region reports for
-/// that item — see that module's `icons_still_paint_at_the_absolute_row`
-/// and `hit_regions_are_bar_relative_not_absolute` tests. `'▎'` is unique
-/// to that one call site (nothing else in the TUI backend paints it), so
-/// `find` unambiguously locates the active item's row without a brute-force
-/// scan.
+/// first panel (Explorer) is active by default. `AppShell::build_activity_bar`
+/// doesn't set `active_accent`/`active_bg` (it has no `Theme` to source a
+/// colour from — see quadraui#658/#381), so as of #658 there is no
+/// left-edge accent glyph to search for here (the rasterisers no longer
+/// fall back to a theme default when those fields are `None`). Instead
+/// this searches for `"E│"` — the Explorer icon glyph immediately
+/// followed by the activity bar's right-edge separator column, which only
+/// `tui::activity_bar::draw_activity_bar` ever paints (`'│'` is unique to
+/// that separator; no other TUI chrome uses it), so the pair unambiguously
+/// locates the Explorer row without depending on any active-item styling.
 #[test]
 fn shell_menu_activity_bar_click_still_switches_panel_when_no_modal_open() {
     let mut driver = driver_with_shell(ShellMenuDemo::new(), ShellMenuDemo::config(), 100, 30);
 
-    let (x, y) = driver.find("▎").unwrap_or_else(|| {
+    let (x, y) = driver.find("E│").unwrap_or_else(|| {
         panic!(
-            "Explorer (active by default) should paint its accent bar:\n{}",
+            "Explorer's activity-bar row (icon + separator) should be painted:\n{}",
             driver.screen()
         )
     });


### PR DESCRIPTION
Closes #658

Automated PR opened by coordinator for review of issue #658.