### PR TITLE
#504: Backend API unit hygiene: cursor_position→Point, retire TabBarHits f64 legacy, f32 hit structs, native-unit selection ranges

### DIFF
--- a/quadraui/examples/common/activity_style_demo.rs
+++ b/quadraui/examples/common/activity_style_demo.rs
@@ -146,7 +146,7 @@ impl AppLogic for ActivityStyleDemo {
                 let hits = backend.activity_bar_layout(bar_rect, &self.bar());
                 let rel_y = position.y - bar_rect.y;
                 for hit in &hits {
-                    if (rel_y as f64) >= hit.y_start && (rel_y as f64) < hit.y_end {
+                    if rel_y >= hit.y_start && rel_y < hit.y_end {
                         if let Some(idx) = (0..LABELS.len()).find(|&i| hit.id == item_id(i)) {
                             self.activate(idx);
                             return Reaction::Redraw;

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -1674,7 +1674,7 @@ pub enum ImagePaintResult {
 
 /// Shift every x-span in `hits` right by `dx`.
 ///
-/// [`tab_bar_layout_to_hits`] yields **bar-relative** x (the primitive
+/// [`tab_bar_hits_from_layout`] yields **bar-relative** x (the primitive
 /// measures from `0.0`), but the [`TabBarHits`] contract is
 /// target-surface (absolute) coordinates. Rasterisers and the no-paint
 /// `tab_bar_layout` variants both call this with `rect.x` so the two
@@ -1712,7 +1712,36 @@ pub fn shift_tab_bar_hits(hits: &mut TabBarHits, dx: f64) {
 /// Spans are **bar-relative** on return; callers that owe the
 /// [`TabBarHits`] absolute contract must follow up with
 /// [`shift_tab_bar_hits`] using `rect.x`.
+///
+/// # Deprecated (issue #504)
+///
+/// Renamed to [`tab_bar_hits_from_layout`] — same body, same contract.
+/// `TabBarHits`'s `f64` coordinate fields predate the crate's f32-native
+/// convention (`Point`/`Rect`), and this converter is the thing that
+/// keeps constructing them; every in-repo caller now goes through the
+/// new name so this deprecated one has **zero in-repo callers**, per
+/// CLAUDE.md's two-PR deprecate-then-remove protocol. Full retirement of
+/// `TabBarHits` itself (the `f64` fields, and the six `Backend` trait
+/// methods that return it) is a separate, much larger follow-up: `vimcode`
+/// holds a real, non-doc-only dependency on `TabBarHits`'s field types
+/// (`src/core/engine/mod.rs`, `src/core/engine/terminal_ops.rs`,
+/// `src/gtk/mod.rs`), and two of the four backends (`macos::tab_bar`,
+/// `win::tab_bar`) construct `TabBarHits` directly without ever computing
+/// an intermediate `TabBarLayout`, so a safe migration needs new native
+/// per-backend rasterisers, not just a signature change.
+#[deprecated(since = "0.0.1", note = "renamed to `tab_bar_hits_from_layout`")]
 pub fn tab_bar_layout_to_hits(layout: &TabBarLayout, bar: &TabBar) -> TabBarHits {
+    tab_bar_hits_from_layout(layout, bar)
+}
+
+/// Convert a `TabBarLayout` to the legacy `TabBarHits` struct.
+///
+/// Spans are **bar-relative** on return; callers that owe the
+/// [`TabBarHits`] absolute contract must follow up with
+/// [`shift_tab_bar_hits`] using `rect.x`. See
+/// [`tab_bar_layout_to_hits`]'s doc for why `TabBarHits` itself — not
+/// just this converter's name — is still legacy (issue #504).
+pub fn tab_bar_hits_from_layout(layout: &TabBarLayout, bar: &TabBar) -> TabBarHits {
     let mut slot_positions = vec![(0.0, 0.0); bar.tabs.len()];
     let mut close_bounds = vec![None; bar.tabs.len()];
     let mut right_segment_bounds = Vec::new();
@@ -1777,15 +1806,42 @@ pub fn activity_bar_hits(rect: Rect, bar: &ActivityBar, lh: f32) -> Vec<Activity
 /// terminal cursor) populate the actual cursor cell.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct EditorPaintResult {
+    /// Terminal-cell `(x, y)` cursor position, if the host is responsible
+    /// for terminal-cursor positioning. `None` when the backend painted
+    /// its own caret OR when the cursor is outside the viewport.
+    ///
+    /// # Deprecated (issue #504)
+    ///
+    /// This field leaked a TUI-only representation — `ratatui::Frame::
+    /// set_cursor_position` wants a `(u16, u16)` cell pair — into a
+    /// portable trait return type every other backend had to fake with
+    /// `None`. [`Self::cursor_position_native`] replaces it with a
+    /// [`Point`] in each backend's own native unit (TUI still rounds to
+    /// the nearest cell internally before widening).
+    ///
+    /// Kept alive, and still populated by the TUI backend, because
+    /// `vimcode` (`src/tui_main/render_impl.rs`) reads this field
+    /// directly and passes it straight into `Frame::set_cursor_position`,
+    /// which only has `impl From<(u16, u16)> for Position` — there is no
+    /// `From<Point>` quadraui could add (orphan rule). Per CLAUDE.md's
+    /// two-PR deprecate-then-remove protocol, removing this field is a
+    /// separate follow-up PR, gated on that vimcode call site migrating
+    /// to `cursor_position_native` first.
+    #[deprecated(
+        since = "0.0.1",
+        note = "use `cursor_position_native` (`Point`, native units) instead; kept populated by the TUI backend until vimcode's `Frame::set_cursor_position(result.cursor_position)` call site migrates (issue #504)"
+    )]
+    pub cursor_position: Option<(u16, u16)>,
+
     /// Cursor's painted position in backend-native units (issue #504 —
-    /// this used to be a terminal-cell `(u16, u16)` pair leaked from the
-    /// TUI backend's `ratatui::Frame::set_cursor_position` plumbing; every
-    /// other backend just wants a [`Point`] in its own native unit), if
-    /// the host is responsible for terminal-cursor positioning. `None`
-    /// when the backend painted its own caret OR when the cursor is
-    /// outside the viewport. TUI rounds to the nearest cell internally
-    /// before returning.
-    pub cursor_position: Option<Point>,
+    /// the forward-looking replacement for the deprecated
+    /// [`Self::cursor_position`]; every backend but TUI just wants a
+    /// [`Point`] in its own native unit), if the host is responsible for
+    /// terminal-cursor positioning. `None` when the backend painted its
+    /// own caret OR when the cursor is outside the viewport. TUI rounds
+    /// to the nearest cell internally before returning, then widens the
+    /// cell coordinates back into this field's `f32` unit.
+    pub cursor_position_native: Option<Point>,
 }
 
 /// Trait for content that can render itself into a rect using any backend.

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -45,7 +45,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::dispatch::DragState;
-use crate::event::{Rect, UiEvent, Viewport};
+use crate::event::{Point, Rect, UiEvent, Viewport};
 use crate::modal_stack::ModalStack;
 use crate::primitives::activity_bar::{ActivityBarRowHit, ActivityBarStyle};
 use crate::primitives::board::{BoardLayout, BoardModel};
@@ -1750,8 +1750,8 @@ pub fn activity_bar_hits(rect: Rect, bar: &ActivityBar, lh: f32) -> Vec<Activity
         hits.push(ActivityBarRowHit {
             id: item.id.clone(),
             tooltip: item.tooltip.clone(),
-            y_start: y as f64,
-            y_end: (y + lh) as f64,
+            y_start: y,
+            y_end: y + lh,
         });
         y += lh;
     }
@@ -1761,8 +1761,8 @@ pub fn activity_bar_hits(rect: Rect, bar: &ActivityBar, lh: f32) -> Vec<Activity
         hits.push(ActivityBarRowHit {
             id: item.id.clone(),
             tooltip: item.tooltip.clone(),
-            y_start: by as f64,
-            y_end: (by + lh) as f64,
+            y_start: by,
+            y_end: by + lh,
         });
         by += lh;
     }
@@ -1777,11 +1777,15 @@ pub fn activity_bar_hits(rect: Rect, bar: &ActivityBar, lh: f32) -> Vec<Activity
 /// terminal cursor) populate the actual cursor cell.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct EditorPaintResult {
-    /// Cursor's painted position in backend-native units, if the
-    /// host is responsible for terminal-cursor positioning. `None`
+    /// Cursor's painted position in backend-native units (issue #504 —
+    /// this used to be a terminal-cell `(u16, u16)` pair leaked from the
+    /// TUI backend's `ratatui::Frame::set_cursor_position` plumbing; every
+    /// other backend just wants a [`Point`] in its own native unit), if
+    /// the host is responsible for terminal-cursor positioning. `None`
     /// when the backend painted its own caret OR when the cursor is
-    /// outside the viewport.
-    pub cursor_position: Option<(u16, u16)>,
+    /// outside the viewport. TUI rounds to the nearest cell internally
+    /// before returning.
+    pub cursor_position: Option<Point>,
 }
 
 /// Trait for content that can render itself into a rect using any backend.

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -731,9 +731,9 @@ impl AppShell {
         for hit in &hits {
             let item_bounds = Rect::new(
                 layout.activity_bar_bounds.x,
-                layout.activity_bar_bounds.y + hit.y_start as f32,
+                layout.activity_bar_bounds.y + hit.y_start,
                 layout.activity_bar_bounds.width,
-                (hit.y_end - hit.y_start) as f32,
+                hit.y_end - hit.y_start,
             );
             backend.register_zone(hit.id.clone(), item_bounds);
         }
@@ -1099,8 +1099,8 @@ impl AppShell {
         let ab = (*self.cached_activity_bar_bounds.borrow())?;
         let hits = self.cached_activity_hits.borrow();
         for hit in hits.iter() {
-            if position.y >= hit.y_start as f32 + ab.y
-                && position.y < hit.y_end as f32 + ab.y
+            if position.y >= hit.y_start + ab.y
+                && position.y < hit.y_end + ab.y
                 && position.x >= ab.x
                 && position.x < ab.x + ab.width
             {
@@ -1114,9 +1114,9 @@ impl AppShell {
         if contains(layout.activity_bar_bounds, *position) {
             let ab = layout.activity_bar_bounds;
             let hits = self.cached_activity_hits.borrow();
-            self.hovered_activity_idx = hits.iter().position(|hit| {
-                position.y >= hit.y_start as f32 + ab.y && position.y < hit.y_end as f32 + ab.y
-            });
+            self.hovered_activity_idx = hits
+                .iter()
+                .position(|hit| position.y >= hit.y_start + ab.y && position.y < hit.y_end + ab.y);
         } else {
             self.hovered_activity_idx = None;
         }

--- a/quadraui/src/compose/bottom_panel.rs
+++ b/quadraui/src/compose/bottom_panel.rs
@@ -445,7 +445,7 @@ mod tests {
     /// (4 label + 2 padding/close), maximise segment = 3 cells. Converted to
     /// `TabBarHits` exactly as a backend's `draw_tab_bar` would return them.
     fn prime_layout(ctrl: &mut BottomPanelController, strip_x: f32, strip_y: f32, bar_w: f32) {
-        use crate::backend::tab_bar_layout_to_hits;
+        use crate::backend::tab_bar_hits_from_layout;
         use crate::primitives::tab_bar::{SegmentMeasure, TabMeasure};
 
         let tab_bar = ctrl.build_tab_bar();
@@ -465,7 +465,7 @@ mod tests {
         );
         // Mirror the backends: `TabBarHits` are returned in target-surface
         // (absolute) coordinates, i.e. offset by the strip's x origin.
-        let mut hits = tab_bar_layout_to_hits(&layout, &tab_bar);
+        let mut hits = tab_bar_hits_from_layout(&layout, &tab_bar);
         let ox = strip_x as f64;
         for sp in &mut hits.slot_positions {
             if *sp != (0.0, 0.0) {

--- a/quadraui/src/compose/tab_group.rs
+++ b/quadraui/src/compose/tab_group.rs
@@ -1794,7 +1794,7 @@ fn update_split_ratio_inorder(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::tab_bar_layout_to_hits;
+    use crate::backend::tab_bar_hits_from_layout;
     use crate::primitives::tab_bar::{SegmentMeasure, TabMeasure};
 
     // ── Minimal BackendWidget for tests ──────────────────────────────────────
@@ -1854,7 +1854,7 @@ mod tests {
             },
             |_| SegmentMeasure::new(3.0),
         );
-        let mut hits = tab_bar_layout_to_hits(&layout, &bar);
+        let mut hits = tab_bar_hits_from_layout(&layout, &bar);
         // Shift hits to absolute coords (mirror what backends do).
         let ox = strip_x as f64;
         for sp in &mut hits.slot_positions {

--- a/quadraui/src/dispatch.rs
+++ b/quadraui/src/dispatch.rs
@@ -467,6 +467,17 @@ pub struct TextRegion {
 /// [`crate::event::Rect`]) — callers still pass pre-quantized
 /// cell-space coordinates (the "+1" below is one *unit*, i.e. one
 /// character cell, not one pixel), just without the lossy truncation.
+///
+/// # Downstream impact
+///
+/// This function (and its crate-root re-export,
+/// `quadraui::text_selection_line_range`) is `pub`, so its
+/// `Vec<(u16, u16, u16)>` → `Vec<(u16, f32, f32)>` return-type change is
+/// technically a breaking `pub` API change too. `grep -rn
+/// text_selection_line_range ~/src/coord-tui/src ~/src/vimcode/src`
+/// found no direct call sites — vimcode's `core/engine/terminal_ops.rs`
+/// even documents explicitly why it deliberately avoids this function —
+/// so no consumer migration is needed.
 pub fn text_selection_line_range(
     anchor: Point,
     focus: Point,

--- a/quadraui/src/dispatch.rs
+++ b/quadraui/src/dispatch.rs
@@ -452,11 +452,26 @@ pub struct TextRegion {
 ///
 /// Coordinates are clamped to `bounds`. Returns an empty `Vec` when
 /// `anchor == focus` (selection collapsed to a point — plain click).
+///
+/// # Units (issue #504)
+///
+/// `row` is a discrete line/cell-row index (it indexes
+/// [`TextRegion::lines`] and is always integral in every backend's
+/// space) and stays `u16`. `col_start` / `col_end` used to be `u16`
+/// too, silently assuming the caller's x-axis is a whole-cell grid —
+/// true for TUI, but GTK/macOS only get that by pre-quantizing pixel
+/// coordinates into a fake cell grid (`bounds.width / char_width`) and
+/// rounding, which loses the fractional remainder of a viewport that
+/// isn't an exact multiple of the glyph advance. They're `f32` now,
+/// matching every other native-unit span in this crate ([`Point`],
+/// [`crate::event::Rect`]) — callers still pass pre-quantized
+/// cell-space coordinates (the "+1" below is one *unit*, i.e. one
+/// character cell, not one pixel), just without the lossy truncation.
 pub fn text_selection_line_range(
     anchor: Point,
     focus: Point,
     bounds: crate::event::Rect,
-) -> Vec<(u16, u16, u16)> {
+) -> Vec<(u16, f32, f32)> {
     // Empty when anchor == focus (no movement → collapsed click).
     let ax = anchor.x.round() as i32;
     let ay = anchor.y.round() as i32;
@@ -473,17 +488,17 @@ pub fn text_selection_line_range(
         (focus, anchor)
     };
 
-    let region_x = bounds.x.round() as u16;
-    let region_end_x = (bounds.x + bounds.width).round() as u16;
+    let region_x = bounds.x.round();
+    let region_end_x = (bounds.x + bounds.width).round();
     let region_y = bounds.y.round() as u16;
     let region_end_y = (bounds.y + bounds.height).round() as u16;
 
     // Clamp start/end rows and cols to region.
     let start_row = (start.y.round() as u16).clamp(region_y, region_end_y.saturating_sub(1));
     let end_row = (end.y.round() as u16).clamp(region_y, region_end_y.saturating_sub(1));
-    let start_col = (start.x.round() as u16).clamp(region_x, region_end_x);
-    // End col is inclusive → add 1 for the half-open range, then clamp.
-    let end_col = ((end.x.round() as u16).saturating_add(1)).clamp(region_x, region_end_x);
+    let start_col = start.x.round().clamp(region_x, region_end_x);
+    // End col is inclusive → add one unit for the half-open range, then clamp.
+    let end_col = (end.x.round() + 1.0).clamp(region_x, region_end_x);
 
     if start_row == end_row {
         if start_col >= end_col {
@@ -2251,7 +2266,7 @@ mod tests {
         let bounds = rect(0.0, 0.0, 40.0, 10.0);
         let ranges = text_selection_line_range(pt(5.0, 3.0), pt(10.0, 3.0), bounds);
         // Half-open: 5..11 (focus_col 10 is inclusive → +1 = 11).
-        assert_eq!(ranges, vec![(3, 5, 11)]);
+        assert_eq!(ranges, vec![(3, 5.0, 11.0)]);
     }
 
     #[test]
@@ -2259,7 +2274,7 @@ mod tests {
         // Same row, focus before anchor — must swap to document order.
         let bounds = rect(0.0, 0.0, 40.0, 10.0);
         let ranges = text_selection_line_range(pt(10.0, 3.0), pt(5.0, 3.0), bounds);
-        assert_eq!(ranges, vec![(3, 5, 11)]);
+        assert_eq!(ranges, vec![(3, 5.0, 11.0)]);
     }
 
     #[test]
@@ -2270,7 +2285,7 @@ mod tests {
         // Row 1: 2..40 (start_col to region_end)
         // Row 2: 0..40 (full width)
         // Row 3: 0..6  (region_start to focus_col+1)
-        assert_eq!(ranges, vec![(1, 2, 40), (2, 0, 40), (3, 0, 6)]);
+        assert_eq!(ranges, vec![(1, 2.0, 40.0), (2, 0.0, 40.0), (3, 0.0, 6.0)]);
     }
 
     #[test]
@@ -2278,7 +2293,7 @@ mod tests {
         let bounds = rect(0.0, 0.0, 40.0, 10.0);
         // Swap anchor and focus — must produce same result in document order.
         let ranges = text_selection_line_range(pt(5.0, 3.0), pt(2.0, 1.0), bounds);
-        assert_eq!(ranges, vec![(1, 2, 40), (2, 0, 40), (3, 0, 6)]);
+        assert_eq!(ranges, vec![(1, 2.0, 40.0), (2, 0.0, 40.0), (3, 0.0, 6.0)]);
     }
 
     #[test]
@@ -2290,18 +2305,18 @@ mod tests {
         // start_col clamped to 5, end_col clamped to 25.
         assert_eq!(
             ranges[0],
-            (2, 5, 25),
+            (2, 5.0, 25.0),
             "first row: anchor clamped to region x"
         );
         assert_eq!(
             *ranges.last().unwrap(),
-            (6, 5, 25),
+            (6, 5.0, 25.0),
             "last row: focus clamped to region end"
         );
         // All middle rows are full region width.
         for &(_, c_start, c_end) in &ranges[1..ranges.len() - 1] {
-            assert_eq!(c_start, 5);
-            assert_eq!(c_end, 25);
+            assert_eq!(c_start, 5.0);
+            assert_eq!(c_end, 25.0);
         }
     }
 

--- a/quadraui/src/gtk/activity_bar.rs
+++ b/quadraui/src/gtk/activity_bar.rs
@@ -236,8 +236,8 @@ pub fn draw_activity_bar_with_style(
         super::painted_text::show_layout(cr, pango_layout);
 
         regions.push(ActivityBarRowHit {
-            y_start: y,
-            y_end: y + row_h,
+            y_start: y as f32,
+            y_end: (y + row_h) as f32,
             id: item.id.clone(),
             tooltip: item.tooltip.clone(),
         });

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -46,7 +46,7 @@ use gtk4::gdk;
 use gtk4::pango;
 use gtk4::prelude::*;
 
-use crate::backend::{activity_bar_hits, tab_bar_layout_to_hits};
+use crate::backend::{activity_bar_hits, tab_bar_hits_from_layout};
 use crate::desktop::WindowDragArm;
 use crate::dispatch::TextRegion;
 use crate::event::Point;
@@ -787,7 +787,7 @@ impl GtkBackend {
         {
             return None;
         }
-        let mut hits = crate::backend::tab_bar_layout_to_hits(layout, bar);
+        let mut hits = crate::backend::tab_bar_hits_from_layout(layout, bar);
         // `TabBarLayout` is bar-relative; `TabBarHits` are target-surface
         // coordinates (issue #552), exactly as the measured path below.
         crate::backend::shift_tab_bar_hits(&mut hits, rect.x as f64);
@@ -2262,7 +2262,7 @@ impl Backend for GtkBackend {
             },
         );
 
-        let mut hits = tab_bar_layout_to_hits(&layout, bar);
+        let mut hits = tab_bar_hits_from_layout(&layout, bar);
         // Match `draw_tab_bar` (gtk/tab_bar.rs), which shifts by the same
         // origin: `TabBarHits` are target-surface coordinates. Issue #552.
         crate::backend::shift_tab_bar_hits(&mut hits, rect.x as f64);
@@ -2400,7 +2400,7 @@ impl Backend for GtkBackend {
             crate::SegmentMeasure::new(text_w)
         });
 
-        let mut hits = tab_bar_layout_to_hits(&layout, bar);
+        let mut hits = tab_bar_hits_from_layout(&layout, bar);
         crate::backend::shift_tab_bar_hits(&mut hits, rect.x as f64);
 
         let active_idx = bar.tabs.iter().position(|t| t.is_active);

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -4512,8 +4512,8 @@ mod tests {
         assert_eq!(ranges.len(), 1, "single-row selection → 1 range entry");
         let (row_cell, col_start, col_end) = ranges[0];
         assert_eq!(row_cell, 0, "row should be cell row 0");
-        assert_eq!(col_start, 0, "col_start should be 0");
-        assert_eq!(col_end, 6, "col_end = focus_col(5) + 1 = 6 (half-open)");
+        assert_eq!(col_start, 0.0, "col_start should be 0");
+        assert_eq!(col_end, 6.0, "col_end = focus_col(5) + 1 = 6 (half-open)");
 
         // Verify pixel coordinates: 6 cols × 8px = 48px wide.
         let px_x = bounds.x as f64 + col_start as f64 * char_w as f64;

--- a/quadraui/src/gtk/tab_bar.rs
+++ b/quadraui/src/gtk/tab_bar.rs
@@ -15,7 +15,7 @@ use gtk4::cairo::Context;
 use gtk4::pango;
 
 use super::{cairo_rgb, set_source};
-use crate::backend::tab_bar_layout_to_hits;
+use crate::backend::tab_bar_hits_from_layout;
 use crate::primitives::tab_bar::{
     SegmentMeasure, TabBar, TabBarHits, TabBarLayout, TabChrome, TabFrame, TabMeasure,
 };
@@ -662,8 +662,8 @@ pub fn draw_tab_bar_icons_with_chrome(
     // Restore caller's font.
     pango_layout.set_font_description(Some(&saved_font));
 
-    let mut hits = tab_bar_layout_to_hits(&layout, bar);
-    // `tab_bar_layout_to_hits` yields bar-relative positions, but the
+    let mut hits = tab_bar_hits_from_layout(&layout, bar);
+    // `tab_bar_hits_from_layout` yields bar-relative positions, but the
     // `TabBarHits` contract is target-surface coordinates (matching the TUI
     // rasteriser and the painted glyphs above, which all add `x_offset`).
     // Shift every hit range so consumers can hit-test against raw click x.
@@ -1292,7 +1292,7 @@ mod tests {
         }
     }
 
-    /// #646 "not in scope: the hit rect" — `tab_bar_layout_to_hits` (via
+    /// #646 "not in scope: the hit rect" — `tab_bar_hits_from_layout` (via
     /// `TabBarLayout::hit_test`) must keep reporting the tab's hit region
     /// at the full `row_height`, even though the visible chip is now inset.
     /// A click 1px into the strip's top margin — above the chip's

--- a/quadraui/src/macos/activity_bar.rs
+++ b/quadraui/src/macos/activity_bar.rs
@@ -86,8 +86,8 @@ pub fn mac_activity_bar_layout(
     row_plan(height, bar)
         .into_iter()
         .map(|(y, item)| ActivityBarRowHit {
-            y_start: y,
-            y_end: y + ACTIVITY_ROW_PX,
+            y_start: y as f32,
+            y_end: (y + ACTIVITY_ROW_PX) as f32,
             id: item.id.clone(),
             tooltip: item.tooltip.clone(),
         })
@@ -217,8 +217,8 @@ pub unsafe fn draw_activity_bar_with_style(
         );
 
         regions.push(ActivityBarRowHit {
-            y_start: y,
-            y_end: y + ACTIVITY_ROW_PX,
+            y_start: y as f32,
+            y_end: (y + ACTIVITY_ROW_PX) as f32,
             id: item.id.clone(),
             tooltip: item.tooltip.clone(),
         });
@@ -434,16 +434,16 @@ mod tests {
         // 2 top + 1 bottom = 3 visible rows.
         assert_eq!(regions.len(), 3);
         assert_eq!(regions[0].y_start, 0.0);
-        assert_eq!(regions[0].y_end, ACTIVITY_ROW_PX);
+        assert_eq!(regions[0].y_end, ACTIVITY_ROW_PX as f32);
         assert_eq!(regions[0].id, WidgetId::new("activity:explorer"));
 
-        assert_eq!(regions[1].y_start, ACTIVITY_ROW_PX);
-        assert_eq!(regions[1].y_end, 2.0 * ACTIVITY_ROW_PX);
+        assert_eq!(regions[1].y_start, ACTIVITY_ROW_PX as f32);
+        assert_eq!(regions[1].y_end, 2.0 * ACTIVITY_ROW_PX as f32);
         assert_eq!(regions[1].id, WidgetId::new("activity:search"));
 
         // Bottom-pinned item.
-        assert_eq!(regions[2].y_start, H as f64 - ACTIVITY_ROW_PX);
-        assert_eq!(regions[2].y_end, H as f64);
+        assert_eq!(regions[2].y_start, H as f32 - ACTIVITY_ROW_PX as f32);
+        assert_eq!(regions[2].y_end, H as f32);
         assert_eq!(regions[2].id, WidgetId::new("activity:settings"));
     }
 

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -243,10 +243,10 @@ pub enum ActivityBarHit {
 pub struct ActivityBarRowHit {
     /// Top edge of the row, **relative to the bar's `rect.y`** (first
     /// row is `0.0`). Add the bar origin before hit-testing a click.
-    pub y_start: f64,
+    pub y_start: f32,
     /// Bottom edge (exclusive) of the row, **relative to the bar's
     /// `rect.y`**. Add the bar origin before hit-testing a click.
-    pub y_end: f64,
+    pub y_end: f32,
     pub id: WidgetId,
     pub tooltip: String,
 }

--- a/quadraui/src/primitives/activity_bar.rs
+++ b/quadraui/src/primitives/activity_bar.rs
@@ -239,6 +239,20 @@ pub enum ActivityBarHit {
 ///
 /// [`Backend::draw_activity_bar`]: crate::Backend::draw_activity_bar
 /// [`TabBarHits`]: crate::TabBarHits
+///
+/// # `f32`, not `f64` (issue #504)
+///
+/// `y_start` / `y_end` are `f32`, matching every other native-unit span
+/// in the crate (`Point`, `Rect`, `TabBarLayout`'s bounds) — this used to
+/// be `f64`, a mismatch with the all-`f32` [`ActivityBarLayout`] sitting
+/// right next to it. Free change: no downstream (`coord-tui`, `vimcode`)
+/// call site reads these fields (only an unrelated doc comment in
+/// vimcode's `shell_app.rs`), confirmed via `grep -rn ActivityBarRowHit
+/// ~/src/coord-tui/src ~/src/vimcode/src`. GTK/macOS/Win rasterisers
+/// narrow their internal `f64` pixel math to this field's `f32` on
+/// return — consistent with how every other native-unit field in this
+/// crate is produced, and not a new precision concern this change
+/// introduced.
 #[derive(Debug, Clone)]
 pub struct ActivityBarRowHit {
     /// Top edge of the row, **relative to the bar's `rect.y`** (first

--- a/quadraui/src/primitives/tab_bar.rs
+++ b/quadraui/src/primitives/tab_bar.rs
@@ -587,6 +587,36 @@ impl TabChrome {
 /// Apps consume this to dispatch clicks. Tabs before the
 /// scroll offset get sentinel entries so indices in `slot_positions`
 /// / `close_bounds` line up with `bar.tabs`.
+///
+/// # Legacy `f64` coordinates (issue #504)
+///
+/// Every other hit/layout struct in this crate (`TabBarLayout`,
+/// `ActivityBarRowHit`, `StatusBarLayout`, …) uses `f32` — the crate's
+/// native-unit convention (`Point`, `Rect`). This one still uses `f64`
+/// pairs and `available_cols: usize` in **character columns** (a TUI-only
+/// concept even GTK/macOS fake by measuring a Pango sample string),
+/// because it predates that convention and [`TabBarLayout`] — the
+/// intended f32-native replacement — didn't exist yet.
+///
+/// It stays this way rather than being fixed in place because `vimcode`
+/// (`src/core/engine/mod.rs`, `src/core/engine/terminal_ops.rs`,
+/// `src/gtk/mod.rs`) destructures these fields directly as `f64`, and
+/// CLAUDE.md's downstream-consumers policy forbids a hard break — a type
+/// change here needs the same two-PR deprecate-then-remove protocol as
+/// [`crate::backend::EditorPaintResult::cursor_position`], except across
+/// six `Backend` trait methods (`draw_tab_bar`, `draw_tab_bar_icons`,
+/// `draw_tab_bar_with_chrome`, `tab_bar_layout`, `tab_bar_layout_icons`,
+/// `tab_bar_layout_with_chrome`) and four backends, two of which
+/// (`macos::tab_bar`, `win::tab_bar`) construct this struct directly with
+/// no intermediate `TabBarLayout` to source native `f32` coordinates
+/// from. That is real, separate follow-up work, not something this PR's
+/// pass over `EditorPaintResult`/`ActivityBarRowHit` could fold in.
+///
+/// The one piece of this struct's *legacy-ness* this crate can and does
+/// fix without breaking anyone: the converter that constructs it,
+/// [`crate::backend::tab_bar_layout_to_hits`], is deprecated in favour of
+/// [`crate::backend::tab_bar_hits_from_layout`] (same body, new name, zero
+/// remaining in-repo callers of the old one).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct TabBarHits {
     /// `[(start_x, end_x)]` per tab index. Tabs before

--- a/quadraui/src/tui/activity_bar.rs
+++ b/quadraui/src/tui/activity_bar.rs
@@ -184,7 +184,7 @@ pub fn draw_activity_bar_with_style(
         // revealed it. GTK, macOS, and `backend::activity_bar_hits`
         // all already used this space; the TUI was the lone outlier.
         // Issue #552 (the coordinate-space half of #547's height fix).
-        let rel_y = (y - area.y) as f64;
+        let rel_y = (y - area.y) as f32;
         regions.push(ActivityBarRowHit {
             y_start: rel_y,
             y_end: rel_y + 1.0,

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -406,13 +406,16 @@ impl TuiBackend {
         let area = buf.area;
 
         // Cache text before inverting so we read the original cell content.
+        // `text_selection_line_range` reports cell-space columns as f32
+        // (issue #504); TUI cells are always whole units, so round-trip
+        // through `u16` for buffer indexing.
         let mut lines: Vec<String> = Vec::with_capacity(ranges.len());
         for &(row, col_start, col_end) in &ranges {
             if row >= area.y + area.height {
                 continue;
             }
             let mut line = String::new();
-            for col in col_start..col_end {
+            for col in (col_start as u16)..(col_end as u16) {
                 if col < area.x + area.width {
                     line.push_str(buf[(col, row)].symbol());
                 }
@@ -424,7 +427,7 @@ impl TuiBackend {
 
         // Now invert cells for the highlight.
         for (row, col_start, col_end) in ranges {
-            for col in col_start..col_end {
+            for col in (col_start as u16)..(col_end as u16) {
                 if col < area.x + area.width && row < area.y + area.height {
                     let cell = &mut buf[(col, row)];
                     let fg = cell.fg;
@@ -552,7 +555,7 @@ impl TuiBackend {
                 continue;
             }
             let mut line = String::new();
-            for col in col_start..col_end {
+            for col in (col_start as u16)..(col_end as u16) {
                 if col < area.x + area.width {
                     line.push_str(buf[(col, row)].symbol());
                 }
@@ -1722,7 +1725,13 @@ impl Backend for TuiBackend {
         // `last_cursor_position`'s field doc for the full handoff.
         self.last_cursor_position = tui_result.cursor_position;
         crate::backend::EditorPaintResult {
-            cursor_position: tui_result.cursor_position,
+            // `tui_result.cursor_position` is the TUI-internal, already
+            // cell-rounded `(u16, u16)` shape `Frame::set_cursor_position`
+            // needs (see `last_cursor_position`'s doc); widen to the
+            // portable `Point` (issue #504) for the trait's return value.
+            cursor_position: tui_result
+                .cursor_position
+                .map(|(x, y)| crate::event::Point::new(x as f32, y as f32)),
         }
     }
 

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -46,7 +46,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::accelerator::{key_to_binding_name, parse_binding};
-use crate::backend::{activity_bar_hits, tab_bar_layout_to_hits};
+use crate::backend::{activity_bar_hits, tab_bar_hits_from_layout};
 use crate::dispatch::TextRegion;
 use crate::testing::ZoneRec;
 use crate::{
@@ -1408,7 +1408,7 @@ impl Backend for TuiBackend {
             |i| crate::SegmentMeasure::new(bar.right_segments[i].width_cells as f32),
         );
 
-        let mut hits = tab_bar_layout_to_hits(&layout, bar);
+        let mut hits = tab_bar_hits_from_layout(&layout, bar);
         // `TabBarHits` are target-surface (absolute) coordinates per the
         // trait doc — the same space `draw_tab_bar` returns. Without this
         // the no-paint path returned bar-relative x, off by `rect.x`
@@ -1484,7 +1484,7 @@ impl Backend for TuiBackend {
             |i| crate::SegmentMeasure::new(bar.right_segments[i].width_cells as f32),
         );
 
-        let mut hits = tab_bar_layout_to_hits(&layout, bar);
+        let mut hits = tab_bar_hits_from_layout(&layout, bar);
         crate::backend::shift_tab_bar_hits(&mut hits, rect.x as f64);
 
         let active_idx = bar.tabs.iter().position(|t| t.is_active);
@@ -1724,12 +1724,17 @@ impl Backend for TuiBackend {
         // `Frame::set_cursor_position` itself. See
         // `last_cursor_position`'s field doc for the full handoff.
         self.last_cursor_position = tui_result.cursor_position;
+        #[allow(deprecated)] // issue #504: populate the deprecated cell-tuple
+        // field too, until vimcode's `render_impl.rs` call site migrates to
+        // `cursor_position_native` — see `EditorPaintResult::cursor_position`'s
+        // doc for the full deprecation contract.
         crate::backend::EditorPaintResult {
+            cursor_position: tui_result.cursor_position,
             // `tui_result.cursor_position` is the TUI-internal, already
             // cell-rounded `(u16, u16)` shape `Frame::set_cursor_position`
             // needs (see `last_cursor_position`'s doc); widen to the
             // portable `Point` (issue #504) for the trait's return value.
-            cursor_position: tui_result
+            cursor_position_native: tui_result
                 .cursor_position
                 .map(|(x, y)| crate::event::Point::new(x as f32, y as f32)),
         }
@@ -3781,7 +3786,7 @@ mod tests {
     // which is bar-relative. `draw_tab_bar` honoured that on both TUI and
     // GTK by shifting the primitive's bar-relative output by the bar's
     // origin. `Backend::tab_bar_layout` honoured it on neither: it
-    // returned `tab_bar_layout_to_hits` verbatim, so the no-paint path
+    // returned `tab_bar_hits_from_layout` verbatim, so the no-paint path
     // was off by `rect.x` — nonzero for any tab bar sitting right of a
     // sidebar, which is every AppShell layout.
     //

--- a/quadraui/src/tui/run.rs
+++ b/quadraui/src/tui/run.rs
@@ -666,6 +666,11 @@ mod tests {
         /// When false, `render` paints no editor at all — used to verify the
         /// cursor position doesn't linger from a previous frame.
         show_editor: bool,
+        /// Last `Backend::draw_editor` return value, captured verbatim
+        /// (issue #504's `cursor_position` → `cursor_position_native`
+        /// mapping test reads this directly; the terminal-cursor tests
+        /// below go through the higher-level `TuiDriver` handoff instead).
+        last_result: std::cell::RefCell<Option<crate::backend::EditorPaintResult>>,
     }
 
     impl EditorCursorApp {
@@ -673,6 +678,7 @@ mod tests {
             Self {
                 cursor_col,
                 show_editor: true,
+                last_result: std::cell::RefCell::new(None),
             }
         }
 
@@ -740,7 +746,8 @@ mod tests {
         fn render(&self, backend: &mut dyn Backend, _area: ()) {
             if self.show_editor {
                 let editor = self.build_editor();
-                backend.draw_editor(editor.rect, &editor);
+                let result = backend.draw_editor(editor.rect, &editor);
+                *self.last_result.borrow_mut() = Some(result);
             }
         }
 
@@ -780,6 +787,41 @@ mod tests {
             driver.terminal_cursor_position(),
             Some((7, 0)),
             "a later frame's draw_editor call must overwrite the previous cursor position"
+        );
+    }
+
+    /// Issue #504: `TuiBackend::draw_editor` must widen the TUI-internal,
+    /// already cell-rounded `(u16, u16)` cursor position into the portable
+    /// `EditorPaintResult::cursor_position_native` `Point` with the same
+    /// `(x, y)` ordering — and keep populating the deprecated
+    /// `cursor_position` tuple field with the exact same pair, since
+    /// `vimcode`'s `Frame::set_cursor_position(result.cursor_position)`
+    /// call site still relies on it (see that field's doc for the full
+    /// deprecation contract).
+    #[test]
+    fn draw_editor_result_maps_cell_cursor_to_native_point() {
+        let mut driver = TuiDriver::new(EditorCursorApp::new(3), 40, 10);
+        driver.render();
+
+        let result = driver
+            .app()
+            .last_result
+            .borrow()
+            .clone()
+            .expect("render() must call draw_editor and capture its result");
+
+        #[allow(deprecated)] // issue #504: asserting the deprecated shim field too
+        let cell = result.cursor_position;
+        assert_eq!(
+            cell,
+            Some((3, 0)),
+            "deprecated cursor_position must still carry the cell-rounded pair"
+        );
+        assert_eq!(
+            result.cursor_position_native,
+            cell.map(|(x, y)| Point::new(x as f32, y as f32)),
+            "cursor_position_native must be the same (x, y) pair widened to f32, \
+             not swapped or independently computed"
         );
     }
 }

--- a/quadraui/src/win/activity_bar.rs
+++ b/quadraui/src/win/activity_bar.rs
@@ -117,8 +117,8 @@ pub fn draw_activity_bar(
         let _ = dwrite.draw_text(target, icon_str, icon_rect, fg);
 
         regions.push(ActivityBarRowHit {
-            y_start: vi.bounds.y as f64,
-            y_end: (vi.bounds.y + vi.bounds.height) as f64,
+            y_start: vi.bounds.y,
+            y_end: vi.bounds.y + vi.bounds.height,
             id: item.id.clone(),
             tooltip: item.tooltip.clone(),
         });

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -906,8 +906,8 @@ impl Backend for WinBackend {
                         }
                     };
                     ActivityBarRowHit {
-                        y_start: vi.bounds.y as f64,
-                        y_end: (vi.bounds.y + vi.bounds.height) as f64,
+                        y_start: vi.bounds.y,
+                        y_end: vi.bounds.y + vi.bounds.height,
                         id: item.id.clone(),
                         tooltip: item.tooltip.clone(),
                     }

--- a/quadraui/src/win/tab_bar.rs
+++ b/quadraui/src/win/tab_bar.rs
@@ -3,7 +3,7 @@
 //! Calls [`TabBar::layout`] (the D6 layout API) with DirectWrite pixel
 //! measurers, then paints from the resolved `visible_tabs` /
 //! `visible_segments`. Converts to [`TabBarHits`] via the shared
-//! [`crate::backend::tab_bar_layout_to_hits`] / `shift_tab_bar_hits`
+//! [`crate::backend::tab_bar_hits_from_layout`] / `shift_tab_bar_hits`
 //! helpers, the same ones the TUI and GTK backends use — see
 //! `Backend::tab_bar_layout`'s doc for why that shift matters (issue
 //! #552).
@@ -24,7 +24,7 @@
 use windows::Win32::Graphics::Direct2D::ID2D1RenderTarget;
 
 use super::text::{fill_rect, DWrite};
-use crate::backend::{shift_tab_bar_hits, tab_bar_layout_to_hits};
+use crate::backend::{shift_tab_bar_hits, tab_bar_hits_from_layout};
 use crate::event::Rect;
 use crate::theme::Theme;
 use crate::{tab_icon_at, SegmentMeasure, TabBar, TabBarHits, TabBarLayout, TabIcon, TabMeasure};
@@ -147,7 +147,7 @@ fn hits_from_layout(
     icons: &[Option<TabIcon>],
     layout: &TabBarLayout,
 ) -> TabBarHits {
-    let mut hits = tab_bar_layout_to_hits(layout, bar);
+    let mut hits = tab_bar_hits_from_layout(layout, bar);
     shift_tab_bar_hits(&mut hits, rect.x as f64);
     let seg_reserved: f32 = layout
         .visible_segments


### PR DESCRIPTION
Closes #504

Automated PR opened by coordinator for review of issue #504.