### PR TITLE
#500: Terminal: shared cell-overlay ladder + wide-glyph advance helper across tui/gtk/macos (shared half of #440-#442)

### DIFF
--- a/quadraui/src/gtk/terminal.rs
+++ b/quadraui/src/gtk/terminal.rs
@@ -3,9 +3,9 @@
 //! Iterates rows then per-cell, painting cell background then per-cell
 //! glyph (skipped for spaces and `\0`). Overlay flags
 //! (`is_cursor`, `is_find_active`, `is_find_match`, `selected`)
-//! override the cell's `bg`/`fg` to match the legacy bespoke
-//! renderer's behaviour. Bold / italic / underline applied via Pango
-//! `AttrList` per cell.
+//! override the cell's `bg`/`fg` via [`crate::terminal_style::resolve_cell_style`]
+//! — the ladder shared with the TUI and macOS rasterisers (#500). Bold /
+//! italic / underline applied via Pango `AttrList` per cell.
 //!
 //! # Wide characters (#439)
 //!
@@ -18,7 +18,8 @@
 //! double-width glyph — which Pango draws at roughly double the
 //! advance width — got its right half painted over by the
 //! continuation column's background fill. [`draw_terminal_cells`] now
-//! detects wide glyphs with `unicode-width`, paints their background
+//! detects wide glyphs via [`crate::terminal_style::wide_cell_advance`]
+//! (shared with `macos::terminal`, #500), paints their background
 //! across two columns, and skips the continuation column so it's
 //! never independently painted on top of the glyph.
 //!
@@ -34,9 +35,9 @@
 use gtk4::cairo::Context;
 use gtk4::pango;
 use gtk4::pango::AttrList;
-use unicode_width::UnicodeWidthChar;
 
 use crate::primitives::terminal::Terminal;
+use crate::terminal_style::{resolve_cell_style, wide_cell_advance};
 use crate::theme::Theme;
 
 /// Draw `term`'s cell grid into the rectangular region starting at
@@ -100,53 +101,26 @@ pub fn draw_terminal_cells(
             // empty continuation placeholder, so claim it here rather
             // than letting it paint its own (mismatched) background over
             // the glyph's right half.
-            let is_wide = matches!(UnicodeWidthChar::width(cell.ch), Some(2));
-            let cell_w = if is_wide {
-                char_width * 2.0
-            } else {
-                char_width
-            };
+            let (cell_w, cols_advanced) = wide_cell_advance(cell.ch, char_width);
+            let is_wide = cols_advanced == 2;
 
             if cell_x + cell_w > x + cell_area_w {
                 break;
             }
-            let (br, bg, bb) = (cell.bg.r, cell.bg.g, cell.bg.b);
-            let (fr, fg2, fb) = (cell.fg.r, cell.fg.g, cell.fg.b);
-            let (draw_br, draw_bg, draw_bb) = if cell.is_cursor {
-                (fr, fg2, fb)
-            } else if cell.is_find_active {
-                (255u8, 165u8, 0u8)
-            } else if cell.is_find_match {
-                (100u8, 80u8, 20u8)
-            } else if cell.selected {
-                (
-                    theme.selection_bg.r,
-                    theme.selection_bg.g,
-                    theme.selection_bg.b,
-                )
-            } else {
-                (br, bg, bb)
-            };
+            let (draw_bg, draw_fg) = resolve_cell_style(cell, theme);
             cr.set_source_rgb(
-                draw_br as f64 / 255.0,
-                draw_bg as f64 / 255.0,
-                draw_bb as f64 / 255.0,
+                draw_bg.r as f64 / 255.0,
+                draw_bg.g as f64 / 255.0,
+                draw_bg.b as f64 / 255.0,
             );
             cr.rectangle(cell_x, row_y, cell_w, line_height);
             cr.fill().ok();
 
             if cell.ch != ' ' && cell.ch != '\0' {
-                let (draw_fr, draw_fg, draw_fb) = if cell.is_cursor {
-                    (br, bg, bb)
-                } else if cell.is_find_active {
-                    (0u8, 0u8, 0u8)
-                } else {
-                    (fr, fg2, fb)
-                };
                 cr.set_source_rgb(
-                    draw_fr as f64 / 255.0,
-                    draw_fg as f64 / 255.0,
-                    draw_fb as f64 / 255.0,
+                    draw_fg.r as f64 / 255.0,
+                    draw_fg.g as f64 / 255.0,
+                    draw_fg.b as f64 / 255.0,
                 );
 
                 let attrs = AttrList::new();
@@ -199,7 +173,7 @@ pub fn draw_terminal_cells(
             }
 
             cell_x += cell_w;
-            col += if is_wide { 2 } else { 1 };
+            col += cols_advanced;
         }
     }
 }

