### PR TITLE
#456: Two APIs paint the same primitive (Backend::draw_* vs Surface + ScreenLayout) — a cross-backend drift generator

### DIFF
--- a/quadraui/docs/ARCHITECTURE.md
+++ b/quadraui/docs/ARCHITECTURE.md
@@ -48,3 +48,17 @@ quadraui_win::draw_tree(...) } }`); the trait itself has no free-standing
 
 **`set_cell` / `cairo_rgb` / `ratatui_color` / etc.** are private
 backend helpers — never call them from primitives.
+
+**Frame composition** in `quadraui/src/frame.rs` sits above `Backend`:
+`ScreenLayout` + `Surface` is the canonical way for a consumer to
+assemble a top-level screen from multiple primitives — pushing
+`Surface` entries and calling `ScreenLayout::draw` routes every backend
+through one call site (rather than each backend calling
+`Backend::draw_<name>` at its own, potentially divergent, call site)
+and derives the click hit-map from the same data that was painted.
+`Backend::draw_*` methods remain the public, low-level rasteriser entry
+point underneath — `ScreenLayout::draw` calls them internally, and
+they're the only path for primitives that don't have a `Surface`
+variant yet. See `docs/DECISIONS.md` D-006 and
+`docs/PRIMITIVE_RULES.md` "One primitive, one canonical paint path"
+(issue #456).

--- a/quadraui/docs/DECISIONS.md
+++ b/quadraui/docs/DECISIONS.md
@@ -548,3 +548,95 @@ Instead:
 
 Future primitive decisions should cite this file when they hit the
 same fork.
+
+## D-006 — `Surface`/`ScreenLayout` is canonical; `Backend::draw_*` is the low-level entry point (issue #456)
+
+### Question
+
+`quadraui` exposes two independent ways to paint the same primitive:
+`backend.draw_<name>(rect, &data)` directly, or
+`layout.push(Surface::<Name> { rect, .. })` followed by `layout.draw(backend)`.
+Nothing steers a consumer toward one, and nothing keeps a call site that
+picks one in sync with a sibling call site (same app, other backend)
+that picks the other. #456 found exactly that in vimcode: the TUI
+palette painted via `b.draw_palette(...)`, the GTK palette via
+`frame.push(Surface::Palette { .. })` — five of six surrounding lines
+identical, only the paint call differing for no reason but that both
+APIs exist. That drift contributed to vimcode#587 (a GTK paint function
+with zero live callers going unnoticed).
+
+### Audit
+
+`SMELL_AUDIT_2026-07.md` §4 quantified the gap: `frame.rs`'s `Surface`
+enum covers 25 primitives. 11 primitives that already have a
+`Backend::draw_<name>` trait method have **no** `Surface` variant:
+Board, DiffView, PipelineView, Toolbar, SidebarPanel, TextInput,
+Spinner, Progress, CommandCenter, DropOverlay, MessageList. `Surface`
+also only ever wraps primitive paints, not the helper draws that exist
+alongside a primitive's main one (`draw_terminal_divider`,
+`draw_settings_chrome`, `draw_tab_bar_with_chrome`,
+`draw_activity_bar_with_style`, `draw_tooltip_with_chrome`), which have
+no z-order slot of their own by design — they're always painted
+adjacent to a primitive that does.
+
+### Decision
+
+**`ScreenLayout` + `Surface` is the canonical path for a consumer
+assembling a top-level screen out of multiple primitives.** Pushing
+`Surface` entries and calling `.draw(backend)` forces both backends'
+call sites through the same list, and `zone_for` (shared by `draw` and
+`hit_map`, see the doc comment on `ScreenLayout::zone_for`) guarantees
+the hit-map matches what was painted — the class of "two backends, two
+different paint calls, silently different behavior" bug #456 describes
+becomes a compile-time non-option for anything routed through
+`Surface`, because there's only one call site to route through.
+
+**`Backend::draw_<name>` is not deprecated, hidden, or downgraded — it
+stays public, documented API**, because:
+
+1. `ScreenLayout::draw` calls it internally. `Surface` is sugar over
+   `Backend::draw_*`, not a replacement for it; the trait method has to
+   stay exactly as public as it is today or the "canonical" path has
+   nothing to delegate to.
+2. The 11 primitives listed above have no `Surface` variant yet, so
+   `Backend::draw_*` is the *only* path available for them. A consumer
+   painting `Toolbar` or `Progress` today is not taking a shortcut —
+   there is no `Surface::Toolbar` to take instead.
+3. Rasteriser tests (`PRIMITIVE_RULES.md` rule 4's paint/click
+   round-trip harness) and compose helpers legitimately call
+   `Backend::draw_*` directly — they're testing or composing the
+   primitive itself, not assembling an app screen, and have no reason
+   to go through `ScreenLayout`.
+
+**Going forward: rule 7 in `PRIMITIVE_RULES.md` ("every primitive gets
+a `Backend::draw_<name>` trait method") is extended one hop.** A new
+primitive that participates in top-level screen composition (i.e. gets
+a `draw_<name>` trait method that a consumer calls directly to paint
+part of a frame) gets its `Surface::<Name>` / `FrameZone::<Name>` /
+`zone_for` arm added in the *same PR* — see the new "One primitive, one
+canonical paint path" section in `PRIMITIVE_RULES.md`. This stops new
+drift; it does not retroactively backfill the 11-primitive gap above,
+which is `SMELL_AUDIT_2026-07.md` §7 Epic D's `D4` ("trait symmetry"),
+scoped separately because it touches 11 primitives' worth of
+`Surface`/`FrameZone` plumbing rather than a single decision.
+
+### What this does NOT mean
+
+- It does not mean `Backend::draw_*` should get `#[doc(hidden)]` or
+  `#[deprecated]`. vimcode's TUI palette call site
+  (`b.draw_palette(...)`, the #456 evidence) is exactly the kind of
+  call a primitive with no `Surface` variant, a rasteriser test, or a
+  compose helper legitimately makes — hiding or deprecating the whole
+  trait surface over an 11-primitive coverage gap would force a worse
+  workaround than the drift it's meant to fix, and would breach rule
+  8's downstream-impact bar for no compensating benefit (both
+  consumers call `Backend::draw_*` methods directly today).
+- It does not retroactively fix vimcode's existing palette divergence
+  — that's vimcode's own migration (tracked as vimcode#587's
+  follow-up). This decision fixes which API a *new* call site should
+  reach for; it doesn't rewrite call sites in other repos.
+- It does not block a primitive that is legitimately never composed
+  into a multi-primitive frame (none identified so far) from staying
+  `Backend::draw_*`-only indefinitely — the rule is "if it's composed
+  into a `ScreenLayout` frame, it needs a `Surface` variant," not
+  "every primitive must have one."

