### PR TITLE
#505: One coordinate-frame convention for all *_layout methods: document, audit, non-zero-origin coverage

### DIFF
--- a/quadraui/docs/DECISIONS.md
+++ b/quadraui/docs/DECISIONS.md
@@ -487,7 +487,7 @@ Every `Backend::<name>_layout` trait method in `quadraui/src/backend.rs`
 was read against its TUI, GTK, and (where implemented) macOS
 implementation, tracing whether the returned `hit_regions` / `bounds`
 are shifted by `rect.x`/`rect.y` (**ABSOLUTE**) or left relative to
-`rect`'s origin (**LOCAL**). Result, 19 methods audited (excludes
+`rect`'s origin (**LOCAL**). Result, 20 methods audited (excludes
 `tab_bar_layout*` and `activity_bar_layout`, already resolved by #552):
 
 | Frame | Methods |
@@ -498,16 +498,17 @@ are shifted by `rect.x`/`rect.y` (**ABSOLUTE**) or left relative to
 **No live cross-backend mismatch was found.** For every method, every
 backend that implements it agrees with its siblings on which frame it
 uses — unlike the historical `mac_tree_layout` bug, nothing here
-silently drifts between backends today. What *was* missing: 16 of the
-19 methods' trait doc comments said nothing at all about coordinate
-frame, so the agreement was accidental (preserved by copy-paste and
-`#499`'s later unification into shared `layout_metrics` helpers) rather
-than contracted.
+silently drifts between backends today. What *was* missing: 19 of the
+20 methods' trait doc comments said nothing at all about coordinate
+frame (the sole exception, `status_bar_layout`, already had its
+bar-local frame stated from #552), so the agreement was accidental
+(preserved by copy-paste and `#499`'s later unification into shared
+`layout_metrics` helpers) rather than contracted.
 
 ### Decision
 
 **Keep both frames — do not collapse everything to LOCAL.** Converting
-the 14 ABSOLUTE methods to LOCAL would be a breaking change to every
+the 15 ABSOLUTE methods to LOCAL would be a breaking change to every
 caller of every one of them (both in-tree composers and, per
 `CLAUDE.md`'s downstream-consumers policy, `coord-tui` and `vimcode` if
 either calls them directly) for a purely cosmetic uniformity gain — the

--- a/quadraui/docs/DECISIONS.md
+++ b/quadraui/docs/DECISIONS.md
@@ -463,4 +463,87 @@ payoff is discoverability, honest APIs, and a plugin-friendly serde
 surface that holds up as the crate grows.
 
 Future primitive decisions should cite this file when they hit the
+similar tension between "share the algorithm" and "keep the concept
+distinct."
+
+---
+
+## D-005 — `*_layout` coordinate-frame convention (issue #505)
+
+### Question
+
+`LESSONS.md` records a rule from a shipped bug (`mac_tree_layout` /
+`mac_form_layout` silently returning absolute coords while their
+TUI/GTK twins returned local, drifting clicks by `area.y` on macOS):
+*"layout helpers return local-frame coords."* Issue #505 asked whether
+that rule is actually followed trait-wide, or whether — as
+`tab_bar_layout`'s already-documented absolute-coordinate exception
+(#552) suggested — the real picture is more mixed and the doc comments
+just don't say so.
+
+### Audit
+
+Every `Backend::<name>_layout` trait method in `quadraui/src/backend.rs`
+was read against its TUI, GTK, and (where implemented) macOS
+implementation, tracing whether the returned `hit_regions` / `bounds`
+are shifted by `rect.x`/`rect.y` (**ABSOLUTE**) or left relative to
+`rect`'s origin (**LOCAL**). Result, 19 methods audited (excludes
+`tab_bar_layout*` and `activity_bar_layout`, already resolved by #552):
+
+| Frame | Methods |
+|---|---|
+| **LOCAL** | `data_table_layout`, `status_bar_layout`, `text_display_layout`, `tree_layout`, `form_layout` |
+| **ABSOLUTE** | `text_input_layout`, `msv_layout`, `menu_bar_layout`, `split_layout`, `split_tree_layout`, `panel_layout`, `toast_stack_layout`, `pipeline_view_layout`, `progress_layout`, `spinner_layout`, `command_center_layout`, `toolbar_layout`, `sidebar_panel_layout`, `chart_layout`, `minimap_layout` |
+
+**No live cross-backend mismatch was found.** For every method, every
+backend that implements it agrees with its siblings on which frame it
+uses — unlike the historical `mac_tree_layout` bug, nothing here
+silently drifts between backends today. What *was* missing: 16 of the
+19 methods' trait doc comments said nothing at all about coordinate
+frame, so the agreement was accidental (preserved by copy-paste and
+`#499`'s later unification into shared `layout_metrics` helpers) rather
+than contracted.
+
+### Decision
+
+**Keep both frames — do not collapse everything to LOCAL.** Converting
+the 14 ABSOLUTE methods to LOCAL would be a breaking change to every
+caller of every one of them (both in-tree composers and, per
+`CLAUDE.md`'s downstream-consumers policy, `coord-tui` and `vimcode` if
+either calls them directly) for a purely cosmetic uniformity gain — the
+audit found no bug the conversion would fix, only a documentation gap.
+Instead:
+
+1. Each method's doc comment now states its frame explicitly, in the
+   words **LOCAL** or **ABSOLUTE** (grep-able), matching the audited
+   reality above. Landed in the same PR as this decision — see
+   `quadraui/src/backend.rs`'s module doc "Coordinate frames for
+   `*_layout` methods" and each method's doc comment.
+2. `PRIMITIVE_RULES.md` gained a "Coordinate frames for `*_layout`
+   methods" section stating the convention going forward: a new
+   primitive's layout method picks LOCAL if a parent composer paints it
+   inline and already tracks the origin, ABSOLUTE if it's painted as a
+   freestanding widget at its own screen rect. `LESSONS.md`'s original
+   rule is marked superseded and points here instead of re-asserting
+   "always local."
+3. `tab_bar_layout`'s ABSOLUTE convention (audited and fixed under
+   #552, opposite of `activity_bar_layout`'s LOCAL one) is ratified by
+   this decision, not treated as an outstanding exception to resolve —
+   it's simply one more ABSOLUTE-frame method in the table above.
+
+### What this does NOT mean
+
+- It does not mean "frame doesn't matter." The rule that *does* still
+  bind unconditionally: whichever frame a method picks, every backend
+  implementing it must agree with its siblings, that agreement is
+  stated on the doc comment, and it is regression-tested at a non-zero
+  `rect.x`/`rect.y` (the case that hides a LOCAL/ABSOLUTE mixup, per
+  the `mac_tree_layout` postmortem). A future primitive that lets its
+  backends silently disagree on frame is still a bug of exactly this
+  kind.
+- It does not block deprecating an individual method's frame later —
+  `PRIMITIVE_RULES.md` rule 8's two-PR deprecation protocol applies if
+  a specific method's frame ever needs to change.
+
+Future primitive decisions should cite this file when they hit the
 same fork.

--- a/quadraui/docs/LESSONS.md
+++ b/quadraui/docs/LESSONS.md
@@ -175,10 +175,25 @@ first non-zero-offset consumer of `mac_tree_layout`. Existing tests
 all used `area=(0, 0)` so the shift was a no-op and the bug
 invisible.
 
-Rule: layout helpers return local-frame coords. Paint loops shift
-inline (`bounds.x + area.x`). Every layout helper needs at least
-one regression test using non-zero `area.y` — `area=(0, 0)` is the
-case where the bug doesn't manifest.
+Rule (superseded — see below): layout helpers return local-frame
+coords. Paint loops shift inline (`bounds.x + area.x`). Every layout
+helper needs at least one regression test using non-zero `area.y` —
+`area=(0, 0)` is the case where the bug doesn't manifest.
+
+**Update (issue #505):** the #505 audit of every `Backend::*_layout`
+trait method found that "always local" was never actually the norm —
+of 19 audited methods, only 5 are LOCAL (including `mac_tree_layout`'s
+fixed frame); the other 14 are deliberately **ABSOLUTE** (shifted by
+`rect.x`/`rect.y`), and every backend agrees with its own siblings on
+which one, with no live cross-backend mismatch found. The part of this
+rule that still holds, unconditionally: **a `*_layout` method and its
+TUI/GTK/macOS twins must agree on frame with each other**, that
+agreement must be stated on the trait doc comment (not just implied),
+and every `*_layout` method needs a non-zero-origin regression test —
+`area=(0, 0)` is exactly the case that hides a mixup, as it did here.
+The "which frame" decision itself now lives in
+`PRIMITIVE_RULES.md`'s "Coordinate frames for `*_layout` methods" and
+`DECISIONS.md` D-005, not in a blanket "local by default" claim.
 
 ## Dropdown item sizing must use backend-native units
 

--- a/quadraui/docs/LESSONS.md
+++ b/quadraui/docs/LESSONS.md
@@ -182,8 +182,8 @@ helper needs at least one regression test using non-zero `area.y` —
 
 **Update (issue #505):** the #505 audit of every `Backend::*_layout`
 trait method found that "always local" was never actually the norm —
-of 19 audited methods, only 5 are LOCAL (including `mac_tree_layout`'s
-fixed frame); the other 14 are deliberately **ABSOLUTE** (shifted by
+of 20 audited methods, only 5 are LOCAL (including `mac_tree_layout`'s
+fixed frame); the other 15 are deliberately **ABSOLUTE** (shifted by
 `rect.x`/`rect.y`), and every backend agrees with its own siblings on
 which one, with no live cross-backend mismatch found. The part of this
 rule that still holds, unconditionally: **a `*_layout` method and its

--- a/quadraui/docs/PRIMITIVE_RULES.md
+++ b/quadraui/docs/PRIMITIVE_RULES.md
@@ -140,6 +140,51 @@ section** naming each consumer file that must move, or stating "no
 consumer hits" with the grep. A public-API PR without one should be sent
 back at review.
 
+## Coordinate frames for `*_layout` methods (issue #505)
+
+Every `Backend::<name>_layout` method — and its `draw_<name>` twin, where
+one returns hit-region data — returns its `hit_regions` / `bounds` in
+one of exactly two frames, and its doc comment states which one:
+
+- **LOCAL** — relative to the `rect` passed in; `(0, 0)` is `rect`'s
+  top-left corner. The caller subtracts `rect.x` / `rect.y` from an
+  absolute click coordinate before calling `hit_test`.
+- **ABSOLUTE** — shifted by `rect.x` / `rect.y` (target-surface
+  coordinates). The caller compares raw click coordinates against the
+  returned bounds with no further adjustment.
+
+**Which one a given primitive uses is a design choice made once, not a
+per-backend one.** In practice: primitives a parent composer paints
+*inline* and already tracks the origin for (`tree_layout`,
+`form_layout`, `data_table_layout`, `text_display_layout`,
+`status_bar_layout`, `activity_bar_layout`) are LOCAL. Primitives
+painted as a freestanding widget at their own screen rect, where the
+caller has no other reason to track that rect, are ABSOLUTE
+(`tab_bar_layout`, `menu_bar_layout`, `split_layout`,
+`split_tree_layout`, `panel_layout`, `toast_stack_layout`,
+`pipeline_view_layout`, `progress_layout`, `spinner_layout`,
+`command_center_layout`, `toolbar_layout`, `sidebar_panel_layout`,
+`chart_layout`, `minimap_layout`, `msv_layout`, `text_input_layout`).
+See `quadraui/docs/DECISIONS.md` D-005 for the full audit and why the
+split isn't collapsed to one frame everywhere.
+
+**The rule this enforces is not "always LOCAL" — `docs/LESSONS.md`'s
+"Layout helpers must return coords in the same frame across backends"
+predates this audit and reads that way; treat this section as its
+successor.** The rule is: (1) the method's doc comment states its frame
+explicitly — **LOCAL** or **ABSOLUTE**, in those words, so grep finds
+every one — and (2) every backend implementation actually agrees with
+that statement and with its TUI/GTK/macOS siblings. A `*_layout` doc
+comment with neither word is an #505 regression.
+
+**Every `*_layout` method needs a non-zero-origin regression test** on
+every backend it ships on (TUI + GTK always; macOS per #483
+availability) — `rect.x != 0` or `rect.y != 0`. `area = (0, 0)` is
+exactly the case where a LOCAL/ABSOLUTE mixup is invisible (adding or
+skipping `rect.x` is a no-op when `rect.x == 0`), which is why the
+historical `mac_tree_layout` bug (`docs/LESSONS.md`) shipped past
+tests that all used the origin.
+
 ## Shared pixel-layout math (#499)
 
 `gtk::tree::gtk_tree_layout` and `macos::tree::mac_tree_layout` used to

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -6,6 +6,40 @@
 //! with platform-native drawing + input.
 //!
 //! See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §4 for design rationale.
+//!
+//! ## Coordinate frames for `*_layout` methods (issue #505)
+//!
+//! Every `Backend::<name>_layout` method (and its `draw_<name>` twin,
+//! where one returns hit-region data) documents **which** of two frames
+//! its `hit_regions` / `bounds` fields are in — there is no third option
+//! and no undocumented exception:
+//!
+//! - **LOCAL** — relative to `rect`'s origin; `(0, 0)` is `rect`'s
+//!   top-left corner. Used by primitives a parent composer paints
+//!   *inline* and localises clicks for before calling `hit_test`
+//!   (`tree_layout`, `form_layout`, `data_table_layout`,
+//!   `text_display_layout`, `status_bar_layout`, `activity_bar_layout`).
+//! - **ABSOLUTE** — shifted by `rect.x` / `rect.y`, i.e. target-surface
+//!   coordinates a caller can compare directly against raw click
+//!   coordinates with no further adjustment. Used by primitives that are
+//!   painted as a freestanding widget at their own screen rect and whose
+//!   callers don't otherwise track that rect (`tab_bar_layout`,
+//!   `menu_bar_layout`, `split_layout`, `split_tree_layout`,
+//!   `panel_layout`, `toast_stack_layout`, `pipeline_view_layout`,
+//!   `progress_layout`, `spinner_layout`, `command_center_layout`,
+//!   `toolbar_layout`, `sidebar_panel_layout`, `chart_layout`,
+//!   `minimap_layout`, `msv_layout`, `text_input_layout`).
+//!
+//! Both frames are legitimate — the rule this file enforces is that the
+//! frame is *stated on the method's doc comment* and *matches what every
+//! backend implementation actually returns* (see
+//! `quadraui/docs/DECISIONS.md` D-005 for why the split exists and why
+//! it isn't collapsed to one frame; `quadraui/docs/PRIMITIVE_RULES.md`
+//! "Coordinate frames for `*_layout` methods" for the authoring rule).
+//! `quadraui/docs/LESSONS.md` "Layout helpers must return coords in the
+//! same frame across backends" records the bug class this convention
+//! guards against: a `*_layout` twin that silently disagrees with its
+//! own TUI/GTK siblings about which frame it returns.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -766,12 +800,21 @@ pub trait Backend {
     /// (a terminal cell can't be subdivided).
     fn draw_tree(&mut self, rect: Rect, tree: &TreeView);
     fn draw_list(&mut self, rect: Rect, list: &ListView);
+    /// Draw `table` into `rect` and return its layout for hit-testing.
+    /// Coordinate frame: **LOCAL** — `hit_regions` / row bounds are
+    /// relative to `rect`'s origin, matching [`Self::data_table_layout`]
+    /// (issue #505).
     fn draw_data_table(
         &mut self,
         rect: Rect,
         table: &DataTable,
         hovered_idx: Option<usize>,
     ) -> DataTableLayout;
+    /// Compute the data-table layout without painting. Coordinate frame:
+    /// **LOCAL** — relative to `rect`'s origin, `(0, 0)` at `rect`'s
+    /// top-left; callers subtract `rect.x` / `rect.y` from absolute
+    /// click coordinates before calling `hit_test` (issue #505; see the
+    /// module doc's *Coordinate frames* section).
     fn data_table_layout(&self, rect: Rect, table: &DataTable) -> DataTableLayout;
     /// Horizontal scrollbar geometry for `list` rendered into `rect`, or
     /// `None` when its content fits. Each backend supplies its native row
@@ -1107,15 +1150,26 @@ pub trait Backend {
     /// this to drive hit-testing for scrollbar drag interaction without
     /// re-deriving metrics — paint and click consume one layout per
     /// frame, the source-of-truth contract.
+    ///
+    /// Coordinate frame: **LOCAL** — relative to `rect`'s origin
+    /// (issue #505).
     fn text_display_layout(&self, rect: Rect, td: &TextDisplay) -> TextDisplayLayout;
 
     /// Draw a [`TextInput`] (multi-line text entry) and return the
     /// resolved layout for hit-testing. Backends paint the border,
     /// text lines, cursor, and placeholder (when active).
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `content_bounds` / hit regions
+    /// are shifted by `rect.x` / `rect.y`, matching [`Self::text_input_layout`]
+    /// (issue #505).
     fn draw_text_input(&mut self, rect: Rect, ti: &TextInput) -> TextInputLayout;
 
     /// Compute the layout `draw_text_input` would produce. Used by
     /// hosts to route clicks without re-rendering.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`;
+    /// callers compare directly against raw click coordinates
+    /// (issue #505).
     fn text_input_layout(&self, rect: Rect, ti: &TextInput) -> TextInputLayout;
 
     /// Draw a [`Tooltip`] popup at its caller-resolved layout, with the
@@ -1184,6 +1238,10 @@ pub trait Backend {
     /// to drive hit-testing without re-deriving metrics — paint and
     /// click consume one layout per frame, the source-of-truth
     /// contract `MultiSectionView` exists to enforce.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `hit_regions` / body bounds are
+    /// shifted by `rect.x` / `rect.y`; callers compare them directly
+    /// against raw click coordinates (issue #505).
     fn msv_layout(&self, rect: Rect, view: &MultiSectionView) -> MultiSectionViewLayout;
 
     /// Return the layout metrics this backend uses for MSV layout.
@@ -1196,6 +1254,14 @@ pub trait Backend {
     /// to row indices without re-deriving the row pitch (1 cell
     /// uniform on TUI; `1.0×`/`1.4×` line_height by `Decoration` on
     /// GTK).
+    ///
+    /// Coordinate frame: **LOCAL** — `visible_rows.bounds` / `hit_regions`
+    /// are relative to `rect`'s origin (`(0, 0)` at `rect`'s top-left);
+    /// callers subtract `rect.x` / `rect.y` from absolute click
+    /// coordinates before calling `hit_test` (issue #505; see
+    /// `primitives::layout_metrics::tree_layout`'s doc, and
+    /// `docs/LESSONS.md`'s `mac_tree_layout` postmortem for why this
+    /// frame is load-bearing).
     fn tree_layout(&self, rect: Rect, tree: &TreeView) -> TreeViewLayout;
 
     /// Compute the form layout the rasteriser would produce for `form`
@@ -1203,6 +1269,9 @@ pub trait Backend {
     /// to drive hit-testing — especially for `ToggleGroup` and
     /// `ButtonRow` fields where per-item hit regions depend on
     /// backend-specific text measurement.
+    ///
+    /// Coordinate frame: **LOCAL** — relative to `rect`'s origin
+    /// (issue #505).
     fn form_layout(&self, rect: Rect, form: &Form) -> FormLayout;
 
     /// Draw an [`Editor`]. Returns paint-side data the host needs
@@ -1298,7 +1367,8 @@ pub trait Backend {
     /// Draw a [`MenuBar`]. The backend computes the layout internally
     /// with native metrics (cells for TUI, Pango pixels for GTK) and
     /// returns the [`MenuBarLayout`] so hosts can route clicks via
-    /// `layout.hit_test(x, y)` without re-deriving metrics.
+    /// `layout.hit_test(x, y)` without re-deriving metrics. Same
+    /// coordinate frame as [`Self::menu_bar_layout`] (ABSOLUTE).
     fn draw_menu_bar(&mut self, rect: Rect, bar: &MenuBar) -> MenuBarLayout;
 
     /// Compute the menu-bar layout the rasteriser would produce for
@@ -1306,17 +1376,24 @@ pub trait Backend {
     /// call this in click handlers to resolve hits against the same
     /// layout that was painted — never re-derive with a hand-rolled
     /// measurer.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505).
     fn menu_bar_layout(&self, rect: Rect, bar: &MenuBar) -> MenuBarLayout;
 
     /// Draw a [`Split`] divider. The backend computes the layout with
     /// its native divider thickness (1 cell for TUI, ~4px for GTK)
     /// and returns the [`SplitLayout`] so hosts can route clicks and
     /// drive drag operations. Pane content is NOT drawn — hosts paint
-    /// into `layout.first_bounds` / `layout.second_bounds`.
+    /// into `layout.first_bounds` / `layout.second_bounds`. Same
+    /// coordinate frame as [`Self::split_layout`] (ABSOLUTE).
     fn draw_split(&mut self, rect: Rect, split: &Split) -> SplitLayout;
 
     /// Compute the split layout without painting. Hosts call this in
     /// drag handlers to recompute the ratio from cursor position.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `first_bounds` / `divider_bounds`
+    /// / `second_bounds` are shifted by `rect.x` / `rect.y` (issue #505).
     fn split_layout(&self, rect: Rect, split: &Split) -> SplitLayout;
 
     /// Draw a [`SplitTree`]'s dividers. The backend computes the
@@ -1326,12 +1403,16 @@ pub trait Backend {
     /// [`SplitTreeLayout::hit_test_divider_cell`] /
     /// [`SplitTreeLayout::hit_test_leaf`]) and drive drag operations
     /// via [`crate::DragTarget::SplitDivider`]. Leaf content is NOT
-    /// drawn — hosts paint into each `layout.leaves[i].1` rect.
+    /// drawn — hosts paint into each `layout.leaves[i].1` rect. Same
+    /// coordinate frame as [`Self::split_tree_layout`] (ABSOLUTE).
     fn draw_split_tree(&mut self, rect: Rect, tree: &SplitTree) -> SplitTreeLayout;
 
     /// Compute the split-tree layout without painting. Hosts call this
     /// in drag handlers to recompute a divider's ratio from cursor
     /// position without re-painting.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — leaf / divider bounds are
+    /// shifted by `rect.x` / `rect.y` (issue #505).
     fn split_tree_layout(&self, rect: Rect, tree: &SplitTree) -> SplitTreeLayout;
 
     /// Draw a [`Panel`] chrome (title bar + action buttons). The
@@ -1339,33 +1420,45 @@ pub trait Backend {
     /// (1 cell for TUI, line_height for GTK) and returns the
     /// [`PanelLayout`] so hosts can route clicks to actions, title
     /// bar, or content. Content is NOT drawn — hosts paint into
-    /// `layout.content_bounds`.
+    /// `layout.content_bounds`. Same coordinate frame as
+    /// [`Self::panel_layout`] (ABSOLUTE).
     fn draw_panel(&mut self, rect: Rect, panel: &Panel) -> PanelLayout;
 
     /// Compute the panel layout without painting. Hosts call this in
     /// click handlers to resolve hits without re-deriving metrics.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `title_bar_bounds` / action /
+    /// `content_bounds` are shifted by `rect.x` / `rect.y` (issue #505).
     fn panel_layout(&self, rect: Rect, panel: &Panel) -> PanelLayout;
 
     /// Draw a [`ToastStack`] overlay. The backend computes the layout
     /// with its native toast dimensions (cell-width boxes for TUI,
     /// pixel boxes for GTK) and returns the [`ToastStackLayout`] so
-    /// hosts can route clicks to dismiss, action, or body.
+    /// hosts can route clicks to dismiss, action, or body. Same
+    /// coordinate frame as [`Self::toast_stack_layout`] (ABSOLUTE).
     fn draw_toast_stack(&mut self, rect: Rect, stack: &ToastStack) -> ToastStackLayout;
 
     /// Compute the toast-stack layout without painting. Hosts call
     /// this in click handlers to resolve hits.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505).
     fn toast_stack_layout(&self, rect: Rect, stack: &ToastStack) -> ToastStackLayout;
 
     /// Draw a [`PipelineView`] (horizontal multi-stage workflow widget).
     /// The backend paints stage boxes, status icons, labels, optional
     /// action buttons, and arrow connectors. Returns the
     /// [`PipelineViewLayout`] so hosts can route clicks via
-    /// `layout.hit_test(x, y)` without re-deriving metrics.
+    /// `layout.hit_test(x, y)` without re-deriving metrics. Same
+    /// coordinate frame as [`Self::pipeline_view_layout`] (ABSOLUTE).
     fn draw_pipeline_view(&mut self, rect: Rect, view: &PipelineView) -> PipelineViewLayout;
 
     /// Compute pipeline-view layout without painting. Hosts call this in
     /// click handlers to resolve hits against the same layout that was
     /// painted — never re-derive with a hand-rolled measurer.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505).
     fn pipeline_view_layout(&self, rect: Rect, view: &PipelineView) -> PipelineViewLayout;
 
     /// Draw a [`DiffView`] (two-pane side-by-side or unified diff viewer).
@@ -1375,24 +1468,38 @@ pub trait Backend {
 
     /// Draw a [`ProgressBar`]. The backend paints the track, fill,
     /// optional label, and optional cancel affordance. Returns the
-    /// [`ProgressBarLayout`] so hosts can route clicks.
+    /// [`ProgressBarLayout`] so hosts can route clicks. Same
+    /// coordinate frame as [`Self::progress_layout`] (ABSOLUTE).
     fn draw_progress(&mut self, rect: Rect, bar: &ProgressBar) -> ProgressBarLayout;
 
     /// Compute progress-bar layout without painting.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505).
     fn progress_layout(&self, rect: Rect, bar: &ProgressBar) -> ProgressBarLayout;
 
     /// Draw a [`Spinner`] (indeterminate activity indicator). Returns
-    /// the [`SpinnerLayout`] for host hit-testing.
+    /// the [`SpinnerLayout`] for host hit-testing. Same coordinate
+    /// frame as [`Self::spinner_layout`] (ABSOLUTE).
     fn draw_spinner(&mut self, rect: Rect, spinner: &Spinner) -> SpinnerLayout;
 
     /// Compute spinner layout without painting.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505).
     fn spinner_layout(&self, rect: Rect, spinner: &Spinner) -> SpinnerLayout;
 
     /// Draw a [`CommandCenter`] (nav arrows + search box). Returns the
-    /// [`CommandCenterLayout`] so hosts can route clicks.
+    /// [`CommandCenterLayout`] so hosts can route clicks. Same
+    /// coordinate frame as [`Self::command_center_layout`] (ABSOLUTE).
     fn draw_command_center(&mut self, rect: Rect, cc: &CommandCenter) -> CommandCenterLayout;
 
     /// Compute command-center layout without painting.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505; regression-tested against `LESSONS.md`'s "same
+    /// frame across backends" rule by `mac_command_center_layout`'s
+    /// non-zero-origin test).
     fn command_center_layout(&self, rect: Rect, cc: &CommandCenter) -> CommandCenterLayout;
 
     /// Draw a [`Toolbar`] (horizontal strip of action buttons above a
@@ -1401,7 +1508,8 @@ pub trait Backend {
     /// rasteriser can tint the matching button's background (same
     /// pattern as `StatusBar`). Returns the [`ToolbarLayout`] so hosts
     /// can route clicks via `layout.hit_test(x, y)` without re-deriving
-    /// metrics.
+    /// metrics. Same coordinate frame as [`Self::toolbar_layout`]
+    /// (ABSOLUTE).
     fn draw_toolbar(
         &mut self,
         rect: Rect,
@@ -1412,6 +1520,9 @@ pub trait Backend {
 
     /// Compute toolbar layout without painting. Hosts call this after
     /// `ScreenLayout::draw()` to recover hit regions for click dispatch.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505).
     fn toolbar_layout(&self, rect: Rect, bar: &Toolbar) -> ToolbarLayout;
 
     /// Draw a [`SidebarPanel`] — optional header toolbar + content
@@ -1421,7 +1532,8 @@ pub trait Backend {
     /// `Panel` rasteriser contract.
     ///
     /// `hovered_toolbar_id` / `pressed_toolbar_id` are forwarded to
-    /// the nested toolbar paint for hover / pressed tints.
+    /// the nested toolbar paint for hover / pressed tints. Same
+    /// coordinate frame as [`Self::sidebar_panel_layout`] (ABSOLUTE).
     fn draw_sidebar_panel(
         &mut self,
         rect: Rect,
@@ -1433,13 +1545,17 @@ pub trait Backend {
     /// Compute sidebar-panel layout without painting. Hosts call this
     /// in click handlers to resolve hits to the toolbar / content /
     /// outside without re-deriving metrics.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `content_bounds` / toolbar
+    /// bounds are shifted by `rect.x` / `rect.y` (issue #505).
     fn sidebar_panel_layout(&self, rect: Rect, panel: &SidebarPanel) -> SidebarPanelLayout;
 
     /// Draw a [`Chart`] (sparkline, line, or bar). `hovered_point`
     /// carries per-frame hover state (series_idx, data_idx) so the
     /// rasteriser can highlight the data point under the cursor.
     /// Returns the [`ChartLayout`] so hosts can route clicks and
-    /// resolve nearest-point from mouse position.
+    /// resolve nearest-point from mouse position. Same coordinate
+    /// frame as [`Self::chart_layout`] (ABSOLUTE).
     fn draw_chart(
         &mut self,
         rect: Rect,
@@ -1449,6 +1565,10 @@ pub trait Backend {
     ) -> ChartLayout;
 
     /// Compute chart layout without painting.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `bounds` / `hit_regions` /
+    /// `data_point_positions` are shifted by `rect.x` / `rect.y`
+    /// (issue #505).
     fn chart_layout(&self, rect: Rect, chart: &Chart) -> ChartLayout;
 
     /// Draw a [`BoardModel`] (kanban/pipeline board widget).
@@ -1481,6 +1601,7 @@ pub trait Backend {
     /// Returns [`MinimapPaintResult`] carrying the resolved
     /// [`MinimapLayout`] so hosts can route clicks via
     /// `result.layout.hit_test(x, y)` without re-deriving geometry.
+    /// Same coordinate frame as [`Self::minimap_layout`] (ABSOLUTE).
     ///
     /// No default impl — every backend implementer sees this as a
     /// compile error and fills in a real rasteriser (`PRIMITIVE_RULES.md`
@@ -1492,6 +1613,10 @@ pub trait Backend {
     /// this from `AppLogic::handle` (which only has `&mut self`, not the
     /// `MinimapPaintResult` `render` produced) to hit-test a click
     /// against the same geometry the last paint used.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — shifted by `rect.x` / `rect.y`
+    /// (issue #505). Not implemented on macOS (`todo!()`, out of scope
+    /// per #382) — do not call on that backend.
     fn minimap_layout(&self, rect: Rect, minimap: &Minimap) -> MinimapLayout;
 
     /// Paint `image` within `rect`, honoring `image.fit` (see

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -5283,6 +5283,87 @@ mod tests {
         );
     }
 
+    /// `data_table_layout` is documented **LOCAL** (issue #505):
+    /// `GtkBackend`'s impl never reads `rect.x`/`rect.y` at all — it
+    /// only forwards `rect.width`/`rect.height` to `DataTable::layout`
+    /// — so a non-zero origin must produce byte-identical column/row
+    /// geometry to the zero-origin case. This guards against a future
+    /// edit that starts folding `rect.x`/`rect.y` in (an accidental
+    /// switch to ABSOLUTE, the exact bug class `LESSONS.md`'s
+    /// `mac_tree_layout` postmortem describes).
+    #[test]
+    fn gtk_backend_data_table_layout_ignores_rect_origin() {
+        use crate::primitives::data_table::{Column, ColumnWidth, DataRow};
+        use crate::types::StyledText;
+
+        let table = crate::DataTable {
+            id: WidgetId::new("dt"),
+            columns: vec![Column {
+                title: "Name".into(),
+                width: ColumnWidth::Fixed(40.0),
+                align: Default::default(),
+            }],
+            rows: vec![DataRow {
+                cells: vec![StyledText::plain("a")],
+                decoration: Default::default(),
+            }],
+            selected_idx: None,
+            scroll_offset: 0,
+            sort: None,
+            has_focus: false,
+            show_scrollbar: false,
+            min_total_width: None,
+            h_scroll: 0.0,
+            column_overrides: vec![],
+            footer: None,
+        };
+
+        let backend = GtkBackend::new();
+        let at_origin =
+            Backend::data_table_layout(&backend, QRect::new(0.0, 0.0, 100.0, 50.0), &table);
+        let shifted =
+            Backend::data_table_layout(&backend, QRect::new(7.0, 13.0, 100.0, 50.0), &table);
+
+        assert_eq!(
+            at_origin.columns, shifted.columns,
+            "LOCAL data_table_layout must not shift column bounds by rect.x/rect.y"
+        );
+    }
+
+    /// `form_layout` is documented **LOCAL** (issue #505): `GtkBackend`'s
+    /// impl calls `form.layout(rect.width, rect.height, ..)` — `rect.x`/
+    /// `rect.y` are never read — so a non-zero origin must produce
+    /// byte-identical hit-region geometry to the zero-origin case.
+    #[test]
+    fn gtk_backend_form_layout_ignores_rect_origin() {
+        use crate::primitives::form::{FieldKind, FormField};
+        use crate::types::StyledText;
+
+        let form = crate::primitives::form::Form {
+            id: WidgetId::new("f"),
+            fields: vec![FormField {
+                id: WidgetId::new("f1"),
+                label: StyledText::plain("Name"),
+                kind: FieldKind::Label,
+                hint: StyledText::plain(""),
+                disabled: false,
+                validation: None,
+            }],
+            focused_field: None,
+            scroll_offset: 0,
+            has_focus: false,
+        };
+
+        let backend = GtkBackend::new();
+        let at_origin = Backend::form_layout(&backend, QRect::new(0.0, 0.0, 100.0, 50.0), &form);
+        let shifted = Backend::form_layout(&backend, QRect::new(7.0, 13.0, 100.0, 50.0), &form);
+
+        assert_eq!(
+            at_origin.hit_regions, shifted.hit_regions,
+            "LOCAL form_layout must not shift hit regions by rect.x/rect.y"
+        );
+    }
+
     /// #416 review follow-up: `SidebarPanel` composes a `Toolbar` header
     /// internally (`gtk::sidebar_panel::draw_sidebar_panel` calls
     /// `gtk::toolbar::draw_toolbar` directly, bypassing

--- a/quadraui/src/gtk/chart.rs
+++ b/quadraui/src/gtk/chart.rs
@@ -661,4 +661,37 @@ mod tests {
             "rightmost sub-bar should be series 2"
         );
     }
+
+    /// `chart_layout` is documented **ABSOLUTE** (issue #505):
+    /// `plot_area` / `data_point_positions` must be shifted by the
+    /// chart's own origin, not left at (0, 0) — the case that hides a
+    /// LOCAL/ABSOLUTE mixup.
+    fn layout_round_trip_at(x: f64, y: f64) {
+        let chart = bar_chart(
+            ChartKind::Bar,
+            vec![series("a", vec![1.0, 2.0])],
+            (0.0, 2.0),
+        );
+        let layout = gtk_chart_layout(&chart, x, y, 100.0, 40.0, 12.0, 6.0);
+
+        assert_eq!(layout.plot_area.x as f64, x);
+        assert!(!layout.data_point_positions.is_empty());
+        for &(_, _, px, py) in &layout.data_point_positions {
+            assert!(
+                px as f64 >= x && py as f64 >= y,
+                "data point ({px}, {py}) must not fall left of/above the chart's own origin ({x}, {y})"
+            );
+        }
+    }
+
+    #[test]
+    fn layout_round_trip() {
+        layout_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn layout_round_trip_at_nonzero_origin() {
+        layout_round_trip_at(7.0, 13.0);
+    }
 }

--- a/quadraui/src/gtk/command_center.rs
+++ b/quadraui/src/gtk/command_center.rs
@@ -146,3 +146,62 @@ pub fn draw_command_center(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::command_center::CommandCenterHit;
+    use crate::types::WidgetId;
+    use pangocairo::cairo::{Context as CairoContext, Format, ImageSurface};
+
+    fn headless_pango_layout() -> (ImageSurface, pango::Layout) {
+        let surface = ImageSurface::create(Format::ARgb32, 400, 100).expect("create ImageSurface");
+        let cr = CairoContext::new(&surface).expect("Context::new");
+        let layout = pangocairo::functions::create_layout(&cr);
+        (surface, layout)
+    }
+
+    /// `command_center_layout` is documented **ABSOLUTE** (issue #505):
+    /// `back_bounds` / `search_bounds` must be shifted by the strip's
+    /// own origin, not left at (0, 0) — the case that hides a
+    /// LOCAL/ABSOLUTE mixup (also regression-tested for macOS as
+    /// `mac_command_center_layout`'s non-zero-origin test, cited from
+    /// this method's trait doc comment).
+    fn round_trip_at(x: f64, y: f64) {
+        let (_surface, pango_layout) = headless_pango_layout();
+        let cc = CommandCenter {
+            id: WidgetId::new("cc"),
+            back_enabled: true,
+            forward_enabled: true,
+            search_label: "project".into(),
+        };
+        let layout = gtk_command_center_layout(&cc, &pango_layout, x, y, 400.0, 24.0);
+
+        let back = layout.back_bounds.expect("back bounds present");
+        assert!(
+            back.x as f64 >= x,
+            "back.x={} must not fall left of the strip's own origin {x}",
+            back.x
+        );
+
+        let search = layout.search_bounds.expect("search bounds present");
+        let scx = search.x + 1.0;
+        let scy = search.y + 1.0;
+        assert_eq!(layout.hit_test(scx, scy), CommandCenterHit::SearchBox);
+
+        let bcx = back.x + back.width / 2.0;
+        let bcy = back.y + back.height / 2.0;
+        assert_eq!(layout.hit_test(bcx, bcy), CommandCenterHit::Back);
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/minimap.rs
+++ b/quadraui/src/gtk/minimap.rs
@@ -699,28 +699,47 @@ mod tests {
 
     // ── paint/click round trip ────────────────────────────────────────
 
-    #[test]
-    fn paint_and_click_round_trip_returns_seek_for_the_clicked_fraction() {
+    /// Shared body for `paint_and_click_round_trip_returns_seek_for_the_clicked_fraction`
+    /// — `minimap_layout` is documented **ABSOLUTE**
+    /// (`docs/PRIMITIVE_RULES.md` "Coordinate frames for `*_layout`
+    /// methods", issue #505), so `hit_test` must be called with
+    /// coordinates shifted by the same `x`/`y` origin the strip was
+    /// painted at.
+    fn paint_and_click_round_trip_at(x: f64, y: f64) {
         let mm = minimap_from(vec!["x"; 8], 8);
         let (cr, pango_layout) = surface_and_layout();
         let layout = draw_minimap(
             &cr,
             &pango_layout,
-            0.0,
-            0.0,
+            x,
+            y,
             40.0,
             100.0,
             &mm,
             &Theme::default(),
         );
         assert_eq!(
-            layout.hit_test(20.0, 50.0),
+            layout.hit_test((x + 20.0) as f32, (y + 50.0) as f32),
             MinimapHit::Seek { fraction: 0.5 }
         );
         assert_eq!(
-            layout.hit_test(20.0, 0.0),
+            layout.hit_test((x + 20.0) as f32, y as f32),
             MinimapHit::Seek { fraction: 0.0 }
         );
+    }
+
+    #[test]
+    fn paint_and_click_round_trip_returns_seek_for_the_clicked_fraction() {
+        paint_and_click_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"): `(x, y) = (0, 0)` is exactly the case where a
+    /// LOCAL/ABSOLUTE mixup in `gtk_minimap_layout` would be invisible.
+    #[test]
+    fn paint_and_click_round_trip_returns_seek_for_the_clicked_fraction_at_nonzero_origin() {
+        paint_and_click_round_trip_at(7.0, 13.0);
     }
 
     #[test]

--- a/quadraui/src/gtk/multi_section_view.rs
+++ b/quadraui/src/gtk/multi_section_view.rs
@@ -1090,4 +1090,42 @@ mod tests {
             item_h
         );
     }
+
+    /// `msv_layout` is documented **ABSOLUTE** (issue #505): section
+    /// header/body bounds must start at the view's own origin, not
+    /// (0, 0) — the case that hides a LOCAL/ABSOLUTE mixup.
+    fn header_hit_round_trip_at(x: f32, y: f32) {
+        let view = view_with(vec![tree_section("alpha", &["a1", "a2"])]);
+        let bounds = QRect::new(x, y, 100.0, 60.0);
+        let layout = gtk_msv_layout(&view, bounds, LINE_HEIGHT);
+
+        let sl = &layout.sections[0];
+        assert_eq!(sl.header_bounds.x, x);
+        assert_eq!(sl.header_bounds.y, y);
+
+        let hx = sl.header_bounds.x + 5.0;
+        let hy = sl.header_bounds.y + sl.header_bounds.height / 2.0;
+        match layout.hit_test(hx, hy) {
+            MultiSectionViewHit::Header { section, .. } => assert_eq!(section, 0),
+            other => panic!("expected Header hit at ({hx}, {hy}), got {other:?}"),
+        }
+
+        let bx = sl.body_bounds.x + 1.0;
+        let by = sl.body_bounds.y + 1.0;
+        match layout.hit_test(bx, by) {
+            MultiSectionViewHit::Body { section } => assert_eq!(section, 0),
+            other => panic!("expected Body hit at ({bx}, {by}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn header_hit_round_trip() {
+        header_hit_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn header_hit_round_trip_at_nonzero_origin() {
+        header_hit_round_trip_at(7.0, 13.0);
+    }
 }

--- a/quadraui/src/gtk/panel.rs
+++ b/quadraui/src/gtk/panel.rs
@@ -97,3 +97,55 @@ pub fn draw_panel(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::panel::{Panel, PanelAction, PanelHit};
+    use crate::types::{StyledText, WidgetId};
+
+    /// `panel_layout` is documented **ABSOLUTE** (issue #505):
+    /// `title_bar_bounds` / `content_bounds` must start at the panel's
+    /// own origin, not at (0, 0) — the case that would hide a
+    /// LOCAL/ABSOLUTE mixup.
+    fn round_trip_at(x: f64, y: f64) {
+        let panel = Panel {
+            id: WidgetId::new("p"),
+            title: Some(StyledText::plain("Title")),
+            actions: vec![PanelAction {
+                id: WidgetId::new("close"),
+                icon: "×".into(),
+                tooltip: String::new(),
+                is_active: false,
+            }],
+            accent: None,
+            collapsed: false,
+        };
+        let layout = gtk_panel_layout(&panel, x, y, 200.0, 100.0, 20.0);
+
+        let tb = layout.title_bar_bounds.expect("title bar present");
+        assert_eq!(tb.x as f64, x);
+        assert_eq!(tb.y as f64, y);
+        assert_eq!(layout.content_bounds.x as f64, x);
+
+        let va = &layout.visible_actions[0];
+        let acx = va.bounds.x + va.bounds.width / 2.0;
+        let acy = va.bounds.y + va.bounds.height / 2.0;
+        assert_eq!(layout.hit_test(acx, acy), PanelHit::Action(va.id.clone()));
+
+        let ccx = layout.content_bounds.x + 1.0;
+        let ccy = layout.content_bounds.y + 1.0;
+        assert_eq!(layout.hit_test(ccx, ccy), PanelHit::Content(panel.id));
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/pipeline_view.rs
+++ b/quadraui/src/gtk/pipeline_view.rs
@@ -422,4 +422,39 @@ mod tests {
             "no focus → reserved strip above the box must stay background white, got {px:?}"
         );
     }
+
+    /// `pipeline_view_layout` is documented **ABSOLUTE** (issue #505):
+    /// `box_bounds` / `action_bounds` must be shifted by the widget's
+    /// own origin, not left at (0, 0) — the case that hides a
+    /// LOCAL/ABSOLUTE mixup.
+    fn hit_test_round_trip_at(x: f64, y: f64) {
+        use crate::primitives::pipeline_view::PipelineHit;
+
+        let mut view = make_view();
+        view.stages[0].action = Some("Retry".into());
+        let layout = gtk_pipeline_view_layout(&view, x, y, 200.0, 50.0);
+
+        let stage = &layout.stages[0];
+        assert_eq!(stage.box_bounds.x as f64, x);
+
+        let action = stage.action_bounds.expect("action bounds present");
+        let acx = action.x + action.width / 2.0;
+        let acy = action.y + action.height / 2.0;
+        assert_eq!(layout.hit_test(acx, acy), PipelineHit::Action(0));
+
+        let bcx = stage.box_bounds.x + 2.0;
+        let bcy = stage.box_bounds.y + 2.0;
+        assert_eq!(layout.hit_test(bcx, bcy), PipelineHit::Body(0));
+    }
+
+    #[test]
+    fn hit_test_round_trip() {
+        hit_test_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn hit_test_round_trip_at_nonzero_origin() {
+        hit_test_round_trip_at(7.0, 13.0);
+    }
 }

--- a/quadraui/src/gtk/progress.rs
+++ b/quadraui/src/gtk/progress.rs
@@ -93,3 +93,54 @@ pub fn draw_progress(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::progress::ProgressBarHit;
+    use crate::types::WidgetId;
+
+    /// `progress_layout` is documented **ABSOLUTE** (issue #505):
+    /// `fill_bounds` / `cancel_bounds` must start at the bar's own
+    /// origin, not (0, 0) — the case that hides a LOCAL/ABSOLUTE mixup.
+    fn round_trip_at(x: f64, y: f64) {
+        let bar = ProgressBar {
+            id: WidgetId::new("prog"),
+            label: String::new(),
+            value: Some(0.5),
+            frame_idx: 0,
+            cancellable: true,
+            accent: None,
+        };
+        let layout = gtk_progress_layout(&bar, x, y, 100.0, 20.0);
+
+        let fb = layout.fill_bounds.expect("determinate fill present");
+        assert_eq!(fb.x as f64, x);
+        assert_eq!(fb.y as f64, y);
+
+        let cb = layout.cancel_bounds.expect("cancel bounds present");
+        let ccx = cb.x + cb.width / 2.0;
+        let ccy = cb.y + cb.height / 2.0;
+        assert_eq!(
+            layout.hit_test(ccx, ccy),
+            ProgressBarHit::Cancel(bar.id.clone())
+        );
+
+        let bcx = fb.x + 1.0;
+        assert_eq!(
+            layout.hit_test(bcx, y as f32 + 1.0),
+            ProgressBarHit::Body(bar.id)
+        );
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/sidebar_panel.rs
+++ b/quadraui/src/gtk/sidebar_panel.rs
@@ -129,3 +129,44 @@ pub fn draw_sidebar_panel(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::sidebar_panel::SidebarPanelHit;
+
+    /// `sidebar_panel_layout` is documented **ABSOLUTE** (issue #505):
+    /// `content_bounds` must start at the panel's own origin, not
+    /// (0, 0) — the case that hides a LOCAL/ABSOLUTE mixup.
+    fn round_trip_at(x: f64, y: f64) {
+        let panel = SidebarPanel {
+            id: WidgetId::new("sp"),
+            toolbar: None,
+            toolbar_height: None,
+        };
+        let layout = gtk_sidebar_panel_layout(&panel, None, 6.0, 14.0, x, y, 100.0, 60.0);
+
+        assert_eq!(layout.content_bounds.x as f64, x);
+        assert_eq!(layout.content_bounds.y as f64, y);
+
+        let cx = layout.content_bounds.x + 1.0;
+        let cy = layout.content_bounds.y + 1.0;
+        match layout.hit_test(cx, cy) {
+            SidebarPanelHit::Content { x: rel_x, y: rel_y } => {
+                assert!((rel_x - 1.0).abs() < 0.01 && (rel_y - 1.0).abs() < 0.01);
+            }
+            other => panic!("expected Content hit at ({cx}, {cy}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/spinner.rs
+++ b/quadraui/src/gtk/spinner.rs
@@ -64,3 +64,53 @@ pub fn draw_spinner(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::spinner::SpinnerHit;
+    use crate::types::WidgetId;
+    use pangocairo::cairo::{Context as CairoContext, Format, ImageSurface};
+
+    fn headless_pango_layout() -> (ImageSurface, pango::Layout) {
+        let surface = ImageSurface::create(Format::ARgb32, 200, 200).expect("create ImageSurface");
+        let cr = CairoContext::new(&surface).expect("Context::new");
+        let layout = pangocairo::functions::create_layout(&cr);
+        (surface, layout)
+    }
+
+    /// `spinner_layout` is documented **ABSOLUTE** (issue #505):
+    /// `bounds` must start at the spinner's own origin, not (0, 0) —
+    /// the case that hides a LOCAL/ABSOLUTE mixup.
+    fn round_trip_at(x: f64, y: f64) {
+        let (_surface, pango_layout) = headless_pango_layout();
+        let spinner = Spinner {
+            id: WidgetId::new("spin"),
+            label: "Indexing".into(),
+            frame_idx: 0,
+            accent: None,
+        };
+        let layout = gtk_spinner_layout(&spinner, &pango_layout, x, y);
+
+        assert_eq!(layout.bounds.x as f64, x);
+        assert_eq!(layout.bounds.y as f64, y);
+
+        let cx = layout.bounds.x + 1.0;
+        let cy = layout.bounds.y + 1.0;
+        assert_eq!(
+            layout.hit_test(cx, cy, &spinner.id),
+            SpinnerHit::Body(spinner.id.clone())
+        );
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/split.rs
+++ b/quadraui/src/gtk/split.rs
@@ -45,3 +45,54 @@ pub fn draw_split(
 
     layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::split::{Split, SplitDirection, SplitHit};
+    use crate::types::WidgetId;
+
+    fn round_trip_at(x: f64, y: f64) {
+        let split = Split {
+            id: WidgetId::new("s"),
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first_min: 0.0,
+            second_min: 0.0,
+        };
+        let layout = gtk_split_layout(&split, x, y, 100.0, 40.0);
+
+        // `split_layout` is documented **ABSOLUTE** (issue #505):
+        // `first_bounds` must start exactly at the origin the split was
+        // laid out at, not at (0, 0).
+        assert_eq!(layout.first_bounds.x as f64, x);
+        assert_eq!(layout.first_bounds.y as f64, y);
+
+        // A click inside the first pane's own (absolute) bounds must
+        // resolve back to it without any further coordinate shift.
+        let cx = layout.first_bounds.x + layout.first_bounds.width / 2.0;
+        let cy = layout.first_bounds.y + layout.first_bounds.height / 2.0;
+        assert_eq!(
+            layout.hit_test(cx, cy),
+            SplitHit::FirstPane(split.id.clone())
+        );
+
+        let dx = layout.divider_bounds.x + layout.divider_bounds.width / 2.0;
+        let dy = layout.divider_bounds.y + layout.divider_bounds.height / 2.0;
+        assert_eq!(layout.hit_test(dx, dy), SplitHit::Divider(split.id));
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"): `(x, y) = (0, 0)` is exactly the case where a
+    /// LOCAL/ABSOLUTE mixup in `gtk_split_layout` would be invisible.
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/split_tree.rs
+++ b/quadraui/src/gtk/split_tree.rs
@@ -61,11 +61,72 @@ pub fn draw_split_tree(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::Point;
     use crate::primitives::split_tree::SplitDirection;
     use crate::types::WidgetId;
 
     fn wid(s: &str) -> WidgetId {
         WidgetId::new(s)
+    }
+
+    /// `split_tree_layout` is documented **ABSOLUTE** (issue #505):
+    /// leaf/divider bounds are shifted by the origin, so `(x, y) = (0, 0)`
+    /// is exactly the case where a LOCAL/ABSOLUTE mixup is invisible.
+    fn round_trip_at(x: f64, y: f64) {
+        let tree = SplitTree::split(
+            SplitDirection::Horizontal,
+            0.5,
+            SplitTree::leaf(wid("a")),
+            SplitTree::leaf(wid("b")),
+        );
+        let layout = gtk_split_tree_layout(&tree, x, y, 100.0, 40.0);
+
+        assert_eq!(
+            layout.leaves[0].1.x as f64, x,
+            "first leaf must start at the split's own x"
+        );
+        assert_eq!(
+            layout.leaves[0].1.y as f64, y,
+            "first leaf must start at the split's own y"
+        );
+
+        let d = &layout.dividers[0];
+        let cross_mid = y as f32 + 20.0;
+        assert_eq!(
+            layout.hit_test_divider(
+                Point {
+                    x: d.position,
+                    y: cross_mid
+                },
+                1.0
+            ),
+            Some(d.split_index)
+        );
+        assert_eq!(
+            layout.hit_test_leaf(Point {
+                x: x as f32 + 1.0,
+                y: cross_mid
+            }),
+            Some(&wid("a"))
+        );
+        assert_eq!(
+            layout.hit_test_leaf(Point {
+                x: d.position + 10.0,
+                y: cross_mid
+            }),
+            Some(&wid("b"))
+        );
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
     }
 
     #[test]

--- a/quadraui/src/gtk/status_bar.rs
+++ b/quadraui/src/gtk/status_bar.rs
@@ -149,3 +149,98 @@ pub fn draw_status_bar(
 
     bar_layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::status_bar::StatusBarHit;
+    use crate::types::Color;
+    use pangocairo::cairo::{Context as CairoContext, Format, ImageSurface};
+
+    fn headless_cairo_and_pango() -> (ImageSurface, pango::Layout) {
+        let surface = ImageSurface::create(Format::ARgb32, 200, 200).expect("create ImageSurface");
+        let cr = CairoContext::new(&surface).expect("Context::new");
+        let layout = pangocairo::functions::create_layout(&cr);
+        (surface, layout)
+    }
+
+    fn test_bar() -> StatusBar {
+        StatusBar {
+            id: WidgetId::new("sb"),
+            left_segments: vec![StatusBarSegment {
+                text: "Ready".into(),
+                fg: Color::rgb(255, 255, 255),
+                bg: Color::rgb(0, 0, 0),
+                bold: false,
+                action_id: Some(WidgetId::new("sb:action")),
+            }],
+            right_segments: vec![],
+        }
+    }
+
+    /// `status_bar_layout` is documented **LOCAL** (issue #505):
+    /// `StatusBar::layout` (called by `draw_status_bar` internally) only
+    /// ever receives `width`/`line_height` — the `x`/`y` this function
+    /// paints at are used purely to offset the Cairo drawing calls, never
+    /// folded into the returned `StatusBarLayout`. Painting at a
+    /// non-zero origin must therefore produce byte-identical segment
+    /// bounds / hit regions to painting at the origin — the same
+    /// "ignores origin" shape `data_table_layout`/`form_layout` already
+    /// guard on GTK (`gtk::backend` tests), which `status_bar_layout`
+    /// had no equivalent for.
+    fn round_trip_at(x: f64, y: f64) {
+        let (surface, pango_layout) = headless_cairo_and_pango();
+        let cr = CairoContext::new(&surface).expect("Context::new");
+        let theme = Theme::default();
+        let bar = test_bar();
+
+        let at_origin = draw_status_bar(
+            &cr,
+            &pango_layout,
+            0.0,
+            0.0,
+            100.0,
+            20.0,
+            &bar,
+            &theme,
+            None,
+            None,
+        );
+        let shifted = draw_status_bar(
+            &cr,
+            &pango_layout,
+            x,
+            y,
+            100.0,
+            20.0,
+            &bar,
+            &theme,
+            None,
+            None,
+        );
+
+        assert_eq!(
+            at_origin, shifted,
+            "LOCAL status_bar_layout must not shift segment bounds by x/y"
+        );
+
+        let seg = shifted.visible_segments[0];
+        let cx = seg.bounds.x + 1.0;
+        let cy = seg.bounds.y + 1.0;
+        assert_eq!(
+            shifted.hit_test(cx, cy),
+            StatusBarHit::Segment(bar.left_segments[0].action_id.clone().unwrap())
+        );
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/text_display.rs
+++ b/quadraui/src/gtk/text_display.rs
@@ -186,3 +186,64 @@ pub fn gtk_text_display_layout(
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::text_display::{TextDisplayHit, TextDisplayLine};
+    use crate::types::{Decoration, StyledSpan, WidgetId};
+
+    fn display(show_scrollbar: bool) -> TextDisplay {
+        TextDisplay {
+            id: WidgetId::new("td"),
+            lines: (0..20)
+                .map(|i| TextDisplayLine {
+                    spans: vec![StyledSpan::plain(format!("line{i}"))],
+                    decoration: Decoration::Normal,
+                    timestamp: None,
+                })
+                .collect(),
+            scroll_offset: 0,
+            auto_scroll: false,
+            max_lines: 0,
+            has_focus: false,
+            title: None,
+            show_scrollbar,
+        }
+    }
+
+    /// `text_display_layout` is documented **LOCAL** (issue #505):
+    /// `gtk_text_display_layout` never reads `rect.x`/`rect.y`, so the
+    /// returned `scrollbar_bounds` / `hit_test` results must be
+    /// identical regardless of where `rect` is positioned — the
+    /// opposite regression from the ABSOLUTE methods (a LOCAL method
+    /// that accidentally starts folding in the origin), but the same
+    /// "must agree across origins" contract.
+    fn scrollbar_thumb_round_trip_at(x: f32, y: f32) {
+        let rect = crate::event::Rect::new(x, y, 20.0, 5.0);
+        let d = display(true);
+        let layout = gtk_text_display_layout(&d, rect, 1.0);
+
+        let thumb = layout.thumb_bounds.expect("thumb bounds present");
+        // LOCAL frame: thumb bounds must not have absorbed rect.x/rect.y.
+        assert!(
+            thumb.x < rect.width,
+            "thumb.x={} must stay inside the local frame",
+            thumb.x
+        );
+
+        let hit = layout.hit_test(thumb.x + 0.5, thumb.y + 0.5);
+        assert_eq!(hit, TextDisplayHit::ScrollbarThumb);
+    }
+
+    #[test]
+    fn scrollbar_thumb_paint_and_click_round_trip() {
+        scrollbar_thumb_round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn scrollbar_thumb_paint_and_click_round_trip_at_nonzero_origin() {
+        scrollbar_thumb_round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/text_input.rs
+++ b/quadraui/src/gtk/text_input.rs
@@ -164,3 +164,56 @@ pub fn draw_text_input(
 
     li
 }
+
+#[cfg(test)]
+mod layout_tests {
+    use super::*;
+    use crate::event::Point;
+    use crate::primitives::text_input::TextInputHit;
+    use crate::types::WidgetId;
+
+    /// `text_input_layout` is documented **ABSOLUTE** (issue #505):
+    /// `content_bounds` / hit regions must be shifted by `rect.x`/
+    /// `rect.y`, not left at (0, 0) — the case that hides a
+    /// LOCAL/ABSOLUTE mixup.
+    fn round_trip_at(x: f32, y: f32) {
+        let ti = TextInput {
+            id: WidgetId::new("ti"),
+            lines: vec!["hello".into()],
+            cursor_line: 0,
+            cursor_col: 0,
+            placeholder: None,
+            scroll_offset: 0,
+            scroll_col: 0,
+            has_focus: true,
+        };
+        let rect = crate::event::Rect::new(x, y, 40.0, 20.0);
+        let layout = gtk_text_input_layout(&ti, rect, 10.0, 8.0);
+
+        // Content sits inset by a fixed border + padding from `rect`'s
+        // own origin (1px border + 1 char-width horizontal padding, 1px
+        // vertical) — ABSOLUTE means that inset tracks `rect.x`/`rect.y`
+        // exactly, not a fixed (0, 0)-relative offset.
+        assert_eq!(layout.content_bounds.x, x + 1.0 + 8.0);
+        assert_eq!(layout.content_bounds.y, y + 1.0);
+
+        let p = Point::new(layout.content_bounds.x + 0.5, layout.content_bounds.y + 0.5);
+        let hit = layout
+            .hit_regions
+            .iter()
+            .find(|(r, _)| r.contains(p))
+            .map(|(_, h)| h.clone());
+        assert_eq!(hit, Some(TextInputHit::Line { line_idx: 0 }));
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/toolbar.rs
+++ b/quadraui/src/gtk/toolbar.rs
@@ -262,3 +262,63 @@ pub fn draw_toolbar(
     cr.restore().ok();
     toolbar_layout
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::toolbar::ToolbarHit;
+    use crate::types::WidgetId;
+
+    fn test_toolbar() -> Toolbar {
+        Toolbar {
+            id: WidgetId::new("tb"),
+            buttons: vec![ToolbarButton::Action {
+                id: WidgetId::new("tb:action"),
+                label: "Refine".into(),
+                icon: None,
+                key_hint: None,
+                enabled: true,
+                is_active: false,
+                tooltip: String::new(),
+            }],
+            bg: None,
+            focused_index: None,
+        }
+    }
+
+    /// `toolbar_layout` is documented **ABSOLUTE** (issue #505):
+    /// `gtk_toolbar_layout` forwards `x`/`y` straight through to
+    /// `Toolbar::layout` as `origin_x`/`origin_y`, which folds them into
+    /// every visible item's `bounds` — so a non-zero origin must shift
+    /// bounds by exactly `(x, y)`, unlike the LOCAL primitives
+    /// (`status_bar_layout`, `data_table_layout`, `form_layout`) that
+    /// ignore it entirely. `pango_layout: None` exercises the
+    /// `char_width` fallback measurer, the same path a click-time
+    /// (outside-frame) hit test uses.
+    fn round_trip_at(x: f64, y: f64) {
+        let bar = test_toolbar();
+        let layout = gtk_toolbar_layout(&bar, None, 8.0, x, y, 100.0, 20.0);
+
+        let vis = &layout.visible_items[0];
+        assert_eq!(vis.bounds.x as f64, x);
+        assert_eq!(vis.bounds.y as f64, y);
+
+        let ccx = vis.bounds.x + 1.0;
+        let ccy = vis.bounds.y + 1.0;
+        assert_eq!(
+            layout.hit_test(ccx, ccy),
+            ToolbarHit::Button(WidgetId::new("tb:action"))
+        );
+    }
+
+    #[test]
+    fn paint_and_click_round_trip() {
+        round_trip_at(0.0, 0.0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md).
+    #[test]
+    fn paint_and_click_round_trip_at_nonzero_origin() {
+        round_trip_at(7.0, 13.0);
+    }
+}

--- a/quadraui/src/gtk/tree.rs
+++ b/quadraui/src/gtk/tree.rs
@@ -905,4 +905,40 @@ mod tests {
             }
         }
     }
+
+    /// `tree_layout` is documented **LOCAL** (issue #505): `bounds` must
+    /// stay relative to `area`'s origin regardless of where `area`
+    /// itself lives — the same contract `mac_tree_layout`'s
+    /// `layout_returns_local_coords_when_area_offset` guards (#44
+    /// postmortem, `docs/LESSONS.md`). Since #499, `gtk_tree_layout` and
+    /// `mac_tree_layout` share one implementation
+    /// (`layout_metrics::tree_layout`), but this repo's own GTK test
+    /// suite had no non-zero-origin coverage of its own until now.
+    #[test]
+    fn layout_returns_local_coords_when_area_offset() {
+        let tree = make_tree(vec![leaf(0, "alpha"), leaf(1, "beta"), leaf(2, "gamma")]);
+        let area = QRect::new(0.0, 60.0, 240.0, 180.0);
+        let layout = gtk_tree_layout(&tree, area, 16.0);
+
+        let first = &layout.visible_rows[0];
+        assert_eq!(
+            first.bounds.y, 0.0,
+            "visible_rows.bounds.y must be local (0.0), got {}",
+            first.bounds.y,
+        );
+
+        for vr in &layout.visible_rows {
+            let abs_x = area.x + vr.bounds.x + vr.bounds.width * 0.5;
+            let abs_y = area.y + vr.bounds.y + vr.bounds.height * 0.5;
+            // Localise the way a host must (subtract area.x/area.y)
+            // before calling hit_test, per the documented contract.
+            let hit = layout.hit_test(abs_x - area.x, abs_y - area.y);
+            assert!(
+                matches!(hit, TreeViewHit::Row(idx) if idx == vr.row_idx),
+                "row {} at local bounds {:?} did not round-trip through localised hit_test",
+                vr.row_idx,
+                vr.bounds,
+            );
+        }
+    }
 }

--- a/quadraui/src/tui/minimap.rs
+++ b/quadraui/src/tui/minimap.rs
@@ -260,20 +260,39 @@ mod tests {
         assert_ne!(buf[(0u16, 1u16)].bg, ratatui_color(theme.accent_bg));
     }
 
-    #[test]
-    fn paint_and_click_round_trip_returns_seek_for_the_clicked_fraction() {
+    /// Shared body for `paint_and_click_round_trip_returns_seek_for_the_clicked_fraction`
+    /// — see `docs/PRIMITIVE_RULES.md`'s "Coordinate frames for
+    /// `*_layout` methods" (issue #505): `minimap_layout` is documented
+    /// **ABSOLUTE**, so `hit_test` must be called with coordinates
+    /// shifted by the same `origin_x`/`origin_y` the minimap was
+    /// painted at, not with area-local coordinates.
+    fn paint_and_click_round_trip_at(origin_x: u16, origin_y: u16) {
         let mm = minimap_from(vec!["x"; 8], 8);
-        let area = Rect::new(0, 0, 4, 8); // 2 rows of 4 lines each -> track height 8
+        let area = Rect::new(origin_x, origin_y, 4, 8); // 2 rows of 4 lines each -> track height 8
         let mut buf = Buffer::empty(area);
         let layout = draw_minimap(&mut buf, area, &mm, &Theme::default());
         assert_eq!(
-            layout.hit_test(2.0, 4.0),
+            layout.hit_test(origin_x as f32 + 2.0, origin_y as f32 + 4.0),
             MinimapHit::Seek { fraction: 0.5 }
         );
         assert_eq!(
-            layout.hit_test(2.0, 0.0),
+            layout.hit_test(origin_x as f32 + 2.0, origin_y as f32),
             MinimapHit::Seek { fraction: 0.0 }
         );
+    }
+
+    #[test]
+    fn paint_and_click_round_trip_returns_seek_for_the_clicked_fraction() {
+        paint_and_click_round_trip_at(0, 0);
+    }
+
+    /// Non-zero-origin regression guard (issue #505 / LESSONS.md
+    /// "Layout helpers must return coords in the same frame across
+    /// backends"): `area = (0, 0)` is exactly the case where a
+    /// LOCAL/ABSOLUTE mixup in `tui_minimap_layout` would be invisible.
+    #[test]
+    fn paint_and_click_round_trip_returns_seek_for_the_clicked_fraction_at_nonzero_origin() {
+        paint_and_click_round_trip_at(7, 13);
     }
 
     #[test]


### PR DESCRIPTION
Closes #505

Automated PR opened by coordinator for review of issue #505.