--- a/quadraui/src/lib.rs
+++ b/quadraui/src/lib.rs
@@ -106,6 +106,7 @@ pub mod diff;
 pub mod frame;
 pub mod primitives;
 pub mod shell;
+pub mod terminal_style;
 pub mod testing;
 pub mod text_util;
 pub mod theme;

--- a/quadraui/src/macos/terminal.rs
+++ b/quadraui/src/macos/terminal.rs
@@ -4,7 +4,26 @@
 //! `term.cells[row][col]`, fills each cell's background, then paints
 //! the glyph (skipped for `' '` and `'\0'`). Overlay flags
 //! (`is_cursor`, `is_find_active`, `is_find_match`, `selected`)
-//! override the cell's `bg` / `fg` to match the GTK contract.
+//! override the cell's `bg` / `fg` via
+//! [`crate::terminal_style::resolve_cell_style`] — the ladder shared
+//! with the TUI and GTK rasterisers (#500).
+//!
+//! # Wide characters (#440, fixed by #500's shared helper)
+//!
+//! Before #500, this rasteriser advanced a flat `char_width` per grid
+//! column regardless of glyph width, so a double-width character (CJK,
+//! emoji, ...) — which vt100 represents as the glyph's own column plus
+//! a trailing blank "continuation" column, see
+//! [`crate::terminal_engine::TerminalSession::to_terminal`] — got its
+//! right half painted over by the continuation column's own background.
+//! This mirrors the bug GTK fixed in #439. [`draw_terminal_cells`] now
+//! uses [`crate::terminal_style::wide_cell_advance`] (shared with
+//! `gtk::terminal`) to paint the wide glyph's background across both
+//! columns and skip the continuation column, matching the GTK fix.
+//! Unlike GTK's follow-up glyph-scaling (`wide_glyph_x_scale`), the
+//! glyph itself is still drawn at its natural Core Text advance — the
+//! ragged-packing follow-up is out of scope here; #500's acceptance bar
+//! is "paints without clipping," not pixel-tight packing.
 //!
 //! Bold / italic / underline attributes are **not** rendered yet —
 //! Core Text would need a per-cell `CTFont` (or attributed-string
@@ -22,6 +41,7 @@ use core_text::font::CTFont;
 
 use super::text::draw_text;
 use crate::primitives::terminal::Terminal;
+use crate::terminal_style::{resolve_cell_style, wide_cell_advance};
 use crate::theme::Theme;
 use crate::types::Color;
 
@@ -85,36 +105,29 @@ pub unsafe fn draw_terminal_cells(
             break;
         }
         let mut cell_x = x;
-        for cell in row {
-            if cell_x + char_width > x + cell_area_w {
+        let mut col = 0usize;
+        while col < row.len() {
+            let cell = &row[col];
+            // Double-width glyphs (CJK, emoji, ...) get a two-column cell:
+            // the vt100 grid already reserves the following column as an
+            // empty continuation placeholder, so claim it here rather
+            // than letting it paint its own (mismatched) background over
+            // the glyph's right half — mirrors `gtk::terminal`'s #439 fix.
+            let (cell_w, cols_advanced) = wide_cell_advance(cell.ch, char_width);
+
+            if cell_x + cell_w > x + cell_area_w {
                 break;
             }
-            let cell_bg = if cell.is_cursor {
-                cell.fg
-            } else if cell.is_find_active {
-                Color::rgb(255, 165, 0)
-            } else if cell.is_find_match {
-                Color::rgb(100, 80, 20)
-            } else if cell.selected {
-                theme.selection_bg
-            } else {
-                cell.bg
-            };
-            fill_rect(ctx, cell_x, row_y, char_width, line_height, cell_bg);
+            let (cell_bg, cell_fg) = resolve_cell_style(cell, theme);
+            fill_rect(ctx, cell_x, row_y, cell_w, line_height, cell_bg);
 
             if cell.ch != ' ' && cell.ch != '\0' {
-                let cell_fg = if cell.is_cursor {
-                    cell.bg
-                } else if cell.is_find_active {
-                    Color::rgb(0, 0, 0)
-                } else {
-                    cell.fg
-                };
                 let s = cell.ch.to_string();
                 draw_text(ctx, font, &s, cell_x, row_y, color_to_cg(cell_fg));
             }
 
-            cell_x += char_width;
+            cell_x += cell_w;
+            col += cols_advanced;
         }
     }
 }