--- a/quadraui/docs/PRIMITIVE_RULES.md
+++ b/quadraui/docs/PRIMITIVE_RULES.md
@@ -50,7 +50,10 @@ Read this when adding or changing a primitive.
    rasterisers but no trait coverage.** That's how the
    *Cross-backend portability commitment* stays load-bearing —
    if a primitive isn't on the trait, downstream consumer code has to
-   pick a backend explicitly.
+   pick a backend explicitly. **If the new primitive is composed into
+   top-level screens (most are), add its `Surface`/`FrameZone` variant
+   in the same PR** — see "One primitive, one canonical paint path"
+   below (issue #456).
 8. **Public API changes are versioned by deprecation, not by
    announcement.** See rule 8 in full below — it is the one rule whose
    failure mode lands in *other repos*.
@@ -184,6 +187,52 @@ exactly the case where a LOCAL/ABSOLUTE mixup is invisible (adding or
 skipping `rect.x` is a no-op when `rect.x == 0`), which is why the
 historical `mac_tree_layout` bug (`docs/LESSONS.md`) shipped past
 tests that all used the origin.
+
+## One primitive, one canonical paint path (issue #456)
+
+`quadraui` has two ways to paint a primitive: `backend.draw_<name>(rect,
+&data)` directly, or `layout.push(Surface::<Name> { rect, .. })` +
+`layout.draw(backend)` via `quadraui::frame::ScreenLayout`. Nothing
+stops two backends of the same consumer app from picking different
+ones for the identical call site — and when they do, the two paint
+paths silently drift, because the compiler can't see across the split.
+That's exactly what happened in vimcode: the TUI palette painted via
+`b.draw_palette(...)`, the GTK palette via `Surface::Palette`, with
+every other line at both call sites identical (#456; contributed to
+vimcode#587).
+
+**`ScreenLayout` + `Surface` is the canonical path for a consumer
+assembling a top-level screen from multiple primitives** — it forces
+both backends through the same call site and its `zone_for` helper
+keeps the hit-map in lock-step with what was painted by construction
+(see `quadraui/src/frame.rs`'s module doc). `Backend::draw_<name>`
+stays public, non-deprecated, low-level API — `ScreenLayout::draw`
+calls it internally, and it's the *only* path for any primitive that
+has no `Surface` variant yet. See `DECISIONS.md` D-006 for the full
+audit and why `Backend::draw_*` isn't hidden or deprecated over that
+gap.
+
+**Going forward:** when rule 7 above has you adding a `Backend::draw_<name>`
+method for a primitive that's composed into top-level screens (i.e. a
+consumer will paint it as one layer of a multi-primitive frame, not
+just as the sole content of its own pane), add its `Surface::<Name>` /
+`FrameZone::<Name>` variant and `ScreenLayout::zone_for` arm in the
+**same PR**. Skipping this is how the trait and `Surface` started drifting apart in
+the first place (11 primitives have a trait
+method but no `Surface` variant as of the #456 audit — Board,
+DiffView, PipelineView, Toolbar, SidebarPanel, TextInput, Spinner,
+Progress, CommandCenter, DropOverlay, MessageList). Backfilling that
+existing gap is tracked separately (`SMELL_AUDIT_2026-07.md` §7 Epic D,
+`D4`) — this rule stops it from growing, it doesn't retroactively close
+it.
+
+**When `Backend::draw_*` direct calls are still the right choice**, even
+for a primitive that does have a `Surface` variant: a rasteriser's own
+paint/click round-trip test (rule 4), a compose helper painting a
+primitive it fully owns, or any call site that has no need for the
+frame-level hit-map `ScreenLayout` produces. The rule is "assembling a
+multi-primitive screen goes through `Surface`," not "never call
+`Backend::draw_*` directly."
 
 ## Shared pixel-layout math (#499)
 

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -7,6 +7,21 @@
 //!
 //! See `quadraui/docs/BACKEND_TRAIT_PROPOSAL.md` §4 for design rationale.
 //!
+//! ## `draw_*` here vs. `Surface` in `frame.rs` (issue #456)
+//!
+//! Every `draw_<name>` method below is the low-level rasteriser entry
+//! point for its primitive — always public, never deprecated. A
+//! consumer assembling a top-level screen from multiple primitives
+//! should reach for [`crate::frame::ScreenLayout`] + [`crate::frame::Surface`]
+//! instead of calling `draw_*` methods directly: it routes every
+//! backend through the same call site, so two backends of one app
+//! cannot silently paint the same primitive two different ways (the
+//! drift #456 documents). `ScreenLayout::draw` calls these `draw_*`
+//! methods internally — see `frame.rs`'s module doc and
+//! `quadraui/docs/DECISIONS.md` D-006 for the full picture, including
+//! the primitives that have no `Surface` variant yet and must still be
+//! painted via `draw_*` directly.
+//!
 //! ## Coordinate frames for `*_layout` methods (issue #505)
 //!
 //! Every `Backend::<name>_layout` method (and its `draw_<name>` twin,

--- a/quadraui/src/frame.rs
+++ b/quadraui/src/frame.rs
@@ -12,6 +12,23 @@
 //! instead push the same [`Surface`] entries into a `ScreenLayout`
 //! purely for hit-testing and call [`ScreenLayout::hit_map`], which
 //! registers every zone without invoking any `backend.draw_*()` call.
+//!
+//! ## `Surface` vs. calling `Backend::draw_*` directly (issue #456)
+//!
+//! `ScreenLayout` + [`Surface`] is the **canonical path for a consumer
+//! assembling a top-level screen out of multiple primitives**: pushing
+//! `Surface` entries and calling [`ScreenLayout::draw`] routes both
+//! backends through the same call site, so they cannot each paint the
+//! identical primitive a different way — the drift #456 found in
+//! vimcode, where the TUI palette painted via `backend.draw_palette(..)`
+//! and GTK's identical call site instead pushed a `Surface::Palette`,
+//! for no reason but that both APIs existed. `Backend::draw_<name>`
+//! remains public, low-level API — `ScreenLayout::draw` calls it
+//! internally, some primitives have no `Surface` variant yet, and
+//! rasteriser tests / compose helpers call it directly by design. See
+//! `quadraui/docs/DECISIONS.md` D-006 for the full decision and
+//! `quadraui/docs/PRIMITIVE_RULES.md` "One primitive, one canonical
+//! paint path" for the authoring rule this implies for new primitives.
 
 use crate::event::Rect;
 use crate::primitives::activity_bar::ActivityBar;


### PR DESCRIPTION
Closes #456

Automated PR opened by coordinator for review of issue #456.