### PR TITLE
#683: Activity-bar icons have no Nerd-Font fallback path — plumb Icon{glyph,fallback} through PanelDefinition/ActivityItem

### DIFF
--- a/quadraui/examples/common/activity_style_demo.rs
+++ b/quadraui/examples/common/activity_style_demo.rs
@@ -46,7 +46,7 @@ impl ActivityStyleDemo {
             .enumerate()
             .map(|(i, icon)| ActivityItem {
                 id: item_id(i),
-                icon: (*icon).to_string(),
+                icon: (*icon).into(),
                 tooltip: LABELS[i].to_string(),
                 is_active: i == self.active,
                 is_keyboard_selected: false,

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -334,8 +334,21 @@ pub trait Backend {
     fn set_theme(&mut self, _theme: crate::Theme) {}
 
     /// Sync the nerd-fonts flag so icon-bearing surfaces (`draw_tree`,
-    /// `draw_multi_section_view`, etc.) render `Icon::glyph` when `true`
-    /// and `Icon::fallback` when `false`.
+    /// `draw_multi_section_view`, `draw_activity_bar`, etc.) render
+    /// `Icon::glyph` when `true` and `Icon::fallback` when `false`.
+    ///
+    /// **Default value, and why every backend now agrees on it (issue
+    /// #683):** every backend that owns this flag (`TuiBackend`,
+    /// `GtkBackend`, `MacBackend`) starts it at `false` — fallback, not
+    /// glyph. Before #683 the TUI defaulted to `true` and GTK to `false`,
+    /// so identical `ShellConfig` produced a different icon variant
+    /// depending only on which backend launched the app. `false` is the
+    /// safer default of the two failure modes: a wrong `false` shows a
+    /// plain-but-correct ASCII/Unicode glyph, while a wrong `true` shows
+    /// tofu — particularly for the TUI, where Nerd Font availability is a
+    /// property of the user's terminal that the app cannot see or
+    /// control. Hosts that know their environment has Nerd Fonts (or that
+    /// probe for it) call this explicitly to opt in.
     ///
     /// Call at the start of `render_content()` if the setting can change
     /// at runtime (a settings toggle, a config file reload), or once from

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -16,7 +16,7 @@ use std::cell::RefCell;
 
 use crate::primitives::activity_bar::{ActivityBar, ActivityBarRowHit, ActivityItem};
 use crate::primitives::status_bar::{StatusBar, StatusBarSegment};
-use crate::types::{Color, WidgetId};
+use crate::types::{Color, Icon, WidgetId};
 use crate::{Backend, ButtonMask, MouseButton, Point, Rect, UiEvent};
 
 // ── Public types ─────────────────────────────────────────────────────
@@ -25,7 +25,12 @@ use crate::{Backend, ButtonMask, MouseButton, Point, Rect, UiEvent};
 #[derive(Debug, Clone)]
 pub struct PanelDefinition {
     pub id: WidgetId,
-    pub icon: String,
+    /// Icon painted on the panel's activity-bar row — `glyph` for a Nerd
+    /// Font / icon-font variant, `fallback` for ASCII/basic-Unicode. Which
+    /// one paints is decided by the backend's `nerd_fonts_enabled` flag
+    /// (issue #683), not by this type. Forwarded verbatim into the built
+    /// [`ActivityItem::icon`] by [`AppShell::build_activity_bar`].
+    pub icon: Icon,
     pub tooltip: String,
     pub title: String,
 }
@@ -1335,6 +1340,45 @@ mod tests {
         let bar = s.build_activity_bar();
         assert_eq!(bar.bottom_items.len(), 1);
         assert_eq!(bar.bottom_items[0].id, WidgetId::new("panel:settings"));
+    }
+
+    /// #683 acceptance: `PanelDefinition::icon` (now `Icon`, not `String`)
+    /// survives `AppShell::build_activity_bar` unchanged into
+    /// `ActivityItem::icon`, and the TUI rasteriser picks the right half —
+    /// `glyph` when `nerd_fonts_enabled`, `fallback` otherwise. A rendered-
+    /// output assertion, not just a type-level check on `PanelDefinition`
+    /// / `ActivityItem` in isolation, per this issue's Tests section.
+    #[test]
+    #[cfg(feature = "tui")]
+    fn build_activity_bar_icon_reaches_the_painted_column_via_the_nerd_fonts_flag() {
+        let panels = vec![PanelDefinition {
+            id: WidgetId::new("panel:explorer"),
+            icon: Icon::new("\u{f07c}", "E"),
+            tooltip: "Explorer".into(),
+            title: "EXPLORER".into(),
+        }];
+        let s = AppShell::new(panels, 3.0);
+        let bar = s.build_activity_bar();
+        assert_eq!(bar.top_items[0].icon, Icon::new("\u{f07c}", "E"));
+
+        let theme = crate::theme::Theme::default();
+        let paint = |nerd_fonts_enabled: bool| -> String {
+            let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 10));
+            let area = ratatui::layout::Rect::new(0, 0, 4, 10);
+            crate::tui::draw_activity_bar(&mut buf, area, &bar, &theme, None, nerd_fonts_enabled);
+            (area.x..area.x + area.width)
+                .map(|x| buf[(x, area.y)].symbol().to_string())
+                .collect::<String>()
+        };
+
+        assert!(
+            paint(true).contains('\u{f07c}'),
+            "nerd_fonts_enabled: true should paint the PanelDefinition's glyph"
+        );
+        assert!(
+            paint(false).contains('E'),
+            "nerd_fonts_enabled: false should paint the PanelDefinition's fallback"
+        );
     }
 
     // ── Keyboard navigation ─────────────────────────────────────────

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -13,6 +13,7 @@
 //! responsibility — the shell returns [`AppShellLayout`] with the bounds.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 
 use crate::primitives::activity_bar::{ActivityBar, ActivityBarRowHit, ActivityItem};
 use crate::primitives::status_bar::{StatusBar, StatusBarSegment};
@@ -25,12 +26,25 @@ use crate::{Backend, ButtonMask, MouseButton, Point, Rect, UiEvent};
 #[derive(Debug, Clone)]
 pub struct PanelDefinition {
     pub id: WidgetId,
-    /// Icon painted on the panel's activity-bar row — `glyph` for a Nerd
-    /// Font / icon-font variant, `fallback` for ASCII/basic-Unicode. Which
-    /// one paints is decided by the backend's `nerd_fonts_enabled` flag
-    /// (issue #683), not by this type. Forwarded verbatim into the built
-    /// [`ActivityItem::icon`] by [`AppShell::build_activity_bar`].
-    pub icon: Icon,
+    /// Single icon string painted on the panel's activity-bar row.
+    ///
+    /// [`AppShell::build_activity_bar`] widens this into the built
+    /// [`ActivityItem::icon`] as `Icon { glyph: icon, fallback: icon }` —
+    /// i.e. the same string paints whether or not the backend's
+    /// `nerd_fonts_enabled` flag is set. A panel that wants a *distinct*
+    /// Nerd-Font glyph and ASCII fallback attaches the pair with
+    /// [`AppShell::with_panel_icon`] instead of widening this field
+    /// (issue #683).
+    ///
+    /// **This stays a `String` on purpose.** A Rust struct literal pins
+    /// its field's type exactly, and every construction site of this type
+    /// is a literal: fourteen in `coord-tui`'s `shell_config()`, one in
+    /// `vimcode`'s `ext_activity_panels()`, and two in the sealed
+    /// `tests/acceptance/ms-11/structural_parity.rs` fixture that workers
+    /// may not edit. Retyping the field to [`Icon`] breaks all of them at
+    /// once with no deprecation shim available (CLAUDE.md rules 2–3), so
+    /// the glyph/fallback pair rides alongside it instead.
+    pub icon: String,
     pub tooltip: String,
     pub title: String,
 }
@@ -135,6 +149,12 @@ pub struct AppShell {
     /// (indices `panels.len()..panels.len()+bottom_items.len()`).
     /// Saturates at the ends; does not wrap.
     activity_cursor: usize,
+    /// Per-panel Nerd-Font glyph + ASCII fallback pairs, keyed by
+    /// [`WidgetId`], registered via [`Self::with_panel_icon`]. Consulted by
+    /// [`Self::build_activity_bar`] in preference to widening the panel's
+    /// single [`PanelDefinition::icon`] string (issue #683). Covers both
+    /// top panels and bottom items.
+    icon_overrides: HashMap<WidgetId, Icon>,
 }
 
 impl AppShell {
@@ -167,12 +187,59 @@ impl AppShell {
             cached_activity_bar_bounds: RefCell::new(None),
             activity_keyboard_focused: false,
             activity_cursor: 0,
+            icon_overrides: HashMap::new(),
         }
     }
 
     pub fn with_bottom_items(mut self, items: Vec<PanelDefinition>) -> Self {
         self.bottom_items = items;
         self
+    }
+
+    /// Attach a distinct Nerd-Font glyph + ASCII fallback pair to one
+    /// activity-bar row, overriding the single-string
+    /// [`PanelDefinition::icon`] that panel was registered with (#683).
+    ///
+    /// `id` may name a top panel or a bottom item; unknown ids are stored
+    /// but never consulted, so registration order relative to
+    /// [`Self::with_bottom_items`] / [`Self::register_panel`] does not
+    /// matter. Calling this twice for the same id keeps the last pair.
+    ///
+    /// Which half actually paints is the backend's decision, driven by its
+    /// `nerd_fonts_enabled` flag — `glyph` when the icon font is available,
+    /// `fallback` otherwise. Panels that never call this get
+    /// `glyph == fallback == PanelDefinition::icon`, i.e. exactly the
+    /// pre-#683 behaviour.
+    ///
+    /// ```
+    /// # use quadraui::compose::app_shell::{AppShell, PanelDefinition};
+    /// # use quadraui::types::{Icon, WidgetId};
+    /// let shell = AppShell::new(
+    ///     vec![PanelDefinition {
+    ///         id: WidgetId::new("panel:explorer"),
+    ///         icon: "E".to_string(),
+    ///         tooltip: "Explorer".to_string(),
+    ///         title: "EXPLORER".to_string(),
+    ///     }],
+    ///     20.0,
+    /// )
+    /// .with_panel_icon(WidgetId::new("panel:explorer"), Icon::new("\u{f07c}", "E"));
+    /// assert_eq!(shell.build_activity_bar().top_items[0].icon.glyph, "\u{f07c}");
+    /// ```
+    #[must_use]
+    pub fn with_panel_icon(mut self, id: WidgetId, icon: Icon) -> Self {
+        self.icon_overrides.insert(id, icon);
+        self
+    }
+
+    /// The [`Icon`] an activity-bar row paints: the pair registered via
+    /// [`Self::with_panel_icon`] when there is one, otherwise the panel's
+    /// single icon string widened to `glyph == fallback`.
+    fn resolved_icon(&self, def: &PanelDefinition) -> Icon {
+        self.icon_overrides
+            .get(&def.id)
+            .cloned()
+            .unwrap_or_else(|| Icon::from(def.icon.clone()))
     }
 
     pub fn with_min_width(mut self, min: f32) -> Self {
@@ -564,7 +631,7 @@ impl AppShell {
             .enumerate()
             .map(|(i, p)| ActivityItem {
                 id: p.id.clone(),
-                icon: p.icon.clone(),
+                icon: self.resolved_icon(p),
                 tooltip: p.tooltip.clone(),
                 is_active: self.active_panel == Some(i) && self.sidebar_visible,
                 is_keyboard_selected: focused && self.activity_cursor == i,
@@ -577,7 +644,7 @@ impl AppShell {
             .enumerate()
             .map(|(j, p)| ActivityItem {
                 id: p.id.clone(),
-                icon: p.icon.clone(),
+                icon: self.resolved_icon(p),
                 tooltip: p.tooltip.clone(),
                 is_active: false,
                 is_keyboard_selected: focused && self.activity_cursor == np + j,
@@ -1342,43 +1409,80 @@ mod tests {
         assert_eq!(bar.bottom_items[0].id, WidgetId::new("panel:settings"));
     }
 
-    /// #683 acceptance: `PanelDefinition::icon` (now `Icon`, not `String`)
-    /// survives `AppShell::build_activity_bar` unchanged into
+    /// #683 acceptance: the `Icon` pair registered with
+    /// `AppShell::with_panel_icon` survives `build_activity_bar` into
     /// `ActivityItem::icon`, and the TUI rasteriser picks the right half —
     /// `glyph` when `nerd_fonts_enabled`, `fallback` otherwise. A rendered-
     /// output assertion, not just a type-level check on `PanelDefinition`
     /// / `ActivityItem` in isolation, per this issue's Tests section.
     #[test]
     #[cfg(feature = "tui")]
-    fn build_activity_bar_icon_reaches_the_painted_column_via_the_nerd_fonts_flag() {
+    fn with_panel_icon_reaches_the_painted_column_via_the_nerd_fonts_flag() {
         let panels = vec![PanelDefinition {
             id: WidgetId::new("panel:explorer"),
-            icon: Icon::new("\u{f07c}", "E"),
+            icon: "E".to_string(),
             tooltip: "Explorer".into(),
             title: "EXPLORER".into(),
         }];
-        let s = AppShell::new(panels, 3.0);
+        let s = AppShell::new(panels, 3.0)
+            .with_panel_icon(WidgetId::new("panel:explorer"), Icon::new("\u{f07c}", "E"));
         let bar = s.build_activity_bar();
         assert_eq!(bar.top_items[0].icon, Icon::new("\u{f07c}", "E"));
 
-        let theme = crate::theme::Theme::default();
-        let paint = |nerd_fonts_enabled: bool| -> String {
-            let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 10));
-            let area = ratatui::layout::Rect::new(0, 0, 4, 10);
-            crate::tui::draw_activity_bar(&mut buf, area, &bar, &theme, None, nerd_fonts_enabled);
-            (area.x..area.x + area.width)
-                .map(|x| buf[(x, area.y)].symbol().to_string())
-                .collect::<String>()
-        };
+        assert!(
+            paint_first_row(&bar, true).contains('\u{f07c}'),
+            "nerd_fonts_enabled: true should paint the override's glyph"
+        );
+        assert!(
+            paint_first_row(&bar, false).contains('E'),
+            "nerd_fonts_enabled: false should paint the override's fallback"
+        );
+    }
 
-        assert!(
-            paint(true).contains('\u{f07c}'),
-            "nerd_fonts_enabled: true should paint the PanelDefinition's glyph"
-        );
-        assert!(
-            paint(false).contains('E'),
-            "nerd_fonts_enabled: false should paint the PanelDefinition's fallback"
-        );
+    /// #683: a panel with no `with_panel_icon` override paints its single
+    /// `PanelDefinition::icon` string under *both* settings of the
+    /// `nerd_fonts_enabled` flag — the pre-#683 behaviour, preserved so
+    /// that leaving the field a `String` is not a silent downgrade.
+    #[test]
+    #[cfg(feature = "tui")]
+    fn panel_without_icon_override_paints_its_string_under_either_nerd_font_setting() {
+        let panels = vec![PanelDefinition {
+            id: WidgetId::new("panel:explorer"),
+            icon: "E".to_string(),
+            tooltip: "Explorer".into(),
+            title: "EXPLORER".into(),
+        }];
+        let bar = AppShell::new(panels, 3.0).build_activity_bar();
+        assert_eq!(bar.top_items[0].icon, Icon::new("E", "E"));
+
+        assert!(paint_first_row(&bar, true).contains('E'));
+        assert!(paint_first_row(&bar, false).contains('E'));
+    }
+
+    /// #683: `with_panel_icon` reaches bottom items too, not just top
+    /// panels — both go through the same `resolved_icon` seam.
+    #[test]
+    fn with_panel_icon_applies_to_bottom_items() {
+        let s =
+            shell().with_panel_icon(WidgetId::new("panel:settings"), Icon::new("\u{f013}", "*"));
+        let bar = s.build_activity_bar();
+        assert_eq!(bar.bottom_items[0].icon, Icon::new("\u{f013}", "*"));
+        // Untouched top panels keep the widened single-string form.
+        assert_eq!(bar.top_items[0].icon, Icon::new("E", "E"));
+    }
+
+    /// Paints `bar` into a 4-cell-wide activity column and returns row 0's
+    /// symbols concatenated, so a test can assert on what actually landed
+    /// in the buffer rather than on the model.
+    #[cfg(feature = "tui")]
+    fn paint_first_row(bar: &ActivityBar, nerd_fonts_enabled: bool) -> String {
+        let theme = crate::theme::Theme::default();
+        let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 10));
+        let area = ratatui::layout::Rect::new(0, 0, 4, 10);
+        crate::tui::draw_activity_bar(&mut buf, area, bar, &theme, None, nerd_fonts_enabled);
+        (area.x..area.x + area.width)
+            .map(|x| buf[(x, area.y)].symbol().to_string())
+            .collect::<String>()
     }
 
     // ── Keyboard navigation ─────────────────────────────────────────

--- a/quadraui/src/gtk/activity_bar.rs
+++ b/quadraui/src/gtk/activity_bar.rs
@@ -47,6 +47,11 @@ pub const ICON_FONT_DESC: &str = "Symbols Nerd Font, monospace 18";
 /// `ActivityBarStyle::default()`, i.e. no active-row fill — see that
 /// function for the full visual contract and #658's reasoning for why the
 /// fill lives in a separate style value rather than a field here.
+///
+/// `nerd_fonts_enabled` picks which half of each item's [`crate::Icon`]
+/// paints — `glyph` when `true`, `fallback` when `false` (issue #683).
+/// Pass the backend's own flag (`Backend::set_nerd_fonts`).
+#[allow(clippy::too_many_arguments)]
 pub fn draw_activity_bar(
     cr: &Context,
     pango_layout: &pango::Layout,
@@ -55,6 +60,7 @@ pub fn draw_activity_bar(
     bar: &ActivityBar,
     theme: &Theme,
     hovered_idx: Option<usize>,
+    nerd_fonts_enabled: bool,
 ) -> Vec<ActivityBarRowHit> {
     draw_activity_bar_with_style(
         cr,
@@ -65,6 +71,7 @@ pub fn draw_activity_bar(
         &ActivityBarStyle::default(),
         theme,
         hovered_idx,
+        nerd_fonts_enabled,
     )
 }
 
@@ -101,6 +108,7 @@ pub fn draw_activity_bar_with_style(
     style: &ActivityBarStyle,
     theme: &Theme,
     hovered_idx: Option<usize>,
+    nerd_fonts_enabled: bool,
 ) -> Vec<ActivityBarRowHit> {
     // Background.
     let (br, bgc, bb) = (
@@ -211,7 +219,12 @@ pub fn draw_activity_bar_with_style(
             }
         }
 
-        pango_layout.set_text(&item.icon);
+        let icon_str = if nerd_fonts_enabled {
+            item.icon.glyph.as_str()
+        } else {
+            item.icon.fallback.as_str()
+        };
+        pango_layout.set_text(icon_str);
         let (iw, ih) = pango_layout.pixel_size();
         let fg = if item.is_active || is_hovered || item.is_keyboard_selected {
             active_fg
@@ -337,6 +350,7 @@ mod tests {
                 style,
                 &Theme::default(),
                 None,
+                false,
             );
         }
         surface.flush();
@@ -423,5 +437,80 @@ mod tests {
                  active_accent is set"
             );
         }
+    }
+
+    /// #683: `nerd_fonts_enabled` selects `Icon::glyph` vs `Icon::fallback`.
+    /// Uses two ASCII strings of clearly different width (`"WWWW"` vs
+    /// `"E"`) rather than a real Nerd Font codepoint, so the assertion
+    /// holds headless even without the Symbols Nerd Font installed —
+    /// same reasoning as `icon_glyph_shrinks_while_row_height_is_unchanged`
+    /// above. Measures the painted glyph's pixel bounding-box width via
+    /// foreground-vs-background scanning: whichever half of the `Icon`
+    /// paints, a wider string produces a wider non-background run.
+    #[test]
+    fn nerd_fonts_flag_selects_glyph_or_fallback() {
+        use crate::types::Icon;
+
+        let bar = ActivityBar {
+            id: WidgetId::new("bar"),
+            top_items: vec![ActivityItem {
+                id: WidgetId::new("activity:explorer"),
+                icon: Icon::new("WWWW", "E"),
+                tooltip: String::new(),
+                is_active: false,
+                is_keyboard_selected: false,
+            }],
+            bottom_items: vec![],
+            active_accent: None,
+            selection_bg: None,
+            is_keyboard_focused: false,
+        };
+
+        let painted_width = |nerd_fonts_enabled: bool| -> i32 {
+            let mut surface =
+                ImageSurface::create(Format::ARgb32, ROW_W, ACTIVITY_ROW_PX as i32).unwrap();
+            {
+                let cr = Context::new(&surface).unwrap();
+                let pango_layout = pangocairo::functions::create_layout(&cr);
+                draw_activity_bar_with_style(
+                    &cr,
+                    &pango_layout,
+                    ROW_W as f64,
+                    ACTIVITY_ROW_PX,
+                    &bar,
+                    &ActivityBarStyle::default(),
+                    &Theme::default(),
+                    None,
+                    nerd_fonts_enabled,
+                );
+            }
+            surface.flush();
+            let stride = surface.stride() as usize;
+            let data = surface.data().unwrap();
+            let theme = Theme::default();
+            let bg = (theme.tab_bar_bg.r, theme.tab_bar_bg.g, theme.tab_bar_bg.b);
+            let mid_y = (ACTIVITY_ROW_PX as i32) / 2;
+            let mut left = None;
+            let mut right = None;
+            for x in 0..ROW_W {
+                if pixel(&data, stride, x, mid_y) != bg {
+                    left.get_or_insert(x);
+                    right = Some(x);
+                }
+            }
+            match (left, right) {
+                (Some(l), Some(r)) => r - l + 1,
+                _ => 0,
+            }
+        };
+
+        let glyph_width = painted_width(true);
+        let fallback_width = painted_width(false);
+        assert!(
+            glyph_width > fallback_width,
+            "nerd_fonts_enabled: true should paint the wider glyph half \
+             (\"WWWW\", measured {glyph_width}px) vs the narrower fallback \
+             half (\"E\", measured {fallback_width}px) painted when false"
+        );
     }
 }

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -2078,6 +2078,7 @@ impl Backend for GtkBackend {
             bar,
             &self.current_theme,
             hovered_idx,
+            self.nerd_fonts_enabled,
         );
         cr.restore().ok();
         hits
@@ -2109,6 +2110,7 @@ impl Backend for GtkBackend {
             style,
             &self.current_theme,
             hovered_idx,
+            self.nerd_fonts_enabled,
         );
         cr.restore().ok();
         hits

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -1115,14 +1115,14 @@ mod tests {
             top_items: vec![
                 ActivityItem {
                     id: WidgetId::new("activity:explorer"),
-                    icon: "\u{f07c}".to_string(),
+                    icon: "\u{f07c}".into(),
                     tooltip: "Explorer".to_string(),
                     is_active: true,
                     is_keyboard_selected: false,
                 },
                 ActivityItem {
                     id: WidgetId::new("activity:search"),
-                    icon: "\u{f422}".to_string(),
+                    icon: "\u{f422}".into(),
                     tooltip: "Search".to_string(),
                     is_active: false,
                     is_keyboard_selected: true,
@@ -1130,7 +1130,7 @@ mod tests {
             ],
             bottom_items: vec![ActivityItem {
                 id: WidgetId::new("activity:settings"),
-                icon: "\u{f013}".to_string(),
+                icon: "\u{f013}".into(),
                 tooltip: "Settings".to_string(),
                 is_active: false,
                 is_keyboard_selected: false,
@@ -3479,7 +3479,7 @@ mod tests {
     fn make_activity_item(id: &str, icon: char) -> primitives::activity_bar::ActivityItem {
         primitives::activity_bar::ActivityItem {
             id: WidgetId::new(id),
-            icon: icon.to_string(),
+            icon: icon.to_string().into(),
             tooltip: String::new(),
             is_active: false,
             is_keyboard_selected: false,

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -101,10 +101,19 @@ pub fn mac_activity_bar_layout(
 /// function for the full behaviour and #658's reasoning for why the fill
 /// lives in a separate style value rather than a field on [`ActivityBar`].
 ///
+/// `nerd_fonts_enabled` picks which half of each item's [`crate::Icon`]
+/// paints — `glyph` when `true`, `fallback` when `false` (issue #683).
+/// Unlike GTK's hardcoded "Symbols Nerd Font", macOS paints with whatever
+/// font `set_current_font` installed (see this module's header), so a
+/// caller that hasn't installed a glyph-bearing font should pass `false`
+/// — a wrong `false` shows a plain-but-correct glyph, a wrong `true` shows
+/// tofu.
+///
 /// # Safety
 ///
 /// `ctx` must be a valid `CGContextRef` borrowed for the duration of
 /// the call.
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn draw_activity_bar(
     ctx: CGContextRef,
     font: &CTFont,
@@ -113,6 +122,7 @@ pub unsafe fn draw_activity_bar(
     bar: &ActivityBar,
     theme: &Theme,
     hovered_idx: Option<usize>,
+    nerd_fonts_enabled: bool,
 ) -> Vec<ActivityBarRowHit> {
     draw_activity_bar_with_style(
         ctx,
@@ -123,6 +133,7 @@ pub unsafe fn draw_activity_bar(
         &ActivityBarStyle::default(),
         theme,
         hovered_idx,
+        nerd_fonts_enabled,
     )
 }
 
@@ -144,6 +155,7 @@ pub unsafe fn draw_activity_bar_with_style(
     style: &ActivityBarStyle,
     theme: &Theme,
     hovered_idx: Option<usize>,
+    nerd_fonts_enabled: bool,
 ) -> Vec<ActivityBarRowHit> {
     CGContextSaveGState(ctx);
 
@@ -184,7 +196,12 @@ pub unsafe fn draw_activity_bar_with_style(
             }
         }
 
-        let (iw, ih) = measure_text(font, &item.icon);
+        let icon_str = if nerd_fonts_enabled {
+            item.icon.glyph.as_str()
+        } else {
+            item.icon.fallback.as_str()
+        };
+        let (iw, ih) = measure_text(font, icon_str);
         let fg = if item.is_active || is_hovered {
             active_fg
         } else {
@@ -193,7 +210,7 @@ pub unsafe fn draw_activity_bar_with_style(
         draw_text(
             ctx,
             font,
-            &item.icon,
+            icon_str,
             (width - iw) / 2.0,
             y + (ACTIVITY_ROW_PX - ih) / 2.0,
             color_to_cg(fg),

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -200,6 +200,12 @@ pub struct MacBackend {
     /// type's doc comment) — so the `origin_x`/`origin_y` `arm()`
     /// arguments are always `0.0` and go unread.
     pending_window_press: WindowDragArm<Retained<NSEvent>>,
+    /// Mirrors `TuiBackend::nerd_fonts_enabled` / `GtkBackend::nerd_fonts_enabled`
+    /// (issue #683). Picks `Icon::glyph` vs `Icon::fallback` in
+    /// `draw_activity_bar`. Set via [`Backend::set_nerd_fonts`]; defaults
+    /// to `false` — see that method's doc for why every backend now
+    /// agrees on this default.
+    nerd_fonts_enabled: bool,
 }
 
 /// Position tolerance, in points, for [`MacBackend::fold_double_click`]'s
@@ -347,6 +353,7 @@ impl MacBackend {
             focused_activity_bar: None,
             window: None,
             pending_window_press: WindowDragArm::new(),
+            nerd_fonts_enabled: false,
         }
     }
 
@@ -583,6 +590,10 @@ impl Backend for MacBackend {
 
     fn set_theme(&mut self, theme: Theme) {
         self.set_current_theme(theme);
+    }
+
+    fn set_nerd_fonts(&mut self, enabled: bool) {
+        self.nerd_fonts_enabled = enabled;
     }
 
     fn poll_events(&mut self) -> Vec<UiEvent> {
@@ -1143,6 +1154,7 @@ impl Backend for MacBackend {
                 bar,
                 &theme,
                 hovered_idx,
+                self.nerd_fonts_enabled,
             )
         }
     }
@@ -1179,6 +1191,7 @@ impl Backend for MacBackend {
                 style,
                 &theme,
                 hovered_idx,
+                self.nerd_fonts_enabled,
             )
         }
     }

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -29,7 +29,7 @@
 //! beside the primitive, not inside it.**
 
 use crate::event::Rect;
-use crate::types::{Color, Modifiers, WidgetId};
+use crate::types::{Color, Icon, Modifiers, WidgetId};
 use serde::{Deserialize, Serialize};
 
 /// Declarative description of an activity bar.
@@ -82,9 +82,13 @@ pub struct ActivityItem {
     /// Opaque widget id for click routing. The adapter picks a meaningful
     /// namespaced string (e.g. `"activity:explorer"`, `"activity:ext:foo"`).
     pub id: WidgetId,
-    /// Glyph to render — single character for the TUI cell-based layout;
-    /// GTK backend can render wider strings when font supports them.
-    pub icon: String,
+    /// Icon to render — `glyph` for a Nerd Font / icon-font variant,
+    /// `fallback` for ASCII/basic-Unicode. Which one paints is decided by
+    /// the backend's `nerd_fonts_enabled` flag (issue #683), not by this
+    /// primitive. TUI paints a single cell (`glyph.chars().next()` /
+    /// `fallback.chars().next()`); GTK can render wider strings when the
+    /// font supports them.
+    pub icon: Icon,
     /// Hover tooltip text. TUI ignores (no hover UI); GTK uses as a native
     /// `set_tooltip_text`.
     #[serde(default)]

--- a/quadraui/src/tui/activity_bar.rs
+++ b/quadraui/src/tui/activity_bar.rs
@@ -19,12 +19,19 @@ use crate::theme::Theme;
 /// `ActivityBarStyle::default()`, i.e. no active-row fill — see that
 /// function for the full behaviour and #658's reasoning for why the fill
 /// lives in a separate style value rather than a field on [`ActivityBar`].
+///
+/// `nerd_fonts_enabled` picks which half of each item's [`crate::Icon`]
+/// paints — `glyph` when `true`, `fallback` when `false` (issue #683).
+/// Pass the backend's own flag (`Backend::set_nerd_fonts`), same as
+/// [`super::list::draw_list`].
+#[allow(clippy::too_many_arguments)]
 pub fn draw_activity_bar(
     buf: &mut Buffer,
     area: Rect,
     bar: &ActivityBar,
     theme: &Theme,
     hovered_idx: Option<usize>,
+    nerd_fonts_enabled: bool,
 ) -> Vec<ActivityBarRowHit> {
     draw_activity_bar_with_style(
         buf,
@@ -33,12 +40,14 @@ pub fn draw_activity_bar(
         &ActivityBarStyle::default(),
         theme,
         hovered_idx,
+        nerd_fonts_enabled,
     )
 }
 
 /// [`draw_activity_bar`] with an explicit [`ActivityBarStyle`] request
 /// (#658). `ActivityBarStyle::default()` reproduces [`draw_activity_bar`]
-/// cell for cell.
+/// cell for cell. See [`draw_activity_bar`] for `nerd_fonts_enabled`.
+#[allow(clippy::too_many_arguments)]
 pub fn draw_activity_bar_with_style(
     buf: &mut Buffer,
     area: Rect,
@@ -46,6 +55,7 @@ pub fn draw_activity_bar_with_style(
     style: &ActivityBarStyle,
     theme: &Theme,
     hovered_idx: Option<usize>,
+    nerd_fonts_enabled: bool,
 ) -> Vec<ActivityBarRowHit> {
     if area.width == 0 || area.height == 0 {
         return Vec::new();
@@ -136,8 +146,15 @@ pub fn draw_activity_bar_with_style(
         }
 
         // Icon glyph — centered in the available width (excluding accent
-        // column and separator column).
-        let icon_ch = item.icon.chars().next().unwrap_or(' ');
+        // column and separator column). Picks `Icon::glyph` /
+        // `Icon::fallback` per `nerd_fonts_enabled` (#683); TUI paints
+        // only the resolved string's first character.
+        let icon_str = if nerd_fonts_enabled {
+            item.icon.glyph.as_str()
+        } else {
+            item.icon.fallback.as_str()
+        };
+        let icon_ch = icon_str.chars().next().unwrap_or(' ');
         let content_start = area.x + 1; // after accent column
         let content_end = sep_col; // before separator
         let content_w = content_end.saturating_sub(content_start);
@@ -187,7 +204,7 @@ pub fn draw_activity_bar_with_style(
 mod tests {
     use super::*;
     use crate::primitives::activity_bar::ActivityItem;
-    use crate::types::{Color, WidgetId};
+    use crate::types::{Color, Icon, WidgetId};
 
     fn item(id: &str, icon: &str) -> ActivityItem {
         ActivityItem {
@@ -229,7 +246,7 @@ mod tests {
 
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
         let area = Rect::new(0, 3, 3, 10);
-        let hits = draw_activity_bar(&mut buf, area, &b, &theme, None);
+        let hits = draw_activity_bar(&mut buf, area, &b, &theme, None, false);
 
         let span = |id: &str| {
             let h = hits
@@ -266,7 +283,7 @@ mod tests {
 
         let spans = |y: u16| {
             let mut buf = Buffer::empty(Rect::new(0, 0, 40, 30));
-            let hits = draw_activity_bar(&mut buf, Rect::new(0, y, 3, 10), &b, &theme, None);
+            let hits = draw_activity_bar(&mut buf, Rect::new(0, y, 3, 10), &b, &theme, None, false);
             hits.iter()
                 .map(|h| (h.y_start, h.y_end))
                 .collect::<Vec<_>>()
@@ -294,7 +311,7 @@ mod tests {
         let theme = Theme::default();
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
         let area = Rect::new(0, 3, 4, 10);
-        draw_activity_bar(&mut buf, area, &b, &theme, None);
+        draw_activity_bar(&mut buf, area, &b, &theme, None, false);
 
         let row_text = |y: u16| {
             (area.x..area.x + area.width)
@@ -311,6 +328,35 @@ mod tests {
             row_text(4).contains('S'),
             "second icon on screen row 4, got {:?}",
             row_text(4)
+        );
+    }
+
+    /// #683: `nerd_fonts_enabled` picks `Icon::glyph` when `true` and
+    /// `Icon::fallback` when `false` — the activity bar had no fallback
+    /// path at all before this issue, painting whatever bare string it
+    /// was handed on every backend regardless of Nerd Font availability.
+    #[test]
+    fn nerd_fonts_flag_selects_glyph_or_fallback() {
+        let mut b = bar();
+        b.top_items[0].icon = Icon::new("\u{f07c}", "E");
+        let theme = Theme::default();
+
+        let row_text = |nerd_fonts_enabled: bool| {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
+            let area = Rect::new(0, 0, 4, 10);
+            draw_activity_bar(&mut buf, area, &b, &theme, None, nerd_fonts_enabled);
+            (area.x..area.x + area.width)
+                .map(|x| buf[(x, area.y)].symbol().to_string())
+                .collect::<String>()
+        };
+
+        assert!(
+            row_text(true).contains('\u{f07c}'),
+            "nerd_fonts_enabled: true should paint the glyph half of the Icon"
+        );
+        assert!(
+            row_text(false).contains('E'),
+            "nerd_fonts_enabled: false should paint the fallback half of the Icon"
         );
     }
 
@@ -331,7 +377,7 @@ mod tests {
 
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 20));
         let area = Rect::new(0, 0, 3, 10);
-        draw_activity_bar_with_style(&mut buf, area, &b, &style, &theme, None);
+        draw_activity_bar_with_style(&mut buf, area, &b, &style, &theme, None, false);
 
         let fill = qc(fill_color);
         assert_ne!(
@@ -372,6 +418,7 @@ mod tests {
             &ActivityBarStyle::default(),
             &theme,
             None,
+            false,
         );
 
         assert_eq!(

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -114,7 +114,11 @@ pub struct TuiBackend {
     current_theme: crate::Theme,
     /// Whether the rasterisers should use Nerd Font glyphs (`true`)
     /// or ASCII fallbacks (`false`). Apps set this from their own
-    /// settings via [`Self::set_nerd_fonts`]; defaults to `true`.
+    /// settings via [`Self::set_nerd_fonts`]; defaults to `false` —
+    /// see that trait method's doc for why every backend now agrees
+    /// on this default (issue #683; was `true` here and `false` on
+    /// GTK, so the same app showed a different icon variant depending
+    /// on which backend it launched under).
     nerd_fonts_enabled: bool,
     double_click: super::events::DoubleClickDetector,
     /// Whether [`Self::translate_injected`] should run raw `MouseDown`
@@ -221,7 +225,7 @@ impl TuiBackend {
             services: TuiPlatformServices::new(),
             current_frame_ptr: Cell::new(std::ptr::null_mut()),
             current_theme: crate::Theme::default(),
-            nerd_fonts_enabled: true,
+            nerd_fonts_enabled: false,
             double_click: super::events::DoubleClickDetector::new(),
             double_click_folding: true,
             text_regions: Vec::new(),
@@ -1301,10 +1305,18 @@ impl Backend for TuiBackend {
         }
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
+        let nerd_fonts = self.nerd_fonts_enabled;
         let frame = self
             .current_frame_mut()
             .expect("TuiBackend::draw_activity_bar called outside enter_frame_scope");
-        crate::tui::draw_activity_bar(frame.buffer_mut(), area, bar, &theme, hovered_idx)
+        crate::tui::draw_activity_bar(
+            frame.buffer_mut(),
+            area,
+            bar,
+            &theme,
+            hovered_idx,
+            nerd_fonts,
+        )
     }
 
     fn draw_activity_bar_with_style(
@@ -1322,6 +1334,7 @@ impl Backend for TuiBackend {
         }
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
+        let nerd_fonts = self.nerd_fonts_enabled;
         let frame = self
             .current_frame_mut()
             .expect("TuiBackend::draw_activity_bar_with_style called outside enter_frame_scope");
@@ -1332,6 +1345,7 @@ impl Backend for TuiBackend {
             style,
             &theme,
             hovered_idx,
+            nerd_fonts,
         )
     }
 

--- a/quadraui/src/tui/list.rs
+++ b/quadraui/src/tui/list.rs
@@ -36,8 +36,11 @@ use crate::types::{Decoration, StyledText};
 ///   when there isn't room past the main text.
 ///
 /// `nerd_fonts_enabled` controls which icon variant gets painted —
-/// pass `crate::icons::nerd_fonts_enabled()` from the consumer's icon
-/// registry, or `false` to always use ASCII fallbacks.
+/// pass the consumer's own Nerd Font resolver (there is no `icons`
+/// module in this crate; `crate::icons` is `vimcode`'s own capability
+/// probe, not something quadraui ships), or forward the value most
+/// recently given to [`crate::Backend::set_nerd_fonts`], or `false` to
+/// always use ASCII fallbacks.
 pub fn draw_list(
     buf: &mut Buffer,
     area: Rect,

--- a/quadraui/src/types.rs
+++ b/quadraui/src/types.rs
@@ -180,6 +180,24 @@ impl Icon {
     }
 }
 
+/// Collapse a bare string into an [`Icon`] with `glyph == fallback` — the
+/// common case for a caller that has one glyph and doesn't distinguish a
+/// Nerd Font variant from its plain-text fallback (issue #683). Keeps the
+/// `.into()` idiom working at call sites that previously produced a
+/// `String` for an icon field.
+impl From<&str> for Icon {
+    fn from(s: &str) -> Self {
+        Self::new(s, s)
+    }
+}
+
+/// See [`impl From<&str> for Icon`] — same collapse, owned-`String` input.
+impl From<String> for Icon {
+    fn from(s: String) -> Self {
+        Self::new(s.clone(), s)
+    }
+}
+
 /// Stable identifier for a widget across frames.
 ///
 /// Owned `String` so plugins can generate IDs at runtime. Apps should

--- a/quadraui/src/win/activity_bar.rs
+++ b/quadraui/src/win/activity_bar.rs
@@ -101,14 +101,20 @@ pub fn draw_activity_bar(
         } else {
             theme.inactive_fg
         };
-        let (iw, ih) = dwrite.measure_text(&item.icon).unwrap_or((0.0, 0.0));
+        // Uses the ASCII `fallback` — this rasteriser doesn't take a
+        // per-frame `nerd_fonts_enabled` toggle yet (issue #683 scoped
+        // TUI/GTK/macOS only; Win-GUI has no Nerd Font wiring at all,
+        // matching `macos::tree`/`macos::form`'s same fallback-only
+        // posture until #25's icon-font plumbing lands here too).
+        let icon_str = item.icon.fallback.as_str();
+        let (iw, ih) = dwrite.measure_text(icon_str).unwrap_or((0.0, 0.0));
         let icon_rect = Rect::new(
             row_rect.x + (row_rect.width - iw) / 2.0,
             row_rect.y + (row_rect.height - ih) / 2.0,
             iw.max(1.0),
             ih.max(1.0),
         );
-        let _ = dwrite.draw_text(target, &item.icon, icon_rect, fg);
+        let _ = dwrite.draw_text(target, icon_str, icon_rect, fg);
 
         regions.push(ActivityBarRowHit {
             y_start: vi.bounds.y as f64,

--- a/quadraui/tests/conformance/c0.rs
+++ b/quadraui/tests/conformance/c0.rs
@@ -556,7 +556,7 @@ pub const CASES: &[Case] = &[
                 id: id("activity-bar"),
                 top_items: vec![ActivityItem {
                     id: id("activity-item"),
-                    icon: "c0acty".to_string(),
+                    icon: "c0acty".into(),
                     tooltip: String::new(),
                     is_active: true,
                     is_keyboard_selected: false,
@@ -583,7 +583,7 @@ pub const CASES: &[Case] = &[
                 id: id("activity-bar-style"),
                 top_items: vec![ActivityItem {
                     id: id("activity-item-style"),
-                    icon: "c0actystyle".to_string(),
+                    icon: "c0actystyle".into(),
                     tooltip: String::new(),
                     is_active: true,
                     is_keyboard_selected: false,

--- a/quadraui/tests/conformance/caps.rs
+++ b/quadraui/tests/conformance/caps.rs
@@ -393,11 +393,6 @@ pub const ACCEPTED_DEFAULTS: &[(&str, &str, &str)] = &[
     // which is its own follow-up, not this list's job.
     (
         "macos",
-        "set_nerd_fonts",
-        "icon-form selection not wired to the CoreText renderer yet",
-    ),
-    (
-        "macos",
         "set_editor_font",
         "editor font override not wired to CoreText yet",
     ),

--- a/tests/acceptance/ms-11/structural_parity.rs
+++ b/tests/acceptance/ms-11/structural_parity.rs
@@ -181,13 +181,13 @@ mod ms11_542_structural_parity {
                     vec![
                         PanelDefinition {
                             id: WidgetId::new("panel:explorer"),
-                            icon: "E".to_string(),
+                            icon: "E".to_string().into(),
                             tooltip: "Explorer".to_string(),
                             title: "EXPLORER".to_string(),
                         },
                         PanelDefinition {
                             id: WidgetId::new("panel:search"),
-                            icon: "S".to_string(),
+                            icon: "S".to_string().into(),
                             tooltip: "Search".to_string(),
                             title: "SEARCH".to_string(),
                         },

--- a/tests/acceptance/ms-11/structural_parity.rs
+++ b/tests/acceptance/ms-11/structural_parity.rs
@@ -181,13 +181,13 @@ mod ms11_542_structural_parity {
                     vec![
                         PanelDefinition {
                             id: WidgetId::new("panel:explorer"),
-                            icon: "E".to_string().into(),
+                            icon: "E".to_string(),
                             tooltip: "Explorer".to_string(),
                             title: "EXPLORER".to_string(),
                         },
                         PanelDefinition {
                             id: WidgetId::new("panel:search"),
-                            icon: "S".to_string().into(),
+                            icon: "S".to_string(),
                             tooltip: "Search".to_string(),
                             title: "SEARCH".to_string(),
                         },


### PR DESCRIPTION
Closes #683

Automated PR opened by coordinator for review of issue #683.