### PR TITLE
#667: Minimap: fixed row pitch independent of file length, per-column colour blocks with indent, and O(rows+spans) span lookup

### DIFF
--- a/quadraui/examples/common/minimap_app.rs
+++ b/quadraui/examples/common/minimap_app.rs
@@ -1,12 +1,20 @@
 //! Minimap `AppLogic` + `quadraui::{tui,gtk}::run` example ([`tui_minimap`]
 //! / [`gtk_minimap`]).
 //!
-//! A static ~80-line "buffer" rendered as a code-overview minimap, plus a
+//! A static ~300-line "buffer" rendered as a code-overview minimap, plus a
 //! status bar showing the current scroll position. Demonstrates
 //! `sample_lines` (row down-sampling) and `aggregate_spans` (colour
 //! down-sampling) feeding one `Minimap` descriptor that both backends
-//! paint with zero backend-specific app code — GTK via font scaling, TUI
-//! via braille (#382).
+//! paint with zero backend-specific app code — GTK via fixed-pitch
+//! per-column colour blocks, TUI via braille (#382, #667).
+//!
+//! The buffer is deliberately tall enough that GTK's fixed row pitch
+//! (`gtk::minimap::ROW_PITCH_PX`) can't show every row in a typical strip
+//! at once — this app hands `Minimap.lines` every buffer line (no
+//! app-level pre-downsampling to "just enough to fill the strip"; that
+//! was the old `Fill`-only model) and lets `Minimap::layout`'s own
+//! `FixedPitch` slide window decide how much is visible, so scrolling
+//! with Up/Down visibly slides the map (#667).
 //!
 //! Controls:
 //! - Up/Down       scroll the viewport (moves the highlighted band)
@@ -25,9 +33,12 @@ const VIEWPORT_ROWS: usize = 10;
 
 /// TUI packs 4 buffer lines into one braille row; GTK paints 1 buffer
 /// line per row. This example doesn't know (or need to know) which
