### PR TITLE
#663: Minimap ignores its own box: row pitch stretches to fill (3-line file renders at the 64px font clamp) and glyphs aren't clipped to bounds

### DIFF
--- a/quadraui/src/gtk/minimap.rs
+++ b/quadraui/src/gtk/minimap.rs
@@ -119,9 +119,26 @@ pub fn draw_minimap(
         cr.fill().ok();
     }
 
-    let row_px = h / layout.visible_lines.len() as f64;
+    // Row pitch already lives on the layout, post-cap (`Minimap::layout`,
+    // #663) -- read it back rather than recomputing `h /
+    // visible_lines.len()`, which would silently undo the cap and let a
+    // short file's font balloon again. All rows share one pitch, so the
+    // first is representative.
+    let row_px = layout
+        .visible_lines
+        .first()
+        .map(|v| v.bounds.height as f64)
+        .unwrap_or(0.0);
     let mode = render_mode(row_px);
     let saved_font = pango_layout.font_description();
+
+    // Clip all row painting to the strip: a legible pitch can still shape
+    // a line longer than `w`, and below-floor colour bars are already
+    // width-bounded but glyphs are not -- without this, text bled across
+    // whatever the host painted beside the minimap (#663).
+    cr.save().ok();
+    cr.rectangle(x, y, w, h);
+    cr.clip();
 
     for vline in &layout.visible_lines {
         let Some(line) = minimap.lines.get(vline.start_line_idx) else {
@@ -147,6 +164,12 @@ pub fn draw_minimap(
 
     pango_layout.set_attributes(None);
     pango_layout.set_font_description(saved_font.as_ref());
+    // Reset the ellipsize/width state `paint_row_glyphs` set below so it
+    // can't leak onto whatever the shared layout paints next.
+    pango_layout.set_width(-1);
+    pango_layout.set_ellipsize(pango::EllipsizeMode::None);
+
+    cr.restore().ok();
 
     layout
 }
@@ -180,6 +203,12 @@ fn paint_row_glyphs(
     let mut font = saved_font.cloned().unwrap_or_default();
     font.set_absolute_size(minimap_font_px(row_px) * pango::SCALE as f64);
     pango_layout.set_font_description(Some(&font));
+    // Bound the shaped run to the row's own width and ellipsize rather
+    // than shaping (and then relying on the Cairo clip to hide) glyphs
+    // that will never be visible -- keeps shaping cheap even for a very
+    // long line; the `cr.clip()` in `draw_minimap` is the hard guarantee.
+    pango_layout.set_width((vline.bounds.width * pango::SCALE as f32).round() as i32);
+    pango_layout.set_ellipsize(pango::EllipsizeMode::End);
     pango_layout.set_text(text);
 
     let spans: Vec<_> = minimap
@@ -300,14 +329,18 @@ mod tests {
 
     #[test]
     fn same_buffer_at_two_heights_yields_two_different_font_sizes() {
+        // Pitch is bounded (#663: MAX_ROW_PITCH), so read it back from
+        // the resolved layout rather than recomputing `h /
+        // visible_lines.len()` -- that naive division is exactly the
+        // pre-#663 bug and would silently undo the cap.
         let lines: Vec<&str> = vec!["fn main() {}"; 8];
         let mm = minimap_from(lines, 8);
 
-        let tall = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 80.0); // pitch 10px
-        let short = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 16.0); // pitch 2px
+        let tall = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 80.0); // naive pitch 10px, capped to 8px
+        let short = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 16.0); // naive pitch 2px, under the cap
 
-        let tall_px = 80.0 / tall.visible_lines.len() as f64;
-        let short_px = 16.0 / short.visible_lines.len() as f64;
+        let tall_px = tall.visible_lines[0].bounds.height as f64;
+        let short_px = short.visible_lines[0].bounds.height as f64;
         assert_ne!(tall_px, short_px);
 
         let tall_font = minimap_font_px(tall_px);
@@ -316,6 +349,24 @@ mod tests {
             tall_font, short_font,
             "font size must track row pitch, not a fixed constant"
         );
+    }
+
+    #[test]
+    fn short_file_in_a_tall_strip_does_not_hit_the_64px_clamp() {
+        // The exact #663 repro: a 3-line file (e.g. `//! Placeholder
+        // module`) in a strip tall enough that the old `bounds.height /
+        // row_count` division would land at or above
+        // `minimap_font_px`'s 64px ceiling. Capped pitch must keep the
+        // resolved font well under that -- at or below MAX_ROW_PITCH.
+        let mm = minimap_from(vec!["//! Placeholder module"; 3], 3);
+        let layout = gtk_minimap_layout(&mm, 0.0, 0.0, 200.0, 200.0);
+        let row_px = layout.visible_lines[0].bounds.height as f64;
+        let font_px = minimap_font_px(row_px);
+        assert!(
+            font_px <= crate::primitives::minimap::MAX_ROW_PITCH as f64,
+            "a short file's font must stay at/below the pitch ceiling, got {font_px}"
+        );
+        assert!(font_px < 64.0, "must not hit minimap_font_px's clamp");
     }
 
     // ── legibility floor ─────────────────────────────────────────────