@@ -219,6 +232,122 @@ mod tests {
         // background.
         let (r, g, b, _) = s.pixel(0, 0);
         assert_eq!((r, g, b), (magenta.r, magenta.g, magenta.b));
+    }
+
+    /// #440 / #500 regression, mirroring `gtk::terminal`'s
+    /// `wide_cell_background_spans_two_columns` test: a double-width
+    /// glyph (CJK) followed by vt100's blank continuation cell must have
+    /// its background span both columns — the continuation cell's own
+    /// (different) background must NOT paint over the second half of the
+    /// wide glyph's cell. Calls [`draw_terminal_cells`] directly (rather
+    /// than through `MacBackend::draw_terminal`) so the test controls
+    /// `char_width` explicitly instead of depending on Menlo's measured
+    /// advance.
+    #[test]
+    fn wide_cell_background_spans_two_columns() {
+        const CHAR_W: f64 = 10.0;
+        const LINE_H: f64 = 20.0;
+
+        let magenta = Color::rgb(200, 30, 200);
+        let cyan = Color::rgb(30, 200, 200);
+        // The wide glyph's foreground is set equal to its background
+        // (magenta on magenta) so any antialiased glyph ink can't shift
+        // the probed colour — same trick as the GTK twin test, and for
+        // the same reason (font-fallback ink at the probe point would
+        // otherwise vary by host).
+        let row = vec![cell('日', magenta, magenta), cell(' ', magenta, cyan)];
+        let term = Terminal {
+            id: WidgetId::new("term"),
+            cells: vec![row],
+            scrollbar: None,
+        };
+
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let theme = Theme::default();
+        let f = font();
+        // SAFETY: `surface.context_ptr()` is valid for the surface's
+        // lifetime, which outlives this call.
+        unsafe {
+            draw_terminal_cells(
+                surface.context_ptr(),
+                &f,
+                &term,
+                0.0,
+                0.0,
+                W as f64,
+                H as f64,
+                LINE_H,
+                CHAR_W,
+                &theme,
+            );
+        }
+
+        // Probe just past the first single-cell-width boundary, still
+        // within the wide glyph's two-column span: must be magenta, not
+        // cyan.
+        let probe_x = (CHAR_W * 1.5) as u32;
+        let (r, g, b, _) = surface.pixel(probe_x, 5);
+        assert_eq!(
+            (r, g, b),
+            (magenta.r, magenta.g, magenta.b),
+            "wide cell's background should span both columns, not be \
+             overpainted by the continuation cell's background"
+        );
+    }
+
+    /// Companion regression: ordinary narrow (single-width) cells must
+    /// still advance by exactly `char_width` — the wide-cell fix must
+    /// not widen unrelated cells. Mirrors `gtk::terminal`'s
+    /// `narrow_cells_advance_by_single_char_width`.
+    #[test]
+    fn narrow_cells_advance_by_single_char_width() {
+        const CHAR_W: f64 = 10.0;
+        const LINE_H: f64 = 20.0;
+
+        let magenta = Color::rgb(200, 30, 200);
+        let cyan = Color::rgb(30, 200, 200);
+        let white = Color::rgb(255, 255, 255);
+        // 'B' (the probed cell) paints its glyph in its own background
+        // colour so antialiased glyph ink can't corrupt the background
+        // probe.
+        let row = vec![cell('A', white, magenta), cell('B', cyan, cyan)];
+        let term = Terminal {
+            id: WidgetId::new("term"),
+            cells: vec![row],
+            scrollbar: None,
+        };
+
+        let surface = BitmapSurface::new(W, H);
+        surface.fill(0.0, 0.0, 0.0, 0.0);
+        let theme = Theme::default();
+        let f = font();
+        // SAFETY: `surface.context_ptr()` is valid for the surface's
+        // lifetime, which outlives this call.
+        unsafe {
+            draw_terminal_cells(
+                surface.context_ptr(),
+                &f,
+                &term,
+                0.0,
+                0.0,
+                W as f64,
+                H as f64,
+                LINE_H,
+                CHAR_W,
+                &theme,
+            );
+        }
+
+        // Just past the single-cell-width boundary: second cell's own
+        // background (cyan) should already be showing.
+        let probe_x = (CHAR_W * 1.5) as u32;
+        let (r, g, b, _) = surface.pixel(probe_x, 5);
+        assert_eq!(
+            (r, g, b),
+            (cyan.r, cyan.g, cyan.b),
+            "narrow cells must still advance by exactly char_width"
+        );
     }
 
     #[test]