-/// backend it's running under, so it samples generously at the denser
-/// factor — both backends handle receiving more `lines` than they have
-/// rows for by grouping/tiling, per `Minimap::layout`.
+/// backend it's running under, so `syntax_spans` is aggregated at TUI's
+/// coarser `4`-line grid — GTK's per-column colour lookup still resolves
+/// correctly against a coarser span, just at TUI's granularity rather
+/// than its own finer one. Unrelated to how many rows are actually
+/// *visible* at once, which is `Minimap::layout`'s own `MinimapSizing`
+/// concern (#667), not this app's.
 const LINES_PER_ROW: usize = 4;
 
 pub struct MinimapApp {
@@ -37,7 +48,7 @@ pub struct MinimapApp {
 
 impl MinimapApp {
     pub fn new() -> Self {
-        let buffer = (0..80)
+        let buffer = (0..300)
             .map(|i| match i % 6 {
                 0 => format!("fn function_{i}() {{"),
                 1 => "    let value = compute();".to_string(),
@@ -58,10 +69,18 @@ impl MinimapApp {
     }
 
     /// Build the `Minimap` descriptor for the current scroll position.
-    fn minimap(&self, target_rows: usize) -> Minimap {
+    ///
+    /// Unlike the pre-#667 model, this doesn't try to pre-compute "just
+    /// enough rows to fill the strip" from the viewport's pixel height —
+    /// that was only ever needed because `Fill` sizing had no sliding
+    /// window, so a mismatch meant either wasted rows or an over-squeezed
+    /// pitch. `sample_lines` here is called with a target at least as
+    /// large as the buffer, so it's the identity (never upscales): GTK's
+    /// `FixedPitch` layout and TUI's `Fill` layout each decide for
+    /// themselves how much of `lines` actually gets painted.
+    fn minimap(&self) -> Minimap {
         let refs = self.buffer_refs();
-        let target = target_rows.saturating_mul(LINES_PER_ROW).max(1);
-        let lines = sample_lines(&refs, target);
+        let lines = sample_lines(&refs, self.buffer.len());
 
         // A couple of illustrative syntax spans — "fn" in one colour,
         // comments in another — aggregated down to whatever cell size
@@ -173,8 +192,7 @@ impl AppLogic for MinimapApp {
         let viewport = backend.viewport();
         let lh = backend.line_height();
         let minimap_rect = self.minimap_rect(backend);
-        let approx_rows = (minimap_rect.height / lh).max(1.0) as usize;
-        let minimap = self.minimap(approx_rows);
+        let minimap = self.minimap();
         let _ = backend.draw_minimap(minimap_rect, &minimap);
 
         let status_rect = Rect::new(0.0, viewport.height - lh, viewport.width, lh);
@@ -212,9 +230,7 @@ impl AppLogic for MinimapApp {
                 ..
             } => {
                 let minimap_rect = self.minimap_rect(backend);
-                let lh = backend.line_height();
-                let approx_rows = (minimap_rect.height / lh).max(1.0) as usize;
-                let minimap = self.minimap(approx_rows);
+                let minimap = self.minimap();
                 let layout = backend.minimap_layout(minimap_rect, &minimap);
                 if let MinimapHit::Seek { fraction } = layout.hit_test(position.x, position.y) {
                     self.seek(fraction);

--- a/quadraui/examples/gtk_minimap.rs
+++ b/quadraui/examples/gtk_minimap.rs
@@ -1,7 +1,9 @@
 //! Minimap `AppLogic` + `quadraui::gtk::run` example.
 //!
-//! Code-overview minimap demo, painted via GTK font scaling.
-//! Up/Down to scroll, click the minimap to seek, q to quit.
+//! Code-overview minimap demo, painted via GTK's fixed-pitch per-column
+//! colour blocks (#667). Up/Down to scroll, click the minimap to seek, q
+//! to quit — the buffer is taller than the strip, so scrolling slides the
+//! visible window across the map.
 //!
 //! ```sh
 //! cargo run --example gtk_minimap --features gtk

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -1435,12 +1435,14 @@ pub trait Backend {
     /// board instead of failing to build (quadraui#600, PORT-01).
     fn draw_board(&mut self, rect: Rect, model: &BoardModel) -> BoardLayout;
 
-    /// Draw a [`Minimap`] (code-overview density view). GTK paints real
-    /// glyphs at a scaled-down absolute Pango size ("font scaling");
-    /// TUI packs `U+2800`-block braille dots. Both techniques consume
-    /// the exact same [`Minimap`] data — the primitive owns the sampling
-    /// and colour-aggregation math (`sample_lines` / `aggregate_spans`),
-    /// so no backend re-derives it (#382).
+    /// Draw a [`Minimap`] (code-overview density view). GTK tiles rows at
+    /// a fixed pitch and paints one colour block per non-blank character
+    /// column ([`crate::MinimapSizing::FixedPitch`], #667); TUI packs
+    /// `U+2800`-block braille dots at a stretch-to-fill pitch
+    /// ([`crate::MinimapSizing::Fill`]). Both techniques consume the
+    /// exact same [`Minimap`] data — the primitive owns the sampling and
+    /// colour-aggregation math (`sample_lines` / `aggregate_spans`), so
+    /// no backend re-derives it (#382, #667).
     ///
     /// Returns [`MinimapPaintResult`] carrying the resolved
     /// [`MinimapLayout`] so hosts can route clicks via

--- a/quadraui/src/gtk/minimap.rs
+++ b/quadraui/src/gtk/minimap.rs
@@ -69,7 +69,7 @@ pub const COLUMN_CAPACITY: usize = 120;
 
 /// Compute the GTK pixel-unit layout for a [`Minimap`] without painting.
 pub fn gtk_minimap_layout(minimap: &Minimap, x: f64, y: f64, w: f64, h: f64) -> MinimapLayout {
-    minimap.layout(
+    minimap.layout_with_sizing(
         QRect::new(x as f32, y as f32, w as f32, h as f32),
         LINES_PER_ROW,
         MinimapSizing::FixedPitch(ROW_PITCH_PX as f32),

--- a/quadraui/src/gtk/minimap.rs
+++ b/quadraui/src/gtk/minimap.rs
@@ -1,22 +1,44 @@
-//! GTK rasteriser for [`crate::Minimap`]: font scaling (#382).
+//! GTK rasteriser for [`crate::Minimap`]: fixed row pitch, per-column
+//! colour blocks (#667; supersedes the file-length-dependent font scaling
+//! from #382).
 //!
-//! Real glyphs are painted through Pango at a scaled-down **absolute**
-//! size (`FontDescription::set_absolute_size`) — never via `cr.scale()`
-//! on the editor's existing layout, which would blur hinted text and
-//! scale stroke widths along with it (VS Code's `minimap.renderCharacters:
-//! true`). Below [`LEGIBILITY_FLOOR_PX`], shaping tiny glyphs buys
-//! nothing and Pango collapses them into mush, so the rasteriser falls
-//! back to VS Code's `renderCharacters: false` mode: one filled colour
-//! bar per line, width proportional to the line's trimmed length. The
-//! mode switch ([`render_mode`]) is a pure function of the row pitch so
-//! it's deterministic and directly testable without a live surface.
+//! Rows tile at a fixed [`ROW_PITCH_PX`], independent of the file's
+//! length ([`crate::MinimapSizing::FixedPitch`]) — see
+//! `Minimap::layout`'s module docs for the slide behaviour when a file
+//! needs more rows than the strip holds at that pitch. At that pitch,
+//! [`is_legible`] is false, so painting lands in
+//! [`MinimapRenderMode::ColumnBlocks`]: one 1px-wide block per non-blank
+//! character column, coloured by whichever aggregated span covers it,
+//! rather than one bar per line — this is what preserves the indent
+//! silhouette VS Code's `renderCharacters: false` mode reads as (#667).
+//! [`MinimapRenderMode::Characters`] — real glyphs painted through Pango
+//! at a scaled-down **absolute** size (`FontDescription::set_absolute_size`)
+//! — is kept for pitches at or above [`LEGIBILITY_FLOOR_PX`] (not reached
+//! by [`ROW_PITCH_PX`] today, but still a real, tested code path: nothing
+//! stops a future caller from requesting a taller fixed pitch). The mode
+//! switch ([`render_mode`]) is a pure function of the row pitch so it's
+//! deterministic and directly testable without a live surface.
+//!
+//! Both branches bound their per-row cost to [`COLUMN_CAPACITY`] columns:
+//! `ColumnBlocks`' walk stops there, and `Characters` truncates the text
+//! it hands to Pango there too, so a pathologically long line costs no
+//! more to paint or shape than a short one (#667 pt. 3).
+//!
+//! Colour lookups (both branches) walk `syntax_spans` once per paint via
+//! [`SpanCursor`], not once per row — `aggregate_spans` documents its
+//! output as sorted by `(line_idx, start_col)`, and `visible_lines` is
+//! itself always ascending in `start_line_idx`, so a single merge-walk
+//! is O(rows + spans) total rather than the old O(rows * spans) rescan
+//! (#667 pt. 4).
 
 use gtk4::cairo::Context;
 use gtk4::pango;
 
 use super::{cairo_rgb, set_source};
 use crate::event::Rect as QRect;
-use crate::primitives::minimap::{Minimap, MinimapLayout, VisibleMinimapLine};
+use crate::primitives::minimap::{
+    Minimap, MinimapLayout, MinimapSizing, MinimapSpan, VisibleMinimapLine,
+};
 use crate::theme::Theme;
 use crate::types::Color;
 
@@ -24,21 +46,33 @@ use crate::types::Color;
 /// reduction (see [`crate::MinimapGrid`]'s doc for why TUI differs).
 pub const LINES_PER_ROW: usize = 1;
 
+/// The fixed row pitch GTK tiles minimap rows at, in device pixels —
+/// independent of the file's length (#667). VS Code's default minimap
+/// pitch is in the same ~2px ballpark; below [`LEGIBILITY_FLOOR_PX`], so
+/// the default rasteriser always lands in
+/// [`MinimapRenderMode::ColumnBlocks`].
+pub const ROW_PITCH_PX: f64 = 2.0;
+
 /// Below this absolute pixel size, Pango glyph shaping reads as
 /// indistinct mush rather than recognisable code shapes — the
-/// rasteriser falls back to solid colour bars instead ([`render_mode`]).
+/// rasteriser falls back to per-column colour blocks instead
+/// ([`render_mode`]).
 pub const LEGIBILITY_FLOOR_PX: f64 = 4.0;
 
-/// Assumed "wide" line length for the colour-bar fallback's width
-/// proportion — a heuristic, not a measured value (below the legibility
-/// floor there's no live font metric to measure against).
-const ASSUMED_WIDE_LINE_CHARS: f64 = 120.0;
+/// How many character columns a row's paint walk covers before stopping
+/// — bounds both [`MinimapRenderMode::ColumnBlocks`]'s per-column walk
+/// and how much of a line [`MinimapRenderMode::Characters`] hands to
+/// Pango, so a 10,000-character line costs no more than a short one
+/// (#667 pt. 2/3). Also doubles as the assumed "wide" line width a
+/// minimap strip is sized for.
+pub const COLUMN_CAPACITY: usize = 120;
 
 /// Compute the GTK pixel-unit layout for a [`Minimap`] without painting.
 pub fn gtk_minimap_layout(minimap: &Minimap, x: f64, y: f64, w: f64, h: f64) -> MinimapLayout {
     minimap.layout(
         QRect::new(x as f32, y as f32, w as f32, h as f32),
         LINES_PER_ROW,
+        MinimapSizing::FixedPitch(ROW_PITCH_PX as f32),
     )
 }
 
@@ -47,8 +81,9 @@ pub fn gtk_minimap_layout(minimap: &Minimap, x: f64, y: f64, w: f64, h: f64) -> 
 pub enum MinimapRenderMode {
     /// Real Pango glyphs at an absolute scaled-down size.
     Characters,
-    /// One filled bar per row, proportional to trimmed line length.
-    ColorBars,
+    /// One 1px-wide block per non-blank character column, coloured by
+    /// whichever span covers it.
+    ColumnBlocks,
 }
 
 /// Pure function of the row pitch: is `line_px` legible enough to shape
@@ -64,28 +99,19 @@ pub fn render_mode(line_px: f64) -> MinimapRenderMode {
     if is_legible(line_px) {
         MinimapRenderMode::Characters
     } else {
-        MinimapRenderMode::ColorBars
+        MinimapRenderMode::ColumnBlocks
     }
 }
 
 /// The absolute Pango font size (in device pixels) for a row of pitch
 /// `line_px` — clamped to a sane band so a pathologically short or tall
-/// minimap doesn't request a zero or absurd font size. This is a pure
-/// function of the pitch, not a fixed constant: painting the same
-/// buffer at two different `bounds.height` values must yield two
-/// different sizes (that's the "font scaling, not a fixed 6px" contract
-/// from #382).
+/// minimap doesn't request a zero or absurd font size. Only reachable
+/// when a row's pitch clears [`LEGIBILITY_FLOOR_PX`] — not the case for
+/// [`ROW_PITCH_PX`] today, but the function stays pitch-driven rather
+/// than a fixed constant in case a future caller requests a taller fixed
+/// pitch.
 pub fn minimap_font_px(line_px: f64) -> f64 {
     line_px.clamp(1.0, 64.0)
-}
-
-/// Fraction of the minimap's width a colour bar should fill for a line
-/// whose trimmed length is `trimmed_chars`, in the [`MinimapRenderMode::ColorBars`]
-/// fallback. There is no live font metric to measure against below the
-/// legibility floor, so this is a heuristic proportion, not an exact
-/// character-width computation.
-pub fn bar_width_fraction(trimmed_chars: usize) -> f64 {
-    (trimmed_chars as f64 / ASSUMED_WIDE_LINE_CHARS).clamp(0.0, 1.0)
 }
 
 /// Draw a [`Minimap`] onto `cr`. Returns the layout for host click
@@ -133,17 +159,24 @@ pub fn draw_minimap(
     let saved_font = pango_layout.font_description();
 
     // Clip all row painting to the strip: a legible pitch can still shape
-    // a line longer than `w`, and below-floor colour bars are already
+    // a line longer than `w`, and below-floor colour blocks are already
     // width-bounded but glyphs are not -- without this, text bled across
     // whatever the host painted beside the minimap (#663).
     cr.save().ok();
     cr.rectangle(x, y, w, h);
     cr.clip();
 
+    // One merge-walk over `syntax_spans` for the whole paint, not one
+    // linear rescan per row (#667 pt. 4) -- `visible_lines` is always
+    // ascending in `start_line_idx` (see `Minimap::layout`), matching
+    // `SpanCursor`'s own non-decreasing-query requirement.
+    let mut spans = SpanCursor::new(&minimap.syntax_spans);
+
     for vline in &layout.visible_lines {
         let Some(line) = minimap.lines.get(vline.start_line_idx) else {
             continue;
         };
+        let row_spans = spans.row_spans(vline.start_line_idx);
         match mode {
             MinimapRenderMode::Characters => paint_row_glyphs(
                 cr,
@@ -152,12 +185,11 @@ pub fn draw_minimap(
                 vline,
                 row_px,
                 &line.text,
-                vline.start_line_idx,
-                minimap,
+                row_spans,
                 theme,
             ),
-            MinimapRenderMode::ColorBars => {
-                paint_row_bar(cr, vline, &line.text, vline.start_line_idx, minimap, theme)
+            MinimapRenderMode::ColumnBlocks => {
+                paint_row_blocks(cr, vline, &line.text, row_spans, theme)
             }
         }
     }
@@ -174,18 +206,56 @@ pub fn draw_minimap(
     layout
 }
 
-/// Dominant colour for `start_line_idx`, from whichever aggregated
-/// [`crate::MinimapSpan`] covers the most columns of that line (GTK's
-/// `1x1` aggregation grid means at most a handful of spans per line —
-/// see [`crate::aggregate_spans`]). Falls back to `default_fg`.
-fn dominant_color(minimap: &Minimap, start_line_idx: usize, default_fg: Color) -> Color {
-    minimap
-        .syntax_spans
+/// Walks a [`MinimapSpan`] slice — sorted by `(line_idx, start_col)`, per
+/// [`crate::aggregate_spans`]'s documented output order — once across a
+/// caller-driven sequence of *non-decreasing* `line_idx` queries, hence
+/// one merge-walk in O(rows + spans) total rather than one `filter` scan
+/// of the whole slice per row (#667 pt. 4).
+struct SpanCursor<'a> {
+    spans: &'a [MinimapSpan],
+    pos: usize,
+}
+
+impl<'a> SpanCursor<'a> {
+    fn new(spans: &'a [MinimapSpan]) -> Self {
+        Self { spans, pos: 0 }
+    }
+
+    /// The contiguous run of spans covering `line_idx`. `line_idx` must
+    /// be non-decreasing across successive calls (true for `draw_minimap`'s
+    /// row loop) — an out-of-order query would silently miss spans the
+    /// cursor already walked past.
+    fn row_spans(&mut self, line_idx: usize) -> &'a [MinimapSpan] {
+        while self.pos < self.spans.len() && self.spans[self.pos].line_idx < line_idx {
+            self.pos += 1;
+        }
+        let start = self.pos;
+        let mut end = start;
+        while end < self.spans.len() && self.spans[end].line_idx == line_idx {
+            end += 1;
+        }
+        &self.spans[start..end]
+    }
+}
+
+/// The colour covering character column `col`, from a row's own span
+/// slice (already narrowed to that row by [`SpanCursor`]). Falls back to
+/// `default_fg` when no span covers it.
+fn color_at_column(row_spans: &[MinimapSpan], col: usize, default_fg: Color) -> Color {
+    row_spans
         .iter()
-        .filter(|s| s.line_idx == start_line_idx)
-        .max_by_key(|s| s.end_col.saturating_sub(s.start_col))
+        .find(|s| col >= s.start_col && col < s.end_col)
         .map(|s| s.color)
         .unwrap_or(default_fg)
+}
+
+/// Truncate `text` to at most `n` characters, on a char boundary. Never
+/// allocates — returns a borrowed slice.
+fn truncate_to_columns(text: &str, n: usize) -> &str {
+    match text.char_indices().nth(n) {
+        Some((byte_idx, _)) => &text[..byte_idx],
+        None => text,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -196,8 +266,7 @@ fn paint_row_glyphs(
     vline: &VisibleMinimapLine,
     row_px: f64,
     text: &str,
-    start_line_idx: usize,
-    minimap: &Minimap,
+    row_spans: &[MinimapSpan],
     theme: &Theme,
 ) {
     let mut font = saved_font.cloned().unwrap_or_default();
@@ -209,21 +278,20 @@ fn paint_row_glyphs(
     // long line; the `cr.clip()` in `draw_minimap` is the hard guarantee.
     pango_layout.set_width((vline.bounds.width * pango::SCALE as f32).round() as i32);
     pango_layout.set_ellipsize(pango::EllipsizeMode::End);
-    pango_layout.set_text(text);
 
-    let spans: Vec<_> = minimap
-        .syntax_spans
-        .iter()
-        .filter(|s| s.line_idx == start_line_idx)
-        .collect();
+    // Never shape more than the strip's column capacity worth of a line
+    // (#667 pt. 3) -- a pathologically long line must cost no more to
+    // shape than a short one, mirroring `paint_row_blocks`' own walk cap.
+    let truncated = truncate_to_columns(text, COLUMN_CAPACITY);
+    pango_layout.set_text(truncated);
 
-    if spans.is_empty() {
+    if row_spans.is_empty() {
         pango_layout.set_attributes(None);
     } else {
         let to_u16 = |c: u8| -> u16 { ((c as u16) << 8) | c as u16 };
         let attrs = pango::AttrList::new();
-        for span in &spans {
-            let (start, end) = char_range_to_byte_range(text, span.start_col, span.end_col);
+        for span in row_spans {
+            let (start, end) = char_range_to_byte_range(truncated, span.start_col, span.end_col);
             let mut a = pango::AttrColor::new_foreground(
                 to_u16(span.color.r),
                 to_u16(span.color.g),
@@ -241,28 +309,33 @@ fn paint_row_glyphs(
     super::painted_text::show_layout(cr, pango_layout);
 }
 
-fn paint_row_bar(
+/// Paint one 1px-wide block per non-blank character column of `text`,
+/// each coloured by whichever span covers it — VS Code's
+/// `renderCharacters: false` look, which (unlike a single per-line bar)
+/// preserves the line's indent and internal-gap silhouette (#667 pt. 2).
+/// Stops after [`COLUMN_CAPACITY`] columns, so a pathologically long
+/// line costs no more to paint than a short one.
+fn paint_row_blocks(
     cr: &Context,
     vline: &VisibleMinimapLine,
     text: &str,
-    start_line_idx: usize,
-    minimap: &Minimap,
+    row_spans: &[MinimapSpan],
     theme: &Theme,
 ) {
-    let trimmed = text.trim_end().chars().count();
-    let frac = bar_width_fraction(trimmed);
-    if frac <= 0.0 {
-        return;
+    for (col, ch) in text.chars().enumerate().take(COLUMN_CAPACITY) {
+        if ch.is_whitespace() {
+            continue;
+        }
+        let color = color_at_column(row_spans, col, theme.foreground);
+        set_source(cr, color);
+        cr.rectangle(
+            vline.bounds.x as f64 + col as f64,
+            vline.bounds.y as f64,
+            1.0,
+            vline.bounds.height as f64,
+        );
+        cr.fill().ok();
     }
-    let color = dominant_color(minimap, start_line_idx, theme.muted_fg);
-    set_source(cr, color);
-    cr.rectangle(
-        vline.bounds.x as f64,
-        vline.bounds.y as f64,
-        vline.bounds.width as f64 * frac,
-        vline.bounds.height as f64,
-    );
-    cr.fill().ok();
 }
 
 /// Convert a `[start_col, end_col)` character range into UTF-8 byte
@@ -325,48 +398,62 @@ mod tests {
         (cr, layout)
     }
 
-    // ── font scaling, not a fixed size ──────────────────────────────
+    // ── fixed pitch, not file-length-dependent (#667) ────────────────
 
     #[test]
-    fn same_buffer_at_two_heights_yields_two_different_font_sizes() {
-        // Pitch is bounded (#663: MAX_ROW_PITCH), so read it back from
-        // the resolved layout rather than recomputing `h /
-        // visible_lines.len()` -- that naive division is exactly the
-        // pre-#663 bug and would silently undo the cap.
+    fn row_pitch_is_independent_of_the_strip_height() {
+        // Inverts the old #382/#663 contract on purpose: the same
+        // buffer painted into strips of two very different heights must
+        // now resolve to the *same* row pitch. See `Minimap::layout`'s
+        // module docs for why (`MinimapSizing::FixedPitch`).
         let lines: Vec<&str> = vec!["fn main() {}"; 8];
         let mm = minimap_from(lines, 8);
 
-        let tall = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 80.0); // naive pitch 10px, capped to 8px
-        let short = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 16.0); // naive pitch 2px, under the cap
+        let tall = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 800.0);
+        let short = gtk_minimap_layout(&mm, 0.0, 0.0, 40.0, 16.0);
 
         let tall_px = tall.visible_lines[0].bounds.height as f64;
         let short_px = short.visible_lines[0].bounds.height as f64;
-        assert_ne!(tall_px, short_px);
+        assert_eq!(tall_px, ROW_PITCH_PX);
+        assert_eq!(short_px, ROW_PITCH_PX);
+    }
 
-        let tall_font = minimap_font_px(tall_px);
-        let short_font = minimap_font_px(short_px);
-        assert_ne!(
-            tall_font, short_font,
-            "font size must track row pitch, not a fixed constant"
+    #[test]
+    fn row_pitch_is_independent_of_the_file_length() {
+        // The other half of the same guarantee: a 3-line file and a
+        // 10,000-line file painted into the *same* strip must also
+        // resolve to the same row pitch.
+        let short_mm = minimap_from(vec!["fn main() {}"; 3], 3);
+        let long_lines: Vec<String> = (0..10_000).map(|i| format!("line {i}")).collect();
+        let long_refs: Vec<&str> = long_lines.iter().map(String::as_str).collect();
+        let long_mm = minimap_from(long_refs, 10_000);
+
+        let short_layout = gtk_minimap_layout(&short_mm, 0.0, 0.0, 40.0, 400.0);
+        let long_layout = gtk_minimap_layout(&long_mm, 0.0, 0.0, 40.0, 400.0);
+
+        assert_eq!(
+            short_layout.visible_lines[0].bounds.height as f64,
+            ROW_PITCH_PX
+        );
+        assert_eq!(
+            long_layout.visible_lines[0].bounds.height as f64,
+            ROW_PITCH_PX
         );
     }
 
     #[test]
-    fn short_file_in_a_tall_strip_does_not_hit_the_64px_clamp() {
-        // The exact #663 repro: a 3-line file (e.g. `//! Placeholder
-        // module`) in a strip tall enough that the old `bounds.height /
-        // row_count` division would land at or above
-        // `minimap_font_px`'s 64px ceiling. Capped pitch must keep the
-        // resolved font well under that -- at or below MAX_ROW_PITCH.
+    fn short_file_in_a_tall_strip_does_not_stretch() {
+        // A 3-line file at the fixed pitch occupies 6px of a 200px
+        // strip -- it must not stretch to fill it (the pre-#667 `Fill`
+        // behaviour, now GTK-inapplicable).
         let mm = minimap_from(vec!["//! Placeholder module"; 3], 3);
         let layout = gtk_minimap_layout(&mm, 0.0, 0.0, 200.0, 200.0);
-        let row_px = layout.visible_lines[0].bounds.height as f64;
-        let font_px = minimap_font_px(row_px);
+        assert_eq!(layout.visible_lines.len(), 3);
+        let last = layout.visible_lines.last().unwrap();
         assert!(
-            font_px <= crate::primitives::minimap::MAX_ROW_PITCH as f64,
-            "a short file's font must stay at/below the pitch ceiling, got {font_px}"
+            (last.bounds.y + last.bounds.height) < 200.0,
+            "a short file must not stretch its rows to fill the whole strip"
         );
-        assert!(font_px < 64.0, "must not hit minimap_font_px's clamp");
     }
 
     // ── legibility floor ─────────────────────────────────────────────
@@ -375,7 +462,7 @@ mod tests {
     fn legibility_floor_switches_render_mode_on_both_sides() {
         assert_eq!(
             render_mode(LEGIBILITY_FLOOR_PX - 0.1),
-            MinimapRenderMode::ColorBars
+            MinimapRenderMode::ColumnBlocks
         );
         assert_eq!(
             render_mode(LEGIBILITY_FLOOR_PX),
@@ -388,55 +475,226 @@ mod tests {
     }
 
     #[test]
-    fn below_floor_paints_bars_and_shapes_no_text_above_it_shapes_text() {
+    fn default_fixed_pitch_stays_below_the_floor_and_never_shapes_text() {
+        // ROW_PITCH_PX (2px) is below LEGIBILITY_FLOOR_PX (4px), so the
+        // default GTK minimap always lands in ColumnBlocks -- and,
+        // unlike pre-#667, that no longer changes with strip height.
         let mm = minimap_from(vec!["fn main() {}"; 4], 4);
         let (cr, layout) = surface_and_layout();
 
-        // 4 rows over a 4px-tall area -> pitch 1px, well under the floor.
         let _ = draw_minimap(&cr, &layout, 0.0, 0.0, 40.0, 4.0, &mm, &Theme::default());
-        assert_eq!(
-            layout.text(),
-            "",
-            "below the legibility floor, draw_minimap must never call set_text"
-        );
+        assert_eq!(layout.text(), "");
 
-        // Same buffer, 4 rows over a 400px-tall area -> pitch 100px, well
-        // above the floor.
         let _ = draw_minimap(&cr, &layout, 0.0, 0.0, 40.0, 400.0, &mm, &Theme::default());
         assert_eq!(
             layout.text(),
-            "fn main() {}",
-            "above the legibility floor, draw_minimap must shape the row's text"
+            "",
+            "the fixed pitch stays below the legibility floor regardless of strip height"
         );
     }
 
-    // ── colour aggregation lookup ────────────────────────────────────
+    #[test]
+    fn characters_branch_truncates_to_the_column_capacity_before_shaping() {
+        // The Characters branch is unreachable through the default fixed
+        // pitch today, but it must still bound its shaping cost (#667 pt.
+        // 3) -- exercised directly since `draw_minimap` can't reach it
+        // via `ROW_PITCH_PX` alone.
+        let long_line = "y".repeat(10_000);
+        let (cr, pango_layout) = surface_and_layout();
+        let vline = VisibleMinimapLine {
+            start_line_idx: 0,
+            bounds: QRect::new(0.0, 0.0, 400.0, 20.0),
+        };
+        paint_row_glyphs(
+            &cr,
+            &pango_layout,
+            None,
+            &vline,
+            20.0,
+            &long_line,
+            &[],
+            &Theme::default(),
+        );
+        assert_eq!(
+            pango_layout.text().chars().count(),
+            COLUMN_CAPACITY,
+            "must shape no more than COLUMN_CAPACITY characters even for a 10,000-char line"
+        );
+    }
+
+    // ── per-column colour blocks (#667 pt. 2) ─────────────────────────
 
     #[test]
-    fn dominant_color_picks_the_widest_span_for_the_line() {
-        let mut mm = minimap_from(vec!["abcdef"], 1);
-        let red = Color::rgb(255, 0, 0);
-        let blue = Color::rgb(0, 0, 255);
-        mm.syntax_spans.push(MinimapSpan {
-            line_idx: 0,
-            start_col: 0,
-            end_col: 1,
-            color: red,
-        });
-        mm.syntax_spans.push(MinimapSpan {
-            line_idx: 0,
-            start_col: 1,
-            end_col: 6,
-            color: blue,
-        });
-        assert_eq!(dominant_color(&mm, 0, Color::rgb(1, 1, 1)), blue);
+    fn column_blocks_skip_indentation_and_internal_gaps() {
+        // 4-space indent, "x", 2-space internal gap, "y": the walk must
+        // paint no block over the indent or the gap -- only over the two
+        // non-blank columns, preserving the indent silhouette.
+        let mm = minimap_from(vec!["    x  y"], 1);
+        let theme = Theme {
+            background: Color::rgb(10, 10, 10),
+            foreground: Color::rgb(200, 200, 200),
+            ..Theme::default()
+        };
+
+        let mut surface = ImageSurface::create(Format::ARgb32, 20, 4).expect("create surface");
+        {
+            let cr = CairoContext::new(&surface).expect("Context::new");
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            draw_minimap(&cr, &pango_layout, 0.0, 0.0, 20.0, 4.0, &mm, &theme);
+        }
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        let bg = (theme.background.r, theme.background.g, theme.background.b);
+        let fg = (theme.foreground.r, theme.foreground.g, theme.foreground.b);
+
+        for col in 0..4 {
+            assert_eq!(
+                pixel(&data, stride, col, 0),
+                bg,
+                "indent column {col} must stay blank"
+            );
+        }
+        assert_eq!(
+            pixel(&data, stride, 4, 0),
+            fg,
+            "'x' column must paint a block"
+        );
+        for col in 5..7 {
+            assert_eq!(
+                pixel(&data, stride, col, 0),
+                bg,
+                "gap column {col} must stay blank"
+            );
+        }
+        assert_eq!(
+            pixel(&data, stride, 7, 0),
+            fg,
+            "'y' column must paint a block"
+        );
     }
 
     #[test]
-    fn dominant_color_falls_back_to_default_with_no_spans() {
-        let mm = minimap_from(vec!["abc"], 1);
+    fn column_blocks_stop_at_the_column_capacity() {
+        let long_line = "x".repeat(10_000);
+        let mm = minimap_from(vec![&long_line], 1);
+        let theme = Theme {
+            background: Color::rgb(1, 1, 1),
+            foreground: Color::rgb(250, 250, 250),
+            ..Theme::default()
+        };
+        let strip_w = (COLUMN_CAPACITY + 50) as i32;
+
+        let mut surface = ImageSurface::create(Format::ARgb32, strip_w, 4).expect("create surface");
+        {
+            let cr = CairoContext::new(&surface).expect("Context::new");
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            draw_minimap(
+                &cr,
+                &pango_layout,
+                0.0,
+                0.0,
+                strip_w as f64,
+                4.0,
+                &mm,
+                &theme,
+            );
+        }
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+
+        let fg = (theme.foreground.r, theme.foreground.g, theme.foreground.b);
+        let bg = (theme.background.r, theme.background.g, theme.background.b);
+        assert_eq!(
+            pixel(&data, stride, (COLUMN_CAPACITY - 1) as i32, 0),
+            fg,
+            "the last in-capacity column must still paint"
+        );
+        assert_eq!(
+            pixel(&data, stride, COLUMN_CAPACITY as i32, 0),
+            bg,
+            "the walk must stop at COLUMN_CAPACITY and paint no further"
+        );
+    }
+
+    // ── colour lookup (#667 pt. 4) ────────────────────────────────────
+
+    #[test]
+    fn color_at_column_picks_the_span_covering_that_column() {
+        let red = Color::rgb(255, 0, 0);
+        let blue = Color::rgb(0, 0, 255);
+        let spans = vec![
+            MinimapSpan {
+                line_idx: 0,
+                start_col: 0,
+                end_col: 1,
+                color: red,
+            },
+            MinimapSpan {
+                line_idx: 0,
+                start_col: 1,
+                end_col: 6,
+                color: blue,
+            },
+        ];
+        assert_eq!(color_at_column(&spans, 0, Color::rgb(1, 1, 1)), red);
+        assert_eq!(color_at_column(&spans, 3, Color::rgb(1, 1, 1)), blue);
+    }
+
+    #[test]
+    fn color_at_column_falls_back_to_default_outside_any_span() {
         let fallback = Color::rgb(9, 9, 9);
-        assert_eq!(dominant_color(&mm, 0, fallback), fallback);
+        assert_eq!(color_at_column(&[], 2, fallback), fallback);
+    }
+
+    #[test]
+    fn span_cursor_matches_a_full_linear_scan_per_row() {
+        // Same colours out as the old O(rows * spans) `filter` rescan,
+        // just walked once in O(rows + spans) total.
+        let red = Color::rgb(255, 0, 0);
+        let blue = Color::rgb(0, 0, 255);
+        let green = Color::rgb(0, 255, 0);
+        let spans = vec![
+            MinimapSpan {
+                line_idx: 0,
+                start_col: 0,
+                end_col: 2,
+                color: red,
+            },
+            MinimapSpan {
+                line_idx: 0,
+                start_col: 2,
+                end_col: 4,
+                color: blue,
+            },
+            MinimapSpan {
+                line_idx: 2,
+                start_col: 0,
+                end_col: 3,
+                color: green,
+            },
+            MinimapSpan {
+                line_idx: 5,
+                start_col: 1,
+                end_col: 2,
+                color: red,
+            },
+        ];
+        let mut cursor = SpanCursor::new(&spans);
+        for line_idx in 0..6 {
+            let via_cursor = cursor.row_spans(line_idx).to_vec();
+            let via_linear: Vec<MinimapSpan> = spans
+                .iter()
+                .filter(|s| s.line_idx == line_idx)
+                .cloned()
+                .collect();
+            assert_eq!(
+                via_cursor, via_linear,
+                "row {line_idx} spans must match a full linear scan"
+            );
+        }
     }
 
     // ── paint/click round trip ────────────────────────────────────────
@@ -491,7 +749,7 @@ mod tests {
         assert!(layout.visible_lines.is_empty());
     }
 
-    // ── glyph clipping (#663) ───────────────────────────────────────────
+    // ── strip clipping (#663) ───────────────────────────────────────────
 
     /// Read an RGB triple from an ARgb32 surface at pixel (x, y).
     ///
@@ -503,7 +761,7 @@ mod tests {
     }
 
     #[test]
-    fn wide_line_glyphs_never_paint_right_of_bounds() {
+    fn wide_line_blocks_never_paint_right_of_bounds() {
         // Pre-#663 there was no `cr.clip()` and no Pango layout width, so
         // a line wider than the strip painted straight across whatever
         // sat beside it (in vimcode's case, the neighbouring editor
@@ -530,10 +788,11 @@ mod tests {
                 foreground: Color::rgb(255, 255, 255),
                 ..Theme::default()
             };
-            // One row over 40px -> pitch capped at MAX_ROW_PITCH (8px),
-            // above the legibility floor, so this exercises the
-            // Characters branch (glyph shaping), not the colour-bar
-            // fallback.
+            // The fixed pitch (ROW_PITCH_PX, 2px) is below the
+            // legibility floor, so this exercises the ColumnBlocks
+            // branch -- the column-capacity walk on its own already
+            // bounds how far right it paints, but the clip is still the
+            // hard guarantee this test checks.
             draw_minimap(
                 &cr,
                 &pango_layout,

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -94,8 +94,8 @@ pub use menu_bar::{draw_menu_bar, gtk_menu_bar_layout};
 pub use menu_overlay::MenuOverlay;
 pub use message_list::draw_message_list;
 pub use minimap::{
-    bar_width_fraction, draw_minimap, gtk_minimap_layout, is_legible, minimap_font_px, render_mode,
-    MinimapRenderMode, LEGIBILITY_FLOOR_PX,
+    draw_minimap, gtk_minimap_layout, is_legible, minimap_font_px, render_mode, MinimapRenderMode,
+    COLUMN_CAPACITY, LEGIBILITY_FLOOR_PX, ROW_PITCH_PX,
 };
 pub use multi_section_view::{
     draw_multi_section_view, gtk_msv_layout, metrics_for as multi_section_view_metrics,

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -240,7 +240,7 @@ pub use primitives::menu_bar::{
 pub use primitives::message_list::{MessageList, MessageRow};
 pub use primitives::minimap::{
     aggregate_spans, reserved_width, sample_lines, Minimap, MinimapGrid, MinimapHit, MinimapLayout,
-    MinimapLine, MinimapSpan, SyntaxSpan, VisibleMinimapLine,
+    MinimapLine, MinimapSizing, MinimapSpan, SyntaxSpan, VisibleMinimapLine,
 };
 pub use primitives::modal::{Modal, ModalEvent, ModalHit, ModalLayout};
 pub use primitives::multi_section_view::{

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -2023,8 +2023,9 @@ impl Backend for MacBackend {
         }
     }
 
-    /// #382 scopes the `Minimap` rasteriser to GTK (font scaling) and TUI
-    /// (braille) only — macOS and Win-GUI rasterisers are explicitly out
+    /// #382 scopes the `Minimap` rasteriser to GTK (fixed-pitch colour
+    /// blocks, #667) and TUI (braille) only — macOS and Win-GUI
+    /// rasterisers are explicitly out
     /// of scope until those backends carry the rest of the editor chrome.
     /// The trait method itself is still mandatory here (rule 7: no
     /// default impl, in-tree-only cost), so this is a deliberate `todo!`

--- a/quadraui/src/primitives/minimap.rs
+++ b/quadraui/src/primitives/minimap.rs
@@ -20,18 +20,35 @@
 //! for GTK, typically one entry per rendered row; for TUI, four
 //! consecutive entries are packed into one braille row. [`Minimap::layout`]
 //! takes `lines_per_row` (the backend's own grouping factor: `1` for GTK,
-//! `4` for TUI) and groups `lines` into that many rows, tiling them across
-//! `bounds.height` at a pitch that is never allowed to exceed
-//! [`MAX_ROW_PITCH`] (issue #663) — a file short enough that `bounds.height
-//! / row_count` would blow past that ceiling instead top-aligns and only
-//! occupies `row_count * row_h` of the strip, leaving the remainder
-//! unpainted, rather than stretching to fill it. Each
-//! [`VisibleMinimapLine::bounds`] carries the *resolved* (already-capped)
-//! row height, so a rasteriser reads its pitch straight off the layout
+//! `4` for TUI) and groups `lines` into that many rows, then tiles those
+//! rows according to [`MinimapSizing`] (issue #667):
+//!
+//! - [`MinimapSizing::Fill`] — stretch to fill `bounds.height`, at a pitch
+//!   that is never allowed to exceed [`MAX_ROW_PITCH`] (issue #663): a file
+//!   short enough that `bounds.height / row_count` would blow past that
+//!   ceiling instead top-aligns and only occupies `row_count * row_h` of
+//!   the strip, leaving the remainder unpainted, rather than stretching to
+//!   fill it. TUI is the only user — it is cell-native (braille rows) and
+//!   has no font to scale.
+//! - [`MinimapSizing::FixedPitch`] — rows tile top-down at exactly the
+//!   given pitch, regardless of `row_count`. When more rows exist than the
+//!   strip can hold at that pitch, [`Minimap::layout`] doesn't shrink the
+//!   pitch to compress everything in — it slides: only a window of
+//!   `bounds.height / pitch` rows is shown at once, and that window's
+//!   position tracks [`Minimap::visible_row_start`] against
+//!   [`Minimap::total_buffer_lines`] (VS Code's `minimap.size:
+//!   proportional`). GTK is the only user, and this is what makes a
+//!   minimap row's on-screen size independent of the file's length: the
+//!   same buffer, painted into the same strip, always resolves to the same
+//!   `vline.bounds.height` no matter how many lines it has.
+//!
+//! Each [`VisibleMinimapLine::bounds`] carries the *resolved* row height
+//! and position, so a rasteriser reads its pitch straight off the layout
 //! (`vline.bounds.height`) instead of re-deriving it via `bounds.height /
-//! layout.visible_lines.len()` — re-deriving it that way silently
-//! undoes the cap (see the rasteriser spec in #382, and #663 for the bug
-//! this replaced).
+//! layout.visible_lines.len()` — re-deriving it that way silently undoes
+//! both the [`MAX_ROW_PITCH`] cap under `Fill` and the fixed pitch itself
+//! under `FixedPitch` (see the rasteriser spec in #382, #663 for the
+//! `Fill` bug this replaced, and #667 for `FixedPitch`).
 //!
 //! `visible_row_start` / `visible_row_count` describe the *editor's*
 //! current viewport as an index range into `lines` (not a separate scroll
@@ -41,7 +58,8 @@
 //! [`MinimapLine::line_idx`] as the bridge back to real buffer line
 //! numbers (sampling may skip lines, so a `lines`-relative fraction and a
 //! `total_buffer_lines`-relative fraction are not the same thing whenever
-//! sampling is non-uniform).
+//! sampling is non-uniform). [`MinimapSizing::FixedPitch`]'s own slide
+//! offset uses that same buffer-line bridge, for the same reason.
 
 use crate::event::Rect;
 use crate::primitives::scrollbar::Scrollbar;
@@ -145,24 +163,43 @@ pub struct MinimapLayout {
     pub scrollbar: Option<Scrollbar>,
 }
 
-/// Ceiling on a minimap row's pitch, in `bounds`'s own coordinate units
-/// (device pixels for GTK, terminal cell rows for TUI) — issue #663.
+/// Ceiling on a minimap row's pitch under [`MinimapSizing::Fill`], in
+/// `bounds`'s own coordinate units (terminal cell rows for TUI, the only
+/// remaining `Fill` user as of #667 — GTK moved to
+/// [`MinimapSizing::FixedPitch`]) — issue #663.
 ///
-/// Without a ceiling, [`Minimap::layout`]'s `row_h` is `bounds.height /
-/// row_count`, which grows without bound as a file gets shorter than the
-/// strip. For GTK, which maps pitch directly to an absolute Pango font
-/// size (`gtk::minimap::minimap_font_px`), that meant a short file's font
-/// ballooned toward that function's own 64px clamp — a 3-line file
-/// rendered at near-editor scale. `MAX_ROW_PITCH` keeps a minimap always
-/// minimap-sized: comfortably above the 4px legibility floor (so short
-/// files still render real glyphs, not colour bars) but nowhere near a
-/// normal ~18px editor line height. Below the ceiling, `row_count *
-/// row_h` rows top-align inside `bounds` and the remainder of the strip
-/// stays unpainted — mirroring [`sample_lines`]'s own never-upscale rule.
-/// Long files are unaffected: `bounds.height / row_count` is already
-/// below the ceiling once the caller's sampling has downsampled them to
-/// roughly fit the strip.
+/// Without a ceiling, `Fill`'s `row_h` is `bounds.height / row_count`,
+/// which grows without bound as a file gets shorter than the strip.
+/// `MAX_ROW_PITCH` keeps a `Fill`-sized minimap always minimap-sized.
+/// Below the ceiling, `row_count * row_h` rows top-align inside `bounds`
+/// and the remainder of the strip stays unpainted — mirroring
+/// [`sample_lines`]'s own never-upscale rule. Long files are unaffected:
+/// `bounds.height / row_count` is already below the ceiling once the
+/// caller's sampling has downsampled them to roughly fit the strip.
 pub const MAX_ROW_PITCH: f32 = 8.0;
+
+/// How [`Minimap::layout`] sizes rows across `bounds.height` — issue #667.
+///
+/// The two backends want opposite things: TUI's braille rows are
+/// cell-native and have no font to scale, so it always wants to fill the
+/// strip ([`Self::Fill`]). GTK's row pitch drives a Pango font size (or,
+/// below the legibility floor, a colour block), so a file-length-dependent
+/// pitch means a file-length-dependent glyph size — exactly the defect
+/// #667 removes. GTK always wants [`Self::FixedPitch`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MinimapSizing {
+    /// Stretch rows to fill `bounds.height`, capped at [`MAX_ROW_PITCH`]
+    /// (#663). A file shorter than the strip at that cap top-aligns
+    /// rather than stretching further; there is no sliding window — every
+    /// row is always visible.
+    Fill,
+    /// Tile rows top-down at exactly this pitch (in `bounds`'s own
+    /// coordinate units), regardless of `row_count`. When the file needs
+    /// more rows than `bounds.height / pitch` holds, [`Minimap::layout`]
+    /// shows a sliding window onto the map — see the module docs — instead
+    /// of shrinking the pitch to compress everything in.
+    FixedPitch(f32),
+}
 
 /// Classification of a minimap hit-test result.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -192,8 +229,14 @@ impl Minimap {
     /// Compute layout + hit regions. `lines_per_row` is the backend's
     /// grouping factor (`1` for GTK, `4` for TUI) — see the module docs
     /// for why layout needs it but painting-only metrics (font size,
-    /// dot density) don't.
-    pub fn layout(&self, bounds: Rect, lines_per_row: usize) -> MinimapLayout {
+    /// dot density) don't. `sizing` picks the row-pitch strategy — see
+    /// [`MinimapSizing`].
+    pub fn layout(
+        &self,
+        bounds: Rect,
+        lines_per_row: usize,
+        sizing: MinimapSizing,
+    ) -> MinimapLayout {
         let lines_per_row = lines_per_row.max(1);
 
         if self.lines.is_empty() || bounds.width <= 0.0 || bounds.height <= 0.0 {
@@ -206,29 +249,53 @@ impl Minimap {
         }
 
         let row_count = self.lines.len().div_ceil(lines_per_row);
-        // Bounded, not stretch-to-fill: see MAX_ROW_PITCH's doc for why a
-        // short file must not blow its pitch (and, for GTK, its font
-        // size) up to fill the whole strip (#663).
-        let row_h = (bounds.height / row_count as f32).min(MAX_ROW_PITCH);
 
-        let visible_lines: Vec<VisibleMinimapLine> = (0..row_count)
-            .map(|r| VisibleMinimapLine {
-                start_line_idx: r * lines_per_row,
-                bounds: Rect::new(bounds.x, bounds.y + row_h * r as f32, bounds.width, row_h),
+        let (row_h, window_start_row, rows_shown) = match sizing {
+            MinimapSizing::Fill => {
+                // Bounded, not stretch-to-fill: see MAX_ROW_PITCH's doc
+                // for why a short file must not blow its pitch up to fill
+                // the whole strip (#663). No sliding window: every row is
+                // always visible.
+                let row_h = (bounds.height / row_count as f32).min(MAX_ROW_PITCH);
+                (row_h, 0usize, row_count)
+            }
+            MinimapSizing::FixedPitch(px) => {
+                let row_h = px.max(f32::MIN_POSITIVE);
+                let rows_that_fit = (bounds.height / row_h).floor() as usize;
+                let rows_shown = rows_that_fit.min(row_count);
+                let window_start_row = self.slide_window_start_row(row_count, rows_shown);
+                (row_h, window_start_row, rows_shown)
+            }
+        };
+
+        let visible_lines: Vec<VisibleMinimapLine> = (0..rows_shown)
+            .map(|i| {
+                let r = window_start_row + i;
+                VisibleMinimapLine {
+                    start_line_idx: r * lines_per_row,
+                    bounds: Rect::new(bounds.x, bounds.y + row_h * i as f32, bounds.width, row_h),
+                }
             })
             .collect();
 
-        let start_row = (self.visible_row_start / lines_per_row) as f32;
+        // Absolute row positions of the editor's viewport, then clipped
+        // into the visible window (`FixedPitch` may be sliding, so the
+        // editor's viewport band can be partly or wholly off-strip).
+        let start_row_abs = (self.visible_row_start / lines_per_row) as f32;
         let end_line = (self.visible_row_start + self.visible_row_count).min(self.lines.len());
-        let end_row = if end_line == 0 {
+        let end_row_abs = if end_line == 0 {
             0.0
         } else {
             ((end_line - 1) / lines_per_row) as f32 + 1.0
         };
-        let highlight_h = (end_row - start_row).max(0.0) * row_h;
+        let window_lo = window_start_row as f32;
+        let window_hi = (window_start_row + rows_shown) as f32;
+        let clipped_start = start_row_abs.clamp(window_lo, window_hi);
+        let clipped_end = end_row_abs.clamp(window_lo, window_hi);
+        let highlight_h = (clipped_end - clipped_start).max(0.0) * row_h;
         let viewport_highlight = Rect::new(
             bounds.x,
-            bounds.y + start_row * row_h,
+            bounds.y + (clipped_start - window_lo) * row_h,
             bounds.width,
             highlight_h,
         );
@@ -241,6 +308,34 @@ impl Minimap {
             viewport_highlight,
             scrollbar,
         }
+    }
+
+    /// First row index shown by a [`MinimapSizing::FixedPitch`] window of
+    /// `rows_shown` rows out of `row_count` total — the "slide" the module
+    /// docs describe. `0` when the whole map already fits (`row_count <=
+    /// rows_shown`, or `rows_shown == 0`). Otherwise tracks how far
+    /// [`Self::visible_row_start`] (mapped to a real buffer line via
+    /// [`MinimapLine::line_idx`], the same bridge [`Self::scroll_thumb`]
+    /// uses) has advanced through [`Self::total_buffer_lines`], so both
+    /// ends of the file are reachable: the window sits at the top when the
+    /// editor viewport is at the top, and at the bottom when it's at the
+    /// bottom.
+    fn slide_window_start_row(&self, row_count: usize, rows_shown: usize) -> usize {
+        if rows_shown == 0 || row_count <= rows_shown {
+            return 0;
+        }
+        let max_start = row_count - rows_shown;
+        if self.total_buffer_lines <= 1 {
+            return 0;
+        }
+        let start_buffer_line = self
+            .lines
+            .get(self.visible_row_start)
+            .map(|l| l.line_idx)
+            .unwrap_or(0);
+        let denom = (self.total_buffer_lines - 1) as f32;
+        let fraction = (start_buffer_line as f32 / denom).clamp(0.0, 1.0);
+        ((fraction * max_start as f32).round() as usize).min(max_start)
     }
 
     /// Scroll-thumb geometry for the editor's viewport within the whole
@@ -427,7 +522,7 @@ mod tests {
         // (that's `layout_caps_row_pitch_and_top_aligns_short_files`,
         // below).
         let bounds = Rect::new(0.0, 0.0, 10.0, 16.0);
-        let layout = mm.layout(bounds, 2); // 8 lines / 2 per row = 4 rows
+        let layout = mm.layout(bounds, 2, MinimapSizing::Fill); // 8 lines / 2 per row = 4 rows
         assert_eq!(layout.visible_lines.len(), 4);
         assert_eq!(
             layout.visible_lines[0].bounds,
@@ -450,7 +545,7 @@ mod tests {
         // grouped 2-per-row -> row 1 (start) through row 3 (exclusive).
         let mm = minimap(8, 2, 3);
         let bounds = Rect::new(0.0, 0.0, 10.0, 16.0); // pitch 4px, under the cap
-        let layout = mm.layout(bounds, 2);
+        let layout = mm.layout(bounds, 2, MinimapSizing::Fill);
         assert_eq!(layout.viewport_highlight, Rect::new(0.0, 4.0, 10.0, 8.0));
     }
 
@@ -464,7 +559,7 @@ mod tests {
         // the tall strip stays unpainted rather than stretching to fill.
         let mm = minimap(3, 0, 3);
         let bounds = Rect::new(0.0, 0.0, 40.0, 200.0);
-        let layout = mm.layout(bounds, 1);
+        let layout = mm.layout(bounds, 1, MinimapSizing::Fill);
         assert_eq!(layout.visible_lines.len(), 3);
         for vline in &layout.visible_lines {
             assert!(
@@ -490,7 +585,7 @@ mod tests {
     #[test]
     fn layout_empty_lines_is_a_no_op() {
         let mm = minimap(0, 0, 0);
-        let layout = mm.layout(Rect::new(0.0, 0.0, 10.0, 40.0), 4);
+        let layout = mm.layout(Rect::new(0.0, 0.0, 10.0, 40.0), 4, MinimapSizing::Fill);
         assert!(layout.visible_lines.is_empty());
         assert_eq!(layout.viewport_highlight.height, 0.0);
     }
@@ -498,8 +593,85 @@ mod tests {
     #[test]
     fn layout_zero_size_bounds_is_a_no_op() {
         let mm = minimap(8, 0, 4);
-        let layout = mm.layout(Rect::new(0.0, 0.0, 0.0, 0.0), 4);
+        let layout = mm.layout(Rect::new(0.0, 0.0, 0.0, 0.0), 4, MinimapSizing::Fill);
         assert!(layout.visible_lines.is_empty());
+    }
+
+    // ── MinimapSizing::FixedPitch (#667) ────────────────────────────
+
+    #[test]
+    fn fixed_pitch_row_height_is_independent_of_file_length() {
+        // The core #667 acceptance test: the same strip, at the same
+        // fixed pitch, yields an identical row height for a 3-line file
+        // and a 10,000-line file -- unlike `Fill`, where a short file's
+        // pitch balloons and a long file's pitch shrinks.
+        let bounds = Rect::new(0.0, 0.0, 40.0, 400.0);
+        let short = minimap(3, 0, 3);
+        let long = minimap(10_000, 0, 10);
+
+        let short_layout = short.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        let long_layout = long.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+
+        assert_eq!(short_layout.visible_lines[0].bounds.height, 2.0);
+        assert_eq!(long_layout.visible_lines[0].bounds.height, 2.0);
+        assert_eq!(
+            short_layout.visible_lines[0].bounds.height,
+            long_layout.visible_lines[0].bounds.height
+        );
+    }
+
+    #[test]
+    fn fixed_pitch_short_file_top_aligns_without_stretching() {
+        // 3 rows at a 2px pitch only occupy 6px of a 400px strip -- no
+        // windowing needed, no stretching either.
+        let mm = minimap(3, 0, 3);
+        let bounds = Rect::new(0.0, 0.0, 40.0, 400.0);
+        let layout = mm.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        assert_eq!(layout.visible_lines.len(), 3);
+        let last = layout.visible_lines.last().unwrap();
+        assert!(last.bounds.y + last.bounds.height < bounds.height);
+    }
+
+    #[test]
+    fn fixed_pitch_slides_monotonically_and_reaches_both_ends() {
+        // 1000 rows at 2px pitch need 2000px; a 200px strip only shows
+        // 100 at a time, so the window must slide as visible_row_start
+        // advances -- and both ends of the file must be reachable.
+        let bounds = Rect::new(0.0, 0.0, 40.0, 200.0);
+        let n = 1000;
+
+        let mut starts = Vec::new();
+        for visible_row_start in [0, 100, 300, 500, 700, 900, 999] {
+            let mm = minimap(n, visible_row_start, 1);
+            let layout = mm.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+            let first_line_idx = layout.visible_lines.first().unwrap().start_line_idx;
+            starts.push(first_line_idx);
+        }
+
+        assert!(
+            starts.windows(2).all(|w| w[0] <= w[1]),
+            "window start must advance monotonically as visible_row_start advances: {starts:?}"
+        );
+        assert_eq!(
+            starts[0], 0,
+            "scrolled to the top, the window starts at row 0"
+        );
+        assert_eq!(
+            *starts.last().unwrap(),
+            n - 100,
+            "scrolled to the bottom, the window's last row must reach the file's end"
+        );
+    }
+
+    #[test]
+    fn fixed_pitch_whole_file_fits_needs_no_slide() {
+        // row_count (100) <= rows that fit (100 at 2px in 200px): every
+        // row is visible regardless of visible_row_start.
+        let mm = minimap(100, 50, 1);
+        let bounds = Rect::new(0.0, 0.0, 40.0, 200.0);
+        let layout = mm.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        assert_eq!(layout.visible_lines.len(), 100);
+        assert_eq!(layout.visible_lines[0].start_line_idx, 0);
     }
 
     // ── hit_test ─────────────────────────────────────────────────────

--- a/quadraui/src/primitives/minimap.rs
+++ b/quadraui/src/primitives/minimap.rs
@@ -18,10 +18,15 @@
 //!
 //! [`Minimap::lines`] is the *fine-grained* list the app chose to show —
 //! for GTK, typically one entry per rendered row; for TUI, four
-//! consecutive entries are packed into one braille row. [`Minimap::layout`]
-//! takes `lines_per_row` (the backend's own grouping factor: `1` for GTK,
-//! `4` for TUI) and groups `lines` into that many rows, then tiles those
-//! rows according to [`MinimapSizing`] (issue #667):
+//! consecutive entries are packed into one braille row.
+//! [`Minimap::layout_with_sizing`] takes `lines_per_row` (the backend's own
+//! grouping factor: `1` for GTK, `4` for TUI) and groups `lines` into that
+//! many rows, then tiles those rows according to [`MinimapSizing`] (issue
+//! #667). [`Minimap::layout`] is the pre-#667 two-argument shape, kept as a
+//! deprecated shim over `layout_with_sizing(bounds, lines_per_row,
+//! MinimapSizing::Fill)` for source compatibility (see the *Downstream
+//! consumers* section of `CLAUDE.md`) — new call sites should use
+//! `layout_with_sizing` directly:
 //!
 //! - [`MinimapSizing::Fill`] — stretch to fill `bounds.height`, at a pitch
 //!   that is never allowed to exceed [`MAX_ROW_PITCH`] (issue #663): a file
@@ -32,8 +37,8 @@
 //!   has no font to scale.
 //! - [`MinimapSizing::FixedPitch`] — rows tile top-down at exactly the
 //!   given pitch, regardless of `row_count`. When more rows exist than the
-//!   strip can hold at that pitch, [`Minimap::layout`] doesn't shrink the
-//!   pitch to compress everything in — it slides: only a window of
+//!   strip can hold at that pitch, [`Minimap::layout_with_sizing`] doesn't
+//!   shrink the pitch to compress everything in — it slides: only a window of
 //!   `bounds.height / pitch` rows is shown at once, and that window's
 //!   position tracks [`Minimap::visible_row_start`] against
 //!   [`Minimap::total_buffer_lines`] (VS Code's `minimap.size:
@@ -226,12 +231,32 @@ impl MinimapLayout {
 }
 
 impl Minimap {
+    /// Pre-#667 two-argument shape of [`Self::layout_with_sizing`], kept as
+    /// a deprecated shim for source compatibility with out-of-tree callers
+    /// (per CLAUDE.md's rule 8 deprecate-then-remove protocol —
+    /// `vimcode`'s `src/render.rs::minimap_click_line` calls this exact
+    /// 2-arg shape with no version pin on this crate). Forwards to
+    /// [`Self::layout_with_sizing`] with [`MinimapSizing::Fill`], which is
+    /// this method's own pre-#667 behaviour byte-for-byte — this shim does
+    /// not change what any existing caller sees.
+    ///
+    /// New call sites — everything in this crate, and any new downstream
+    /// code — should call [`Self::layout_with_sizing`] directly and choose
+    /// a `sizing` explicitly instead of relying on this default.
+    #[deprecated(
+        since = "0.0.1",
+        note = "use `layout_with_sizing(bounds, lines_per_row, sizing)` instead — this shim defaults to `MinimapSizing::Fill` (#667)"
+    )]
+    pub fn layout(&self, bounds: Rect, lines_per_row: usize) -> MinimapLayout {
+        self.layout_with_sizing(bounds, lines_per_row, MinimapSizing::Fill)
+    }
+
     /// Compute layout + hit regions. `lines_per_row` is the backend's
     /// grouping factor (`1` for GTK, `4` for TUI) — see the module docs
     /// for why layout needs it but painting-only metrics (font size,
     /// dot density) don't. `sizing` picks the row-pitch strategy — see
     /// [`MinimapSizing`].
-    pub fn layout(
+    pub fn layout_with_sizing(
         &self,
         bounds: Rect,
         lines_per_row: usize,
@@ -328,11 +353,16 @@ impl Minimap {
         if self.total_buffer_lines <= 1 {
             return 0;
         }
+        // `visible_row_start` is caller-supplied and expected to stay in
+        // `0..self.lines.len()`; if it's ever out of range, treat that as
+        // "the viewport is past the end of the file" rather than "at the
+        // top" — falling back to `0` would snap the slide window to the
+        // top of the file on out-of-range input, which is the wrong end.
         let start_buffer_line = self
             .lines
             .get(self.visible_row_start)
             .map(|l| l.line_idx)
-            .unwrap_or(0);
+            .unwrap_or_else(|| self.total_buffer_lines.saturating_sub(1));
         let denom = (self.total_buffer_lines - 1) as f32;
         let fraction = (start_buffer_line as f32 / denom).clamp(0.0, 1.0);
         ((fraction * max_start as f32).round() as usize).min(max_start)
@@ -522,7 +552,7 @@ mod tests {
         // (that's `layout_caps_row_pitch_and_top_aligns_short_files`,
         // below).
         let bounds = Rect::new(0.0, 0.0, 10.0, 16.0);
-        let layout = mm.layout(bounds, 2, MinimapSizing::Fill); // 8 lines / 2 per row = 4 rows
+        let layout = mm.layout_with_sizing(bounds, 2, MinimapSizing::Fill); // 8 lines / 2 per row = 4 rows
         assert_eq!(layout.visible_lines.len(), 4);
         assert_eq!(
             layout.visible_lines[0].bounds,
@@ -540,12 +570,28 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // exercising the deprecated shim itself (#667)
+    fn deprecated_layout_shim_matches_layout_with_sizing_fill() {
+        // The pre-#667 two-argument `layout()` must keep resolving exactly
+        // like `layout_with_sizing(.., MinimapSizing::Fill)` -- that's the
+        // whole point of the shim (CLAUDE.md rule 8: `vimcode`'s
+        // `src/render.rs::minimap_click_line` still calls the 2-arg form
+        // with no version pin on this crate, so its behaviour must not
+        // change out from under it).
+        let mm = minimap(8, 2, 3);
+        let bounds = Rect::new(0.0, 0.0, 10.0, 16.0);
+        let shim = mm.layout(bounds, 2);
+        let direct = mm.layout_with_sizing(bounds, 2, MinimapSizing::Fill);
+        assert_eq!(shim, direct);
+    }
+
+    #[test]
     fn layout_viewport_highlight_spans_the_editor_viewport() {
         // visible_row_start=2, visible_row_count=3 -> lines[2..5), rows
         // grouped 2-per-row -> row 1 (start) through row 3 (exclusive).
         let mm = minimap(8, 2, 3);
         let bounds = Rect::new(0.0, 0.0, 10.0, 16.0); // pitch 4px, under the cap
-        let layout = mm.layout(bounds, 2, MinimapSizing::Fill);
+        let layout = mm.layout_with_sizing(bounds, 2, MinimapSizing::Fill);
         assert_eq!(layout.viewport_highlight, Rect::new(0.0, 4.0, 10.0, 8.0));
     }
 
@@ -559,7 +605,7 @@ mod tests {
         // the tall strip stays unpainted rather than stretching to fill.
         let mm = minimap(3, 0, 3);
         let bounds = Rect::new(0.0, 0.0, 40.0, 200.0);
-        let layout = mm.layout(bounds, 1, MinimapSizing::Fill);
+        let layout = mm.layout_with_sizing(bounds, 1, MinimapSizing::Fill);
         assert_eq!(layout.visible_lines.len(), 3);
         for vline in &layout.visible_lines {
             assert!(
@@ -585,7 +631,7 @@ mod tests {
     #[test]
     fn layout_empty_lines_is_a_no_op() {
         let mm = minimap(0, 0, 0);
-        let layout = mm.layout(Rect::new(0.0, 0.0, 10.0, 40.0), 4, MinimapSizing::Fill);
+        let layout = mm.layout_with_sizing(Rect::new(0.0, 0.0, 10.0, 40.0), 4, MinimapSizing::Fill);
         assert!(layout.visible_lines.is_empty());
         assert_eq!(layout.viewport_highlight.height, 0.0);
     }
@@ -593,7 +639,7 @@ mod tests {
     #[test]
     fn layout_zero_size_bounds_is_a_no_op() {
         let mm = minimap(8, 0, 4);
-        let layout = mm.layout(Rect::new(0.0, 0.0, 0.0, 0.0), 4, MinimapSizing::Fill);
+        let layout = mm.layout_with_sizing(Rect::new(0.0, 0.0, 0.0, 0.0), 4, MinimapSizing::Fill);
         assert!(layout.visible_lines.is_empty());
     }
 
@@ -609,8 +655,8 @@ mod tests {
         let short = minimap(3, 0, 3);
         let long = minimap(10_000, 0, 10);
 
-        let short_layout = short.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
-        let long_layout = long.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        let short_layout = short.layout_with_sizing(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        let long_layout = long.layout_with_sizing(bounds, 1, MinimapSizing::FixedPitch(2.0));
 
         assert_eq!(short_layout.visible_lines[0].bounds.height, 2.0);
         assert_eq!(long_layout.visible_lines[0].bounds.height, 2.0);
@@ -626,7 +672,7 @@ mod tests {
         // windowing needed, no stretching either.
         let mm = minimap(3, 0, 3);
         let bounds = Rect::new(0.0, 0.0, 40.0, 400.0);
-        let layout = mm.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        let layout = mm.layout_with_sizing(bounds, 1, MinimapSizing::FixedPitch(2.0));
         assert_eq!(layout.visible_lines.len(), 3);
         let last = layout.visible_lines.last().unwrap();
         assert!(last.bounds.y + last.bounds.height < bounds.height);
@@ -643,7 +689,7 @@ mod tests {
         let mut starts = Vec::new();
         for visible_row_start in [0, 100, 300, 500, 700, 900, 999] {
             let mm = minimap(n, visible_row_start, 1);
-            let layout = mm.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+            let layout = mm.layout_with_sizing(bounds, 1, MinimapSizing::FixedPitch(2.0));
             let first_line_idx = layout.visible_lines.first().unwrap().start_line_idx;
             starts.push(first_line_idx);
         }
@@ -664,12 +710,32 @@ mod tests {
     }
 
     #[test]
+    fn fixed_pitch_out_of_range_visible_row_start_slides_to_the_end() {
+        // `visible_row_start >= lines.len()` is out-of-range input (callers
+        // are expected to keep it in bounds), but `slide_window_start_row`
+        // must not silently snap to the top of the file for it -- that's
+        // the wrong end for a viewport that's (nominally) past the end.
+        let bounds = Rect::new(0.0, 0.0, 40.0, 200.0);
+        let n = 1000;
+        let mut mm = minimap(n, 0, 1);
+        mm.visible_row_start = n; // one past the last valid `lines` index
+
+        let layout = mm.layout_with_sizing(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        let first_line_idx = layout.visible_lines.first().unwrap().start_line_idx;
+        assert_eq!(
+            first_line_idx,
+            n - 100,
+            "out-of-range visible_row_start must slide to the bottom of the file, not the top"
+        );
+    }
+
+    #[test]
     fn fixed_pitch_whole_file_fits_needs_no_slide() {
         // row_count (100) <= rows that fit (100 at 2px in 200px): every
         // row is visible regardless of visible_row_start.
         let mm = minimap(100, 50, 1);
         let bounds = Rect::new(0.0, 0.0, 40.0, 200.0);
-        let layout = mm.layout(bounds, 1, MinimapSizing::FixedPitch(2.0));
+        let layout = mm.layout_with_sizing(bounds, 1, MinimapSizing::FixedPitch(2.0));
         assert_eq!(layout.visible_lines.len(), 100);
         assert_eq!(layout.visible_lines[0].start_line_idx, 0);
     }

--- a/quadraui/src/tui/minimap.rs
+++ b/quadraui/src/tui/minimap.rs
@@ -37,7 +37,7 @@ pub const COLS_PER_CELL: usize = 2;
 /// with no font to scale, so there's no file-length-dependent glyph size
 /// to fix here the way GTK's fixed pitch fixes GTK's.
 pub fn tui_minimap_layout(minimap: &Minimap, area: Rect) -> MinimapLayout {
-    minimap.layout(
+    minimap.layout_with_sizing(
         crate::event::Rect::new(
             area.x as f32,
             area.y as f32,

--- a/quadraui/src/tui/minimap.rs
+++ b/quadraui/src/tui/minimap.rs
@@ -23,7 +23,7 @@ use ratatui::layout::Rect;
 
 use super::braille::pack_braille_cell;
 use super::{ratatui_color, set_cell};
-use crate::primitives::minimap::{Minimap, MinimapLayout};
+use crate::primitives::minimap::{Minimap, MinimapLayout, MinimapSizing};
 use crate::theme::Theme;
 
 /// Buffer lines packed into one terminal row's braille dots.
@@ -32,6 +32,10 @@ pub const LINES_PER_ROW: usize = 4;
 pub const COLS_PER_CELL: usize = 2;
 
 /// Compute the TUI cell-unit layout for a [`Minimap`] without painting.
+///
+/// TUI keeps [`MinimapSizing::Fill`] (#667): braille rows are cell-native
+/// with no font to scale, so there's no file-length-dependent glyph size
+/// to fix here the way GTK's fixed pitch fixes GTK's.
 pub fn tui_minimap_layout(minimap: &Minimap, area: Rect) -> MinimapLayout {
     minimap.layout(
         crate::event::Rect::new(
@@ -41,6 +45,7 @@ pub fn tui_minimap_layout(minimap: &Minimap, area: Rect) -> MinimapLayout {
             area.height as f32,
         ),
         LINES_PER_ROW,
+        MinimapSizing::Fill,
     )
 }
 


### PR DESCRIPTION
Closes #667

Automated PR opened by coordinator for review of issue #667.