@@ -438,5 +489,74 @@ mod tests {
             &Theme::default(),
         );
         assert!(layout.visible_lines.is_empty());
+    }
+
+    // ── glyph clipping (#663) ───────────────────────────────────────────
+
+    /// Read an RGB triple from an ARgb32 surface at pixel (x, y).
+    ///
+    /// Cairo's `ARgb32` stores each pixel as four bytes in native
+    /// (little-endian) byte order: [B, G, R, A].
+    fn pixel(data: &[u8], stride: usize, x: i32, y: i32) -> (u8, u8, u8) {
+        let off = y as usize * stride + x as usize * 4;
+        (data[off + 2], data[off + 1], data[off])
+    }
+
+    #[test]
+    fn wide_line_glyphs_never_paint_right_of_bounds() {
+        // Pre-#663 there was no `cr.clip()` and no Pango layout width, so
+        // a line wider than the strip painted straight across whatever
+        // sat beside it (in vimcode's case, the neighbouring editor
+        // pane). Paint a pathologically long line into a strip embedded
+        // in a wider white canvas and assert nothing right of the strip
+        // is touched.
+        const STRIP_W: i32 = 40;
+        const CANVAS_W: i32 = 200;
+        const H: i32 = 40;
+
+        let long_line = "x".repeat(500);
+        let mm = minimap_from(vec![&long_line], 1);
+
+        let mut surface =
+            ImageSurface::create(Format::ARgb32, CANVAS_W, H).expect("create surface");
+        {
+            let cr = CairoContext::new(&surface).expect("Context::new");
+            cr.set_source_rgb(1.0, 1.0, 1.0); // white sentinel
+            cr.paint().ok();
+
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            let theme = Theme {
+                background: Color::rgb(20, 20, 20),
+                foreground: Color::rgb(255, 255, 255),
+                ..Theme::default()
+            };
+            // One row over 40px -> pitch capped at MAX_ROW_PITCH (8px),
+            // above the legibility floor, so this exercises the
+            // Characters branch (glyph shaping), not the colour-bar
+            // fallback.
+            draw_minimap(
+                &cr,
+                &pango_layout,
+                0.0,
+                0.0,
+                STRIP_W as f64,
+                H as f64,
+                &mm,
+                &theme,
+            );
+        }
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        for y in 0..H {
+            for x in STRIP_W..CANVAS_W {
+                assert_eq!(
+                    pixel(&data, stride, x, y),
+                    (255, 255, 255),
+                    "pixel ({x},{y}) is right of bounds.x + bounds.width and must be untouched"
+                );
+            }
+        }
     }
 }

--- a/quadraui/src/primitives/minimap.rs
+++ b/quadraui/src/primitives/minimap.rs
@@ -20,11 +20,18 @@
 //! for GTK, typically one entry per rendered row; for TUI, four
 //! consecutive entries are packed into one braille row. [`Minimap::layout`]
 //! takes `lines_per_row` (the backend's own grouping factor: `1` for GTK,
-//! `4` for TUI) and groups `lines` into that many rows, tiling
-//! `bounds.height` evenly across them — this is what lets
-//! [`MinimapLayout::visible_lines`].len() serve directly as the row count
-//! the GTK rasteriser divides by for font-pitch (`line_px = bounds.height
-//! / layout.visible_lines.len()`, see the rasteriser spec in #382).
+//! `4` for TUI) and groups `lines` into that many rows, tiling them across
+//! `bounds.height` at a pitch that is never allowed to exceed
+//! [`MAX_ROW_PITCH`] (issue #663) — a file short enough that `bounds.height
+//! / row_count` would blow past that ceiling instead top-aligns and only
+//! occupies `row_count * row_h` of the strip, leaving the remainder
+//! unpainted, rather than stretching to fill it. Each
+//! [`VisibleMinimapLine::bounds`] carries the *resolved* (already-capped)
+//! row height, so a rasteriser reads its pitch straight off the layout
+//! (`vline.bounds.height`) instead of re-deriving it via `bounds.height /
+//! layout.visible_lines.len()` — re-deriving it that way silently
+//! undoes the cap (see the rasteriser spec in #382, and #663 for the bug
+//! this replaced).
 //!
 //! `visible_row_start` / `visible_row_count` describe the *editor's*
 //! current viewport as an index range into `lines` (not a separate scroll
@@ -138,6 +145,25 @@ pub struct MinimapLayout {
     pub scrollbar: Option<Scrollbar>,
 }
 
