### PR TITLE
#495: Extract shared UiEvent constructors + DoubleClickDetector into core dispatch (kill per-backend event boilerplate)

### DIFF
--- a/quadraui/BACKEND.md
+++ b/quadraui/BACKEND.md
@@ -333,6 +333,36 @@ context menu) — without it, long text bleeds past popup borders.
   calls; isolate them in narrow helpers and the surface that touches
   quadraui primitives stays safe.
 
+### Don't re-type `UiEvent` construction — call the shared constructors
+
+Every backend's translator (`gtk::events`, `macos::events`, `tui::events`)
+used to hand-write the same `UiEvent::MouseDown { widget: None, button,
+position, modifiers }`-shaped struct literal, with only the button-number
+and modifier-mask *values* differing per platform (issue #495). That
+duplication is gone: `crate::event` exports free-function constructors —
+[`mouse_down`], [`mouse_up`], [`mouse_moved`], [`scroll`], and
+[`window_resized`] — that own the event shape, including the mouse-wheel
+sign flip (`scroll`'s `dy_native_down_positive` parameter negates once,
+here, instead of every backend re-deriving and re-commenting the same
+negation).
+
+A new backend's event translator is genuinely small once you use these.
+It needs exactly three backend-native pieces:
+
+1. A keysym/keycode → [`Key`] table (see `gdk_key_to_quadraui_key`,
+   `ns_keycode_to_named_key`, `vk_to_named_key` for the existing shapes).
+2. A button-number → [`MouseButton`] map (`gdk_button_to_quadraui`,
+   `ns_button_number_to_quadraui`).
+3. A modifier-bitmask → [`Modifiers`] map (`gdk_modifiers_to_quadraui`,
+   `ns_modifier_flags_to_quadraui`).
+
+...plus one-line wrappers that call the shared constructors with those
+three tables' output. `gtk::events`'s and `macos::events`'s `MouseDown`/
+`MouseUp`/`MouseMoved`/`Scroll`/`WindowResized` translators are ~40 lines
+combined post-#495 — down from each backend independently re-typing the
+five `UiEvent` variant shapes. Grep either module for `UiEvent::Mouse` or
+`UiEvent::Scroll`: there should be none outside `crate::event` itself.
+
 ## 5. Click intercept hierarchy
 
 When the user clicks anywhere, your backend must check potential

--- a/quadraui/src/event.rs
+++ b/quadraui/src/event.rs
@@ -413,3 +413,176 @@ pub enum UiEvent {
     /// unless they want to special-case a platform.
     BackendNative(BackendNativeEvent),
 }
+
+// ─── Shared constructors (issue #495) ───────────────────────────────────────
+//
+// Every backend's `events.rs` (`gtk::events`, `macos::events`, `tui::events`)
+// translates native input into `UiEvent`. Only three things are genuinely
+// backend-native: the keysym/keycode → `Key` table, the button-number →
+// `MouseButton` map, and the modifier-mask → `Modifiers` map. The event
+// *shape* — which fields `MouseDown` carries, that `widget` starts `None`
+// pending hit-test, the scroll sign-flip convention — was previously
+// re-typed identically in each translator. These free functions are the
+// single place that shape lives; backends call them instead of writing the
+// `UiEvent::MouseDown { .. }` struct literal themselves.
+//
+// A new backend's event translation (see `BACKEND.md`'s worked estimate)
+// only needs to supply the three native-mapping tables and call these —
+// roughly 40 lines, not the 150+ each of `gtk::events` / `macos::events`
+// carried before this module existed.
+
+/// Build a [`UiEvent::MouseDown`]. `widget` always starts `None` — hit-test
+/// resolution happens downstream in [`crate::dispatch`], not in the
+/// translator.
+pub fn mouse_down(button: MouseButton, x: f32, y: f32, modifiers: Modifiers) -> UiEvent {
+    UiEvent::MouseDown {
+        widget: None,
+        button,
+        position: Point::new(x, y),
+        modifiers,
+    }
+}
+
+/// Build a [`UiEvent::MouseUp`].
+pub fn mouse_up(button: MouseButton, x: f32, y: f32) -> UiEvent {
+    UiEvent::MouseUp {
+        widget: None,
+        button,
+        position: Point::new(x, y),
+    }
+}
+
+/// Build a [`UiEvent::MouseMoved`].
+pub fn mouse_moved(x: f32, y: f32, buttons: ButtonMask) -> UiEvent {
+    UiEvent::MouseMoved {
+        position: Point::new(x, y),
+        buttons,
+    }
+}
+
+/// Build a [`UiEvent::Scroll`], owning the native-to-quadraui sign flip
+/// once instead of every backend re-deriving (and re-commenting) it.
+///
+/// `dy_native_down_positive` is the backend's raw vertical delta using the
+/// convention where **positive means scroll-down / content-forward** — GTK
+/// `EventControllerScroll`'s `dy`, Cocoa `NSEvent.scrollingDeltaY`, and
+/// crossterm's `ScrollUp`/`ScrollDown` (translated to the equivalent -1.0 /
+/// +1.0 notch) all use this convention natively. `UiEvent::Scroll::delta`'s
+/// convention is the opposite — **positive `y` = up, toward the top of
+/// content** — so this negates once, here, rather than in each caller.
+///
+/// `dx` is passed straight through unnegated: every native backend
+/// quadraui supports already agrees with quadraui's positive-x-is-right
+/// convention, so there is no flip to own.
+///
+/// Win-GUI is the one native backend that does *not* follow the
+/// positive-down convention on its raw delta (`win::events::win_wheel_to_uievent`'s
+/// doc explains why) — its translator does not call this constructor.
+pub fn scroll(dx: f32, dy_native_down_positive: f32, x: f32, y: f32) -> UiEvent {
+    UiEvent::Scroll {
+        widget: None,
+        delta: ScrollDelta::new(dx, -dy_native_down_positive),
+        position: Point::new(x, y),
+    }
+}
+
+/// Build a [`UiEvent::WindowResized`].
+pub fn window_resized(width: f32, height: f32, scale: f32) -> UiEvent {
+    UiEvent::WindowResized {
+        viewport: Viewport::new(width, height, scale),
+    }
+}
+
+#[cfg(test)]
+mod shared_constructor_tests {
+    use super::*;
+
+    #[test]
+    fn mouse_down_builds_expected_shape() {
+        let mods = Modifiers {
+            ctrl: true,
+            ..Default::default()
+        };
+        let ev = mouse_down(MouseButton::Left, 1.0, 2.0, mods);
+        match ev {
+            UiEvent::MouseDown {
+                widget,
+                button,
+                position,
+                modifiers,
+            } => {
+                assert!(widget.is_none());
+                assert_eq!(button, MouseButton::Left);
+                assert_eq!(position, Point::new(1.0, 2.0));
+                assert!(modifiers.ctrl);
+            }
+            other => panic!("expected MouseDown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mouse_up_builds_expected_shape() {
+        let ev = mouse_up(MouseButton::Right, 3.0, 4.0);
+        assert_eq!(
+            ev,
+            UiEvent::MouseUp {
+                widget: None,
+                button: MouseButton::Right,
+                position: Point::new(3.0, 4.0),
+            }
+        );
+    }
+
+    #[test]
+    fn mouse_moved_builds_expected_shape() {
+        let buttons = ButtonMask {
+            left: true,
+            ..Default::default()
+        };
+        let ev = mouse_moved(5.0, 6.0, buttons);
+        assert_eq!(
+            ev,
+            UiEvent::MouseMoved {
+                position: Point::new(5.0, 6.0),
+                buttons,
+            }
+        );
+    }
+
+    #[test]
+    fn scroll_negates_native_down_positive_dy() {
+        // Native wheel-down (dy = +1) becomes quadraui's "not up" (-1).
+        let ev = scroll(0.0, 1.0, 10.0, 20.0);
+        assert_eq!(
+            ev,
+            UiEvent::Scroll {
+                widget: None,
+                delta: ScrollDelta::new(0.0, -1.0),
+                position: Point::new(10.0, 20.0),
+            }
+        );
+    }
+
+    #[test]
+    fn scroll_leaves_dx_unflipped() {
+        let ev = scroll(2.5, 0.0, 0.0, 0.0);
+        match ev {
+            UiEvent::Scroll { delta, .. } => {
+                assert_eq!(delta.x, 2.5);
+                assert_eq!(delta.y, 0.0);
+            }
+            other => panic!("expected Scroll, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn window_resized_builds_expected_shape() {
+        let ev = window_resized(1920.0, 1080.0, 2.0);
+        assert_eq!(
+            ev,
+            UiEvent::WindowResized {
+                viewport: Viewport::new(1920.0, 1080.0, 2.0),
+            }
+        );
+    }
+}

--- a/quadraui/src/gtk/events.rs
+++ b/quadraui/src/gtk/events.rs
@@ -64,21 +64,17 @@ pub fn gdk_button_to_mouse_down(
     y: f64,
     modifiers: gdk::ModifierType,
 ) -> UiEvent {
-    UiEvent::MouseDown {
-        widget: None,
-        button: gdk_button_to_quadraui(button),
-        position: Point::new(x as f32, y as f32),
-        modifiers: gdk_modifiers_to_quadraui(modifiers),
-    }
+    crate::event::mouse_down(
+        gdk_button_to_quadraui(button),
+        x as f32,
+        y as f32,
+        gdk_modifiers_to_quadraui(modifiers),
+    )
 }
 
 /// Translate a GDK button release into [`UiEvent::MouseUp`].
 pub fn gdk_button_to_mouse_up(button: u32, x: f64, y: f64) -> UiEvent {
-    UiEvent::MouseUp {
-        widget: None,
-        button: gdk_button_to_quadraui(button),
-        position: Point::new(x as f32, y as f32),
-    }
+    crate::event::mouse_up(gdk_button_to_quadraui(button), x as f32, y as f32)
 }
 
 /// Translate a GDK motion event into [`UiEvent::MouseMoved`]. GTK
@@ -86,10 +82,7 @@ pub fn gdk_button_to_mouse_up(button: u32, x: f64, y: f64) -> UiEvent {
 /// signal — callers tracking drag state pass an explicit `buttons`
 /// mask (today: filled by `GestureDrag` consumers from gesture state).
 pub fn gdk_motion_to_uievent(x: f64, y: f64, buttons: crate::ButtonMask) -> UiEvent {
-    UiEvent::MouseMoved {
-        position: Point::new(x as f32, y as f32),
-        buttons,
-    }
+    crate::event::mouse_moved(x as f32, y as f32, buttons)
 }
 
 /// Translate a GDK scroll event into [`UiEvent::Scroll`]. `dx`/`dy`
@@ -135,12 +128,17 @@ pub fn gdk_scroll_to_uievent_with_direction(
     y: f64,
     natural_scroll: bool,
 ) -> UiEvent {
-    let sign: f32 = if natural_scroll { 1.0 } else { -1.0 };
-    UiEvent::Scroll {
-        widget: None,
-        delta: crate::ScrollDelta::new(dx as f32, sign * dy as f32),
-        position: Point::new(x as f32, y as f32),
-    }
+    // `crate::event::scroll` always negates its `dy_native_down_positive`
+    // argument to reach quadraui's convention. The natural-scroll flag
+    // needs the *opposite* of that negation, so feed it `-dy` — the
+    // shared constructor's negation then cancels back out to `+dy`.
+    let dy_native_down_positive = if natural_scroll { -dy } else { dy };
+    crate::event::scroll(
+        dx as f32,
+        dy_native_down_positive as f32,
+        x as f32,
+        y as f32,
+    )
 }
 
 /// Translate a `GtkDrawingArea` resize into [`UiEvent::WindowResized`].
@@ -156,9 +154,7 @@ pub fn gdk_scroll_to_uievent_with_direction(
 /// translator so GTK delivers `WindowResized` the same way TUI does via
 /// crossterm's `Resize` event.
 pub fn gdk_resize_to_uievent(width: i32, height: i32, scale: f32) -> UiEvent {
-    UiEvent::WindowResized {
-        viewport: crate::Viewport::new(width as f32, height as f32, scale),
-    }
+    crate::event::window_resized(width as f32, height as f32, scale)
 }
 
 /// Translate `gdk::ModifierType` to `quadraui::Modifiers`. Maps the

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -336,8 +336,8 @@ pub use backend::{
     MessageDialogOptions, Notification, PlatformServices, PointerShape, ResizeEdge,
 };
 pub use event::{
-    BackendNativeEvent, ButtonMask, Key, MouseButton, NamedKey, Point, Rect, ScrollDelta, UiEvent,
-    Viewport,
+    mouse_down, mouse_moved, mouse_up, scroll, window_resized, BackendNativeEvent, ButtonMask, Key,
+    MouseButton, NamedKey, Point, Rect, ScrollDelta, UiEvent, Viewport,
 };
 pub use frame::{FrameHitMap, FrameZone, ScreenLayout, Surface};
 pub use shell::{ShellApp, ShellConfig, ShellContext};

--- a/quadraui/src/macos/events.rs
+++ b/quadraui/src/macos/events.rs
@@ -32,7 +32,7 @@
 //! the backend queue land with `MacBackend` in #35. For now the
 //! translators are reachable only from tests.
 
-use crate::{ButtonMask, Key, Modifiers, MouseButton, NamedKey, Point, ScrollDelta, UiEvent};
+use crate::{ButtonMask, Key, Modifiers, MouseButton, NamedKey, UiEvent};
 
 // ─── NSEventModifierFlags bits ──────────────────────────────────────────────
 //
@@ -81,21 +81,17 @@ pub fn ns_button_number_to_quadraui(n: i64) -> MouseButton {
 /// Build a [`UiEvent::MouseDown`] from a translated `NSEvent`.
 /// `x`, `y` are view-local points; `flags` is `NSEvent.modifierFlags()`.
 pub fn ns_mouse_down(button: i64, x: f64, y: f64, flags: usize) -> UiEvent {
-    UiEvent::MouseDown {
-        widget: None,
-        button: ns_button_number_to_quadraui(button),
-        position: Point::new(x as f32, y as f32),
-        modifiers: ns_modifier_flags_to_quadraui(flags),
-    }
+    crate::event::mouse_down(
+        ns_button_number_to_quadraui(button),
+        x as f32,
+        y as f32,
+        ns_modifier_flags_to_quadraui(flags),
+    )
 }
 
 /// Build a [`UiEvent::MouseUp`] from a translated `NSEvent`.
 pub fn ns_mouse_up(button: i64, x: f64, y: f64) -> UiEvent {
-    UiEvent::MouseUp {
-        widget: None,
-        button: ns_button_number_to_quadraui(button),
-        position: Point::new(x as f32, y as f32),
-    }
+    crate::event::mouse_up(ns_button_number_to_quadraui(button), x as f32, y as f32)
 }
 
 /// Build a [`UiEvent::MouseMoved`] from `mouseMoved:` / `mouseDragged:`.
@@ -103,20 +99,13 @@ pub fn ns_mouse_up(button: i64, x: f64, y: f64) -> UiEvent {
 /// the event type (`mouseMoved:` → all-false; `mouseDragged:` → the dragged
 /// button bit set).
 pub fn ns_mouse_moved(x: f64, y: f64, buttons: ButtonMask) -> UiEvent {
-    UiEvent::MouseMoved {
-        position: Point::new(x as f32, y as f32),
-        buttons,
-    }
+    crate::event::mouse_moved(x as f32, y as f32, buttons)
 }
 
 /// Build a [`UiEvent::Scroll`] from `scrollWheel:` deltas. Negates
 /// `dy` so the result follows quadraui's "positive y = up" convention.
 pub fn ns_scroll(dx: f64, dy: f64, x: f64, y: f64) -> UiEvent {
-    UiEvent::Scroll {
-        widget: None,
-        delta: ScrollDelta::new(dx as f32, -dy as f32),
-        position: Point::new(x as f32, y as f32),
-    }
+    crate::event::scroll(dx as f32, dy as f32, x as f32, y as f32)
 }
 
 /// Translate `keyDown:` into a [`UiEvent::KeyPressed`].
@@ -250,9 +239,7 @@ pub fn ns_keycode_to_named_key(key_code: u16) -> Option<NamedKey> {
 /// `viewFrameDidChange:` observer (#486), which dispatches the result
 /// synchronously alongside mouse/keyboard events.
 pub fn ns_resize_to_uievent(width: f64, height: f64, scale: f32) -> UiEvent {
-    UiEvent::WindowResized {
-        viewport: crate::Viewport::new(width as f32, height as f32, scale),
-    }
+    crate::event::window_resized(width as f32, height as f32, scale)
 }
 
 /// Build a [`UiEvent::WindowFocused`] from `windowDidBecomeKey:` /

--- a/quadraui/src/tui/events.rs
+++ b/quadraui/src/tui/events.rs
@@ -35,9 +35,7 @@
 //!   trait-side dispatch fills that in via the modal stack and per-
 //!   primitive layout hit_test.
 
-use crate::{
-    ButtonMask, Key, Modifiers, MouseButton, NamedKey, Point, ScrollDelta, UiEvent, Viewport,
-};
+use crate::{ButtonMask, Key, Modifiers, MouseButton, NamedKey, UiEvent};
 use ratatui::crossterm::event::{
     Event as CtEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton as CtMouseButton,
     MouseEvent, MouseEventKind,
@@ -54,9 +52,7 @@ pub fn crossterm_to_uievents(event: CtEvent) -> Vec<UiEvent> {
     match event {
         CtEvent::Key(k) => crossterm_key_to_uievent(k).into_iter().collect(),
         CtEvent::Mouse(m) => crossterm_mouse_to_uievent(m).into_iter().collect(),
-        CtEvent::Resize(w, h) => vec![UiEvent::WindowResized {
-            viewport: Viewport::new(w as f32, h as f32, 1.0),
-        }],
+        CtEvent::Resize(w, h) => vec![crate::event::window_resized(w as f32, h as f32, 1.0)],
         CtEvent::Paste(text) => vec![UiEvent::ClipboardPaste(text)],
         CtEvent::FocusGained => vec![UiEvent::WindowFocused(true)],
         CtEvent::FocusLost => vec![UiEvent::WindowFocused(false)],
@@ -82,48 +78,33 @@ pub fn crossterm_key_to_uievent(event: KeyEvent) -> Option<UiEvent> {
 
 /// Translate one crossterm mouse event.
 pub fn crossterm_mouse_to_uievent(event: MouseEvent) -> Option<UiEvent> {
-    let position = Point::new(event.column as f32, event.row as f32);
+    let x = event.column as f32;
+    let y = event.row as f32;
     let modifiers = crossterm_modifiers_to_quadraui(event.modifiers);
     match event.kind {
-        MouseEventKind::Down(b) => Some(UiEvent::MouseDown {
-            widget: None,
-            button: crossterm_mouse_button_to_quadraui(b),
-            position,
+        MouseEventKind::Down(b) => Some(crate::event::mouse_down(
+            crossterm_mouse_button_to_quadraui(b),
+            x,
+            y,
             modifiers,
-        }),
-        MouseEventKind::Up(b) => Some(UiEvent::MouseUp {
-            widget: None,
-            button: crossterm_mouse_button_to_quadraui(b),
-            position,
-        }),
-        MouseEventKind::Drag(b) => Some(UiEvent::MouseMoved {
-            position,
-            buttons: button_mask_with_held(b),
-        }),
-        MouseEventKind::Moved => Some(UiEvent::MouseMoved {
-            position,
-            buttons: ButtonMask::default(),
-        }),
-        MouseEventKind::ScrollUp => Some(UiEvent::Scroll {
-            widget: None,
-            delta: ScrollDelta { x: 0.0, y: 1.0 },
-            position,
-        }),
-        MouseEventKind::ScrollDown => Some(UiEvent::Scroll {
-            widget: None,
-            delta: ScrollDelta { x: 0.0, y: -1.0 },
-            position,
-        }),
-        MouseEventKind::ScrollLeft => Some(UiEvent::Scroll {
-            widget: None,
-            delta: ScrollDelta { x: -1.0, y: 0.0 },
-            position,
-        }),
-        MouseEventKind::ScrollRight => Some(UiEvent::Scroll {
-            widget: None,
-            delta: ScrollDelta { x: 1.0, y: 0.0 },
-            position,
-        }),
+        )),
+        MouseEventKind::Up(b) => Some(crate::event::mouse_up(
+            crossterm_mouse_button_to_quadraui(b),
+            x,
+            y,
+        )),
+        MouseEventKind::Drag(b) => Some(crate::event::mouse_moved(x, y, button_mask_with_held(b))),
+        MouseEventKind::Moved => Some(crate::event::mouse_moved(x, y, ButtonMask::default())),
+        // crossterm reports discrete scroll "notches" rather than a
+        // continuous native delta; each direction maps to the raw
+        // native-down-positive value `crate::event::scroll` expects a
+        // continuous GTK/Cocoa wheel delta to carry, so up/down = ∓1.0
+        // and left/right pass straight through as `dx` (unflipped, same
+        // as every other backend).
+        MouseEventKind::ScrollUp => Some(crate::event::scroll(0.0, -1.0, x, y)),
+        MouseEventKind::ScrollDown => Some(crate::event::scroll(0.0, 1.0, x, y)),
+        MouseEventKind::ScrollLeft => Some(crate::event::scroll(-1.0, 0.0, x, y)),
+        MouseEventKind::ScrollRight => Some(crate::event::scroll(1.0, 0.0, x, y)),
     }
 }
 


### PR DESCRIPTION
Closes #495

Automated PR opened by coordinator for review of issue #495.