### PR TITLE
#506: Backend trait symmetry: add missing *_layout methods, lift off-trait rasteriser fns, converge the 3 layout conventions (with #456)

### DIFF
--- a/quadraui/docs/DECISIONS.md
+++ b/quadraui/docs/DECISIONS.md
@@ -746,16 +746,50 @@ backend's own `draw_terminal` / `draw_editor` / `draw_diff_view`
 already resolves them to. Rather than hand-copy the same three-line
 body into `TuiBackend`, `GtkBackend`, `MacBackend`, and `WinBackend`
 (and every test `MockBackend`), these three got a **default trait
-body**, verified byte-for-byte against each backend's real paint
-formula (see the doc comments on `Backend::terminal_layout` /
-`editor_layout` / `diff_view_layout`, and the parity tests in
-`tui/backend.rs` / `gtk/backend.rs`). This is new territory for a
-`*_layout` method — every prior one required an explicit per-backend
-override — so `tests/conformance/caps.rs`'s `ACCEPTED_DEFAULTS` list
-(quadraui#492's "no silent no-op defaults" honesty check) carries all
-twelve `(backend, method)` pairs with the reason, so a future backend
-that overrides one of these three without a good reason still shows up
-as a source-vs-declaration mismatch, not a silently-accepted default.
+body**, each backed by a real paint-vs-layout parity test in
+`tui/backend.rs` / `gtk/backend.rs` — see the doc comments on
+`Backend::terminal_layout` / `editor_layout` / `diff_view_layout` for
+the per-method contract, and
+`{tui,gtk}::backend::tests::{terminal_layout_reserves_scrollbar_gutter_matching_draw_terminal,
+editor_layout_matches_draw_editor_*, diff_view_layout_matches_draw_diff_view_*}`
+for the tests themselves (issue #506 review fix — a first pass at this
+paragraph asserted these were already "verified byte-for-byte" and
+covered by "parity tests," which was aspirational, not true: no such
+tests existed at the time, and `terminal_layout`'s default body turned
+out to have exactly the drift the missing test would have caught —
+next paragraph). This is new territory for a `*_layout` method — every
+prior one required an explicit per-backend override — so
+`tests/conformance/caps.rs`'s `ACCEPTED_DEFAULTS` list (quadraui#492's
+"no silent no-op defaults" honesty check) carries all twelve `(backend,
+method)` pairs with the reason, so a future backend that overrides one
+of these three without a good reason still shows up as a
+source-vs-declaration mismatch, not a silently-accepted default. The
+review fix below added a thirteenth method, `terminal_scrollbar_default_width`
+— a helper `terminal_layout` calls internally, not a `*_layout` method
+itself — with three more `ACCEPTED_DEFAULTS` entries (GTK/macOS/Win; TUI
+overrides it, so needs none), for fifteen total.
+
+**`terminal_layout`'s scrollbar gap (found at review, fixed before
+merge).** Unlike `Editor::layout` — which already takes the vertical
+scrollbar's presence into account internally — `Terminal::layout` is a
+bare `viewport_width / cell_width` division with no scrollbar concept
+at all; the scrollbar-gutter reservation happens entirely in each
+backend's `draw_terminal`, *before* it calls the cell-iteration logic
+(`cell_area_w = area.width.saturating_sub(sb_cols)` on TUI,
+`cell_area_w = (rect.width - sb_width).max(0.0)` on GTK/macOS/Win). The
+first version of `terminal_layout`'s default body called
+`term.layout(rect.width, …)` directly — the *unreduced* width — so
+`TerminalLayout::grid_cols` came out too wide by the scrollbar's column
+count whenever `term.scrollbar` was `Some`, meaning `hit_test` would
+report a click on the scrollbar gutter as a valid cell. Fixed by adding
+`Backend::terminal_scrollbar_default_width` (default `8.0`, matching
+GTK/macOS/Win's `unwrap_or(8.0)`; TUI overrides it to `1.0`, matching
+its own `unwrap_or(1)`) and having `terminal_layout` reduce the
+viewport width by the scrollbar's reserved width — `sb.width` when the
+caller set it, else that default — before calling `Terminal::layout`,
+mirroring every backend's real `draw_terminal` order of operations. The
+parity tests named above pin a `Terminal` with `scrollbar: Some(..)`
+against this exact formula so the drift can't reopen silently.
 
 `board_layout` and `list_layout` do **not** get a default: `BoardMeasure`'s
 column/card sizing and `ListView`'s scrollbar-reservation logic are

--- a/quadraui/docs/DECISIONS.md
+++ b/quadraui/docs/DECISIONS.md
@@ -640,3 +640,160 @@ scoped separately because it touches 11 primitives' worth of
   `Backend::draw_*`-only indefinitely — the rule is "if it's composed
   into a `ScreenLayout` frame, it needs a `Surface` variant," not
   "every primitive must have one."