--- a/quadraui/src/terminal_style.rs
+++ b/quadraui/src/terminal_style.rs
@@ -1,0 +1,216 @@
+//! Shared terminal-cell rendering helpers consumed by every rasteriser
+//! that paints [`crate::primitives::terminal::Terminal`] cell grids
+//! (`tui`, `gtk`, `macos` today — `win`'s terminal rasteriser still
+//! carries its own copy, see the note at the bottom of this doc comment).
+//!
+//! Unconditionally compiled (no feature gate), matching [`crate::theme`]
+//! and [`crate::text_util`]: the logic here has no platform dependency,
+//! only [`crate::primitives::terminal::TerminalCell`] and
+//! [`crate::theme::Theme`].
+//!
+//! # Overlay ladder (#500)
+//!
+//! Before this module, `tui/terminal.rs`, `gtk/terminal.rs`, and
+//! `macos/terminal.rs` each carried their own copy of the same
+//! cursor → find-active → find-match → selection precedence ladder, with
+//! the two find-highlight colours hardcoded as magic RGB literals in
+//! three places instead of one. [`resolve_cell_style`] is now the single
+//! definition; the colours live on [`Theme`] as methods
+//! ([`Theme::find_active_bg`], [`Theme::find_active_fg`],
+//! [`Theme::find_match_bg`]) rather than fields — see the "adding a
+//! field here is a breaking change" note on `Theme` itself and the #620
+//! precedent it documents. A method costs nothing downstream; a new
+//! field would be `error[E0063]: missing field` in `coord-tui`'s
+//! exhaustive palette literals on their very next build.
+//!
+//! # Wide-glyph advance (#500, fix vehicle for #440's macOS half)
+//!
+//! [`crate::terminal_engine::TerminalSession::to_terminal`] builds its
+//! cell grid straight from vt100's model: a double-width character
+//! (CJK, emoji, ...) occupies its own column plus one trailing
+//! "continuation" column that vt100 reports as an empty cell. A
+//! *pixel*-based rasteriser (GTK, macOS — anything that doesn't map one
+//! terminal column to one grid cell like TUI does) must claim that
+//! continuation column as part of the wide glyph's box, or the
+//! continuation column's own (possibly different) background paints
+//! over the glyph's right half. That was #439's original GTK bug; #440
+//! tracked the same defect on macOS, which advanced a flat `char_width`
+//! per column with no wide-glyph awareness at all.
+//! [`wide_cell_advance`] is the shared classification both rasterisers
+//! now use.
+//!
+//! **TUI does not call this** — its `cells[row][col]` grid already maps
+//! 1:1 to terminal columns, so writing the wide glyph into its column
+//! and the vt100-supplied blank into the next column (exactly what
+//! [`crate::tui::terminal::draw_terminal`] already does) is already
+//! correct with no special-casing: `ratatui::buffer::Buffer`'s own
+//! diff/render logic understands multi-width symbols from the glyph's
+//! own `cell_width()` and skips re-emitting a blank continuation column
+//! it didn't ask for.
+
+use crate::primitives::terminal::TerminalCell;
+use crate::text_util::is_wide_char;
+use crate::theme::Theme;
+use crate::types::Color;
+
+/// Resolve the `(background, foreground)` colours to paint one terminal
+/// cell, applying the cursor / find / selection overlay precedence
+/// ladder once for every backend.
+///
+/// Precedence, highest first:
+/// 1. `is_cursor` — invert: bg becomes the cell's own fg, fg becomes the
+///    cell's own bg.
+/// 2. `is_find_active` — bg becomes [`Theme::find_active_bg`], fg
+///    becomes [`Theme::find_active_fg`].
+/// 3. `is_find_match` — bg becomes [`Theme::find_match_bg`]; fg is left
+///    as the cell's own.
+/// 4. `selected` — bg becomes `theme.selection_bg`; fg is left as the
+///    cell's own.
+/// 5. none of the above — the cell's own `bg` / `fg`, unchanged.
+pub fn resolve_cell_style(cell: &TerminalCell, theme: &Theme) -> (Color, Color) {
+    if cell.is_cursor {
+        (cell.fg, cell.bg)
+    } else if cell.is_find_active {
+        (theme.find_active_bg(), theme.find_active_fg())
+    } else if cell.is_find_match {
+        (theme.find_match_bg(), cell.fg)
+    } else if cell.selected {
+        (theme.selection_bg, cell.fg)
+    } else {
+        (cell.bg, cell.fg)
+    }
+}
+
+/// Pixel box width and grid-column stride for one cell in a pixel-based
+/// rasteriser's per-row paint loop.
+///
+/// Returns `(cell_w, cols_advanced)`. When `ch` classifies as a wide
+/// glyph (double-width per [`crate::text_util::is_wide_char`]), it
+/// claims its own column plus the following vt100-supplied blank
+/// continuation column: `cell_w = char_width * 2.0`, `cols_advanced =
+/// 2`. Every other cell advances by exactly one column at `char_width`.
+///
+/// Callers walk a row with an index (`while col < row.len()`), painting
+/// the background across `cell_w` and then stepping `col += cols`, so
+/// the continuation column is claimed rather than independently
+/// painted on top of the glyph — see this module's doc comment. Not
+/// used by the TUI rasteriser.
+pub fn wide_cell_advance(ch: char, char_width: f64) -> (f64, usize) {
+    if is_wide_char(ch) {
+        (char_width * 2.0, 2)
+    } else {
+        (char_width, 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(ch: char, fg: Color, bg: Color) -> TerminalCell {
+        TerminalCell {
+            ch,
+            fg,
+            bg,
+            bold: false,
+            italic: false,
+            underline: false,
+            selected: false,
+            is_cursor: false,
+            is_find_match: false,
+            is_find_active: false,
+        }
+    }
+
+    #[test]
+    fn default_cell_uses_own_colors() {
+        let fg = Color::rgb(200, 200, 200);
+        let bg = Color::rgb(10, 10, 10);
+        let c = cell('a', fg, bg);
+        let theme = Theme::default();
+        assert_eq!(resolve_cell_style(&c, &theme), (bg, fg));
+    }
+
+    #[test]
+    fn cursor_cell_inverts_fg_bg() {
+        let fg = Color::rgb(200, 200, 200);
+        let bg = Color::rgb(10, 10, 10);
+        let mut c = cell('a', fg, bg);
+        c.is_cursor = true;
+        let theme = Theme::default();
+        assert_eq!(resolve_cell_style(&c, &theme), (fg, bg));
+    }
+
+    #[test]
+    fn find_active_cell_uses_theme_highlight() {
+        let fg = Color::rgb(200, 200, 200);
+        let bg = Color::rgb(10, 10, 10);
+        let mut c = cell('a', fg, bg);
+        c.is_find_active = true;
+        let theme = Theme::default();
+        assert_eq!(
+            resolve_cell_style(&c, &theme),
+            (theme.find_active_bg(), theme.find_active_fg())
+        );
+    }
+
+    #[test]
+    fn find_match_cell_keeps_own_fg() {
+        let fg = Color::rgb(200, 200, 200);
+        let bg = Color::rgb(10, 10, 10);
+        let mut c = cell('a', fg, bg);
+        c.is_find_match = true;
+        let theme = Theme::default();
+        assert_eq!(resolve_cell_style(&c, &theme), (theme.find_match_bg(), fg));
+    }
+
+    #[test]
+    fn selected_cell_uses_theme_selection_bg_and_own_fg() {
+        let fg = Color::rgb(200, 200, 200);
+        let bg = Color::rgb(10, 10, 10);
+        let mut c = cell('a', fg, bg);
+        c.selected = true;
+        let theme = Theme::default();
+        assert_eq!(resolve_cell_style(&c, &theme), (theme.selection_bg, fg));
+    }
+
+    #[test]
+    fn cursor_takes_precedence_over_every_other_overlay() {
+        let fg = Color::rgb(200, 200, 200);
+        let bg = Color::rgb(10, 10, 10);
+        let mut c = cell('a', fg, bg);
+        c.is_cursor = true;
+        c.is_find_active = true;
+        c.is_find_match = true;
+        c.selected = true;
+        let theme = Theme::default();
+        assert_eq!(resolve_cell_style(&c, &theme), (fg, bg));
+    }
+
+    #[test]
+    fn find_active_takes_precedence_over_find_match_and_selected() {
+        let fg = Color::rgb(200, 200, 200);
+        let bg = Color::rgb(10, 10, 10);
+        let mut c = cell('a', fg, bg);
+        c.is_find_active = true;
+        c.is_find_match = true;
+        c.selected = true;
+        let theme = Theme::default();
+        assert_eq!(
+            resolve_cell_style(&c, &theme),
+            (theme.find_active_bg(), theme.find_active_fg())
+        );
+    }
+
+    #[test]
+    fn narrow_char_advances_one_column() {
+        assert_eq!(wide_cell_advance('a', 10.0), (10.0, 1));
+        assert_eq!(wide_cell_advance(' ', 10.0), (10.0, 1));
+    }
+
+    #[test]
+    fn wide_char_advances_two_columns_at_double_width() {
+        assert_eq!(wide_cell_advance('日', 10.0), (20.0, 2));
+        assert_eq!(wide_cell_advance('中', 9.0), (18.0, 2));
+    }
+}

--- a/quadraui/src/text_util.rs
+++ b/quadraui/src/text_util.rs
@@ -142,6 +142,17 @@ pub fn display_width(s: &str) -> usize {
     s.chars().map(|c| char_cell_width(c) as usize).sum()
 }
 
+/// Whether `c` is a double-width glyph (CJK, emoji, ...) per
+/// [`char_cell_width`] — i.e. `char_cell_width(c) == 2`.
+///
+/// Named for callers that only need the wide/narrow classification, not
+/// the numeric width: pixel-based terminal rasterisers (`gtk`, `macos`)
+/// use this to decide whether a cell claims one grid column or two — see
+/// [`crate::terminal_style::wide_cell_advance`], issue #500.
+pub fn is_wide_char(c: char) -> bool {
+    char_cell_width(c) == 2
+}
+
 /// Case-sensitive subsequence fuzzy match with a relevance score and
 /// per-match byte positions.
 ///
@@ -446,6 +457,15 @@ mod tests {
         assert_eq!(display_width("ab日本"), 2 + 2 + 2);
         assert_eq!(display_width(""), 0);
         assert_eq!(display_width("hello"), 5);
+    }
+
+    #[test]
+    fn is_wide_char_classifies_cjk_and_ascii() {
+        assert!(is_wide_char('日'));
+        assert!(is_wide_char('中'));
+        assert!(!is_wide_char('a'));
+        assert!(!is_wide_char(' '));
+        assert!(!is_wide_char('\u{0301}'));
     }
 
     // ── fuzzy_score ─────────────────────────────────────────────────────

--- a/quadraui/src/theme.rs
+++ b/quadraui/src/theme.rs
@@ -326,6 +326,42 @@ impl Theme {
     pub fn tab_active_border_top(&self) -> Color {
         self.accent_fg
     }
+
+    // ── Terminal find-highlight lift (#500) ─────────────────────────────
+    //
+    // `tui/terminal.rs`, `gtk/terminal.rs`, and `macos/terminal.rs` each
+    // hardcoded the same two RGB literals for the find-match overlay
+    // (`rgb(255, 165, 0)` active, `rgb(100, 80, 20)` dim) — see #500. The
+    // shared ladder in `crate::terminal_style::resolve_cell_style` reads
+    // them from here instead.
+    //
+    // **These are methods, not `Theme` fields, on purpose** — same
+    // reasoning as [`Self::tab_active_border_top`] above. Unlike that
+    // method, these don't derive from an existing field (there's no
+    // "find highlight" colour anywhere else in `Theme` to reuse), but a
+    // method with a hardcoded literal is still purely additive: it adds
+    // no new field for `coord-tui`'s exhaustive palette literals
+    // (`tui/src/settings.rs`) to miss, so it costs nothing downstream.
+    // Promote to a real field only if a consumer asks to theme these
+    // independently — that's rule 8's "if it must break" path, one field
+    // per PR with a `## Downstream impact` section.
+
+    /// Background painted over the currently-active find match —
+    /// terminal find-highlight convention (bright orange).
+    pub fn find_active_bg(&self) -> Color {
+        Color::rgb(255, 165, 0)
+    }
+
+    /// Foreground painted over [`Self::find_active_bg`] (black, for
+    /// contrast against the bright orange).
+    pub fn find_active_fg(&self) -> Color {
+        Color::rgb(0, 0, 0)
+    }
+
+    /// Background painted over non-active find matches (dim highlight).
+    pub fn find_match_bg(&self) -> Color {
+        Color::rgb(100, 80, 20)
+    }
 }
 
 impl Default for Theme {
@@ -444,6 +480,21 @@ mod tests {
             Color::rgb(140, 200, 240),
             "default accent must match the value #620 originally shipped as a field"
         );
+    }
+
+    /// #500: the terminal find-highlight colours are exposed as
+    /// *methods*, not `Theme` fields, for the same reason as
+    /// `tab_active_border_top` above — see
+    /// `exhaustive_theme_literal_still_compiles` below.
+    #[test]
+    fn terminal_find_highlight_colours_match_the_pre_shared_literals() {
+        let theme = Theme::default();
+        // Same RGB literals `tui`/`gtk`/`macos::terminal` each hardcoded
+        // independently before #500 — the shared ladder must not change
+        // the shipped colours, only where they're defined.
+        assert_eq!(theme.find_active_bg(), Color::rgb(255, 165, 0));
+        assert_eq!(theme.find_active_fg(), Color::rgb(0, 0, 0));
+        assert_eq!(theme.find_match_bg(), Color::rgb(100, 80, 20));
     }
 
     /// The accent stays *themeable* despite not having its own field: an

--- a/quadraui/src/tui/terminal.rs
+++ b/quadraui/src/tui/terminal.rs
@@ -1,9 +1,10 @@
 //! TUI rasteriser for [`crate::Terminal`] cell grids.
 //!
 //! Iterates `cells[row][col]`, writing styled characters into the
-//! ratatui buffer with overlay colour logic matching the GTK rasteriser:
+//! ratatui buffer using [`crate::terminal_style::resolve_cell_style`] —
+//! the overlay ladder shared with the GTK and macOS rasterisers (#500):
 //! cursor inverts fg/bg, selection uses `theme.selection_bg`, find-match
-//! and find-active use fixed highlight colours.
+//! and find-active use the highlight colours on [`Theme`].
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -11,6 +12,7 @@ use ratatui::style::{Color as RatatuiColor, Modifier};
 
 use crate::primitives::scrollbar::Scrollbar;
 use crate::primitives::terminal::Terminal;
+use crate::terminal_style::resolve_cell_style;
 use crate::theme::Theme;
 
 use super::{draw_scrollbar, ratatui_color};
@@ -39,7 +41,8 @@ pub fn draw_terminal(buf: &mut Buffer, area: Rect, term: &Terminal, theme: &Them
             }
             let x = area.x + col_idx as u16;
 
-            let (draw_bg, draw_fg) = resolve_cell_colors(cell, theme);
+            let (bg, fg) = resolve_cell_style(cell, theme);
+            let (draw_bg, draw_fg) = (ratatui_color(bg), ratatui_color(fg));
 
             let buf_cell = &mut buf[(x, y)];
             // ratatui ≥ 0.30 debug_asserts on ASCII control chars in cell symbols.
@@ -81,26 +84,6 @@ pub fn draw_terminal(buf: &mut Buffer, area: Rect, term: &Terminal, theme: &Them
             1.0,
         );
         draw_scrollbar(buf, &sb, theme, theme.background);
-    }
-}
-
-fn resolve_cell_colors(
-    cell: &crate::primitives::terminal::TerminalCell,
-    theme: &Theme,
-) -> (RatatuiColor, RatatuiColor) {
-    let bg = ratatui_color(cell.bg);
-    let fg = ratatui_color(cell.fg);
-
-    if cell.is_cursor {
-        (fg, bg)
-    } else if cell.is_find_active {
-        (RatatuiColor::Rgb(255, 165, 0), RatatuiColor::Rgb(0, 0, 0))
-    } else if cell.is_find_match {
-        (RatatuiColor::Rgb(100, 80, 20), fg)
-    } else if cell.selected {
-        (ratatui_color(theme.selection_bg), fg)
-    } else {
-        (bg, fg)
     }
 }
 