+/// Ceiling on a minimap row's pitch, in `bounds`'s own coordinate units
+/// (device pixels for GTK, terminal cell rows for TUI) — issue #663.
+///
+/// Without a ceiling, [`Minimap::layout`]'s `row_h` is `bounds.height /
+/// row_count`, which grows without bound as a file gets shorter than the
+/// strip. For GTK, which maps pitch directly to an absolute Pango font
+/// size (`gtk::minimap::minimap_font_px`), that meant a short file's font
+/// ballooned toward that function's own 64px clamp — a 3-line file
+/// rendered at near-editor scale. `MAX_ROW_PITCH` keeps a minimap always
+/// minimap-sized: comfortably above the 4px legibility floor (so short
+/// files still render real glyphs, not colour bars) but nowhere near a
+/// normal ~18px editor line height. Below the ceiling, `row_count *
+/// row_h` rows top-align inside `bounds` and the remainder of the strip
+/// stays unpainted — mirroring [`sample_lines`]'s own never-upscale rule.
+/// Long files are unaffected: `bounds.height / row_count` is already
+/// below the ceiling once the caller's sampling has downsampled them to
+/// roughly fit the strip.
+pub const MAX_ROW_PITCH: f32 = 8.0;
+
 /// Classification of a minimap hit-test result.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MinimapHit {
@@ -180,7 +206,10 @@ impl Minimap {
         }
 
         let row_count = self.lines.len().div_ceil(lines_per_row);
-        let row_h = bounds.height / row_count as f32;
+        // Bounded, not stretch-to-fill: see MAX_ROW_PITCH's doc for why a
+        // short file must not blow its pitch (and, for GTK, its font
+        // size) up to fill the whole strip (#663).
+        let row_h = (bounds.height / row_count as f32).min(MAX_ROW_PITCH);
 
         let visible_lines: Vec<VisibleMinimapLine> = (0..row_count)
             .map(|r| VisibleMinimapLine {
@@ -393,20 +422,24 @@ mod tests {
     #[test]
     fn layout_tiles_rows_evenly_across_bounds() {
         let mm = minimap(8, 2, 3);
-        let bounds = Rect::new(0.0, 0.0, 10.0, 40.0);
+        // 4 rows over 16px: pitch 4px, comfortably under MAX_ROW_PITCH,
+        // so this exercises even tiling rather than the pitch cap
+        // (that's `layout_caps_row_pitch_and_top_aligns_short_files`,
+        // below).
+        let bounds = Rect::new(0.0, 0.0, 10.0, 16.0);
         let layout = mm.layout(bounds, 2); // 8 lines / 2 per row = 4 rows
         assert_eq!(layout.visible_lines.len(), 4);
         assert_eq!(
             layout.visible_lines[0].bounds,
-            Rect::new(0.0, 0.0, 10.0, 10.0)
+            Rect::new(0.0, 0.0, 10.0, 4.0)
         );
         assert_eq!(
             layout.visible_lines[1].bounds,
-            Rect::new(0.0, 10.0, 10.0, 10.0)
+            Rect::new(0.0, 4.0, 10.0, 4.0)
         );
         assert_eq!(
             layout.visible_lines[3].bounds,
-            Rect::new(0.0, 30.0, 10.0, 10.0)
+            Rect::new(0.0, 12.0, 10.0, 4.0)
         );
         assert_eq!(layout.visible_lines[3].start_line_idx, 6);
     }
@@ -416,9 +449,42 @@ mod tests {
         // visible_row_start=2, visible_row_count=3 -> lines[2..5), rows
         // grouped 2-per-row -> row 1 (start) through row 3 (exclusive).
         let mm = minimap(8, 2, 3);
-        let bounds = Rect::new(0.0, 0.0, 10.0, 40.0);
+        let bounds = Rect::new(0.0, 0.0, 10.0, 16.0); // pitch 4px, under the cap
         let layout = mm.layout(bounds, 2);
-        assert_eq!(layout.viewport_highlight, Rect::new(0.0, 10.0, 10.0, 20.0));
+        assert_eq!(layout.viewport_highlight, Rect::new(0.0, 4.0, 10.0, 8.0));
+    }
+
+    #[test]
+    fn layout_caps_row_pitch_and_top_aligns_short_files() {
+        // A 3-line file (lines_per_row=1 -> 3 rows) inside a tall 200px
+        // strip. Uncapped, row_h would be 200/3 ~= 66.7px -- a 3-line
+        // file rendering at near-editor scale (#663). Capped, no row's
+        // pitch may exceed MAX_ROW_PITCH, and the rows top-align, only
+        // occupying the strip's top `row_count * row_h` -- the rest of
+        // the tall strip stays unpainted rather than stretching to fill.
+        let mm = minimap(3, 0, 3);
+        let bounds = Rect::new(0.0, 0.0, 40.0, 200.0);
+        let layout = mm.layout(bounds, 1);
+        assert_eq!(layout.visible_lines.len(), 3);
+        for vline in &layout.visible_lines {
+            assert!(
+                vline.bounds.height <= MAX_ROW_PITCH,
+                "row pitch {} exceeds the MAX_ROW_PITCH ceiling",
+                vline.bounds.height
+            );
+        }
+        assert_eq!(
+            layout.visible_lines[0].bounds.y, bounds.y,
+            "rows must top-align to the strip"
+        );
+        let last = layout.visible_lines.last().unwrap();
+        let occupied = last.bounds.y + last.bounds.height;
+        assert!(
+            occupied < bounds.height,
+            "a short file must not stretch its rows to fill the whole strip \
+             (occupied {occupied}, strip height {})",
+            bounds.height
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #663

Automated PR opened by coordinator for review of issue #663.