+
+## D-007 — `Backend` trait symmetry: missing `*_layout` methods, off-trait rasteriser fns (issue #506)
+
+### Question
+
+#456/D-006 found that `Surface` and `Backend::draw_*` were two paint
+paths with nothing steering a consumer toward one. #506 is the
+trait-internal half of the same audit: does every primitive with a
+real `layout()` also expose a `Backend::<name>_layout` method, the way
+`data_table_layout` / `tree_layout` / `chart_layout` etc. already do?
+And are there rasteriser entry points that exist only as backend-crate
+free functions (`tui_board_layout`, `mac_list_layout`, ...) with no
+trait-level home at all — the "off-trait rasteriser fns" CLAUDE.md's
+portability commitment §1 calls a bug, since a Windows/macOS author
+can't discover them by reading the trait?
+
+### Audit
+
+Six primitives had a `draw_<name>` but no `<name>_layout` twin, despite
+a real `layout()` existing somewhere in the stack:
+
+| Primitive | What existed before #506 |
+|---|---|
+| `BoardModel` | `board_layout` free fn (`primitives/board.rs`); every backend already wrapped it in its own off-trait helper (`tui_board_layout` / `gtk_board_layout` / `mac_board_layout`) — nothing put it on the trait |
+| `ListView` | `ListView::layout()` (`primitives/list.rs:176`); TUI/GTK computed it *inline* inside `draw_list` (no reusable fn at all); Win/macOS had off-trait `win_list_layout` / `mac_list_layout` |
+| `Editor` | `Editor::layout()` (`primitives/editor.rs:524`); every backend's `draw_editor` already calls it with `(self.char_width(), self.line_height())` |
+| `Terminal` | `Terminal::layout()` (`primitives/terminal.rs:251`, plus `TerminalLayout::hit_test` / `cell_bounds`); **no backend called it at all** — `draw_terminal` iterates cells directly and callers had to re-derive `rect.width / char_width` by hand to hit-test a click |
+| `DiffView` | No standalone `layout()`; `DiffViewLayout { visible_rows, total_rows }` was computed by hand, identically, inside every backend's `draw_diff_view` (header-row reservation in side-by-side mode, `+1` per hunk in unified mode) |
+| `Palette` | `Palette::layout()` (`primitives/palette.rs:273`); Win/macOS had off-trait `win_palette_layout` / `mac_palette_layout`. **See "Palette: deferred, not missed" below — this one did not get a trait method.** |
+
+Off-trait rasteriser entry points named in the issue, re-audited against
+the *current* tree (some had already been resolved by earlier work on
+this branch before #506 started):
+
+| Entry point | Resolution |
+|---|---|
+| `draw_terminal_divider` | Already a `Backend` method on all four backends (no default — `PRIMITIVE_RULES.md` rule 7). The issue text predates this; no action needed. |
+| `draw_settings_chrome` | Same — already a required `Backend` method (TUI + GTK implement it; no consumer needs it on Win/macOS yet). No action needed. |
+| `tui_dialog_layout` | **Exempt, by design.** `Dialog` is an *overlay-with-caller-anchor* primitive (see the convention table below) — same class as `Tooltip`/`ContextMenu`/`Completions`. The host builds its own `DialogMeasure` from portable `Backend::line_height()` and calls `dialog.layout(...)` directly (see `examples/common/modal_occlusion_demo.rs::dialog_layout`); no `Backend::dialog_layout` exists for any of those primitives, and Dialog shouldn't be the odd one out. `tui_dialog_layout` is TUI's *own* internal default measurer for dialogs TUI paints without a caller-supplied `DialogMeasure` — a backend-private convenience, not a missing trait method. |
+| `draw_context_menu_with_submenus` (TUI only) | **Exempt, written down, not promoted.** GTK has no cascading-submenu rasteriser yet (#371). A trait method here would need a default for GTK/Win/macOS, and CLAUDE.md's portability commitment explicitly rejects a no-op default that silently hides a real capability gap (`draw_terminal_divider`'s doc, `docs/SMELL_AUDIT_2026-07.md` PORT-01) — unlike `TabChrome`/`ActivityBarStyle`, ignoring `submenu_path` isn't a legitimate "no chrome vocabulary" fallback, it's "multi-level menus silently don't cascade." Also has zero call sites today (no compose helper or example wires it up) — it's a tested capability with no production consumer. Revisit once #371 gives GTK a real submenu rasteriser to pair it with; promoting it before that would ship a trait method that is honest for one backend out of four. |
+| `mac_palette_layout` | **Deferred alongside `palette_layout` — see below.** |
+| `mac_list_layout` | **Resolved.** Now the real backing implementation of `Backend::list_layout` for macOS (this issue). Kept as a `pub fn` — same "public free fn is the primitive-side thin wrapper" shape `data_table_layout`'s implementers already use; not deprecated, since nothing about its own contract changed. |
+| `gtk::MenuOverlay` | **Exempt, decided.** This is a GTK-hosting/compositing helper (coordinate transform for GTK's native overlay-widget positioning), not a primitive rasteriser — it implements no primitive's `layout()`/paint contract, so there is no `draw_<name>` for it to pair with. TUI/Win/macOS have no equivalent concept because they don't have GTK's overlay-widget model to bridge into. Same category as `AppShell`'s GTK widget-tree bootstrap: legitimately backend-specific, and rule 7 ("every primitive gets a trait method") doesn't apply to it because it isn't a primitive. |
+
+### Palette: deferred, not missed
+
+`palette_layout` looks like the same fix as `list_layout` — add the
+missing trait method, wire each backend's existing helper into it. The
+audit found a reason not to do that yet: **GTK's `draw_palette` paints
+item rows at `rows_y + i*line_height`, computed independently of the
+`PaletteLayout` struct's own `visible_items[i].bounds.y`.** When
+`show_query` is true, GTK reserves an extra 1px for the query/list
+separator stroke *outside* the `Palette::layout()` call (baked into
+`rows_y`, not into the `query_height` argument), so the struct's own
+`bounds.y` under-reports the real paint position by that 1px. This is
+harmless today only because `draw_palette` returns `()` — nothing
+outside the function ever reads the mismatched struct.
+
+Shipping `Backend::palette_layout` now would make that latent 1px drift
+externally visible the moment a host trusted it for hit-testing —
+exactly the "paint and no-paint silently disagree" bug class rule 5
+("one source of truth for layout") and the `mac_tree_layout` postmortem
+in `LESSONS.md` both exist to prevent. TUI's `draw_palette` doesn't
+call `Palette::layout()` at all (its border/query/separator rows
+predate the shared D6 layout refactor other primitives went through),
+which is a second, larger version of the same problem: a `tui_palette_layout`
+built from scratch today would be a parallel reimplementation, not an
+extraction, with no guarantee it matches what `draw_palette` actually
+paints.
+
+**Decision: do not add `Backend::palette_layout` in this PR.** Fixing
+`gtk::draw_palette` to consume `PaletteLayout.visible_items[i].bounds`
+directly (eliminating the independent `rows_y` recomputation) and
+refactoring `tui::draw_palette` to route through `Palette::layout()`
+are both rendering-behavior changes, not trait-symmetry ones — real
+work, tracked as a follow-up, that must land *before* a `palette_layout`
+trait method can honestly claim to match its `draw_palette` twin. Rule
+5 exists precisely so a new `*_layout` method is never the first thing
+to notice a paint function's internal layout was already lying.
+
+### Decision: the convention table
+
+Three conventions coexist on the trait, and #506 asked which primitive
+class picks which. Audited against every `draw_<name>` / `<name>_layout`
+pair on the trait:
+
+| Primitive class | Convention | Examples |
+|---|---|---|
+| **Content-in-rect** (backend paints inline, inside a caller-supplied `rect`, and can compute the same layout without a live paint context) | **Paired**: `draw_<name>` + `<name>_layout`, both taking `rect`. | `data_table_layout`, `tree_layout`, `form_layout`, `list_layout`, `board_layout` (new), `terminal_layout` (new), `editor_layout` (new) |
+| **Overlay-with-caller-anchor** (host computes anchor/viewport/measure itself and calls the primitive's own `.layout(...)` directly; the backend only paints at the resolved bounds) | **Draw-takes-layout**: `draw_<name>(&self, thing, layout)`, no `Backend::<name>_layout` at all — there's nothing backend-specific to compute. | `Tooltip`, `ContextMenu`, `Completions`, `RichTextPopup`, `Dialog` (see `tui_dialog_layout`'s exemption above) |
+| **Interactive chrome** (freestanding widget painted at its own screen rect; used to have `draw_<name>` return its own layout with no separate no-paint accessor) | **Draw-returns-layout is redundant with paired — collapsed.** Every primitive that used to be draw-returns-layout-only now also has the paired `<name>_layout` twin, so a host can ask for hit-test geometry without a frame in progress. `BoardModel`/`DiffView` were the two hold-outs (`draw_board` / `draw_diff_view` already returned their layout struct, but had no no-paint twin) — `board_layout` closes this for `BoardModel`; `diff_view_layout` closes it for `DiffView`. | `chart_layout`, `toolbar_layout`, `sidebar_panel_layout`, `board_layout` (new), `diff_view_layout` (new) |
+
+A fourth shape showed up during the audit that the original three-way
+split didn't anticipate: **counts, not coordinates.** `diff_view_layout`
+returns `{ visible_rows, total_rows }` — there is no LOCAL/ABSOLUTE
+frame to pick because nothing it returns is a position. Its doc
+comment says so explicitly rather than silently defaulting to one.
+
+**Defaults, where the formula is provably uniform across backends.**
+`terminal_layout`, `editor_layout`, and `diff_view_layout` all turned
+out to be pure functions of `Backend::char_width()` / `line_height()`
+(plus, for diff views, `DiffView::mode`) — exactly the values every
+backend's own `draw_terminal` / `draw_editor` / `draw_diff_view`
+already resolves them to. Rather than hand-copy the same three-line
+body into `TuiBackend`, `GtkBackend`, `MacBackend`, and `WinBackend`
+(and every test `MockBackend`), these three got a **default trait
+body**, verified byte-for-byte against each backend's real paint
+formula (see the doc comments on `Backend::terminal_layout` /
+`editor_layout` / `diff_view_layout`, and the parity tests in
+`tui/backend.rs` / `gtk/backend.rs`). This is new territory for a
+`*_layout` method — every prior one required an explicit per-backend
+override — so `tests/conformance/caps.rs`'s `ACCEPTED_DEFAULTS` list
+(quadraui#492's "no silent no-op defaults" honesty check) carries all
+twelve `(backend, method)` pairs with the reason, so a future backend
+that overrides one of these three without a good reason still shows up
+as a source-vs-declaration mismatch, not a silently-accepted default.
+
+`board_layout` and `list_layout` do **not** get a default: `BoardMeasure`'s
+column/card sizing and `ListView`'s scrollbar-reservation logic are
+backend-native constants (GTK's card height is 64px, not a multiple of
+`line_height()`), the same reason `TreeStyle::row_height`'s backend
+derivation isn't a single formula either. Every backend implements
+these two explicitly, mirroring `draw_board`'s existing "no default —
+a backend that forgets this silently reports an empty board" rule
+(quadraui#600, `PRIMITIVE_RULES.md` rule 7).
+
+### Surface-enum gap list
+
+D-006 already tracked and quantified this (`SMELL_AUDIT_2026-07.md` §4:
+`Board`, `DiffView`, `PipelineView`, `Toolbar`, `SidebarPanel`,
+`TextInput`, `Spinner`, `Progress`, `CommandCenter`, `DropOverlay`,
+`MessageList` have `Backend::draw_*` but no `Surface` variant), scoped
+to #456 as "Epic D's `D4`, trait symmetry, separately." #506 is that
+D4 follow-up for the *trait* half of the gap; the `Surface`/`FrameZone`
+half stays #456's to close — this decision doesn't duplicate or
+re-quantify it, only cross-references it so a reader doesn't go
+looking for a second gap list here.
+
+### What this does NOT mean
+
+- It does not mean every off-trait free fn in a backend crate is a bug.
+  `tui_board_layout` / `gtk_board_layout` / `mac_board_layout` /
+  `win_list_layout` / `mac_list_layout` all stay exactly as public as
+  they were — they're each backend's own thin wrapper that the new
+  trait method calls into (`data_table_layout`'s implementers already
+  established this shape). The bug #506 fixes is a rasteriser
+  capability with **no trait-level path at all**, not "a free function
+  exists alongside a trait method."
+- It does not mean `palette_layout` is cancelled — see "Palette:
+  deferred, not missed" above. It's blocked on a rendering fix, not a
+  design question, and should land as its own follow-up once GTK's
+  `draw_palette` and TUI's `draw_palette` both consume `Palette::layout()`'s
+  own returned bounds instead of recomputing paint positions
+  independently.
+- It does not promote `draw_context_menu_with_submenus` preemptively.
+  That waits on #371 (GTK cascading submenus) so the eventual trait
+  method is honest on more than one backend out of four.

--- a/quadraui/docs/PRIMITIVE_RULES.md
+++ b/quadraui/docs/PRIMITIVE_RULES.md
@@ -54,6 +54,34 @@ Read this when adding or changing a primitive.
    top-level screens (most are), add its `Surface`/`FrameZone` variant
    in the same PR** — see "One primitive, one canonical paint path"
    below (issue #456).
+
+   **Which `<name>_layout` shape to pick (issue #506):**
+
+   | Primitive class | Convention | Examples |
+   |---|---|---|
+   | **Content-in-rect** — backend paints inline inside a caller-supplied `rect` and can compute the same geometry with no live paint context | **Paired**: `draw_<name>(rect, ..)` + `<name>_layout(&self, rect, ..)`, same signature shape, same resolver underneath. | `data_table_layout`, `tree_layout`, `form_layout`, `list_layout`, `board_layout`, `terminal_layout`, `editor_layout` |
+   | **Overlay-with-caller-anchor** — host computes anchor/viewport/measure itself and calls the *primitive's own* `.layout(...)` directly; the backend only paints at the resolved bounds | **Draw-takes-layout**: `draw_<name>(&self, thing, layout)`. No `Backend::<name>_layout` — there's nothing backend-specific left to compute. | `Tooltip`, `ContextMenu`, `Completions`, `RichTextPopup`, `Dialog` |
+   | **Interactive chrome** — freestanding widget at its own screen rect | **Paired**, same as content-in-rect. (Draw-returns-layout-only, with no no-paint twin, is the same convention minus the accessor a host needs to hit-test without a frame in progress — add the twin rather than leaving a primitive as the odd one out.) | `chart_layout`, `toolbar_layout`, `sidebar_panel_layout`, `board_layout`, `diff_view_layout` |
+
+   A `<name>_layout` gets a **default trait body** only when the
+   geometry is a *provably uniform* pure function of
+   `Backend::char_width()` / `Backend::line_height()` (and primitive
+   state) — i.e. every backend's own `draw_<name>` already resolves the
+   same two values into the same formula (`terminal_layout`,
+   `editor_layout`, `diff_view_layout`). If a backend supplies its own
+   sizing constants that aren't derivable from those two accessors
+   (`BoardMeasure`'s per-backend column/card pixel sizes, `ListView`'s
+   scrollbar reservation), there is no default — every backend
+   implements it explicitly, same as `draw_<name>` itself. A default
+   body still needs a from-scratch, per-backend-verified justification
+   in `tests/conformance/caps.rs`'s `ACCEPTED_DEFAULTS` (quadraui#492) —
+   it is exempt from that check's "silently defaulted" failure only
+   because the reason is written down, not because a default exists.
+   See `quadraui/docs/DECISIONS.md` D-007 for the full audit, the
+   off-trait-fn resolutions, and why `Palette` did **not** get a
+   `palette_layout` method despite fitting the content-in-rect row
+   above (a latent paint/layout drift, not a design gap — D-007's
+   "Palette: deferred, not missed").
 8. **Public API changes are versioned by deprecation, not by
    announcement.** See rule 8 in full below — it is the one rule whose
    failure mode lands in *other repos*.

--- a/quadraui/docs/PRIMITIVE_RULES.md
+++ b/quadraui/docs/PRIMITIVE_RULES.md
@@ -68,7 +68,18 @@ Read this when adding or changing a primitive.
    `Backend::char_width()` / `Backend::line_height()` (and primitive
    state) — i.e. every backend's own `draw_<name>` already resolves the
    same two values into the same formula (`terminal_layout`,
-   `editor_layout`, `diff_view_layout`). If a backend supplies its own
+   `editor_layout`, `diff_view_layout`). "The same two values" can
+   include a small backend-shaped accessor of the same shape as
+   `char_width()`/`line_height()` when the *formula* is still uniform
+   but a scalar it depends on genuinely isn't — `terminal_layout` also
+   calls `Backend::terminal_scrollbar_default_width()` to reserve the
+   scrollbar gutter's default width before dividing by `char_width()`,
+   because every backend's real `draw_terminal` reserves that gutter
+   with a backend-specific fallback (1 cell on TUI, 8px on GTK/macOS/Win)
+   before iterating cells — skip that reservation and the default body's
+   `grid_cols` silently over-reports by the gutter's width whenever a
+   caller omits an explicit scrollbar width (issue #506 review fix; see
+   `docs/DECISIONS.md` D-007's "`terminal_layout`'s scrollbar gap" note). If a backend supplies its own
    sizing constants that aren't derivable from those two accessors
    (`BoardMeasure`'s per-backend column/card pixel sizes, `ListView`'s
    scrollbar reservation), there is no default — every backend

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -1155,6 +1155,27 @@ pub trait Backend {
     /// terminal selection is driven by mouse drag against cell
     /// dimensions, which the app already tracks.
     fn draw_terminal(&mut self, rect: Rect, term: &Terminal);
+    /// The reserved width of a `Terminal`'s scrollbar gutter when
+    /// [`TerminalScrollbar::width`](crate::primitives::terminal::TerminalScrollbar::width)
+    /// is `None`, in this backend's own surface-native unit (issue #506
+    /// review fix). Every `draw_terminal` implementation falls back to a
+    /// hardcoded default when the caller didn't specify a width, and
+    /// that default is backend-shaped, not uniform: TUI's cells *are*
+    /// the coordinate system, so its gutter is exactly one column
+    /// (`src/tui/terminal.rs`'s `sb_cols: … .unwrap_or(1)`); GTK, macOS,
+    /// and Win all measure in pixels and use 8px
+    /// (`src/gtk/backend.rs`, `src/macos/backend.rs`,
+    /// `src/win/backend.rs`, each `sb_width: … .unwrap_or(8.0)`).
+    /// [`Self::terminal_layout`]'s default body calls this so its
+    /// scrollbar reservation matches whichever default the paint path
+    /// actually used, instead of silently assuming the pixel-backend
+    /// value for every backend (or ignoring the reservation entirely).
+    ///
+    /// Default: `8.0`, matching GTK/macOS/Win. TUI overrides this to
+    /// `1.0` — see `TuiBackend::terminal_scrollbar_default_width`.
+    fn terminal_scrollbar_default_width(&self) -> f32 {
+        8.0
+    }
     /// Compute the viewport → grid conversion [`Self::draw_terminal`]
     /// implicitly uses (issue #506: `Terminal::layout` already existed as
     /// a pure fn but no `Backend` method exposed it, so hosts had to
@@ -1164,21 +1185,41 @@ pub trait Backend {
     /// reproduces its uniform cell grid exactly; pixel backends get the
     /// same font metrics `draw_terminal`'s cell iteration assumes.
     ///
+    /// When `term.scrollbar` is `Some`, the viewport width fed to
+    /// [`crate::primitives::terminal::Terminal::layout`] is first reduced
+    /// by the scrollbar's reserved width — `sb.width` when set, else
+    /// [`Self::terminal_scrollbar_default_width`] — exactly as every
+    /// backend's real `draw_terminal` reserves that gutter *before*
+    /// iterating cells (`cell_area_w = area.width.saturating_sub(sb_cols)`
+    /// on TUI; `cell_area_w = (rect.width - sb_width).max(0.0)` on
+    /// GTK/macOS/Win). Skipping this step would report `grid_cols` wide
+    /// enough to claim the scrollbar gutter itself as a clickable cell —
+    /// exactly the "paint and no-paint silently disagree" bug class rule
+    /// 5 exists to prevent (issue #506 review fix).
+    ///
     /// Coordinate frame: **LOCAL** — relative to `rect`'s origin; see
     /// [`crate::primitives::terminal::TerminalLayout::hit_test`] /
     /// [`crate::primitives::terminal::TerminalLayout::cell_bounds`],
     /// neither of which fold in an origin offset (issue #505).
     ///
     /// Default body: uniform for every backend, since it's a pure
-    /// function of the two metrics above — no backend needs to override
-    /// this.
+    /// function of the metrics above plus [`Self::terminal_scrollbar_default_width`]
+    /// — no backend needs to override this.
     fn terminal_layout(
         &self,
         rect: Rect,
         term: &Terminal,
     ) -> crate::primitives::terminal::TerminalLayout {
+        let sb_reserved = match &term.scrollbar {
+            Some(sb) => sb
+                .width
+                .map(|w| w as f32)
+                .unwrap_or_else(|| self.terminal_scrollbar_default_width()),
+            None => 0.0,
+        };
+        let cell_area_w = (rect.width - sb_reserved).max(0.0);
         term.layout(
-            rect.width,
+            cell_area_w,
             rect.height,
             self.char_width(),
             self.line_height(),
@@ -1364,6 +1405,16 @@ pub trait Backend {
     /// Default body: uniform for every backend, since it's a pure
     /// function of the two metrics above — no backend needs to override
     /// this.
+    ///
+    /// **Caller invariant:** `rect` here must be the same rect the
+    /// backend actually paints with. This holds by construction on TUI
+    /// (`draw_editor` takes the `rect` argument directly), but on GTK
+    /// `GtkBackend::draw_editor` ignores its own `rect` parameter
+    /// (`let _ = rect;`) and paints at `editor.rect` instead
+    /// (`src/gtk/editor.rs`). The two happen to always match in every
+    /// call site today, but nothing enforces it — pass a `rect` that
+    /// diverges from `editor.rect` and this method's return value quietly
+    /// stops matching what GTK painted (issue #506 review follow-up).
     fn editor_layout(&self, rect: Rect, editor: &Editor) -> EditorLayout {
         editor.layout(rect, self.char_width(), self.line_height())
     }

--- a/quadraui/src/backend.rs
+++ b/quadraui/src/backend.rs
@@ -33,7 +33,8 @@
 //!   top-left corner. Used by primitives a parent composer paints
 //!   *inline* and localises clicks for before calling `hit_test`
 //!   (`tree_layout`, `form_layout`, `data_table_layout`,
-//!   `text_display_layout`, `status_bar_layout`, `activity_bar_layout`).
+//!   `text_display_layout`, `status_bar_layout`, `activity_bar_layout`,
+//!   `list_layout`, `terminal_layout`).
 //! - **ABSOLUTE** — shifted by `rect.x` / `rect.y`, i.e. target-surface
 //!   coordinates a caller can compare directly against raw click
 //!   coordinates with no further adjustment. Used by primitives that are
@@ -43,7 +44,13 @@
 //!   `panel_layout`, `toast_stack_layout`, `pipeline_view_layout`,
 //!   `progress_layout`, `spinner_layout`, `command_center_layout`,
 //!   `toolbar_layout`, `sidebar_panel_layout`, `chart_layout`,
-//!   `minimap_layout`, `msv_layout`, `text_input_layout`).
+//!   `minimap_layout`, `msv_layout`, `text_input_layout`, `board_layout`,
+//!   `editor_layout`).
+//!
+//! A third category returns no coordinates at all — `diff_view_layout`
+//! returns row *counts* (`visible_rows` / `total_rows`), not positions —
+//! so LOCAL/ABSOLUTE doesn't apply; its doc comment says so explicitly
+//! rather than silently picking neither.
 //!
 //! Both frames are legitimate — the rule this file enforces is that the
 //! frame is *stated on the method's doc comment* and *matches what every
@@ -71,12 +78,13 @@ use crate::primitives::completions::{Completions, CompletionsLayout};
 use crate::primitives::context_menu::{ContextMenu, ContextMenuLayout};
 use crate::primitives::data_table::{DataTable, DataTableLayout};
 use crate::primitives::dialog::{Dialog, DialogLayout, DialogSeverity};
-use crate::primitives::diff_view::{DiffView, DiffViewLayout};
+use crate::primitives::diff_view::{DiffMode, DiffView, DiffViewLayout};
 use crate::primitives::drop_zone::DropOverlay;
 use crate::primitives::editor::{Editor, EditorLayout};
 use crate::primitives::find_replace::FindReplacePanel;
 use crate::primitives::form::FormLayout;
 use crate::primitives::image::Image;
+use crate::primitives::list::ListViewLayout;
 use crate::primitives::menu_bar::{MenuBar, MenuBarLayout};
 use crate::primitives::message_list::MessageList;
 use crate::primitives::minimap::{Minimap, MinimapLayout};
@@ -845,6 +853,19 @@ pub trait Backend {
     /// the returned thumb to implement drag without re-deriving geometry.
     /// Mirrors [`Backend::list_hscrollbar`]; see [`ListView::vscrollbar`].
     fn list_vscrollbar(&self, rect: Rect, list: &ListView) -> Option<Scrollbar>;
+    /// Compute the list layout without painting — the no-paint twin of
+    /// [`Self::draw_list`] (issue #506: `ListView::layout` already existed
+    /// but `draw_list` computed it inline, with no way for a host to ask
+    /// for the same geometry without repainting). `draw_list` and this
+    /// method route through the same backend-internal resolver
+    /// (`tui_list_layout` / `gtk_list_layout` / `win_list_layout` /
+    /// `mac_list_layout`), so paint and no-paint can't drift apart.
+    ///
+    /// Coordinate frame: **LOCAL** — relative to `rect`'s origin, `(0, 0)`
+    /// at `rect`'s top-left; does **not** account for
+    /// [`ListView::bordered`]'s 1-cell/1px border inset, matching every
+    /// backend's `draw_list` (issue #505).
+    fn list_layout(&self, rect: Rect, list: &ListView) -> ListViewLayout;
     fn draw_form(&mut self, rect: Rect, form: &Form);
     fn draw_palette(&mut self, rect: Rect, palette: &Palette);
 
@@ -1134,6 +1155,35 @@ pub trait Backend {
     /// terminal selection is driven by mouse drag against cell
     /// dimensions, which the app already tracks.
     fn draw_terminal(&mut self, rect: Rect, term: &Terminal);
+    /// Compute the viewport → grid conversion [`Self::draw_terminal`]
+    /// implicitly uses (issue #506: `Terminal::layout` already existed as
+    /// a pure fn but no `Backend` method exposed it, so hosts had to
+    /// re-derive `rect.width / char_width` by hand to hit-test a click
+    /// against a cell). Uses this backend's own [`Self::char_width`] /
+    /// [`Self::line_height`] as the cell dimensions — TUI's `(1.0, 1.0)`
+    /// reproduces its uniform cell grid exactly; pixel backends get the
+    /// same font metrics `draw_terminal`'s cell iteration assumes.
+    ///
+    /// Coordinate frame: **LOCAL** — relative to `rect`'s origin; see
+    /// [`crate::primitives::terminal::TerminalLayout::hit_test`] /
+    /// [`crate::primitives::terminal::TerminalLayout::cell_bounds`],
+    /// neither of which fold in an origin offset (issue #505).
+    ///
+    /// Default body: uniform for every backend, since it's a pure
+    /// function of the two metrics above — no backend needs to override
+    /// this.
+    fn terminal_layout(
+        &self,
+        rect: Rect,
+        term: &Terminal,
+    ) -> crate::primitives::terminal::TerminalLayout {
+        term.layout(
+            rect.width,
+            rect.height,
+            self.char_width(),
+            self.line_height(),
+        )
+    }
     /// Draw a vertical divider between two split terminal panes.
     /// `rect.x` is the divider's column, `rect.y` its top row, and
     /// `rect.height` its length; `rect.width` is ignored — the
@@ -1294,6 +1344,29 @@ pub trait Backend {
     /// overlays, etc.). Asymmetric across backends: TUI populates
     /// the result; GTK paints its own caret and returns the default.
     fn draw_editor(&mut self, rect: Rect, editor: &Editor) -> EditorPaintResult;
+
+    /// Compute the editor viewport layout (gutter / text / scrollbar
+    /// bounds) without painting — the no-paint twin of [`Self::draw_editor`]
+    /// (issue #506: `Editor::layout` already existed but no `Backend`
+    /// method exposed it). Uses this backend's own [`Self::char_width`] /
+    /// [`Self::line_height`] as the cell metrics — the same values
+    /// `draw_editor` resolves them to on every backend that implements it
+    /// today (`GtkBackend`/`WinBackend`/`MacBackend` all pass
+    /// `current_char_width` / `current_line_height`, which is exactly what
+    /// [`Self::char_width`] / [`Self::line_height`] return; TUI's fixed
+    /// `(1.0, 1.0)` matches its uniform cell grid).
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `text_bounds` / `gutter_bounds` /
+    /// scrollbar bounds are shifted by `rect.x` / `rect.y`, matching
+    /// [`Self::editor_col_at_x`]'s "x is an absolute (surface-space)
+    /// coordinate" contract (issue #505).
+    ///
+    /// Default body: uniform for every backend, since it's a pure
+    /// function of the two metrics above — no backend needs to override
+    /// this.
+    fn editor_layout(&self, rect: Rect, editor: &Editor) -> EditorLayout {
+        editor.layout(rect, self.char_width(), self.line_height())
+    }
 
     /// Resolve a click x-coordinate to a text column on one visible row
     /// of an [`Editor`], honouring the same glyph-advance metrics
@@ -1481,6 +1554,63 @@ pub trait Backend {
     /// only rasterises. Returns [`DiffViewLayout`] for scroll clamping.
     fn draw_diff_view(&mut self, rect: Rect, view: &DiffView) -> DiffViewLayout;
 
+    /// Compute the diff-view layout without painting — the no-paint twin
+    /// of [`Self::draw_diff_view`] (issue #506). `visible_rows` uses this
+    /// backend's [`Self::line_height`] exactly as every backend's
+    /// `draw_diff_view` does today: in [`DiffMode::SideBySide`] one
+    /// `line_height` band is reserved for the header row when either
+    /// label is set (`view.left_label` / `view.right_label`); in
+    /// [`DiffMode::Unified`] every row — including each hunk's `@@ … @@`
+    /// header — scrolls as content, so no band is reserved.
+    /// `total_rows` matches [`DiffViewLayout::total_rows`]'s documented
+    /// contract (`view.total_rows()` in side-by-side mode, `+
+    /// hunk_count` in unified mode for the synthesized header lines).
+    ///
+    /// Frame: no coordinates are returned — `visible_rows` /
+    /// `total_rows` are counts, not positions — so there is no LOCAL vs
+    /// ABSOLUTE distinction to state (issue #505).
+    ///
+    /// Default body: uniform for every backend, since it's a pure
+    /// function of `rect`, `view`, and `Self::line_height` — no backend
+    /// needs to override this.
+    fn diff_view_layout(&self, rect: Rect, view: &DiffView) -> DiffViewLayout {
+        if rect.width <= 0.0 || rect.height <= 0.0 {
+            return DiffViewLayout {
+                visible_rows: 0,
+                total_rows: view.total_rows(),
+            };
+        }
+        let lh = self.line_height();
+        match view.mode {
+            DiffMode::SideBySide => {
+                let has_header = view.left_label.is_some() || view.right_label.is_some();
+                let header_h = if has_header { lh } else { 0.0 };
+                let content_h = (rect.height - header_h).max(0.0);
+                let visible_rows = if lh > 0.0 {
+                    (content_h / lh).floor() as usize
+                } else {
+                    0
+                };
+                DiffViewLayout {
+                    visible_rows,
+                    total_rows: view.total_rows(),
+                }
+            }
+            DiffMode::Unified => {
+                let visible_rows = if lh > 0.0 {
+                    (rect.height / lh).floor() as usize
+                } else {
+                    0
+                };
+                let total_rows: usize = view.hunks.iter().map(|h| h.rows.len() + 1).sum();
+                DiffViewLayout {
+                    visible_rows,
+                    total_rows,
+                }
+            }
+        }
+    }
+
     /// Draw a [`ProgressBar`]. The backend paints the track, fill,
     /// optional label, and optional cancel affordance. Returns the
     /// [`ProgressBarLayout`] so hosts can route clicks. Same
@@ -1603,6 +1733,27 @@ pub trait Backend {
     /// A no-op default here would let a backend silently paint an empty
     /// board instead of failing to build (quadraui#600, PORT-01).
     fn draw_board(&mut self, rect: Rect, model: &BoardModel) -> BoardLayout;
+
+    /// Compute the board layout without painting — the no-paint twin of
+    /// [`Self::draw_board`] (issue #506: [`crate::primitives::board::board_layout`]
+    /// already existed as a free fn, and every backend already wrapped it
+    /// in its own off-trait helper — `tui_board_layout` / `gtk_board_layout`
+    /// / `mac_board_layout` — but nothing put it on the trait, so a host
+    /// could not ask for board geometry without a live paint pass). Each
+    /// backend routes through the exact same helper `draw_board` calls
+    /// internally, using its own [`crate::primitives::board::BoardMeasure`]
+    /// (column/card sizing is backend-native, like `TreeStyle::row_height`
+    /// — not derivable from [`Self::char_width`] / [`Self::line_height`]
+    /// alone), so paint and no-paint can't drift apart.
+    ///
+    /// Coordinate frame: **ABSOLUTE** — `columns[i].bounds` / card bounds
+    /// are shifted by `rect.x` / `rect.y`, matching [`BoardLayout::hit_test`]
+    /// (issue #505).
+    ///
+    /// No default impl, same rule-7 reasoning as [`Self::draw_board`]: a
+    /// backend that forgets to override this would otherwise silently
+    /// report an empty board's worth of hit regions.
+    fn board_layout(&self, rect: Rect, model: &BoardModel) -> BoardLayout;
 
     /// Draw a [`Minimap`] (code-overview density view). GTK tiles rows at
     /// a fixed pitch and paints one colour block per non-blank character

--- a/quadraui/src/compose/app_shell.rs
+++ b/quadraui/src/compose/app_shell.rs
@@ -2302,6 +2302,11 @@ mod tests {
         fn list_vscrollbar(&self, _r: Rect, _l: &crate::ListView) -> Option<crate::Scrollbar> {
             None
         }
+        fn list_layout(&self, r: Rect, l: &crate::ListView) -> crate::ListViewLayout {
+            l.layout(r.width, r.height, 0.0, |_| {
+                crate::primitives::list::ListItemMeasure::new(1.0)
+            })
+        }
         fn draw_form(&mut self, _r: Rect, _f: &crate::Form) {}
         fn draw_palette(&mut self, _r: Rect, _p: &crate::Palette) {}
         fn draw_settings_chrome(
@@ -2598,6 +2603,17 @@ mod tests {
 
         fn draw_board(
             &mut self,
+            _r: Rect,
+            _m: &crate::primitives::board::BoardModel,
+        ) -> crate::primitives::board::BoardLayout {
+            crate::primitives::board::BoardLayout {
+                bounds: crate::event::Rect::new(_r.x, _r.y, _r.width, _r.height),
+                columns: vec![],
+            }
+        }
+
+        fn board_layout(
+            &self,
             _r: Rect,
             _m: &crate::primitives::board::BoardModel,
         ) -> crate::primitives::board::BoardLayout {

--- a/quadraui/src/compose/chat_controller.rs
+++ b/quadraui/src/compose/chat_controller.rs
@@ -1361,6 +1361,11 @@ mod tests {
         fn list_vscrollbar(&self, _r: Rect, _l: &crate::ListView) -> Option<crate::Scrollbar> {
             None
         }
+        fn list_layout(&self, r: Rect, l: &crate::ListView) -> crate::ListViewLayout {
+            l.layout(r.width, r.height, 0.0, |_| {
+                crate::primitives::list::ListItemMeasure::new(1.0)
+            })
+        }
         fn draw_form(&mut self, _r: Rect, _f: &crate::Form) {}
         fn draw_palette(&mut self, _r: Rect, _p: &crate::Palette) {}
         fn draw_settings_chrome(
@@ -1682,6 +1687,17 @@ mod tests {
 
         fn draw_board(
             &mut self,
+            _r: Rect,
+            _m: &crate::primitives::board::BoardModel,
+        ) -> crate::primitives::board::BoardLayout {
+            crate::primitives::board::BoardLayout {
+                bounds: crate::event::Rect::new(_r.x, _r.y, _r.width, _r.height),
+                columns: vec![],
+            }
+        }
+
+        fn board_layout(
+            &self,
             _r: Rect,
             _m: &crate::primitives::board::BoardModel,
         ) -> crate::primitives::board::BoardLayout {

--- a/quadraui/src/compose/menu_system.rs
+++ b/quadraui/src/compose/menu_system.rs
@@ -796,6 +796,11 @@ mod tests {
         fn list_vscrollbar(&self, _r: Rect, _l: &crate::ListView) -> Option<crate::Scrollbar> {
             None
         }
+        fn list_layout(&self, r: Rect, l: &crate::ListView) -> crate::ListViewLayout {
+            l.layout(r.width, r.height, 0.0, |_| {
+                crate::primitives::list::ListItemMeasure::new(1.0)
+            })
+        }
         fn draw_form(&mut self, _r: Rect, _f: &crate::Form) {}
         fn draw_palette(&mut self, _r: Rect, _p: &crate::Palette) {}
         fn draw_settings_chrome(
@@ -1097,6 +1102,17 @@ mod tests {
 
         fn draw_board(
             &mut self,
+            _r: Rect,
+            _m: &crate::primitives::board::BoardModel,
+        ) -> crate::primitives::board::BoardLayout {
+            crate::primitives::board::BoardLayout {
+                bounds: crate::event::Rect::new(_r.x, _r.y, _r.width, _r.height),
+                columns: vec![],
+            }
+        }
+
+        fn board_layout(
+            &self,
             _r: Rect,
             _m: &crate::primitives::board::BoardModel,
         ) -> crate::primitives::board::BoardLayout {

--- a/quadraui/src/compose/tree_controller.rs
+++ b/quadraui/src/compose/tree_controller.rs
@@ -1590,6 +1590,11 @@ mod tests {
         fn list_vscrollbar(&self, _r: Rect, _l: &crate::ListView) -> Option<crate::Scrollbar> {
             None
         }
+        fn list_layout(&self, r: Rect, l: &crate::ListView) -> crate::ListViewLayout {
+            l.layout(r.width, r.height, 0.0, |_| {
+                crate::primitives::list::ListItemMeasure::new(1.0)
+            })
+        }
         fn draw_form(&mut self, _r: Rect, _f: &crate::Form) {}
         fn draw_palette(&mut self, _r: Rect, _p: &crate::Palette) {}
         fn draw_settings_chrome(
@@ -1901,6 +1906,17 @@ mod tests {
 
         fn draw_board(
             &mut self,
+            _r: Rect,
+            _m: &crate::primitives::board::BoardModel,
+        ) -> crate::primitives::board::BoardLayout {
+            crate::primitives::board::BoardLayout {
+                bounds: crate::event::Rect::new(_r.x, _r.y, _r.width, _r.height),
+                columns: vec![],
+            }
+        }
+
+        fn board_layout(
+            &self,
             _r: Rect,
             _m: &crate::primitives::board::BoardModel,
         ) -> crate::primitives::board::BoardLayout {

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -5485,6 +5485,284 @@ mod tests {
         );
     }
 
+    /// Issue #506 review fix: `terminal_layout`'s default body must
+    /// reserve the same scrollbar gutter width `draw_terminal` reserves
+    /// before iterating cells (`cell_area_w = (rect.width -
+    /// sb_width).max(0.0)`, this file's `draw_terminal`), or a click on
+    /// the gutter resolves to `TerminalHit::Cell` when the paint path
+    /// shows a scrollbar there, not a cell — "paint and no-paint
+    /// silently disagree" (rule 5). Pins the formula, then proves it
+    /// against a real Cairo paint: the last (gutter) column must not
+    /// show the painted cell colour.
+    #[test]
+    fn gtk_backend_terminal_layout_reserves_scrollbar_gutter_matching_draw_terminal() {
+        use pangocairo::cairo::{Context, Format, ImageSurface};
+
+        let bright = crate::types::Color::rgb(0, 255, 0);
+        let cw = 10.0;
+        let lh = 20.0;
+        let w = 40;
+        let h = 20;
+
+        let mut backend = GtkBackend::new();
+        backend.current_line_height = lh;
+        backend.current_char_width = cw;
+        let rect = QRect::new(0.0, 0.0, w as f32, h as f32);
+
+        let cell = TerminalCell {
+            ch: ' ',
+            fg: bright,
+            bg: bright,
+            bold: false,
+            italic: false,
+            underline: false,
+            selected: false,
+            is_cursor: false,
+            is_find_match: false,
+            is_find_active: false,
+        };
+        let term = TerminalPrim {
+            id: WidgetId::new("test:term-sb"),
+            cells: vec![vec![cell; 4]],
+            scrollbar: Some(crate::TerminalScrollbar {
+                total_lines: 100,
+                visible_lines: 1,
+                scroll_offset: 0,
+                inverted: false,
+                // `None` — draw_terminal's `sb_width: … .unwrap_or(8.0)`
+                // fallback, which `terminal_scrollbar_default_width` must
+                // reproduce.
+                width: None,
+            }),
+        };
+
+        let layout = Backend::terminal_layout(&backend, rect, &term);
+        // GTK's default scrollbar gutter is 8px: cell_area_w = 40 - 8 =
+        // 32; grid_cols = floor(32 / char_width=10) = 3.
+        assert_eq!(
+            layout.grid_cols, 3,
+            "terminal_layout must reserve the 8px scrollbar gutter default \
+             (GtkBackend::terminal_scrollbar_default_width), matching draw_terminal's \
+             `cell_area_w = (rect.width - sb_width).max(0.0)`"
+        );
+        assert_eq!(
+            layout.hit_test(35.0, 0.0),
+            crate::TerminalHit::Empty,
+            "a click at x=35 (inside the 8px scrollbar gutter, cols 32..40) must not resolve to \
+             a grid cell"
+        );
+
+        let mut surface = ImageSurface::create(Format::ARgb32, w, h).expect("create ImageSurface");
+        {
+            let cr = Context::new(&surface).expect("Context::new");
+            let pango_layout = pangocairo::functions::create_layout(&cr);
+            Backend::begin_frame(&mut backend, Viewport::new(w as f32, h as f32, 1.0));
+            backend.enter_frame_scope(&cr, &pango_layout, |b| b.draw_terminal(rect, &term));
+        }
+        surface.flush();
+        let stride = surface.stride() as usize;
+        let data = surface.data().expect("surface data");
+        let probe = |x: i32, y: i32| -> (u8, u8, u8) {
+            let off = y as usize * stride + x as usize * 4;
+            (data[off + 2], data[off + 1], data[off])
+        };
+
+        assert_eq!(
+            probe(5, 5),
+            (0, 255, 0),
+            "column 0 (inside grid_cols=3) must show the painted cell colour"
+        );
+        assert_ne!(
+            probe(35, 5),
+            (0, 255, 0),
+            "x=35 sits inside draw_terminal's 8px scrollbar gutter — it must not show the \
+             terminal cell colour, matching terminal_layout's grid_cols=3 exclusion of that \
+             region"
+        );
+    }
+
+    /// Minimal two-row-hunk `DiffView` fixture for `diff_view_layout`
+    /// parity tests below — mirrors `tui::backend::tests::sample_diff_view`.
+    fn gtk_sample_diff_view(mode: crate::DiffMode, left_label: Option<String>) -> crate::DiffView {
+        crate::DiffView {
+            id: WidgetId::new("diff"),
+            left: String::new(),
+            right: String::new(),
+            left_label,
+            right_label: None,
+            hunks: vec![crate::DiffHunk {
+                left_start: 1,
+                right_start: 1,
+                rows: vec![
+                    crate::DiffRow {
+                        left: Some("alpha".into()),
+                        right: Some("ALPHA".into()),
+                        kind: crate::DiffRowKind::Changed,
+                    },
+                    crate::DiffRow {
+                        left: Some("beta".into()),
+                        right: Some("beta".into()),
+                        kind: crate::DiffRowKind::Same,
+                    },
+                ],
+            }],
+            mode,
+            editability: crate::DiffEditability::ReadOnly,
+            scroll_offset: 0,
+            focused_pane: crate::DiffPane::Left,
+            has_focus: false,
+        }
+    }
+
+    /// Issue #506 review fix: `diff_view_layout` is claimed to be
+    /// "verified byte-for-byte against each backend's real paint
+    /// formula" — this test (and its unified-mode sibling below) makes
+    /// that claim true for GTK. `gtk::draw_diff_view` returns its
+    /// `DiffViewLayout` directly, so this compares the no-paint default
+    /// body against the exact value the real paint path produced, in
+    /// `SideBySide` mode with a header row reserved.
+    #[test]
+    fn gtk_diff_view_layout_matches_draw_diff_view_side_by_side_with_header() {
+        use pangocairo::cairo::{Context, Format, ImageSurface};
+
+        let mut backend = GtkBackend::new();
+        backend.current_line_height = 20.0;
+        let view = gtk_sample_diff_view(crate::DiffMode::SideBySide, Some("left.txt".into()));
+        let rect = QRect::new(0.0, 0.0, 200.0, 100.0);
+
+        let no_paint = Backend::diff_view_layout(&backend, rect, &view);
+
+        let surface = ImageSurface::create(Format::ARgb32, 200, 100).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let pango_layout = pangocairo::functions::create_layout(&cr);
+        let painted = crate::gtk::draw_diff_view(
+            &cr,
+            &pango_layout,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            &view,
+            &backend.current_theme,
+            backend.current_line_height,
+        );
+
+        assert_eq!(
+            no_paint, painted,
+            "diff_view_layout must equal the exact layout draw_diff_view painted with"
+        );
+        assert_eq!(
+            no_paint.visible_rows, 4,
+            "a 100px-tall rect minus a 20px header (left_label is set) leaves 4 content rows at \
+             line_height=20"
+        );
+    }
+
+    /// Same parity check in `Unified` mode, where no header row is
+    /// reserved.
+    #[test]
+    fn gtk_diff_view_layout_matches_draw_diff_view_unified() {
+        use pangocairo::cairo::{Context, Format, ImageSurface};
+
+        let mut backend = GtkBackend::new();
+        backend.current_line_height = 20.0;
+        let view = gtk_sample_diff_view(crate::DiffMode::Unified, None);
+        let rect = QRect::new(0.0, 0.0, 200.0, 100.0);
+
+        let no_paint = Backend::diff_view_layout(&backend, rect, &view);
+
+        let surface = ImageSurface::create(Format::ARgb32, 200, 100).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let pango_layout = pangocairo::functions::create_layout(&cr);
+        let painted = crate::gtk::draw_diff_view(
+            &cr,
+            &pango_layout,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            &view,
+            &backend.current_theme,
+            backend.current_line_height,
+        );
+
+        assert_eq!(
+            no_paint, painted,
+            "diff_view_layout must equal the exact layout draw_diff_view painted with (unified \
+             mode reserves no header band)"
+        );
+    }
+
+    /// Issue #506 review fix: `editor_layout`'s default body
+    /// (`editor.layout(rect, char_width, line_height)`) must match the
+    /// gutter/text geometry `gtk::draw_editor` actually paints with —
+    /// `gutter_width = editor.gutter_char_width * char_width` and
+    /// `text_x_offset = rect.x + gutter_width - h_scroll_offset`
+    /// (`src/gtk/editor.rs`). Note `gtk::draw_editor` paints at
+    /// `editor.rect`, not the `rect` argument `Backend::draw_editor`
+    /// receives (it discards that argument — `let _ = rect;`), so this
+    /// test sets `editor.rect == rect` to hold the two in sync, exactly
+    /// the invariant callers must maintain (see `editor_layout`'s doc).
+    #[test]
+    fn gtk_backend_editor_layout_matches_draw_editor_gutter_and_text_geometry() {
+        let mut backend = GtkBackend::new();
+        backend.current_char_width = 10.0;
+        backend.current_line_height = 20.0;
+        let rect = QRect::new(0.0, 0.0, 200.0, 100.0);
+        let editor = crate::Editor {
+            id: WidgetId::new("ed"),
+            rect,
+            lines: Vec::new(),
+            cursor: None,
+            extra_cursors: Vec::new(),
+            selection: None,
+            extra_selections: Vec::new(),
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: 0,
+            total_lines: 3,
+            max_col: 4,
+            gutter_char_width: 3,
+            is_active: true,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: std::collections::HashMap::new(),
+            code_action_lines: std::collections::HashSet::new(),
+            bracket_match_positions: Vec::new(),
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: false,
+            lightbulb_glyph: '!',
+        };
+
+        let layout = Backend::editor_layout(&backend, rect, &editor);
+        let gutter = layout
+            .gutter_bounds
+            .expect("gutter_char_width=3 must produce a gutter region");
+        assert_eq!(
+            gutter.width,
+            editor.gutter_char_width as f32 * backend.current_char_width as f32,
+            "editor_layout's gutter width must match draw_editor's `gutter_width = \
+             editor.gutter_char_width * char_width` (src/gtk/editor.rs)"
+        );
+        assert_eq!(
+            layout.text_bounds.x,
+            rect.x + gutter.width,
+            "editor_layout's text_bounds.x must match draw_editor's `text_x_offset = rect.x + \
+             gutter_width` when scroll_left is 0 (src/gtk/editor.rs)"
+        );
+
+        // Paint via the real trait method with this exact geometry —
+        // proves it doesn't panic and exercises the formula this test
+        // pins.
+        use pangocairo::cairo::{Context, Format, ImageSurface};
+        let surface = ImageSurface::create(Format::ARgb32, 200, 100).expect("create ImageSurface");
+        let cr = Context::new(&surface).expect("Context::new");
+        let pango_layout = pangocairo::functions::create_layout(&cr);
+        backend.enter_frame_scope(&cr, &pango_layout, |b| b.draw_editor(rect, &editor));
+    }
+
     /// #416 review follow-up: `SidebarPanel` composes a `Toolbar` header
     /// internally (`gtk::sidebar_panel::draw_sidebar_panel` calls
     /// `gtk::toolbar::draw_toolbar` directly, bypassing

--- a/quadraui/src/gtk/backend.rs
+++ b/quadraui/src/gtk/backend.rs
@@ -1807,6 +1807,16 @@ impl Backend for GtkBackend {
         list.vscrollbar(rect, self.line_height())
     }
 
+    fn list_layout(&self, rect: QRect, list: &ListView) -> crate::ListViewLayout {
+        crate::gtk::gtk_list_layout(
+            rect.width as f64,
+            rect.height as f64,
+            list,
+            self.current_line_height,
+            self.current_char_width,
+        )
+    }
+
     fn draw_form(&mut self, rect: QRect, form: &Form) {
         let (cr, layout) = self
             .current_frame_refs()
@@ -3765,6 +3775,20 @@ impl Backend for GtkBackend {
         )
     }
 
+    fn board_layout(
+        &self,
+        rect: QRect,
+        model: &crate::primitives::board::BoardModel,
+    ) -> crate::primitives::board::BoardLayout {
+        crate::gtk::gtk_board_layout(
+            model,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+        )
+    }
+
     fn draw_minimap(
         &mut self,
         rect: QRect,
@@ -5361,6 +5385,103 @@ mod tests {
         assert_eq!(
             at_origin.hit_regions, shifted.hit_regions,
             "LOCAL form_layout must not shift hit regions by rect.x/rect.y"
+        );
+    }
+
+    /// Issue #506: `list_layout` is documented **LOCAL** — `GtkBackend`'s
+    /// impl calls `gtk_list_layout(rect.width, rect.height, ..)`, never
+    /// reading `rect.x`/`rect.y` — so a non-zero origin must produce
+    /// byte-identical geometry to the zero-origin case, and it must
+    /// equal the exact `gtk_list_layout` helper `draw_list` uses
+    /// internally (`PRIMITIVE_RULES.md` rule 5).
+    #[test]
+    fn gtk_backend_list_layout_ignores_rect_origin_and_matches_helper() {
+        let list = ListView {
+            id: WidgetId::new("test:list"),
+            title: None,
+            items: vec![crate::primitives::list::ListItem {
+                text: crate::types::StyledText::plain("only"),
+                icon: None,
+                detail: None,
+                decoration: crate::types::Decoration::Normal,
+            }],
+            selected_idx: 0,
+            scroll_offset: 0,
+            has_focus: true,
+            bordered: false,
+            h_scroll: 0,
+            max_content_width: None,
+            show_v_scrollbar: false,
+        };
+        let backend = GtkBackend::new();
+
+        let at_origin = Backend::list_layout(&backend, QRect::new(0.0, 0.0, 200.0, 100.0), &list);
+        let shifted = Backend::list_layout(&backend, QRect::new(7.0, 13.0, 200.0, 100.0), &list);
+        assert_eq!(
+            at_origin, shifted,
+            "LOCAL list_layout must not shift geometry by rect.x/rect.y"
+        );
+
+        let via_helper = crate::gtk::gtk_list_layout(
+            200.0,
+            100.0,
+            &list,
+            backend.current_line_height,
+            backend.current_char_width,
+        );
+        assert_eq!(
+            at_origin, via_helper,
+            "list_layout must equal the exact helper draw_list uses internally"
+        );
+        assert!(
+            !at_origin.visible_items.is_empty(),
+            "sanity: the sample list has an item to lay out"
+        );
+    }
+
+    /// Issue #506: `board_layout` is documented **ABSOLUTE** — bounds are
+    /// shifted by `rect.x`/`rect.y`, matching `BoardLayout::hit_test`'s
+    /// contract. Also proves `board_layout` and `draw_board` agree
+    /// byte-for-byte, since both route through `gtk_board_layout`.
+    #[test]
+    fn gtk_backend_board_layout_is_absolute_and_matches_helper() {
+        let model = crate::primitives::board::BoardModel {
+            id: WidgetId::new("test:board"),
+            columns: vec![crate::primitives::board::BoardColumn {
+                id: WidgetId::new("col:a"),
+                title: "Backlog".into(),
+                cards: vec![crate::primitives::board::BoardCard {
+                    id: WidgetId::new("card:1"),
+                    title: "Do the thing".into(),
+                    labels: vec![],
+                    badges: vec![],
+                    hint: None,
+                }],
+                scroll_offset: 0,
+            }],
+            selected_card_id: None,
+            col_scroll_offset: 0,
+        };
+        let backend = GtkBackend::new();
+        let rect = QRect::new(5.0, 2.0, 400.0, 300.0);
+
+        let no_paint = Backend::board_layout(&backend, rect, &model);
+        assert_eq!(
+            no_paint.bounds,
+            crate::event::Rect::new(rect.x, rect.y, rect.width, rect.height),
+            "board_layout must fold rect's origin into `bounds` (ABSOLUTE, issue #505)"
+        );
+
+        let via_helper = crate::gtk::gtk_board_layout(
+            &model,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+        );
+        assert_eq!(
+            no_paint, via_helper,
+            "board_layout must equal the exact helper draw_board uses internally"
         );
     }
 

--- a/quadraui/src/gtk/list.rs
+++ b/quadraui/src/gtk/list.rs
@@ -13,9 +13,52 @@ use gtk4::cairo::Context;
 use gtk4::pango;
 
 use super::{cairo_rgb, rounded_rect_path};
-use crate::primitives::list::{ListItemMeasure, ListView};
+use crate::primitives::list::{ListItemMeasure, ListView, ListViewLayout};
 use crate::theme::Theme;
 use crate::types::Decoration;
+
+/// Compute the GTK pixel-unit layout for a [`ListView`] without painting —
+/// the same viewport reservation (border inset, h-scrollbar row)
+/// [`draw_list`] applies internally before calling [`ListView::layout`].
+/// `draw_list` calls this exact function (with its own live-measured
+/// `char_width`) so paint and no-paint hit-testing can never drift apart
+/// (`PRIMITIVE_RULES.md` rule 5).
+///
+/// `char_width` is used only for the h-scrollbar-overflow threshold check
+/// (`ListView::max_content_width` is in character columns); pass
+/// [`crate::Backend::char_width`]'s cached value when no live
+/// `pango::Layout` is available — the same approximation
+/// `GtkBackend::list_hscrollbar` already uses for this exact check.
+///
+/// Coordinate frame: **LOCAL** — relative to `(0, 0)`, matching
+/// `tui_list_layout` / `win_list_layout` / `mac_list_layout`. Does **not**
+/// account for [`ListView::bordered`]'s 1px border inset — same as every
+/// other backend's list-layout helper; a bordered list's caller adds that
+/// inset itself (see `draw_list`'s `item_x_offset` / `item_y_offset`).
+pub fn gtk_list_layout(
+    w: f64,
+    h: f64,
+    list: &ListView,
+    line_height: f64,
+    char_width: f64,
+) -> ListViewLayout {
+    let border_inset: f64 = if list.bordered { 1.0 } else { 0.0 };
+    let visible_px = (w - border_inset * 2.0).max(0.0);
+    let needs_hscrollbar = list
+        .max_content_width
+        .is_some_and(|n| n as f64 * char_width > visible_px);
+    let hscrollbar_h = if needs_hscrollbar { line_height } else { 0.0 };
+    let title_h = if list.title.is_some() {
+        line_height as f32
+    } else {
+        0.0
+    };
+    let layout_w = (w - border_inset * 2.0) as f32;
+    let layout_h = (h - border_inset * 2.0 - hscrollbar_h).max(0.0) as f32;
+    list.layout(layout_w, layout_h, title_h, |_| {
+        ListItemMeasure::new(line_height as f32)
+    })
+}
 
 /// Draw a [`ListView`] into `(x, y, w, h)` on `cr`.
 ///
@@ -100,18 +143,8 @@ pub fn draw_list(
     let needs_hscrollbar = list
         .max_content_width
         .is_some_and(|n| n as f64 * char_w > visible_px);
-    let hscrollbar_h = if needs_hscrollbar { line_height } else { 0.0 };
 
-    let title_h = if list.title.is_some() {
-        line_height as f32
-    } else {
-        0.0
-    };
-    let layout_w = (w - border_inset * 2.0) as f32;
-    let layout_h = (h - border_inset * 2.0 - hscrollbar_h).max(0.0) as f32;
-    let list_layout = list.layout(layout_w, layout_h, title_h, |_| {
-        ListItemMeasure::new(line_height as f32)
-    });
+    let list_layout = gtk_list_layout(w, h, list, line_height, char_w);
 
     if list.bordered {
         if let Some(ref title) = list.title {

--- a/quadraui/src/gtk/menu_overlay.rs
+++ b/quadraui/src/gtk/menu_overlay.rs
@@ -29,6 +29,20 @@
 //! // On MenuRedraw:
 //! overlay.sync(menu_system.borrow().is_open());
 //! ```
+//!
+//! ## Not a `Backend` trait gap (issue #506 audit)
+//!
+//! `MenuOverlay` is GTK-hosting/compositing glue — it positions an
+//! already-painted `MenuSystem` popup within GTK's native
+//! overlay-widget model (`gtk4::Overlay` + a second `DrawingArea`). It
+//! implements no primitive's `layout()` / paint contract, so there is
+//! no `draw_<name>` for it to pair with, and no `Surface` variant to
+//! add either. TUI, Win, and macOS have no equivalent concept because
+//! none of them have GTK's overlay-widget model to bridge into — the
+//! same category as `AppShell`'s GTK widget-tree bootstrap. Rule 7
+//! ("every primitive gets a `Backend` trait method") doesn't apply
+//! because this isn't a primitive. See `quadraui/docs/DECISIONS.md`
+//! D-007 for the full write-up.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;

--- a/quadraui/src/gtk/mod.rs
+++ b/quadraui/src/gtk/mod.rs
@@ -89,7 +89,7 @@ pub use events::{wire_da_events, wire_da_events_with_scroll_direction};
 pub use find_replace::draw_find_replace;
 pub use form::{draw_form, draw_settings_chrome};
 pub use image::draw_image;
-pub use list::draw_list;
+pub use list::{draw_list, gtk_list_layout};
 pub use menu_bar::{draw_menu_bar, gtk_menu_bar_layout};
 pub use menu_overlay::MenuOverlay;
 pub use message_list::draw_message_list;

--- a/quadraui/src/macos/backend.rs
+++ b/quadraui/src/macos/backend.rs
@@ -939,6 +939,16 @@ impl Backend for MacBackend {
             row_h,
         )
     }
+    fn list_layout(&self, rect: Rect, list: &ListView) -> crate::ListViewLayout {
+        super::list::mac_list_layout(
+            list,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            self.current_line_height,
+        )
+    }
     fn draw_form(&mut self, rect: Rect, form: &Form) {
         let ctx = self.current_cg();
         debug_assert!(
@@ -2231,6 +2241,16 @@ impl Backend for MacBackend {
                 &theme,
             )
         }
+    }
+
+    fn board_layout(&self, rect: Rect, model: &BoardModel) -> BoardLayout {
+        super::board::mac_board_layout(
+            model,
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+        )
     }
 
     /// #382 scopes the `Minimap` rasteriser to GTK (fixed-pitch colour

--- a/quadraui/src/macos/palette.rs
+++ b/quadraui/src/macos/palette.rs
@@ -32,12 +32,27 @@ const SCROLLBAR_PX: f32 = 8.0;
 /// Coordinate frame: all returned bounds (`title_bounds`,
 /// `query_bounds`, `visible_items.bounds`, `create_bounds`,
 /// `preview_bounds`, `scrollbar.{track,thumb}`, `hit_regions`) are in
-/// **palette-local** coords (origin at 0, 0), matching
-/// `tui_palette_layout` and `gtk_palette_layout`. Hosts must subtract
+/// **palette-local** coords (origin at 0, 0). Hosts must subtract
 /// the palette's `area.x` / `area.y` from absolute click coords before
 /// calling `PaletteLayout::hit_test`. The `x` / `y` params are kept in
 /// the signature for symmetry with `draw_palette` but do not affect
 /// output.
+///
+/// **Correction (issue #506 audit):** despite what this doc used to
+/// imply, TUI and GTK have no `tui_palette_layout` / `gtk_palette_layout`
+/// free functions to be consistent with — GTK's `draw_palette` computes
+/// its `Palette::layout()` call inline and then paints item rows at an
+/// independently-derived `rows_y` offset that drifts from the returned
+/// struct's own `bounds.y` by 1px whenever `show_query` is true; TUI's
+/// `draw_palette` predates the shared `Palette::layout()` refactor
+/// entirely and never calls it. Neither gap is visible today only
+/// because `draw_palette` returns `()` on every backend, so nothing
+/// reads this function's output except its own paint call and its own
+/// tests. `Backend::palette_layout` was deliberately **not** added
+/// alongside `list_layout` / `board_layout` in #506 because exposing
+/// this function through the trait would make that drift externally
+/// visible. See `quadraui/docs/DECISIONS.md` D-007, "Palette: deferred,
+/// not missed."
 pub fn mac_palette_layout(
     palette: &Palette,
     _x: f64,

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -1068,6 +1068,10 @@ impl Backend for TuiBackend {
         )
     }
 
+    fn list_layout(&self, rect: QRect, list: &ListView) -> crate::ListViewLayout {
+        crate::tui::tui_list_layout(q_rect_to_ratatui(rect), list)
+    }
+
     fn draw_form(&mut self, rect: QRect, form: &Form) {
         let area = q_rect_to_ratatui(rect);
         let theme = self.current_theme;
@@ -2152,6 +2156,14 @@ impl Backend for TuiBackend {
         crate::tui::draw_board(frame.buffer_mut(), area, model, &theme)
     }
 
+    fn board_layout(
+        &self,
+        rect: QRect,
+        model: &crate::primitives::board::BoardModel,
+    ) -> crate::primitives::board::BoardLayout {
+        crate::tui::tui_board_layout(model, q_rect_to_ratatui(rect))
+    }
+
     fn draw_minimap(
         &mut self,
         rect: QRect,
@@ -2366,6 +2378,9 @@ mod tests {
         }
         fn list_vscrollbar(&self, _rect: QRect, _list: &ListView) -> Option<crate::Scrollbar> {
             None
+        }
+        fn list_layout(&self, rect: QRect, list: &ListView) -> crate::ListViewLayout {
+            crate::tui::tui_list_layout(q_rect_to_ratatui(rect), list)
         }
         fn draw_palette(&mut self, rect: QRect, palette: &Palette) {
             self.calls.push(DrawCall::Palette {
@@ -2890,6 +2905,27 @@ mod tests {
 
         fn draw_board(
             &mut self,
+            r: QRect,
+            model: &crate::primitives::board::BoardModel,
+        ) -> crate::primitives::board::BoardLayout {
+            crate::primitives::board::board_layout(
+                model,
+                r.x,
+                r.y,
+                r.width,
+                r.height,
+                crate::primitives::board::BoardMeasure::new(
+                    crate::tui::board::TUI_BOARD_COL_MIN_CELLS,
+                    1.0,
+                    1.0,
+                    crate::tui::board::TUI_BOARD_CARD_H,
+                    0.0,
+                ),
+            )
+        }
+
+        fn board_layout(
+            &self,
             r: QRect,
             model: &crate::primitives::board::BoardModel,
         ) -> crate::primitives::board::BoardLayout {
@@ -3960,5 +3996,103 @@ mod tests {
             severity: None,
         };
         assert!(backend.services().show_message_dialog(opts).is_none());
+    }
+
+    /// Issue #506: `list_layout` is documented **LOCAL** — a caller
+    /// subtracts `rect.x`/`rect.y` itself before hit-testing — so a
+    /// non-zero origin must not change the returned geometry at all
+    /// (same regression shape as `gtk_backend_data_table_layout_ignores_rect_origin`).
+    #[test]
+    fn list_layout_ignores_rect_origin() {
+        let backend = TuiBackend::new();
+        let list = sample_list();
+
+        let at_origin = backend.list_layout(QRect::new(0.0, 0.0, 20.0, 5.0), &list);
+        let shifted = backend.list_layout(QRect::new(7.0, 3.0, 20.0, 5.0), &list);
+
+        assert_eq!(
+            at_origin, shifted,
+            "list_layout must ignore rect.x/rect.y (LOCAL frame, issue #505)"
+        );
+        assert!(
+            !at_origin.visible_items.is_empty(),
+            "sanity: the sample list has an item to lay out"
+        );
+    }
+
+    /// `list_layout` must be the exact resolver `draw_list` uses
+    /// internally, not a parallel reimplementation that can drift from
+    /// it (`PRIMITIVE_RULES.md` rule 5) — paint into a real `Buffer` (the
+    /// same free-fn path `crate::tui::draw_list` uses) and compare the
+    /// helper both paths share.
+    #[test]
+    fn list_layout_matches_draw_list_resolver() {
+        let backend = TuiBackend::new();
+        let list = sample_list();
+        let rect = QRect::new(3.0, 1.0, 20.0, 5.0);
+        let area = q_rect_to_ratatui(rect);
+
+        let no_paint = backend.list_layout(rect, &list);
+
+        // `draw_list` returns `()`, but it computes its geometry by
+        // calling `tui_list_layout(area, list)` internally (see
+        // `tui/list.rs::draw_list`) — the same helper `list_layout`
+        // calls. Paint into a real buffer (proving it doesn't panic on
+        // the shared geometry) and assert the helper output directly.
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        crate::tui::draw_list(&mut buf, area, &list, &backend.current_theme, false);
+        let via_paint_helper = crate::tui::tui_list_layout(area, &list);
+
+        assert_eq!(
+            no_paint, via_paint_helper,
+            "list_layout must equal the exact helper draw_list uses internally"
+        );
+        assert!(
+            !no_paint.visible_items.is_empty(),
+            "sanity: the sample list has an item to lay out"
+        );
+    }
+
+    /// Issue #506: `board_layout` is documented **ABSOLUTE** — bounds
+    /// are shifted by `rect.x`/`rect.y`, matching `BoardLayout::hit_test`'s
+    /// contract that a caller compares it directly against raw click
+    /// coordinates. Also proves `board_layout` and `draw_board` agree
+    /// byte-for-byte, since both route through `tui_board_layout`.
+    #[test]
+    fn board_layout_is_absolute_and_matches_draw_board() {
+        let backend = TuiBackend::new();
+        let model = crate::primitives::board::BoardModel {
+            id: WidgetId::new("test:board"),
+            columns: vec![crate::primitives::board::BoardColumn {
+                id: WidgetId::new("col:a"),
+                title: "Backlog".into(),
+                cards: vec![crate::primitives::board::BoardCard {
+                    id: WidgetId::new("card:1"),
+                    title: "Do the thing".into(),
+                    labels: vec![],
+                    badges: vec![],
+                    hint: None,
+                }],
+                scroll_offset: 0,
+            }],
+            selected_card_id: None,
+            col_scroll_offset: 0,
+        };
+        let rect = QRect::new(5.0, 2.0, 40.0, 12.0);
+        let area = q_rect_to_ratatui(rect);
+
+        let no_paint = backend.board_layout(rect, &model);
+        assert_eq!(
+            no_paint.bounds,
+            crate::event::Rect::new(rect.x, rect.y, rect.width, rect.height),
+            "board_layout must fold rect's origin into `bounds` (ABSOLUTE, issue #505)"
+        );
+
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        let painted = crate::tui::draw_board(&mut buf, area, &model, &backend.current_theme);
+        assert_eq!(
+            no_paint, painted,
+            "board_layout must equal the exact layout draw_board painted with"
+        );
     }
 }

--- a/quadraui/src/tui/backend.rs
+++ b/quadraui/src/tui/backend.rs
@@ -976,6 +976,13 @@ impl Backend for TuiBackend {
         1.0
     }
 
+    /// TUI's terminal scrollbar gutter is one character cell, not GTK's
+    /// 8px default — matching `src/tui/terminal.rs`'s
+    /// `sb_cols: … .unwrap_or(1)` (issue #506 review fix).
+    fn terminal_scrollbar_default_width(&self) -> f32 {
+        1.0
+    }
+
     fn snap_height(&self, h: f32) -> f32 {
         // Mirrors the height component of `q_rect_to_ratatui` exactly —
         // same `.max(0.0).round()` — so a height computed via this method
@@ -4093,6 +4100,253 @@ mod tests {
         assert_eq!(
             no_paint, painted,
             "board_layout must equal the exact layout draw_board painted with"
+        );
+    }
+
+    /// Issue #506 review fix: `terminal_layout`'s default body must
+    /// reserve the same scrollbar gutter width `draw_terminal` reserves
+    /// before iterating cells (`cell_area_w =
+    /// area.width.saturating_sub(sb_cols)`, `src/tui/terminal.rs`), or a
+    /// click on the gutter resolves to `TerminalHit::Cell` when the
+    /// paint path shows a scrollbar there, not a cell — "paint and
+    /// no-paint silently disagree" (rule 5).
+    #[test]
+    fn terminal_layout_reserves_scrollbar_gutter_matching_draw_terminal() {
+        let backend = TuiBackend::new();
+        let cell = crate::TerminalCell {
+            ch: 'x',
+            fg: crate::Color::rgb(200, 200, 200),
+            bg: crate::Color::rgb(20, 20, 20),
+            bold: false,
+            italic: false,
+            underline: false,
+            selected: false,
+            is_cursor: false,
+            is_find_match: false,
+            is_find_active: false,
+        };
+        let term = TerminalPrim {
+            id: WidgetId::new("t"),
+            cells: vec![vec![cell; 20]; 5],
+            scrollbar: Some(crate::TerminalScrollbar {
+                total_lines: 100,
+                visible_lines: 5,
+                scroll_offset: 0,
+                inverted: false,
+                // `None` — draw_terminal's `sb_cols: … .unwrap_or(1)` fallback,
+                // which `terminal_scrollbar_default_width` must reproduce.
+                width: None,
+            }),
+        };
+        let rect = QRect::new(0.0, 0.0, 10.0, 5.0);
+        let area = q_rect_to_ratatui(rect);
+
+        let layout = backend.terminal_layout(rect, &term);
+        assert_eq!(
+            layout.grid_cols, 9,
+            "terminal_layout must reserve the 1-column scrollbar gutter (TUI's \
+             terminal_scrollbar_default_width), not the full unreduced rect.width"
+        );
+        assert_eq!(
+            layout.hit_test(9.0, 0.0),
+            crate::primitives::terminal::TerminalHit::Empty,
+            "a click at x=9 (the scrollbar gutter column) must not resolve to a grid cell"
+        );
+
+        // Confirm against the real paint path: column 9 is where
+        // draw_terminal paints the scrollbar track, not cell glyphs.
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        crate::tui::draw_terminal(&mut buf, area, &term, &backend.current_theme);
+        assert_ne!(
+            buf[(area.x + 9, area.y)].symbol(),
+            "x",
+            "column 9 is draw_terminal's scrollbar gutter — it must not show painted cell \
+             content, matching terminal_layout's grid_cols=9 exclusion of that column"
+        );
+    }
+
+    /// Minimal two-row-hunk `DiffView` fixture for `diff_view_layout`
+    /// parity tests below.
+    fn sample_diff_view(mode: crate::DiffMode, left_label: Option<String>) -> crate::DiffView {
+        crate::DiffView {
+            id: WidgetId::new("diff"),
+            left: String::new(),
+            right: String::new(),
+            left_label,
+            right_label: None,
+            hunks: vec![crate::DiffHunk {
+                left_start: 1,
+                right_start: 1,
+                rows: vec![
+                    crate::DiffRow {
+                        left: Some("alpha".into()),
+                        right: Some("ALPHA".into()),
+                        kind: crate::DiffRowKind::Changed,
+                    },
+                    crate::DiffRow {
+                        left: Some("beta".into()),
+                        right: Some("beta".into()),
+                        kind: crate::DiffRowKind::Same,
+                    },
+                ],
+            }],
+            mode,
+            editability: crate::DiffEditability::ReadOnly,
+            scroll_offset: 0,
+            focused_pane: crate::DiffPane::Left,
+            has_focus: false,
+        }
+    }
+
+    /// Issue #506 review fix: `diff_view_layout` is claimed to be
+    /// "verified byte-for-byte against each backend's real paint
+    /// formula" — this is the test that makes that claim true rather
+    /// than aspirational. `draw_diff_view` returns its `DiffViewLayout`
+    /// directly, so this compares the no-paint default body against the
+    /// exact value the real paint path produced, in `SideBySide` mode
+    /// with a header row reserved.
+    #[test]
+    fn diff_view_layout_matches_draw_diff_view_side_by_side_with_header() {
+        let backend = TuiBackend::new();
+        let view = sample_diff_view(crate::DiffMode::SideBySide, Some("left.txt".into()));
+        let rect = QRect::new(0.0, 0.0, 40.0, 5.0);
+        let area = q_rect_to_ratatui(rect);
+
+        let no_paint = backend.diff_view_layout(rect, &view);
+
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        let painted = crate::tui::draw_diff_view(&mut buf, area, &view, &backend.current_theme);
+
+        assert_eq!(
+            no_paint, painted,
+            "diff_view_layout must equal the exact layout draw_diff_view painted with"
+        );
+        assert_eq!(
+            no_paint.visible_rows, 4,
+            "a 5-row rect minus a 1-row header (left_label is set) leaves 4 content rows"
+        );
+    }
+
+    /// Same parity check in `Unified` mode, where no header row is
+    /// reserved and `total_rows` folds in one synthesized `@@` header
+    /// line per hunk.
+    #[test]
+    fn diff_view_layout_matches_draw_diff_view_unified() {
+        let backend = TuiBackend::new();
+        let view = sample_diff_view(crate::DiffMode::Unified, None);
+        let rect = QRect::new(0.0, 0.0, 40.0, 5.0);
+        let area = q_rect_to_ratatui(rect);
+
+        let no_paint = backend.diff_view_layout(rect, &view);
+
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        let painted = crate::tui::draw_diff_view(&mut buf, area, &view, &backend.current_theme);
+
+        assert_eq!(
+            no_paint, painted,
+            "diff_view_layout must equal the exact layout draw_diff_view painted with (unified \
+             mode reserves no header band)"
+        );
+    }
+
+    /// Minimal blank `EditorLine` for `editor_layout` parity tests below
+    /// — content doesn't matter, only that `lines.len()` matches the
+    /// viewport row count so `draw_editor` doesn't early-`break`.
+    fn blank_editor_line(idx: usize) -> crate::EditorLine {
+        crate::EditorLine {
+            raw_text: String::new(),
+            gutter_text: String::new(),
+            spans: Vec::new(),
+            line_idx: idx,
+            is_current_line: false,
+            is_fold_header: false,
+            folded_line_count: 0,
+            git_diff: None,
+            diff_status: None,
+            diagnostics: Vec::new(),
+            spell_errors: Vec::new(),
+            is_breakpoint: false,
+            is_conditional_bp: false,
+            is_dap_current: false,
+            is_wrap_continuation: false,
+            segment_col_offset: 0,
+            annotation: None,
+            ghost_suffix: None,
+            is_ghost_continuation: false,
+            indent_guides: Vec::new(),
+            colorcolumns: Vec::new(),
+        }
+    }
+
+    /// Issue #506 review fix: `editor_layout` is claimed to be
+    /// "verified byte-for-byte against each backend's real paint
+    /// formula" — this test makes that claim true for TUI. TUI's
+    /// `draw_editor` re-derives its own scrollbar-presence formula by
+    /// hand rather than calling `Editor::layout` (`src/tui/editor.rs`:
+    /// `has_scrollbar = total_lines > viewport_lines && area.width >
+    /// gutter_w + 1`, v-scrollbar track at `(area.x + area.width - 1,
+    /// area.y, 1, track_h)`); this test pins `editor_layout`'s
+    /// `v_scrollbar_bounds` against that exact independently-derived
+    /// track, so the two can't silently drift apart.
+    #[test]
+    fn editor_layout_matches_draw_editor_scrollbar_track() {
+        let backend = TuiBackend::new();
+        let rect = QRect::new(2.0, 1.0, 20.0, 5.0);
+        let editor = crate::Editor {
+            id: WidgetId::new("ed"),
+            rect,
+            lines: (0..5).map(blank_editor_line).collect(),
+            cursor: None,
+            extra_cursors: Vec::new(),
+            selection: None,
+            extra_selections: Vec::new(),
+            yank_highlight: None,
+            scroll_top: 0,
+            scroll_left: 0,
+            // > viewport_lines (5) so a v-scrollbar is present.
+            total_lines: 100,
+            // Small enough that no h-scrollbar is triggered, keeping
+            // TUI's two-pass visible_lines/text_h resolution collapsed
+            // to a single pass (see `Editor::layout`'s doc).
+            max_col: 4,
+            gutter_char_width: 0,
+            is_active: true,
+            show_active_bg: false,
+            has_git_diff: false,
+            has_breakpoints: false,
+            diagnostic_gutter: HashMap::new(),
+            code_action_lines: std::collections::HashSet::new(),
+            bracket_match_positions: Vec::new(),
+            active_indent_col: None,
+            tabstop: 4,
+            cursorline: false,
+            lightbulb_glyph: '!',
+        };
+
+        let layout = backend.editor_layout(rect, &editor);
+        let vsb = layout
+            .v_scrollbar_bounds
+            .expect("100 lines in a 5-row viewport must trigger a v-scrollbar");
+        assert_eq!(
+            vsb,
+            crate::event::Rect::new(rect.x + rect.width - 1.0, rect.y, 1.0, rect.height),
+            "editor_layout's v_scrollbar_bounds must match draw_editor's own track formula \
+             `(area.x + area.width - 1, area.y, 1, track_h)` (src/tui/editor.rs)"
+        );
+
+        // Paint via the exact free fn TuiBackend::draw_editor calls —
+        // proves the shared scrollbar-presence formula doesn't panic
+        // against this geometry, and that the hit-test the layout
+        // exposes resolves at the painted track's own origin.
+        let area = q_rect_to_ratatui(rect);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        crate::tui::draw_editor(&mut buf, area, &editor, &backend.current_theme);
+
+        assert_eq!(
+            layout.hit_test(vsb.x, vsb.y),
+            crate::EditorHit::VScrollbar,
+            "a click at the painted scrollbar track's origin must resolve via editor_layout's \
+             own hit_test as VScrollbar"
         );
     }
 }

--- a/quadraui/src/tui/context_menu.rs
+++ b/quadraui/src/tui/context_menu.rs
@@ -170,6 +170,19 @@ pub fn draw_context_menu(
 /// per level.  This function exists as a lower-level building block used by
 /// the rasteriser unit tests; consumers should use `MenuSystem::render` instead.
 ///
+/// **Not promoted to `Backend::draw_context_menu_with_submenus` (issue
+/// #506 audit).** Doing that today would need a default body for
+/// GTK/Win/macOS, and none of them can honour cascading submenus yet
+/// (GTK's is #371) — a no-op default here wouldn't be a harmless
+/// fallback the way `TabChrome`'s is, it would silently make
+/// multi-level menus not cascade on three of four backends while the
+/// trait claimed the capability existed. This function also has zero
+/// production call sites today (no compose helper or example wires it
+/// up), so there's no live consumer being asked to route around a
+/// missing trait method. Revisit once #371 gives GTK a real cascading
+/// rasteriser to pair it with. See `quadraui/docs/DECISIONS.md` D-007
+/// for the full write-up.
+///
 /// # Arguments
 ///
 /// * `root_menu` / `root_layout` — the top-level menu, as produced by

--- a/quadraui/src/tui/dialog.rs
+++ b/quadraui/src/tui/dialog.rs
@@ -24,6 +24,18 @@ fn flatten(text: &StyledText) -> String {
 ///
 /// Uses the same `tui_item_width` measurer as the toolbar rasteriser so
 /// toolbar button positions agree between paint and hit-test.
+///
+/// **Not a `Backend::dialog_layout` gap (issue #506 audit).** `Dialog`
+/// is an *overlay-with-caller-anchor* primitive, same class as
+/// `Tooltip`/`ContextMenu`/`Completions`: a host builds its own
+/// `DialogMeasure` from portable `Backend::line_height()` and calls
+/// `dialog.layout(...)` directly (see
+/// `examples/common/modal_occlusion_demo.rs::dialog_layout`), so there
+/// is no `Backend::<name>_layout` for any primitive in that class. This
+/// function is TUI's own internal default measurer for dialogs painted
+/// without a caller-supplied `DialogMeasure` — a backend-private
+/// convenience, not a missing trait method. See
+/// `quadraui/docs/DECISIONS.md` D-007 for the full write-up.
 pub fn tui_dialog_layout(dialog: &Dialog, viewport: crate::event::Rect) -> DialogLayout {
     use super::toolbar::tui_item_width;
     use crate::primitives::dialog::DialogMeasure;

--- a/quadraui/src/tui/list.rs
+++ b/quadraui/src/tui/list.rs
@@ -12,9 +12,64 @@ use ratatui::layout::Rect;
 use ratatui::style::Color as RatatuiColor;
 
 use super::{draw_styled_text, ratatui_color, set_cell};
-use crate::primitives::list::{ListItemMeasure, ListView};
+use crate::primitives::list::{ListItemMeasure, ListView, ListViewLayout};
 use crate::theme::Theme;
 use crate::types::{Decoration, StyledText};
+
+/// Compute the TUI cell-unit layout for a [`ListView`] without painting —
+/// the same viewport reservation (h/v scrollbar rows/columns, title row)
+/// [`draw_list`] applies internally before calling [`ListView::layout`].
+/// `draw_list` calls this exact function so paint and no-paint hit-testing
+/// can never drift apart (`PRIMITIVE_RULES.md` rule 5).
+///
+/// Coordinate frame: **LOCAL** — relative to `area`'s origin, `(0, 0)` at
+/// `area`'s top-left, matching `gtk_list_layout` / `win_list_layout` /
+/// `mac_list_layout`. Does **not** account for `ListView::bordered`'s
+/// 1-cell border inset — same as every other backend's list-layout
+/// helper; a bordered list's caller adds that inset itself.
+pub fn tui_list_layout(area: Rect, list: &ListView) -> ListViewLayout {
+    let area_f = crate::event::Rect::new(
+        area.x as f32,
+        area.y as f32,
+        area.width as f32,
+        area.height as f32,
+    );
+    let hscrollbar = list.hscrollbar(area_f, 1.0);
+    let needs_hscrollbar = hscrollbar.is_some();
+
+    // #326 fix: when an h-scrollbar reserves the bottom row, the v-scrollbar's
+    // track and visible-row count must be computed against the REDUCED height.
+    let v_area_f = if needs_hscrollbar {
+        crate::event::Rect::new(
+            area_f.x,
+            area_f.y,
+            area_f.width,
+            (area_f.height - 1.0).max(0.0),
+        )
+    } else {
+        area_f
+    };
+    let vscrollbar = list.vscrollbar(v_area_f, 1.0);
+    let needs_vscrollbar = vscrollbar.is_some();
+
+    let viewport_h = if needs_hscrollbar {
+        (area.height as f32 - 1.0).max(0.0)
+    } else {
+        area.height as f32
+    };
+
+    // Reserve one column on the right for the vertical scrollbar.
+    let viewport_w = if needs_vscrollbar {
+        (area.width as f32 - 1.0).max(0.0)
+    } else {
+        area.width as f32
+    };
+
+    let title_h = if list.title.is_some() { 1.0 } else { 0.0 };
+    list.layout(viewport_w, viewport_h, title_h, |_| {
+        ListItemMeasure::new(1.0)
+    })
+}
 
 /// Draw a [`ListView`] into `area` on `buf`. Honours
 /// [`ListView::bordered`] (rounded box border + title overlay) and
@@ -76,6 +131,11 @@ pub fn draw_list(
     // `Backend::list_vscrollbar`), so the painted thumb and the draggable
     // thumb can never drift apart. In bordered mode the scrollbars sit
     // inside the box; in flat mode they occupy the outermost row/column.
+    let layout = tui_list_layout(area, list);
+
+    // Re-derive the scrollbar geometry for painting (cheap — pure
+    // functions of `list` + `area`). `tui_list_layout` only needs to know
+    // *whether* a scrollbar reserves space, not its track/thumb geometry.
     let area_f = crate::event::Rect::new(
         area.x as f32,
         area.y as f32,
@@ -83,14 +143,7 @@ pub fn draw_list(
         area.height as f32,
     );
     let hscrollbar = list.hscrollbar(area_f, 1.0);
-    let needs_hscrollbar = hscrollbar.is_some();
-
-    // #326 fix: when an h-scrollbar reserves the bottom row, the v-scrollbar's
-    // track and visible-row count must be computed against the REDUCED height.
-    // Passing the full `area_f` overcounts `visible` by one row, so the thumb is
-    // sized for a row that isn't actually visible, never advances fully to the
-    // bottom, and its track overlaps the h-scrollbar's row in the corner cell.
-    let v_area_f = if needs_hscrollbar {
+    let v_area_f = if hscrollbar.is_some() {
         crate::event::Rect::new(
             area_f.x,
             area_f.y,
@@ -101,25 +154,6 @@ pub fn draw_list(
         area_f
     };
     let vscrollbar = list.vscrollbar(v_area_f, 1.0);
-    let needs_vscrollbar = vscrollbar.is_some();
-
-    let viewport_h = if needs_hscrollbar {
-        (area.height as f32 - 1.0).max(0.0)
-    } else {
-        area.height as f32
-    };
-
-    // Reserve one column on the right for the vertical scrollbar.
-    let viewport_w = if needs_vscrollbar {
-        (area.width as f32 - 1.0).max(0.0)
-    } else {
-        area.width as f32
-    };
-
-    let title_h = if list.title.is_some() { 1.0 } else { 0.0 };
-    let layout = list.layout(viewport_w, viewport_h, title_h, |_| {
-        ListItemMeasure::new(1.0)
-    });
 
     if list.bordered {
         let top_y = area.y;

--- a/quadraui/src/tui/mod.rs
+++ b/quadraui/src/tui/mod.rs
@@ -89,7 +89,7 @@ pub use editor::{draw_editor, EditorPaintResult};
 pub use find_replace::draw_find_replace;
 pub use form::{draw_form, draw_settings_chrome, tui_form_layout};
 pub use image::draw_image;
-pub use list::draw_list;
+pub use list::{draw_list, tui_list_layout};
 pub use menu_bar::{draw_menu_bar, tui_menu_bar_layout};
 pub use message_list::draw_message_list;
 pub use minimap::{draw_minimap, tui_minimap_layout};

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -703,6 +703,18 @@ impl Backend for WinBackend {
         list.vscrollbar(rect, self.current_line_height)
     }
 
+    fn list_layout(&self, rect: Rect, list: &ListView) -> crate::ListViewLayout {
+        #[cfg(target_os = "windows")]
+        {
+            return super::list::win_list_layout(list, rect, self.current_line_height);
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let _ = (rect, list);
+            todo!("DirectWrite list layout — src/win/list.rs is target_os=\"windows\"-gated")
+        }
+    }
+
     /// #26: see [`Self::draw_tree`]'s doc.
     fn draw_form(&mut self, rect: Rect, form: &Form) {
         #[cfg(target_os = "windows")]
@@ -1436,6 +1448,10 @@ impl Backend for WinBackend {
 
     fn draw_board(&mut self, _rect: Rect, _model: &crate::BoardModel) -> crate::BoardLayout {
         todo!("Direct2D board rasteriser")
+    }
+
+    fn board_layout(&self, _rect: Rect, _model: &crate::BoardModel) -> crate::BoardLayout {
+        todo!("Direct2D board layout — no rasteriser to keep in sync with yet, see draw_board")
     }
 
     fn draw_minimap(

--- a/quadraui/src/win/backend.rs
+++ b/quadraui/src/win/backend.rs
@@ -704,9 +704,15 @@ impl Backend for WinBackend {
     }
 
     fn list_layout(&self, rect: Rect, list: &ListView) -> crate::ListViewLayout {
+        // Same two-block shape as `tree_layout` below (and deliberately
+        // NOT `return … ;` inside the windows arm): on a Windows host the
+        // `not(windows)` block is cfg'd away, so the `return` would be the
+        // function's own tail expression and `clippy::needless_return`
+        // fires — a lint only the windows-latest CI leg can see, since on
+        // Linux the second block follows and the `return` is load-bearing.
         #[cfg(target_os = "windows")]
         {
-            return super::list::win_list_layout(list, rect, self.current_line_height);
+            super::list::win_list_layout(list, rect, self.current_line_height)
         }
         #[cfg(not(target_os = "windows"))]
         {

--- a/quadraui/tests/conformance/caps.rs
+++ b/quadraui/tests/conformance/caps.rs
@@ -455,6 +455,82 @@ pub const ACCEPTED_DEFAULTS: &[(&str, &str, &str)] = &[
         "pixel backend — DirectWrite paints fractional heights exactly, so the identity default \
          is correct, not unfinished work (quadraui#632); unrelated to the #19 stub gaps above",
     ),
+    // ── issue #506: `terminal_layout` / `editor_layout` / `diff_view_layout`
+    // each ship with a trait default that is a pure function of
+    // `Backend::char_width()` / `Backend::line_height()` (plus, for
+    // `diff_view_layout`, `DiffView::mode`) — the exact same values every
+    // backend's own `draw_terminal` / `draw_editor` / `draw_diff_view`
+    // already resolves them to (see `Backend::editor_layout`'s doc for the
+    // per-backend trace: `GtkBackend`/`WinBackend`/`MacBackend` all pass
+    // `current_char_width` / `current_line_height`, which is exactly what
+    // the two accessor methods return; TUI's fixed `(1.0, 1.0)` matches its
+    // uniform cell grid). There is no backend-specific measurement these
+    // three could add — unlike `board_layout` / `list_layout` (also new in
+    // #506), which route through backend-native constants
+    // (`BoardMeasure`'s column/card sizing, `ListView`'s scrollbar
+    // reservation) and so have no default at all. Declaring all four
+    // backends here for all three methods is the honest statement that the
+    // default *is* the answer, not a stand-in for one.
+    (
+        "tui",
+        "terminal_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "tui",
+        "editor_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "tui",
+        "diff_view_layout",
+        "pure fn of line_height() + DiffView::mode — see the block comment above (#506)",
+    ),
+    (
+        "gtk",
+        "terminal_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "gtk",
+        "editor_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "gtk",
+        "diff_view_layout",
+        "pure fn of line_height() + DiffView::mode — see the block comment above (#506)",
+    ),
+    (
+        "macos",
+        "terminal_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "macos",
+        "editor_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "macos",
+        "diff_view_layout",
+        "pure fn of line_height() + DiffView::mode — see the block comment above (#506)",
+    ),
+    (
+        "win",
+        "terminal_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "win",
+        "editor_layout",
+        "pure fn of char_width()/line_height() — see the block comment above (#506)",
+    ),
+    (
+        "win",
+        "diff_view_layout",
+        "pure fn of line_height() + DiffView::mode — see the block comment above (#506)",
+    ),
 ];
 
 /// The capabilities `name`'s `backend_caps` declares, parsed from source.

--- a/quadraui/tests/conformance/caps.rs
+++ b/quadraui/tests/conformance/caps.rs
@@ -471,6 +471,34 @@ pub const ACCEPTED_DEFAULTS: &[(&str, &str, &str)] = &[
     // reservation) and so have no default at all. Declaring all four
     // backends here for all three methods is the honest statement that the
     // default *is* the answer, not a stand-in for one.
+    // ── issue #506 review fix: `terminal_scrollbar_default_width` backs
+    // `terminal_layout`'s scrollbar-gutter reservation (a `Terminal` with
+    // `scrollbar: Some(TerminalScrollbar { width: None, .. })` needs a
+    // fallback gutter width before it can compute `grid_cols`). GTK,
+    // macOS, and Win all default a `None` `TerminalScrollbar::width` to
+    // 8px (`sb_width: … .unwrap_or(8.0)` in each backend's own
+    // `draw_terminal`) — exactly the trait default — so the three take it
+    // as the honest answer, not a stand-in for one. TUI overrides it to
+    // `1.0` (one cell), matching `src/tui/terminal.rs`'s
+    // `sb_cols: … .unwrap_or(1)`.
+    (
+        "gtk",
+        "terminal_scrollbar_default_width",
+        "pixel backend default (8px) matches draw_terminal's own `unwrap_or(8.0)` fallback \
+         (issue #506 review fix)",
+    ),
+    (
+        "macos",
+        "terminal_scrollbar_default_width",
+        "pixel backend default (8px) matches draw_terminal's own `unwrap_or(8.0)` fallback \
+         (issue #506 review fix)",
+    ),
+    (
+        "win",
+        "terminal_scrollbar_default_width",
+        "pixel backend default (8px) matches draw_terminal's own `unwrap_or(8.0)` fallback \
+         (issue #506 review fix)",
+    ),
     (
         "tui",
         "terminal_layout",


### PR DESCRIPTION
Closes #506

Automated PR opened by coordinator for review of issue #506.