### PR DESCRIPTION
Closes #500

Automated PR opened by coordinator for review of issue #500.

## Summary

Adds `quadraui::terminal_style::{resolve_cell_style, wide_cell_advance}` as the
single definition of the terminal cell-overlay precedence ladder
(cursor → find-active → find-match → selection → base) that was previously
duplicated, with hardcoded magic RGB literals, in `tui/terminal.rs`,
`gtk/terminal.rs` and `macos/terminal.rs`. The two find-highlight colours move
onto `Theme` as **methods** (not fields — see below). `macos/terminal.rs` also
gains the wide-glyph (CJK/emoji) two-column handling GTK got in #439, with a
headless `BitmapSurface` regression test mirroring gtk's; this is the fix
vehicle for the macOS half of #440. `win/terminal.rs` still carries its own
copy of the ladder — out of scope here, left as a follow-up (#337).

## Downstream impact

**No consumer hits.** This PR is purely *additive* to the public API — it adds
six new `pub` items and removes/renames nothing:

| New `pub` item | Kind |
|---|---|
| `quadraui::terminal_style` (module) | new module |
| `terminal_style::resolve_cell_style` | new fn |
| `terminal_style::wide_cell_advance` | new fn |
| `text_util::is_wide_char` | new fn |
| `Theme::find_active_bg` | new method |
| `Theme::find_active_fg` | new method |
| `Theme::find_match_bg` | new method |

No `pub` item is removed, renamed, or has its signature changed, so no consumer
file must move. Per CLAUDE.md → *Downstream consumers* rule 1, the mandated
blast-radius grep was run against both consumer checkouts (all `*.rs`, i.e.
including their test targets, not just `src/`):

```
$ for s in resolve_cell_style wide_cell_advance is_wide_char \
           find_active_bg find_active_fg find_match_bg terminal_style; do
    printf '%-22s -> %s hits\n' "$s" \
      "$(grep -rn "$s" ~/src/coord-tui ~/src/vimcode --include='*.rs' | wc -l)"
  done
resolve_cell_style     -> 0 hits
wide_cell_advance      -> 0 hits
is_wide_char           -> 0 hits
find_active_bg         -> 0 hits
find_active_fg         -> 0 hits
find_match_bg          -> 0 hits
terminal_style         -> 0 hits
```

(Control grep confirming the paths are live checkouts, not a false-negative from
a bad path: `grep -rln 'quadraui' ~/src/coord-tui/src ~/src/vimcode/src` →
`coord-tui/src/boot.rs`, `main.rs`, `settings.rs`, `app/format.rs`,
`commands.rs`, … Both are the post-#2899 layouts — `~/src/coord-tui`, not
`~/src/claude-coordinator/tui`.)

**Deliberately non-breaking shape (rule 2).** The two find-highlight colours are
exposed as `Theme` **methods**, not new `Theme` fields, following the
`tab_active_border_top` precedent. A new *field* on `Theme` would be
`error[E0063]: missing field` in `coord-tui`'s exhaustive palette struct
literals — a hard break on merge for a change that has no reason to be one.
Methods are additive and cost consumers nothing.

- `coord-tui` — pinned to a fixed git rev, so unaffected until someone
  deliberately bumps the pin; additive-only either way. **No files must move.**
- `vimcode` — path-dep against `develop`'s tip, so this lands in its CI on
  merge; additive-only, zero hits. **No files must move.**

No deprecation shim is required (rule 3 does not apply — nothing breaks). No
`#[deprecated]` attribute is added, so the in-repo `-D warnings` /
downstream-allowed `deprecated` split is untouched.

## Cross-references

- #440 (macOS wide-char gap) — fixed by this PR's `macos/terminal.rs` half;
  commented on the issue, left open for its owner to close.
- #441 / #442 — already closed; predate this PR, no action needed.
- #337 (broader grapheme/cell-width tracking, incl. `win/terminal.rs`) —
  commented; remains open, this PR is a partial step only.

## Testing

- 8 new `terminal_style` unit tests covering the ladder's precedence, including
  cursor-beats-everything and find-active's fixed foreground.
- `wide_cell_background_spans_two_columns` + `narrow_cells_advance_by_single_char_width`
  — headless `BitmapSurface` regression tests for the macOS rasteriser,
  mirroring gtk's #439 test. These need no macOS *desktop*; `macos-latest` CI
  can run them, which retires the "BLOCKED: no macOS runner" framing on #440.
